### PR TITLE
Update owa_db_mysql.php

### DIFF
--- a/plugins/db/owa_db_mysql.php
+++ b/plugins/db/owa_db_mysql.php
@@ -180,25 +180,29 @@ class owa_db_mysql extends owa_db {
 
         owa_coreAPI::profile($this, __FUNCTION__, __LINE__, $sql);
 
-        $result = @mysqli_query( $this->connection, $sql );
+        
+        try{/* old behavior did not throw exceptions when using '@' use try...catch */
+            $result = @mysqli_query( $this->connection, $sql );
 
-        owa_coreAPI::profile($this, __FUNCTION__, __LINE__);
-        // Log Errors
+            owa_coreAPI::profile($this, __FUNCTION__, __LINE__);
+            // Log Errors
 
-        if ( mysqli_errno( $this->connection ) ) {
+            if ( mysqli_errno( $this->connection ) ) {
 
-            $this->e->debug(
-                sprintf(
-                    'A MySQL error ocured. Error: (%s) %s. Query: %s',
-                    mysqli_errno( $this->connection ),
-                    htmlspecialchars( mysqli_error( $this->connection ) ),
-                    $sql
-                )
-            );
+                $this->e->debug(
+                    sprintf(
+                        'A MySQL error ocured. Error: (%s) %s. Query: %s',
+                        mysqli_errno( $this->connection ),
+                        htmlspecialchars( mysqli_error( $this->connection ) ),
+                        $sql
+                    )
+                );
+            }
+
+            owa_coreAPI::profile($this, __FUNCTION__, __LINE__);
+        } catch(\Exception){
+            $result = false; /* old behavior made $result false on error */
         }
-
-        owa_coreAPI::profile($this, __FUNCTION__, __LINE__);
-
         $this->new_result = $result;
 
         return $this->new_result;


### PR DESCRIPTION
Added a try...catch block around the query execution. Old behavior did not throw exceptions when using @function() but the current version (php ^8.1) of php-mysqli does. This thrown exception caused install to fail with server 500 prior to installing schema rather than silently failing to pull config from the db.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tested the changes
- [ ] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed
N/A for build

## Pull request type


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?
Install fails with server 500 prior to loading db schema.

Issue Number: https://github.com/Open-Web-Analytics/Open-Web-Analytics/issues/840


## What is the new behavior?
Install proceeds as expected.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No



## Docs need to be updated?

- [ ] Yes
- [X] No

## Other information

Might be worth reviewing all '@function()' calls to see if try...catch might be appropriate though outside this limited scope PR.