### PR TITLE
String null filter patch

### DIFF
--- a/modules/base/classes/resultSetManager.php
+++ b/modules/base/classes/resultSetManager.php
@@ -955,7 +955,9 @@ if ( ! in_array($item['name'], $this->allMetrics) ) {
     }
 
     function numberFormatter($value) {
-
+	if(is_null($value)){
+            return $value;
+        }
         return number_format($value);
     }
 

--- a/modules/base/classes/trackingEventHelpers.php
+++ b/modules/base/classes/trackingEventHelpers.php
@@ -689,6 +689,9 @@ class owa_trackingEventHelpers {
      * @return string
      */
     static function makeUrlCanonical( $url, $event ) {
+	if(is_null($url)){
+	    return $url;
+	}
 
         $site_id = $event->getSiteId();
 

--- a/modules/base/classes/trackingEventHelpers.php
+++ b/modules/base/classes/trackingEventHelpers.php
@@ -1007,6 +1007,9 @@ class owa_trackingEventHelpers {
     }
 
     static function lowercaseString ( $string, $event ) {
+	if(is_null($string)){
+            return($string);
+        }
 
         return strtolower( trim( $string ) );
     }

--- a/modules/base/classes/trackingEventHelpers.php
+++ b/modules/base/classes/trackingEventHelpers.php
@@ -811,6 +811,9 @@ class owa_trackingEventHelpers {
     }
 
     static function utfEncodeProperty( $string, $event ) {
+	if(is_null($string)){
+            return $string;
+        }
 
         return owa_lib::utf8Encode( trim( $string ) );
     }

--- a/owa_requestContainer.php
+++ b/owa_requestContainer.php
@@ -278,7 +278,7 @@ class owa_requestContainer {
                 array_walk_recursive($v, array($this, 'arrayUrlDecode'));
                 $params[$k] = $v;
             } else {
-                $params[$k] = rawurldecode($v);
+                $params[$k] = is_null($v)?$v:rawurldecode($v);
             }
         }
 

--- a/plugins/db/owa_db_mysql.php
+++ b/plugins/db/owa_db_mysql.php
@@ -284,6 +284,9 @@ class owa_db_mysql extends owa_db {
      * @return string
      */
     function prepare( $string ) {
+        if(is_null($string)){
+            return $string;
+        }
 
         if ($this->connection_status == false) {
               $this->connect();


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [N/A] Build (`/path/to/php cli.php cmd=build`) was run locally and any changes were pushed


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Other (please describe): 
Checks for null values before passing variables through to base php functions.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Logs get filled with repeating deprecation warnings when filter/validating strings that are null. When trying to debug the deprecation warnings from passing null values to base php functions was making it difficult to scan the logs. This patch just targeted the frequent offenders by returning early if the value was null instead of a string.
Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Null variables are not further validated or filtered and the methods return early.
-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Docs need to be updated?

- [ ] Yes
- [X] No

<!-- If this introduces a doc update, please describe it below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->