### PR TITLE
fix: 403 Forbidden on the install root of a fresh 1.9.0 install (#950)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -32,11 +32,26 @@
         Require all granted
     </If>
 
+    # The install root DIRECTORY -- "/owa/" in a subdirectory install, "/" when the repo
+    # root is the docroot. A bare directory URL is authorized as the directory itself, so
+    # none of the allows above cover it and it needs its own grant. Gated on owa_env.php,
+    # which exists only in the install root: every other directory stays denied.
+    <If "-f '%{REQUEST_FILENAME}/owa_env.php'">
+        Require all granted
+    </If>
+
 </IfModule>
 
 <IfModule mod_rewrite.c>
 
 RewriteEngine On
+
+# Install root -> index.php. Serves the root's entry point here rather than leaving it
+# to mod_dir, whose DirectoryIndex does not include index.php on every host. Only the
+# bare root matches ^$ (a subdirectory request arrives with a non-empty per-directory
+# path); the slashless "/owa" form is left to mod_dir's canonical 301 -> "/owa/".
+RewriteCond %{REQUEST_URI} /$
+RewriteRule ^$ index.php [L]
 
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d

--- a/tests/e2e/access-hardening.spec.js
+++ b/tests/e2e/access-hardening.spec.js
@@ -82,6 +82,14 @@ const DENIED_PATHS = [
     'webpack.config.js',                              // build metadata
     'package.json',                                   // build metadata
     'composer.json',                                  // build metadata
+    // Bare directory URLs. The install root is allowed (see the root tests below), but
+    // every OTHER directory must stay denied. Most of them carry an inert index.php
+    // anti-listing stub, so a naive "allow any directory containing an index.php" root
+    // fix would serve these as blank 200s; and a root fix that leaned on mod_dir could
+    // surface a mod_autoindex listing here instead (Options Indexes is the distro
+    // default for a docroot). Both are guarded by asserting these stay 403/404.
+    'modules/',
+    'conf/',
 ];
 
 // The site's WAF/rate-limiter allowlists the "Open Web Analytics" UA token (see
@@ -122,4 +130,38 @@ test.describe('web-access hardening policy @server-config', () => {
             expect([403, 404], `${p} should be denied, got ${code}`).toContain(code);
         });
     }
+
+    // The install ROOT itself -- the first URL anyone visits after unpacking, and the one
+    // this suite used to miss completely: ROOT was only ever used as a PREFIX for the
+    // paths above, never requested on its own. That blind spot is how OWA 1.9.0 shipped
+    // a 403 on every fresh install (issue #950) -- authorization runs in the auth phase,
+    // but mod_dir does not map a bare directory URL onto DirectoryIndex until the handler
+    // phase, so deny-all rejected the request as a DIRECTORY before index.php was ever
+    // considered.
+    test('public: the install root is served', async ({ request }) => {
+        const code = await statusOf(request, ROOT);
+        expect(code, 'the install root should be publicly reachable').toBeLessThan(400);
+    });
+
+    // The same directory without its trailing slash. Also 403'd before the fix, and for
+    // the same reason: mod_dir's canonical "add the slash" 301 is a handler-phase
+    // response, so it never ran either.
+    test('public: the install root is served without a trailing slash', async ({ request }) => {
+        const code = await statusOf(request, ROOT.replace(/\/$/, ''));
+        expect(code, 'the slashless install root should be publicly reachable').toBeLessThan(400);
+    });
+
+    // The root must resolve to the index.php ENTRY POINT, not to a directory listing.
+    // Distinguishes the fix working from mod_autoindex papering over it: index.php with
+    // no session redirects into the login flow, so a 2xx listing would fail here.
+    test('public: the install root resolves to the index.php entry point', async ({ request }) => {
+        const res = await request.get(ROOT, {
+            headers: { 'User-Agent': UA },
+            maxRedirects: 0,
+            failOnStatusCode: false,
+        });
+        expect(res.status(), 'root should redirect into the app, not render a listing').toBe(302);
+        expect(res.headers()['location'] || '', 'root should redirect to an OWA entry point')
+            .toMatch(/index\.php\?owa_do=/);
+    });
 });


### PR DESCRIPTION
## Pull request checklist

- [x] Tested the changes
- [x] Build (`npm run build`) was run locally and any changes were pushed

