### PR TITLE
Fixed Error where pushing ['unpause-owa'] leads to TypeError

### DIFF
--- a/modules/base/js/owa.tracker.js
+++ b/modules/base/js/owa.tracker.js
@@ -94,10 +94,15 @@ OWA.commandQueue.prototype = {
 
             this.pause();
         }
+	    
+	if ( method === "unpause-owa") {
+
+            this.unpause();
+        }
 
         // check to see if the command queue has been paused
         // used to stop tracking
-        if ( ! this.is_paused ) {
+        if ( ! this.is_paused && method !== "unpause-owa") {
 
             // is OWATracker created?
             if ( typeof window[obj_name] == "undefined" ) {
@@ -106,11 +111,6 @@ OWA.commandQueue.prototype = {
             }
 
             window[obj_name][method].apply(window[obj_name], args);
-        }
-
-        if ( method === "unpause-owa") {
-
-            this.unpause();
         }
 
         if ( callback && ( typeof callback == 'function') ) {


### PR DESCRIPTION
Got Uncaught TypeError: window[obj_name][method] is undefined when I pushed owa_cmds.push(['unpause-owa']); while owa was not paused, because it would try to use the method on OWATracker. This should fix this Issue.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tested the changes
- [ ] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Currently pushing owa_unpause also got send to OWATracker and caused an error.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- owa_pause is no longer send to OWATracker
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Docs need to be updated?

- [ ] Yes
- [X ] No

<!-- If this introduces a doc update, please describe it below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->