### PR TITLE
Fueling discussion: Is it sensible to assume mysql during setup?

### DIFF
--- a/owa_coreAPI.php
+++ b/owa_coreAPI.php
@@ -472,16 +472,9 @@ class owa_coreAPI {
 
         // Must be called before any entities are created
 
-        if (!defined('OWA_DTD_INT')) {
-            if (defined('OWA_DB_TYPE')) {
-                owa_coreAPI::setupStorageEngine(OWA_DB_TYPE);
-            } else {
-                owa_coreAPI::setupStorageEngine('mysql');
-            }
-
+        if (defined('OWA_DB_TYPE') && !defined('OWA_DTD_INT')) {
+            owa_coreAPI::setupStorageEngine(OWA_DB_TYPE);
         }
-
-
 
         if (!class_exists('owa_entity')):
             require_once(OWA_BASE_CLASSES_DIR.'owa_entity.php');


### PR DESCRIPTION
I can't assess the purpose of this in the broader context of OWA but during install, if I select postgresql (I'm experimenting with that branch on my repo) then  owa_settings.__construct lands here twice. The first time with an explicit entity creation for base.configuration at line 60 in settings.php currently, and the second time on line 80 via a call to setupStorageEngine.

Moreover at the time of the first call OWA_DB_TYPE is as yet unset so it drops back onto a mysql setup (a definite no-no IMO).

There is inconsistent methodology for ensuring a single load, with entityFactory consulting entityFactory (an arbitrary variable known to be set in the database plugin file) to determine if the file's been loaded and setupStorageEngine using a require_once strategy. Again a no-no, consistency of approach is desirable.

Questions on the table:

1. Does entityFactory need to setup the Storage engine at all?
2. Does it need to setup a Storage engine for all entities or only some?
3. Is it ever kosher to fall back on mysql (IMO no)? Or is it better to bail?

This is NOT a complete PR. There is  BIG issue at play still in that:

1. the constructor for owa_configuration requires database information.
2. this information is not yet available for the selected database when it is called in the owa_settings constructor
3. currently this falls back to mysql (the bit this PR changes), but if we don't fall back to something, the configuration constructor fails.
4. I've tried delaying this database configuration in the configuration object but things go wrong fast. It will take more work to understand the nuance of ordering here. 
5. what is clear is the a configurable database engine revels a strange race condition here, that needs resolving methinks (in which the configuration object needs to know about the database but it it doesn't know what type of database yet. 

Am hoping more experience eyes can resolve this and comment. For now this is a very short PR to fuel that thinking. If an issue is more appropriate just say, no problem there. Just figured could work on and evolve this PR to resolve the issue.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested the changes
- [ ] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Docs need to be updated?

- [ ] Yes
- [ ] No

<!-- If this introduces a doc update, please describe it below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->