### PR TITLE
Maksbotan/fix domstream clicks play

### DIFF
--- a/modules/base/css/owa.overlay.css
+++ b/modules/base/css/owa.overlay.css
@@ -56,11 +56,21 @@ body > div.jGrowl.center {
     width:5px;
     height:5px;
     z-index:999997;
+
+    /* This is needed to prevent document.elementFromPoint from
+     * returning marker node instead of real click target.
+     */
+    pointer-events: none;
 }
 
 #owa-cursor {
     position:absolute;
     z-index:999998;
+
+    /* This is needed to prevent document.elementFromPoint from
+     * returning marker node instead of real click target.
+     */
+    pointer-events: none;
 }
 
 #owa-overlay-status {

--- a/modules/base/src/tracker/Player.js
+++ b/modules/base/src/tracker/Player.js
@@ -301,8 +301,12 @@ class Player {
             var accessor_msg = event.dom_element_tag;
         }
 
-        // Try to get node by coordinates using native browser API
+        // Try to get node by coordinates using native browser API.
+        // Need to hide overlay in case click target is under it, otherwise elementFromPoint
+        // will return OWA overlay instead of the real target.
+        jQuery("#owa_overlay").hide();
         var node = document.elementFromPoint(event.click_x, event.click_y);
+        jQuery("#owa_overlay").show();
         if (node) {
             node.click();
         } else {

--- a/modules/base/src/tracker/Player.js
+++ b/modules/base/src/tracker/Player.js
@@ -74,8 +74,19 @@ class Player {
 
 
     moveCursor(x, y) {
+        var that = this;
         this.block();
-        jQuery('#owa-cursor').animate({top: y +'px', left: x +'px'}, { queue:true, duration:100}, 'swing', this.unblock());
+        jQuery('#owa-cursor').animate(
+            {top: y +'px', left: x +'px'},
+            {
+                queue: true,
+                duration: 100,
+                complete: function () {
+                    that.unblock();
+                }
+            },
+            'swing'
+        );
         //console.log("Moving to X: %s Y: %s", x, y);
         this.setStatus("Mouse Movement to: "+x+", "+y);
     }

--- a/modules/base/src/tracker/Player.js
+++ b/modules/base/src/tracker/Player.js
@@ -9,6 +9,7 @@
 
 import { OWA_instance } from '../common/owa.js';
 import * as jQuery from 'jquery';
+import * as jGrowl from 'jgrowl';
 
 class Player {
 

--- a/modules/base/src/tracker/Player.js
+++ b/modules/base/src/tracker/Player.js
@@ -301,16 +301,24 @@ class Player {
             var accessor_msg = event.dom_element_tag;
         }
 
+        // Try to get node by coordinates using native browser API
+        var node = document.elementFromPoint(event.click_x, event.click_y);
+        if (node) {
+            node.click();
+        } else {
+            // Otherwise fallback to getting node by its id or name
+            if (accessor) {
+                jQuery(accessor).click();
+                jQuery(accessor).focus();
+            }
+        }
+
         var d = new Date();
         var id = 'owa-click-marker' + '_' + d.getTime()+1;
         var marker = '<div id="'+id+'" class="owa-click-marker"></div>';
         jQuery('body').append(marker);
         jQuery('#'+id).css({'position': 'absolute','left': event.click_x +'px', 'top': event.click_y +'px', 'z-index' : 89});
 
-        if (accessor) {
-            jQuery(accessor).click();
-            jQuery(accessor).focus();
-        }
         //jQuery('#owa-latest-click').slideToggle('normal');
         //console.log("Clicking: %s", accessor);
         //this.setStatus("Clicking: "+accessor);

--- a/modules/base/src/tracker/Tracker.js
+++ b/modules/base/src/tracker/Tracker.js
@@ -619,16 +619,16 @@ class OWATracker  {
                         if ( Util.is_object( properties[param][i] ) ) {
                             for ( var o_param in properties[param][i] ) {
 
-                                data[ Util.sprintf( OWA.getSetting('ns') + '%s[%s][%s]', param, i, o_param ) ] = Util.urlEncode( properties[ param ][ i ][ o_param ] );
+                                data[ Util.sprintf( OWA.getSetting('ns') + '%s[%s][%s]', param, i, o_param ) ] =  properties[ param ][ i ][ o_param ];
                             }
                         } else {
                             // what the heck is it then. assume string
-                            data[ Util.sprintf(OWA.getSetting('ns') + '%s[%s]', param, i) ] = Util.urlEncode( properties[ param ][ i ] );
+                            data[ Util.sprintf(OWA.getSetting('ns') + '%s[%s]', param, i) ] = properties[ param ][ i ];
                         }
                     }
                 // assume it's a string
                 } else {
-                    data[ Util.sprintf(OWA.getSetting('ns') + '%s', param) ] = Util.urlEncode( properties[ param ] );
+                    data[ Util.sprintf(OWA.getSetting('ns') + '%s', param) ] = properties[ param ];
                 }
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -663,6 +663,12 @@
         "supports-color": "^8.0.0"
       }
     },
+    "jgrowl": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/jgrowl/-/jgrowl-1.4.8.tgz",
+      "integrity": "sha512-JFi609DhWhD4wbnt1/NvYqt702SncgBk2SFssUi6GEUfnxM5TQ9YAKHP/kODwch7Q6QVhOWYvk1QCxLtujwRog==",
+      "requires": {}
+    },
     "jquery": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/Open-Web-Analytics/Open-Web-Analytics#readme",
   "dependencies": {
+    "jgrowl": "^1.4.8",
     "jquery": "^3.6.0",
     "webpack": "^5.66.0",
     "webpack-cli": "^4.9.1",


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [x] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?

I've fixed all problems related to clicks in DOM streams that were bugging me. Specifically:

1. DOM stream player was playing clicks and mouse moves out of order, this is related to wrong `$.animate` usage
2. DOM streams sometimes were not saved, this is related to double url-encoding of POST data
3. DOM stream player was throwing error in `clickEventHandler`, this is due to missing `jGrowl`
4. DOM stream player could click only on DOM nodes with either `id` or `name` attributes. Now it first tries to click on node based on its coordinates

Issue Number: #819 


## What is the new behavior?

IMO, DOM streams are recorded and played correctly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Docs need to be updated?

- [ ] Yes
- [x] No


## Other information