No asset changes in this PR (`.htaccess` + one e2e spec), but the build was verified clean.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: #950

A fresh 1.9.0 install returns **403 Forbidden** on the install root — the first URL anyone visits after unpacking. `http://example.com/owa190/` 403s; the wizard is only reachable by typing `http://example.com/owa190/install.php` explicitly. 1.8.3 did not behave this way.

Reproduced on Apache 2.4.66 with OWA at `/owa/`:

```
/owa/            403     <- the bug
/owa             403     <- no mod_dir 301 either
/owa/index.php   302     <- works
```

**Cause:** the deny-all allowlist added in `7248f35b` (tagged 1.9.0, not in 1.8.3). Apache authorizes in the **auth** phase, but mod_dir does not map a bare directory URL onto `DirectoryIndex` until the **handler** phase — so the request is authorized as the *directory*. Neither the `<FilesMatch>` on public entry points nor the path-prefix `<If>` matches a directory, `Require all denied` stands, and it 403s before `index.php` is ever considered. The slashless `/owa` form dies the same way, since mod_dir's canonical 301 is also a handler-phase response.

This is why the reporter found that deleting `.htaccess` "fixed" it — with no `.htaccess`, `DirectoryIndex` resolves normally. That workaround should be discouraged: it un-hardens the whole tree and makes `owa-config.php` (DB credentials) web-readable.

## What is the new behavior?

The install root serves the app again, with the hardening otherwise untouched. Two changes in `.htaccess`:

- **Authz:** grant the bare install-root directory, gated on `-f '%{REQUEST_FILENAME}/owa_env.php'`. `owa_env.php` exists *only* in the install root, so exactly one directory opens up — the one whose `index.php` is a real entry point. Every other directory keeps hard-denying, which matters because ~32 directories carry inert `index.php` anti-listing stubs that a looser "any directory containing an index.php" gate would serve as blank 200s.
- **Rewrite:** pin the root to `index.php` instead of leaning on mod_dir, because mod_dir's answer depends on config OWA does not control. Core `httpd.conf` ships `DirectoryIndex index.html`; `index.php` is appended by the **PHP package's** `conf.d` drop-in, which is absent on hosts that wire php-fpm through a vhost `SetHandler`. There, mod_dir would find no index for the directory just allowed and fall through to mod_autoindex — turning the fix into a **directory listing**, since `Options Indexes` is the distro default for a docroot. The rewrite removes that dependency entirely (verified: temporarily retargeting the rule proved it takes precedence over mod_dir).

Deliberately **not** used: any `Options` or `DirectoryIndex` directive. Those belong to the `Options`/`Indexes` override classes and would throw a 500 on installs whose `AllowOverride` doesn't grant them. This fix needs no `AllowOverride` beyond what the file already required.

Verified matrix after the fix:

```
/owa/                                302 -> index.php?owa_do=base.loginForm...
/owa                                 301 -> /owa/
/owa/?owa_do=base.loginForm          200      (query strings survive the rewrite)
/owa/modules/  /owa/conf/            403      (no listing, no blank stubs)
/owa/modules/Base/                   403
owa-config.php  Core/Lib.php         403
owa_env.php                          403      (the sentinel is not itself served)
/owa/api/  public/…/owa.tracker.js   200
log.php  install.php  blank.php      200/302
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Strictly widens what is served, by one directory, to restore pre-1.9.0 behavior. Every path in the denied set stays denied.

## Docs need to be updated?

- [ ] Yes
- [x] No

## Other information

**Why it shipped:** `access-hardening.spec.js` had a blind spot precisely here — it computed `ROOT` but only ever used it as a path *prefix* (`ROOT + p`), never requesting the root itself. The one URL every new installer hits first was the one URL the suite didn't cover.

This PR closes that: the root with and without a trailing slash, an assertion that the root resolves to the `index.php` entry point rather than a listing (so mod_autoindex can't paper over a future regression), and `modules/` + `conf/` added to the denied set so neither of the two wrong fixes described above could pass.

**Red/green verified.** All three new tests fail against 1.9.0's `.htaccess` and pass with this change. Full suite: **29/29** on Apache 2.4.66.

**Note on 1.9.0 users:** this is a shipped-release regression affecting every fresh install, so it's probably worth a 1.9.1.
