### PR TITLE
Bugfix: Wrong link for P3P Compact Privacy Policy in site settings

### DIFF
--- a/modules/base/templates/sites_addoredit.tpl
+++ b/modules/base/templates/sites_addoredit.tpl
@@ -61,7 +61,7 @@
 
         <div class="setting" id="p3p_policy">
             <div class="title">P3P Compact Privacy Policy</div>
-            <div class="description">This setting controls the P3P compact privacy policy that is returned to the browser when OWA sets cookies. Click <a href="http://www.p3pwriter.com/LRN_111.asp">here</a> for more information on compact privacy policies and choosing the right one for your web site.</div>
+            <div class="description">This setting controls the P3P compact privacy policy that is returned to the browser when OWA sets cookies. Click <a href="https://www.w3.org/P3P/">here</a> for more information on compact privacy policies and choosing the right one for your web site.</div>
             <div class="field"><input type="text" size="50" name="<?php echo $this->getNs();?>config[p3p_policy]" value="<?php $this->out( @$config['p3p_policy'] );?>"></div>
         </div>
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [ ] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #538 


## What is the new behavior?
The link points now to https://www.w3.org/P3P/

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Docs need to be updated?

- [ ] Yes
- [x] No

<!-- If this introduces a doc update, please describe it below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->