### PR TITLE
Fixing caching bug

### DIFF
--- a/owa_entity.php
+++ b/owa_entity.php
@@ -267,7 +267,7 @@ class owa_entity {
         $status = $db->executeQuery();
         
         // Add to Cache
-        if ($status == true) {
+        if ($status) {
             $this->addToCache();
         }
         


### PR DESCRIPTION
executeQuery returns a truthy value if successful. In the postgresql case it is a string like "resource id='79' type='pgsql result'". I'm a bit puzzled why bools are tested against "=== true"  at all, and being a bool they can be tested just fine in an if, while the if also works for truthy and falsey values.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [ ] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Docs need to be updated?

- [ ] Yes
- [x] No

<!-- If this introduces a doc update, please describe it below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->