### PR TITLE
Bugfix: time stamps in clickstream zeros get not displayed

### DIFF
--- a/modules/base/templates/report_visit.tpl
+++ b/modules/base/templates/report_visit.tpl
@@ -9,7 +9,7 @@
     
     <div class="propertyList">
         <?php foreach($clickstream->resultsRows as $s): ?>
-        <dt><?php $this->out(sprintf('%02d', $s['hour']));?>:<?php $this->out(sprintf('%02d', $s['minute']));?>:<?php $this->out(sprintf('%02d', $s['second']));?></dt>
+        <dt><?php $this->out(date("H:i:s",$s['timestamp']));?></dt>
         <dd>
             <a href="<?php echo $this->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => urlencode( $s['url'] ) ), true );?>"><span><?php echo $s['uri'];?></span></a>
         </dd>

--- a/modules/base/templates/report_visit.tpl
+++ b/modules/base/templates/report_visit.tpl
@@ -9,7 +9,7 @@
     
     <div class="propertyList">
         <?php foreach($clickstream->resultsRows as $s): ?>
-        <dt><?php echo $s['hour'];?>:<?php echo $s['minute'];?>:<?php echo $s['second'];?></dt>
+        <dt><?php $this->out(sprintf('%02d', $s['hour']));?>:<?php $this->out(sprintf('%02d', $s['minute']));?>:<?php $this->out(sprintf('%02d', $s['second']));?></dt>
         <dd>
             <a href="<?php echo $this->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => urlencode( $s['url'] ) ), true );?>"><span><?php echo $s['uri'];?></span></a>
         </dd>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [ ] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #545 


## What is the new behavior?
If there are less than two digits in hour, minute or second leading zeros gets displayed now

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Docs need to be updated?

- [ ] Yes
- [x] No

<!-- If this introduces a doc update, please describe it below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->