### PR TITLE
REST API

### DIFF
--- a/api.php
+++ b/api.php
@@ -34,8 +34,10 @@ require_once(OWA_BASE_DIR.'/owa_php.php');
 
 // define entry point cnstant
 define('OWA_API', true);
+
 // invoke OWA
 $owa = new owa_php;
+$owa->setSetting('base', 'request_mode', 'api');
 
 if ( $owa->isEndpointEnabled( basename( __FILE__ ) ) ) {
 

--- a/api/index.php
+++ b/api/index.php
@@ -33,10 +33,11 @@ define('OWA_RESTAPI', true);
 
 // invoke OWA
 $owa = new owa_php;
+$owa->setSetting('base', 'request_mode', 'rest_api');
 
 if ( $owa->isEndpointEnabled( basename( __FILE__ ) ) ) {
 	
-	$owa->setSetting('base', 'rest_api_mode', true);
+	//$owa->setSetting('base', 'rest_api_mode', true);
 	
 	$s = owa_coreAPI::serviceSingleton();
 

--- a/api/index.php
+++ b/api/index.php
@@ -1,0 +1,51 @@
+<?php
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// $Id$
+//
+
+include_once('../owa_env.php');
+require_once(OWA_BASE_DIR.'/owa_php.php');
+
+/**
+ * REST API
+ * 
+ * @author      Peter Adams <peter@openwebanalytics.com>
+ * @copyright   Copyright &copy; 2020 Peter Adams <peter@openwebanalytics.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GPL v2.0
+ * @since       owa 1.6.7
+ */
+
+// define entry point cnstant
+define('OWA_RESTAPI', true);
+
+// invoke OWA
+$owa = new owa_php;
+
+if ( $owa->isEndpointEnabled( basename( __FILE__ ) ) ) {
+	
+	$owa->setSetting('base', 'rest_api_mode', true);
+	
+	$s = owa_coreAPI::serviceSingleton();
+
+	
+    // run api command and echo page content
+    echo $owa->handleRequest();
+} else {
+    // unload owa
+    $owa->restInPeace();
+}
+
+?>

--- a/cli.php
+++ b/cli.php
@@ -62,7 +62,8 @@ $owa = new owa_caller;
 if ( $owa->isEndpointEnabled( basename( __FILE__ ) ) ) {
 
     // setting CLI mode to true
-    $owa->setSetting('base', 'cli_mode', true);
+    //$owa->setSetting('base', 'cli_mode', true);
+    $owa->setSetting('base', 'request_mode', 'cli');
     // setting user auth
     $owa->setCurrentUser('admin', 'cli-user');
     // run controller or view and echo page content

--- a/index.php
+++ b/index.php
@@ -34,7 +34,6 @@ require_once(OWA_DIR.'owa_php.php');
 // Initialize owa admin
 $owa = new owa_php;
 
-
 if (!$owa->isOwaInstalled()) {
     // redirect to install
     owa_lib::redirectBrowser(owa_coreAPI::getSetting('base','public_url').'install.php');

--- a/modules/base/classes/service.php
+++ b/modules/base/classes/service.php
@@ -50,6 +50,7 @@ class owa_service extends owa_base {
     var $browscap;
     var $geolocation;
     var $formatters = array();
+    var $restApiRoutes = array();
 
     function __construct() {
         owa_coreAPI::profile($this, __FUNCTION__, __LINE__);
@@ -264,6 +265,30 @@ class owa_service extends owa_base {
     function getRequest() {
 
         return $this->request;
+    }
+    
+    function getRestApiRoute( $version, $route_name, $request_method ) {
+	    
+	    if ( array_key_exists( $version, $this->restApiRoutes ) ) {
+		    
+		    if ( array_key_exists( $route_name, $this->restApiRoutes[ $version ] ) ) {
+			    
+			    if ( array_key_exists( $request_method, $this->restApiRoutes[ $version ][ $route_name ] ) ) {
+		    
+		    		return $this->restApiRoutes[ $version ][ $route_name ][ $request_method ] ;
+		    	}
+		    }
+		}
+    }
+    
+    function setRestApiRoute( $version, $route_name, $request_method, $value ) {
+	    
+	    $this->restApiRoutes[$version][ $route_name ][ $request_method ] = $value;
+    }
+    
+    function getAllRestApiRoutes() {
+	    
+	    return $this->restApiRoutes;
     }
 
     function getState() {

--- a/modules/base/classes/settings.php
+++ b/modules/base/classes/settings.php
@@ -714,7 +714,8 @@
                 'logo_image_path'                    => 'base/i/owa-logo-100w.png',
                 'use_64bit_hash'                    => false,
                 'user_id_illegal_chars'                => array( " ", ";", "'", "\"", "|", ")", "("),
-                'archive_old_events'                => true // used by event queues to archive processed events.
+                'archive_old_events'                => true, // used by event queues to archive processed events.
+                'request_mode'						=> 'web_app'
             )
         );
 

--- a/modules/base/classes/siteManager.php
+++ b/modules/base/classes/siteManager.php
@@ -59,7 +59,7 @@ class owa_siteManager extends owa_base {
             $ret = $site->create();
 
             if ($ret) {
-                return $site_id;
+                return $site;
             }
 
         } else {

--- a/modules/base/controllers/addSiteRestController.php
+++ b/modules/base/controllers/addSiteRestController.php
@@ -1,0 +1,36 @@
+<?php
+
+require_once(OWA_BASE_MODULE_DIR.'sitesAdd.php');
+
+class owa_addSiteRestController extends owa_sitesAddController {
+	
+	function init() {
+		
+		$this->setMode( 'rest_api' );	
+	}
+	
+	function success() {
+		
+		$this->setView( 'base.addSiteRest' );
+	}
+	
+	function errorAction() {
+		
+		$this->setView( 'base.addSiteRest' );
+
+	}
+	
+}	
+
+require_once(OWA_DIR.'owa_view.php');
+
+class owa_addSiteRestView extends owa_restApiView {
+	
+	function render() {
+		
+		$this->setResponseData( $this->get('site') );
+	}
+}
+
+
+?>

--- a/modules/base/controllers/addSiteRestController.php
+++ b/modules/base/controllers/addSiteRestController.php
@@ -4,11 +4,6 @@ require_once(OWA_BASE_MODULE_DIR.'sitesAdd.php');
 
 class owa_addSiteRestController extends owa_sitesAddController {
 	
-	function init() {
-		
-		$this->setMode( 'rest_api' );	
-	}
-	
 	function success() {
 		
 		$this->setView( 'base.addSiteRest' );
@@ -19,7 +14,6 @@ class owa_addSiteRestController extends owa_sitesAddController {
 		$this->setView( 'base.addSiteRest' );
 
 	}
-	
 }	
 
 require_once(OWA_DIR.'owa_view.php');
@@ -31,6 +25,5 @@ class owa_addSiteRestView extends owa_restApiView {
 		$this->setResponseData( $this->get('site') );
 	}
 }
-
 
 ?>

--- a/modules/base/module.php
+++ b/modules/base/module.php
@@ -46,13 +46,18 @@ class owa_baseModule extends owa_module {
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
         $this->required_schema_version = 9;
-
-        // create event queues
+        
+        return parent::__construct();
+    }
+    
+    function init() {
+	    
+	    // create event queues
 
         // register queue type implementations
-        $this->registerImplementation('event_queue_types', 'file', 'owa_fileEventQueue', OWA_MODULES_DIR.'base/classes/fileEventQueue.php');
-        $this->registerImplementation('event_queue_types', 'database', 'owa_dbEventQueue', OWA_MODULES_DIR.'base/classes/dbEventQueue.php');
-        $this->registerImplementation('event_queue_types', 'http', 'owa_httpEventQueue', OWA_MODULES_DIR.'base/classes/httpEventQueue.php');
+        $this->registerImplementation('event_queue_types', 'file', 'owa_fileEventQueue', 'classes/fileEventQueue.php');
+        $this->registerImplementation('event_queue_types', 'database', 'owa_dbEventQueue', 'classes/dbEventQueue.php');
+        $this->registerImplementation('event_queue_types', 'http', 'owa_httpEventQueue', 'classes/httpEventQueue.php');
 
         // register named queues
         $this->registerEventQueue( 'incoming_tracking_events', array(
@@ -72,8 +77,9 @@ class owa_baseModule extends owa_module {
         ));
 
         $this->setupTrackingProperties();
+        
+        $this->registerRestApiRoute( 'v1', 'siteProfile', 'POST', 'owa_addSiteRestController', 'controllers/addSiteRestController.php' );
 
-        return parent::__construct();
     }
 
     /**
@@ -668,6 +674,18 @@ class owa_baseModule extends owa_module {
         $this->registerApiMethod('listSiteProfiles',
                 array( $this, 'listSiteProfiles'),
                 array(),
+                '',
+                'edit_sites'
+        );
+        
+        $this->registerApiMethod('AddSiteProfile',
+                array( $this, 'addSiteProfile'),
+                array(
+                	'domain',
+                	'name',
+                	'description',
+                	'site_family'
+                ),
                 '',
                 'edit_sites'
         );

--- a/modules/base/sitesAdd.php
+++ b/modules/base/sitesAdd.php
@@ -74,10 +74,8 @@ class owa_sitesAddController extends owa_adminController {
 	
     function init() {
 	    
-	    $this->setMode( 'web_app' );
-        // require nonce for this action
         $this->setNonceRequired();
-       
+      
     }
 
     function action() {
@@ -116,16 +114,13 @@ class owa_sitesAddController extends owa_adminController {
         
         $this->addValidation('domain', $this->getParam('domain'), 'required', array('stopOnError'	=> true));
 
-        // Check user name exists
-        $v2 = owa_coreAPI::validationFactory('entityDoesNotExist');
-        $v2->setConfig('entity', 'base.site');
-        $v2->setConfig('column', 'domain');
-        $v2->setValues($this->getParam('protocol').$this->getParam('domain'));
-     
-        $msg = $this->getMsg(3206);
-      
-        $v2->setErrorMessage( $msg);
-        $this->setValidation('domain', $v2);
+        $siteEntityConf = [
+             'entity'    => 'base.site',
+             'column'    => 'domain',
+             'errorMsg'  => $this->getMsg(3206)
+         ];
+
+         $this->addValidation('domain', $this->getParam('protocol').$this->getParam('domain'), 'entityDoesNotExist', $siteEntityConf);
     }
     
     function success() {

--- a/modules/base/sitesAdd.php
+++ b/modules/base/sitesAdd.php
@@ -86,13 +86,19 @@ class owa_sitesAddController extends owa_adminController {
 
         $sm = owa_coreAPI::supportClassFactory( 'base', 'siteManager' );
 
-        $ret = $sm->createNewSite( $this->getParam( 'domain' ),
+        $site = $sm->createNewSite( $this->getParam( 'domain' ),
                             $this->getParam( 'name' ),
                             $this->getParam( 'description' ),
                             $this->getParam( 'site_family' )
         );
         
-        owa_coreAPI::notice("Site added successfully. site_id: $ret");
+        if ( $site ) {
+	        
+	    	owa_coreAPI::debug( "Site added successfully. site_id: " . $site->get('site_id') );    
+        }
+        
+        $this->set( 'site', $site->_getProperties() );
+        
     }
     
     function validate() {

--- a/modules/base/sitesAddCli.php
+++ b/modules/base/sitesAddCli.php
@@ -17,6 +17,7 @@
 //
 
 require_once(OWA_BASE_MODULE_DIR.'sitesAdd.php');
+require_once(OWA_DIR.'owa_view.php');
 
 /**
  * Add Site Controller
@@ -32,23 +33,26 @@ require_once(OWA_BASE_MODULE_DIR.'sitesAdd.php');
 
 class owa_sitesAddCliController extends owa_sitesAddController {
     
-    function init() {
-		
-		$this->setMode( 'cli' );
-	}
-	
 	function errorAction() {
 	
-        $this->setView('base.genericCli');
+        $this->setView('base.cli');
     }
     
     function success() {
 	   
-	    $this->setView('base.genericCli');
-	    $site_id = $this->getParam('site_id');
-	    $this->set('status_msg', "Site added successfully. site_id: $site_id");
-		
+	    $this->setView('base.sitesAddCli');
     }    
+}
+
+
+
+class owa_sitesAddCliView extends owa_cliView {
+	
+	function render() {
+		
+		$this->body->set('status_msg', "Site added successfully.");
+	    $this->setResponseData( $this->get('site') ); 
+	}
 }
 
 ?>

--- a/modules/base/sitesAddCli.php
+++ b/modules/base/sitesAddCli.php
@@ -44,10 +44,10 @@ class owa_sitesAddCliController extends owa_sitesAddController {
     
     function success() {
 	   
-	    $this->setView('base.genericCliView');
+	    $this->setView('base.genericCli');
 	    $site_id = $this->getParam('site_id');
 	    $this->set('status_msg', "Site added successfully. site_id: $site_id");
-
+		
     }    
 }
 

--- a/modules/base/templates/msgsCli.php
+++ b/modules/base/templates/msgsCli.php
@@ -2,30 +2,19 @@
 	
 if ( isset($msgs) && ! empty($msgs) ) { 
 	
-	owa_coreAPI::notice( $msgs );
-
-	
+	owa_coreAPI::notice( json_encode( $msgs, JSON_PRETTY_PRINT ) );
 }
 
-if( ! empty( $status_msg ) ) {
+if( isset( $status_msg ) && ! empty( $status_msg ) ) {
 
 	owa_coreAPI::notice( $status_msg );
 
 }
 
-if ( isset($error_msg) && !isset($validation_errors)) {
-
-    owa_coreAPI::notice( $error_msg );
+if ( isset( $error ) && ! empty( $error) ) {
+	
+	owa_coreAPI::notice("Command failed. There were some errors:". "\n" . json_encode( $error, JSON_PRETTY_PRINT ) );
 }
 
-if ( isset( $validation_errors ) && ! empty( $validation_errors ) ) {
-
-    owa_coreAPI::notice('The command parameters had some validation errors:');
-   
-    foreach ($validation_errors as $validation_error) {
-	    
-	        owa_coreAPI::notice( $validation_error );
-    }
-}
 
 ?>

--- a/modules/base/templates/msgsCli.php
+++ b/modules/base/templates/msgsCli.php
@@ -11,10 +11,16 @@ if( isset( $status_msg ) && ! empty( $status_msg ) ) {
 
 }
 
-if ( isset( $error ) && ! empty( $error) ) {
+if ( isset( $error ) && ! empty( $error ) ) {
 	
 	owa_coreAPI::notice("Command failed. There were some errors:". "\n" . json_encode( $error, JSON_PRETTY_PRINT ) );
+	
+} else {
+	
+	if ( isset( $response_data ) && ! empty( $response_data ) ) {
+	
+		owa_coreAPI::notice( "\n" . json_encode( $response_data, JSON_PRETTY_PRINT ) );
+	}
 }
-
 
 ?>

--- a/modules/base/templates/restApiResponse.php
+++ b/modules/base/templates/restApiResponse.php
@@ -1,0 +1,14 @@
+<?php
+	
+echo json_encode( array(
+		    
+		    'requestId'			=> $request_id,
+		    'httpResponse'		=> $http_response,
+		    'error'				=> $error,
+		    'data'				=> $response_data
+		    //'hasNextPage'		=> $hasNextPage,
+		    //'nextPageRequest'	=> ''
+	    ));
+
+
+?>

--- a/owa_caller.php
+++ b/owa_caller.php
@@ -75,7 +75,7 @@ class owa_caller extends owa_base {
         // Log version debug
         $this->e->debug(sprintf('*** Starting Open Web Analytics v%s. Running under PHP v%s (%s) ***', OWA_VERSION, PHP_VERSION, PHP_OS));
         if ( array_key_exists('REQUEST_URI', $_SERVER ) ) {
-            owa_coreAPI::debug( 'Request URL: '.$_SERVER['REQUEST_URI'] );
+            owa_coreAPI::debug( 'Request URL:' . $_SERVER['REQUEST_METHOD'] .' '.$_SERVER['REQUEST_URI'] );
         }
         
         if ( array_key_exists('HTTP_USER_AGENT', $_SERVER ) ) {
@@ -85,11 +85,7 @@ class owa_caller extends owa_base {
         if ( array_key_exists('HTTP_HOST', $_SERVER ) ) {
             owa_coreAPI::debug( 'Host: '.$_SERVER['HTTP_HOST'] );
         }
-        //owa_coreAPI::debug('cookie domain in caller: '. owa_coreAPI::getSetting('base', 'cookie_domain'));
-        // Backtrace. handy for debugging who called OWA    
-        //$bt = debug_backtrace();
-        //$this->e->debug($bt[4]);         
-        
+             
         // load config values from DB
         // Applies config from db or cache
         // check here is needed for installs when the configuration table does not exist.

--- a/owa_controller.php
+++ b/owa_controller.php
@@ -115,13 +115,6 @@ class owa_controller extends owa_base {
      * @var Bool
      */
     var $is_nonce_required = false;
-    
-    /**
-     * Mode the controler is operating in
-     *
-     * @var string web_app|cli|rest_api
-     */
-    var $mode = 'web_app';
 
     /**
      * Constructor
@@ -143,18 +136,17 @@ class owa_controller extends owa_base {
         $this->setViewMethod('delegate');
 
         // clobber anything that needs clobbering by conrete class
-        $this->init();
-        
-        // @todo this isn't needed is we move to an explicit cli controller map
-        if ( $this->getMode() === 'cli' && ! owa_coreAPI::getSetting('base', 'cli_mode') ) {
-	    	
-			owa_coreAPI::notice("Controller not called from CLI");
-            exit;
-	    }
+        $this->init();   
     }
     
+    /**
+	 * Abstract method for setting any controller configuration.
+	 * Fires after constructor but before doAction.
+	 *
+	 */
     function init() {
 	    
+	    return false;
     }
     
     
@@ -228,18 +220,20 @@ class owa_controller extends owa_base {
             
             return $this->data;
         }
-
+		
         /* Check validity of nonce */
-        if ($this->is_nonce_required == true) {
+        if ( owa_coreAPI::getSetting( 'base', 'request_mode' ) === 'web_app' ) {
 	        
-            $nonce = $this->getParam('nonce');
-
-            if (!$nonce || !$this->verifyNonce($nonce)) {
-                $this->e->debug('Nonce is not valid.');
-                return $this->finishActionCall($this->notAuthenticatedAction());
-            }
-        }
-
+	        if ($this->is_nonce_required == true) {
+		        
+	            $nonce = $this->getParam('nonce');
+	
+	            if (!$nonce || !$this->verifyNonce($nonce)) {
+	                $this->e->debug('Nonce is not valid.');
+	                return $this->finishActionCall($this->notAuthenticatedAction());
+	            }
+	        }
+		}
         // TODO: These sets need to be removed and added to pre(), action() or post() methods
         // in various concrete controller classes as they screw up things when
         // redirecting from one controller to another.
@@ -538,19 +532,9 @@ class owa_controller extends owa_base {
 
     }
     
-    /**
-	 * Sets th Mode of the controller
-	 *
-	 * @param $mode string	webapp|cli|api
-	 */
-    public function setMode( $mode ) {
-	    
-	    $this->mode = $mode;
-    }
-    
     public function getMode() {
 	    
-	    return $this->mode;
+	    return owa_coreAPI::getSetting( 'base', 'request_mode' );
     }
 
     function mergeParams($array) {

--- a/owa_controller.php
+++ b/owa_controller.php
@@ -145,6 +145,7 @@ class owa_controller extends owa_base {
         // clobber anything that needs clobbering by conrete class
         $this->init();
         
+        // @todo this isn't needed is we move to an explicit cli controller map
         if ( $this->getMode() === 'cli' && ! owa_coreAPI::getSetting('base', 'cli_mode') ) {
 	    	
 			owa_coreAPI::notice("Controller not called from CLI");
@@ -176,9 +177,9 @@ class owa_controller extends owa_base {
             case 'cli':
             	
             	$this->set('error_msg', $error_msg );
-            	$this->setView('base.genericCliView');
+            	$this->setView('base.genericCli');
             	$this->set( 'msgs', $error_msg );
-            	return $this->data;
+            	
             	break;
             	
             case 'web_app':
@@ -186,14 +187,18 @@ class owa_controller extends owa_base {
             	$data = array();
                 $data['view_method'] = 'redirect';
                 $data['action'] = 'base.updates';
-                return $data;
-                
+                    
             	break;
             	
             case 'rest_api':
             
+            	$this->set('error_msg', $error_msg );
+            	$this->setView('base.restApi');
+            
             	break;
         }
+        
+        return $this->data;
 	}
     /**
      * Handles request from caller
@@ -208,10 +213,10 @@ class owa_controller extends owa_base {
         if ($this->is_admin === true) {
             // do not intercept if its the updatesApply action or a re-install else updates will never apply
             $do = $this->getParam('do');
-             
+            
             if ($do != 'base.updatesApply' && !defined('OWA_INSTALLING') && !defined('OWA_UPDATING')) {
 
-                if (owa_coreAPI::isUpdateRequired()) {
+                if ( owa_coreAPI::isUpdateRequired() ) {
 	            	
 	            	return $this->updateAction();    
 	            }

--- a/owa_coreAPI.php
+++ b/owa_coreAPI.php
@@ -766,20 +766,57 @@ class owa_coreAPI {
      * @param $action string
      *
      */
-    public static function performAction($action, $params = array()) {
+    public static function performAction( $action, $params = array() ) {
 
-        // Load action from service map
         $service = owa_coreAPI::serviceSingleton();
-        $action_map = $service->getMapValue('actions', $action );
+        
+		// Lookup controler for REST API route.
+		if ( owa_coreAPI::getSetting( 'base', 'rest_api_mode' ) ) {
+			
+			owa_coreAPI::debug('Generating REST API route controller...');
+			
+			if ( owa_lib::keyExistsNotEmpty( 'version', $params ) ) {
+			
+				$request_method = $service->request->getRequestType();
+				
+				$route = $service->getRestApiRoute($params['version'], $action, $request_method );
+				owa_coreAPI::debug($route);
+				if ( $route ) {
+					
+					$controller = owa_lib::simpleFactory( $route['class_name'], $route['file'], $params );					
+				
+				} else {
+					
+					owa_coreAPI::debug('No REST API route found');
+					return;	
+				}
 
-        // create the controller object
-        if ( $action_map ) {
-            $controller = owa_lib::simpleFactory( $action_map['class_name'], $action_map['file'], $params );
-        } else {
-            // attempt to use old style convention
-            $controller = owa_coreAPI::moduleFactory($action, 'Controller', $params);
-        }
-
+			} else {
+				
+				owa_coreAPI::debug('Could not generate controller because no version param was on request.');
+				return;
+			}
+			
+		} else {
+			
+			// Load action controller from service map which uses the 'module.action' convention	
+			$action_map = $service->getMapValue('actions', $action );
+				
+			// create the controller object
+	        if ( $action_map ) {
+		        
+	            $controller = owa_lib::simpleFactory( $action_map['class_name'], $action_map['file'], $params );
+	        
+	        } else {
+	        
+	            // attempt to use old style convention
+	            $controller = owa_coreAPI::moduleFactory($action, 'Controller', $params);
+	        }
+	
+			
+		}
+		
+        
         if ( ! $controller || ! method_exists( $controller, 'doAction' ) ) {
 
             owa_coreAPI::debug("No controller is associated with $action.");

--- a/owa_coreAPI.php
+++ b/owa_coreAPI.php
@@ -771,7 +771,7 @@ class owa_coreAPI {
         $service = owa_coreAPI::serviceSingleton();
         
 		// Lookup controler for REST API route.
-		if ( owa_coreAPI::getSetting( 'base', 'rest_api_mode' ) ) {
+		if ( owa_coreAPI::getSetting( 'base', 'request_mode' ) === 'rest_api' ) {
 			
 			owa_coreAPI::debug('Generating REST API route controller...');
 			

--- a/owa_lib.php
+++ b/owa_lib.php
@@ -1383,6 +1383,14 @@ class owa_lib {
         // if it makes it through the checks then it's not private.
         return false;
     }
+    
+    public static function keyExistsNotEmpty( $key, $array ) {
+	    
+	    if ( array_key_exists($key, $array) && ! empty( $array[ $key ] ) )  {
+		    
+		    return true;
+	    }
+    } 
 }
 
 ?>

--- a/owa_module.php
+++ b/owa_module.php
@@ -217,6 +217,11 @@ abstract class owa_module extends owa_base {
      * @var boolean
      */
     var $update_from_cli_required;
+    
+    /**
+	 * Filesystem path of the module's directory
+	 */
+    var $path;
 
     /**
      * Constructor
@@ -224,9 +229,16 @@ abstract class owa_module extends owa_base {
      *
      */
     function __construct() {
-
+		
+		$this->path = OWA_MODULES_DIR . $this->name . '/';
+		
         parent::__construct();
-
+		
+		/**
+		 * Initial registration calls
+		 */
+		$this->init();
+		
         /**
          * Register Filters
          */
@@ -266,6 +278,11 @@ abstract class owa_module extends owa_base {
         $this->_registerEventProcessors();
         $this->_registerEntities();
 
+    }
+    
+    function init() {
+	    
+	    return false;
     }
 
     /**
@@ -935,18 +952,41 @@ abstract class owa_module extends owa_base {
 
 
     /**
-     * Registers an Action Controller
+     * Registers a Web Action and ontroller Implementation
      *
      * @param    $action_name    string    the name of the action used as the value in the 'do' url param
      * @param    $class_name     string    the name of the controller class
      * @param    $file            string    the path to the file housing the class
      *
      */
-    protected function registerAction( $action_name, $class_name, $file = '' ) {
+    protected function registerAction( $action_name, $class_name, $file ) {
 
-        $s = owa_coreAPI::serviceSingleton();
-        $s->setMapValue( 'actions', $action_name, array( 'class_name' => $class_name, 'file' => $file ) );
+       $this->registerImplementation( 'actions', $action_name, $class_name, $file  );
 
+    }
+    
+    /**
+     * Registers a REST API Action and Controller Implementation
+     *
+     * Routes are unique to the version/action/request_method combination
+     *
+     * @param	 $version		 string	   the version namespace of the route
+     * @param    $route__name    string    the name of the action used as the value in the 'do' param of the request
+     * @param	 $request_method string	   the HTTP request method.
+     * @param    $class_name     string    the class name of the controller
+     * @param    $file           string    the module path to the file housing the class
+     *
+     */
+    function registerRestApiRoute( $version, $route_name, $request_method, $class_name, $file ) {
+		
+		if ( $file ) {
+		
+			$file = $this->path . $file;				
+		}
+		
+		$s = owa_coreAPI::serviceSingleton();
+		
+		$s->setRestApiRoute( $version, $route_name, $request_method, array( 'class_name' => $class_name, 'file' => $file ) );
     }
 
     function registerCliCommand($command, $class) {
@@ -970,11 +1010,28 @@ abstract class owa_module extends owa_base {
         $this->api_methods[$api_method_name] = $map;
     }
 
-    function registerImplementation($type, $name, $class_name, $file) {
+    /**
+     * Registers a Component Implementation
+     *
+     * Allows a module to register a specific implementation of a module component. This method stores
+     * the mapping of where an implementation of a specific type and key is located withing the module. 
+     * This is used to store maps for things like controllers, event queues, etc. 
+     *
+     * Implemntations can be overridden by other modules if they share the same key so consider using 
+     * modules namespacing for the key (i.e. module_name.key) to avoid conflicts.
+     *
+     * @param    $type	string	the type/category of implementation		actions|event_queues
+     * @param    $key  string	the key name of the specific implmentation
+     * @param    $class_name     string    the name of the class
+     * @param    $file           string    the partial path to the file housing the class withing the module dir
+     *
+     */
+    function registerImplementation($type, $key, $class_name, $file) {
 
         $s = owa_coreAPI::serviceSingleton();
+        $file = $this->path . $file;
         $class_info = array($class_name, $file);
-        $s->setMapValue($type, $name, $class_info);
+        $s->setMapValue($type, $key, $class_info);
     }
 
     function registerBackgroundJob($name, $command, $cron_tab, $max_processes = 1) {

--- a/owa_requestContainer.php
+++ b/owa_requestContainer.php
@@ -55,9 +55,7 @@ class owa_requestContainer {
 
         // php's server variables
         $this->server = $_SERVER;
-        owa_coreAPI::debug( $_GET );
-        owa_coreAPI::debug('---');
-        owa_coreAPI::debug( $_POST );
+      
         // files
         if (!empty($_FILES)) {
             $this->files = $_FILES;

--- a/owa_view.php
+++ b/owa_view.php
@@ -180,7 +180,9 @@ class owa_view extends owa_base {
             // Load subview
             $this->loadSubView($this->data['subview']);
         endif;
-
+		
+		$this->pre();
+		
         // construct main view.  This might set some properties of the subview.
         if (method_exists($this, 'render')) {
             $this->render($this->data);
@@ -189,19 +191,19 @@ class owa_view extends owa_base {
             $this->construct($this->data);
         }
         //array of errors usually used for field validations
-        if (array_key_exists('validation_errors', $this->data)):
+        if (array_key_exists('validation_errors', $this->data)) {
             $this->body->set('validation_errors', $this->data['validation_errors']);
-        endif;
+       }
 
         // pagination
-        if (array_key_exists('pagination', $this->data)):
+        if (array_key_exists('pagination', $this->data)) {
             $this->body->set('pagination', $this->data['pagination']);
-        endif;
+        }
 
         //$this->_setLinkState();
 
         // assemble subview
-        if (!empty($this->data['subview'])):
+        if (!empty($this->data['subview'])) {
 
             // set view name in template. used for navigation.
             $this->subview->body->caller_params['view'] = $this->data['subview'];
@@ -210,14 +212,14 @@ class owa_view extends owa_base {
             $this->subview->body->set('validation_errors', $this->get('validation_errors'));
 
             // pagination
-            if (array_key_exists('pagination', $this->data)):
+            if (array_key_exists('pagination', $this->data)) {
                 $this->subview->body->set('pagination', $this->data['pagination']);
-            endif;
+            }
 
-            if (array_key_exists('params', $this->data)):
+            if (array_key_exists('params', $this->data)) {
                 $this->subview->body->set('params', $this->data['params']);
                 $this->subview->body->set('do', $this->data['params']['do']);
-            endif;
+            }
 
             // Load subview
             $this->renderSubView($this->data);
@@ -226,7 +228,7 @@ class owa_view extends owa_base {
             $this->body->set('subview', $this->subview_rendered);
 
 
-        endif;
+        }
 
         // assign validation errors
         if (!empty($this->data['validation_errors'])) {
@@ -263,7 +265,16 @@ class owa_view extends owa_base {
             return $this->t->fetch();
         }
     }
-
+    
+	/**
+     * Abstract pre render hook
+     *
+     */
+	function pre() {
+		
+		return false;
+	}
+	
     /**
      * Abstract Alternative rendering method reuires the setting of $this->postProcessView to fire
      *
@@ -709,6 +720,73 @@ class owa_adminView extends owa_view {
     }
 }
 
+/**
+ * Rest API view
+ *
+ * This view assembles the response to REST API requests
+ */
+class owa_restApiView extends owa_view {
+	
+	
+	
+	function __construct() {
+	 	
+	 	parent::__construct();
+	 	
+	 	// load templates
+        $this->t->set_template('wrapper_blank.tpl');
+        
+        $this->body->set_template('restApiResponse.php');
+	 	
+	 	// set header
+	 	owa_lib::setContentTypeHeader( 'json' );
+	 	
+    }
+    
+    /**
+	 * Used to set values of the response that we do not want the
+	 * abstract view to worry about or have ot deal with.
+	 *
+	 */
+    function pre() {
+	   
+		// Generate GUID for response   
+	    $request = owa_coreAPI::getRequest();
+
+        $this->body->set('request_id', $request->guid );
+	    	    
+	    $error = array();
+	    
+	    // set error msgs
+        if ( array_key_exists( 'error_msg', $this->data ) ) {
+	        
+            $error[] = $this->data['error_msg'];
+        }
+        
+        if ( array_key_exists( 'validation_errors', $this->data ) ) {
+	        
+            $error[] = $this->data['validation_errors'];
+        }
+        
+        $http_response = array(
+	        
+	        'status_code'	=> http_response_code()
+        );
+        
+        $this->body->set('http_response', $http_response);
+        $this->body->set('data', '');
+        $this->body->set('error', $error);
+    }
+    
+    /**
+	 * Sets the data payload of the response
+	 */
+    function setResponseData( $data ) {
+	    
+	    $this->body->set( 'response_data', $data );
+    }
+}
+
 class owa_jsonView extends owa_view {
 
     function __construct() {
@@ -788,6 +866,33 @@ class owa_cliView extends owa_view {
     function __construct( $params ) {
 	   	
 		parent::__construct($params);
+    }
+    
+    function pre() {
+	    
+	    $error = array();
+	    
+	    // set error msgs
+        if ( array_key_exists( 'error_msg', $this->data ) ) {
+	        
+            $error[] = $this->data['error_msg'];
+        }
+        
+        if ( array_key_exists( 'validation_errors', $this->data ) ) {
+	        
+            $error[] = $this->data['validation_errors'];
+        }
+        
+		$this->body->set('response_data', '');
+		$this->body->set('error', $error);
+    }
+    
+    /**
+	 * Sets the data payload of the response
+	 */
+    function setResponseData( $data ) {
+	    
+	    $this->body->set( 'response_data', $data );
     }
 
     function render() {

--- a/owa_view.php
+++ b/owa_view.php
@@ -870,6 +870,9 @@ class owa_cliView extends owa_view {
     
     function pre() {
 	    
+	    $this->t->set_template('wrapper_blank.tpl');
+        $this->body->set_template('msgsCli.php');
+	    
 	    $error = array();
 	    
 	    // set error msgs
@@ -894,15 +897,6 @@ class owa_cliView extends owa_view {
 	    
 	    $this->body->set( 'response_data', $data );
     }
-
-    function render() {
-	
-        $this->t->set_template('wrapper_blank.tpl');
-        $this->body->set_template('msgsCli.php');
-        $this->body->set('validation_errors', $this->get('validation_errors'));
-    }
-
-
 }
 
 ?>


### PR DESCRIPTION
This PR adds adds a proper REST based API facility to OWA.

## Route Registration

API routes are registered in modules using a new `registerRestApiRoute` method like so:
```
$this->registerRestApiRoute( 
    'v1',               // the version of the REST API
    'siteProfile',  // the api action
    'POST',         // the http request method
    'owa_addSiteRestController',         // the class name
    'controllers/addSiteRestController.php'       // the module path to the class file
);
```

## Requests

The REST API endpoint is accessible at: `your.owainstance.com/api/` 

All requests must include an `apiKey` for authentication. 

There is currently no URL rewriting, so GET requests need to specify param as query string params (e.g. `/api/?owa_version=v1&owa_do=siteProfile&owa_apiKey=somekey&owa_domain=http://www.foo.com&owa_name=Foo`)

## Response

The response to the API request is JSON and contains the following properties:

- _requestID_ - a GUID for the request
- _error_ - an array of any error or validation msgs
- _data_ - the data payload. Will be empty on error.
- _httpResponse_ - info about the http request. currently just contains status_code. More thought needs to go into what's useful to put in here.

## Controllers 

REST API controllers can extend regular web-app controllers so long as there is a `$this->setMode('rest_api'); call in it's `init` method. I don't love this but PHP doesn't support dual class inheritance... 

## Views

Controllers should delegate to a new concrete class extended from `owa_restApiView` view in order to properly set the data payload of the API response using it's `setResponseData` method.

## Wiki

I've added a new page to document the new API methods.

## Old API

The goal is to depreciate the old api.php endpoint once all it's methods are migrated to the REST API.
