### PR TITLE
fix trends-chart with set resultsPerPage

### DIFF
--- a/modules/base/templates/report_content.tpl
+++ b/modules/base/templates/report_content.tpl
@@ -73,6 +73,7 @@ var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => '
                                                 'dimensions' => 'date',
                                                 'sort' => 'date',
                                                 'format' => 'json',
+                                                'resultsPerPage' => 365,
                                                 'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.rsh = new OWA.resultSetExplorer('trend-chart');

--- a/modules/base/templates/report_dashboard.tpl
+++ b/modules/base/templates/report_dashboard.tpl
@@ -92,6 +92,7 @@
                         'metrics'        => $metrics,
                         'dimensions'     => 'date',
                         'sort'             => 'date',
+                        'resultsPerPage' => 365,
                         'format'         => 'json'
                     ), true);
                 ?>';

--- a/modules/base/templates/report_dimensionDetail.php
+++ b/modules/base/templates/report_dimensionDetail.php
@@ -41,6 +41,7 @@
                                                                 'dimensions' => 'date',
                                                                 'sort' => 'date',
                                                                 'format' => 'json',
+                                                                'resultsPerPage' => 365,
                                                                 'constraints' => $constraints
                                                                 ),true);?>';
 

--- a/modules/base/templates/report_dimensionDetailNoTabs.php
+++ b/modules/base/templates/report_dimensionDetailNoTabs.php
@@ -38,6 +38,7 @@
                                                                     'dimensions' => 'date',
                                                                     'sort' => 'date',
                                                                     'format' => 'json',
+                                                                    'resultsPerPage' => 365,
                                                                     'constraints' => $constraints
                                                                     ),true);?>';
 

--- a/modules/base/templates/report_dimensionalTrend.php
+++ b/modules/base/templates/report_dimensionalTrend.php
@@ -38,6 +38,7 @@
                                                                 'dimensions' => 'date', 
                                                                 'sort' => 'date',
                                                                 'format' => 'json',
+                                                                'resultsPerPage' => 365,
                                                                 'constraints' => $constraints
                                                                 ),true);?>';
                                                                   

--- a/modules/base/templates/report_goals.php
+++ b/modules/base/templates/report_goals.php
@@ -13,6 +13,7 @@
                                                                     'dimensions' => 'date', 
                                                                     'sort' => 'date',
                                                                     'format' => 'json',
+                                                                    'resultsPerPage' => 365,
                                                                     'constraints' => $constraints
                                                                     ),true);?>';
                                                                       

--- a/modules/base/templates/report_traffic.tpl
+++ b/modules/base/templates/report_traffic.tpl
@@ -102,6 +102,7 @@ var aurl = '<?php echo $this->makeApiLink(array('module'	=> 'base',
                                                 'dimensions' => 'date',
                                                 'sort' => 'date',
                                                 'format' => 'json',
+                                                'resultsPerPage' => 365,
                                                 'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.rsh = new OWA.resultSetExplorer('trend-chart');

--- a/modules/base/templates/report_visitors.tpl
+++ b/modules/base/templates/report_visitors.tpl
@@ -8,6 +8,7 @@
                                                     'metrics' => 'uniqueVisitors,newVisitors,repeatVisitors,visits,visitDuration',
                                                     'dimensions' => 'date',
                                                     'sort' => 'date',
+                                                    'resultsPerPage' => 365,
                                                     'format' => 'json'), true);?>';
 
     OWA.items.visitortrend = new OWA.resultSetExplorer('visitor-trend');


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [x] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): 


## What is the current behavior?

When you select a date, the trends-chart does not display all values. The limit is set to 10 values.

Example by selecting 1 year: 
![Screenshot from 2022-11-09 14-31-03](https://user-images.githubusercontent.com/57491181/200843496-0f6e3072-1df4-497d-8763-f62219c3d16e.png)

Issue Number: #862 

## What is the new behavior?

When we select 1 year we now have all the values that are displayed. I have set the max to 365 days.

Example by selecting 1 year (attention I do not have enough values to display the 1 year): 
![Screenshot from 2022-11-09 14-29-49](https://user-images.githubusercontent.com/57491181/200843900-292bc1d5-db71-409a-8f91-1e40703e77e7.png)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Docs need to be updated?

- [ ] Yes
- [x] No