### PR TITLE
fix(release): stop shipping dev dependencies; pin resolution to the PHP floor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,18 @@ jobs:
         git -C ./ push --set-upstream origin release-${{ env.VERSION }}
     # install the composer vendor directory (production deps only — keep the
     # test/static-analysis tooling in require-dev out of the shipped vendor/).
-    - name: Install Composer Dependancies
-      uses: php-actions/composer@v1
+    #
+    # PHP is pinned to the floor in composer.json's require ("php": ">=8.2") so the
+    # packaging step runs on a supported version rather than whatever the runner
+    # happens to default to. What actually holds the floor is config.platform.php in
+    # composer.json, which fixes resolution regardless of the PHP in use.
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
       with:
-        dev: no
+        php-version: '8.2'
+        tools: composer:v2
+    - name: Install Composer Dependancies
+      run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress
     # setup node and build js/asset bundles
     - name: Setup Node/npm 
       uses: actions/setup-node@v4

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     
     "config": {
         "sort-packages": true,
+        "platform": {
+            "php": "8.2.0"
+        },
         "allow-plugins": {
             "wikimedia/composer-merge-plugin": true
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c08863e0b70f4db6e98be3cce348e78",
+    "content-hash": "fb005024e42d4d2c568f2ea4a17362c6",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -80,16 +80,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
+                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
                 "shasum": ""
             },
             "require": {
@@ -188,7 +188,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
             },
             "funding": [
                 {
@@ -204,7 +204,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-07-26T23:23:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -2848,5 +2848,8 @@
         "php": ">=8.2"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2.0"
+    },
     "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Pull request checklist

- [x] Tested the changes
- [x] Build (`npm run build`) was run locally and any changes were pushed

No JS/asset changes in this PR (packaging config only).

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

Targeted for the unpublished **1.9.1** draft release.

## What is the current behavior?

Issue Number: N/A

**1. The release tarball ships dev dependencies.** `vendor/` in `owa_1.9.x_packaged.tar` contains phpunit, phpstan, sebastian, myclabs, nikic, phar-io and theseer. The packaging step intends to exclude them:

```yaml
    - name: Install Composer Dependancies
      uses: php-actions/composer@v1
      with:
        dev: no
```

but `php-actions/composer@v1` accepts only `entryPoint`, `args` and `command`. The unrecognized input is a *warning*, not an error, so the step succeeds while running a plain `composer install` including `require-dev`:

```
! Unexpected input(s) 'dev', valid inputs are ['entryPoint', 'args', 'command']
```

Pre-existing — `dev: no` was added in `04734b3d`, which is tagged 1.9.0, so 1.9.0 shipped them too.

Not web-reachable on Apache (the deny-all `.htaccess` covers `vendor/`, and PHPUnit 10 no longer carries the `eval-stdin.php` file behind CVE-2017-9841 — verified absent). But it is dead weight in the distro, and an nginx install without an equivalent config has no such protection.

**2. Nothing pins dependency resolution to the supported PHP floor.** `composer.json` declares `"php": ">=8.2"` and CI tests 8.2/8.3/8.4, but `config.platform` is unset, so `composer update` resolves against whatever PHP happens to be running. A contributor on 8.4, or a Dependabot PR, could select a package requiring >=8.3 and silently break the minimum supported version. It hasn't bitten yet only because no locked package currently requires above 8.2 — luck, not a constraint. The release workflow also never set up PHP at all, relying on whatever the action's container carried.

## What is the new behavior?

- **`.github/workflows/main.yml`** — replaces the action with `composer install --no-dev --optimize-autoloader --no-interaction --no-progress`. `--no-dev` is a real CLI flag and cannot silently no-op. Adds `setup-php` pinned to **8.2** so packaging runs on the supported floor rather than the runner's drifting default.
- **`composer.json`** — adds `config.platform.php = "8.2.0"`, matching the `>=8.2` floor. This is the part that actually holds the line: it fixes resolution regardless of the PHP in use, so it governs `composer update` on any machine. A `setup-php` pin alone cannot do this, because by the time the workflow runs, the lock has already decided.

Verified: a `--no-dev` install from this lock yields 11 production entries in `vendor/`, with phpunit / phpstan / sebastian / myclabs / phar-io / theseer / nikic all absent. `composer run-script lint`, `phpstan` (no errors) and `test` all pass.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

No runtime code changes. The shipped `vendor/` loses only test/static-analysis tooling that OWA never loads at runtime. `config.platform` constrains resolution to the floor the project already declares.

## Docs need to be updated?

- [ ] Yes
- [x] No

## Other information

### The lock file is not authoritative in this repo — worth a separate look

`composer.lock` here also picks up **guzzle 7.15.1 → 7.15.2**. That is not an authored change, and it is worth knowing why: `wikimedia/composer-merge-plugin` runs a full `composer update` on *every* `composer install`.

```
Installing dependencies from lock file
  - Installing guzzlehttp/guzzle (7.15.1)          <- per the committed lock
Running composer update to apply merge settings    <- plugin fires
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading guzzlehttp/guzzle (7.15.1 => 7.15.2)
Writing lock file                                  <- lock rewritten
Installing dependencies from lock file             <- reinstalls at 7.15.2
```

So the committed lock is advisory: every build re-resolves to whatever is newest at that moment, and release tarballs do not have reproducible dependency versions. I committed the bump rather than fighting it, because the release build applies it regardless — an attempt to pin it surgically was reverted by the plugin on the next install.

This makes the `config.platform` pin in this PR *more* valuable, not less: since every install re-resolves, it is the only thing keeping that re-resolution at the 8.2 floor.

The non-determinism itself is pre-existing and out of scope here, but it should get its own fix — the shipped dependency set currently depends on the wall-clock time of the release build.
