### PR TITLE
refactor(templates): retire the extract() contract for OWA's own templates

### DIFF
--- a/Core/TemplateEngine.php
+++ b/Core/TemplateEngine.php
@@ -104,17 +104,31 @@ class TemplateEngine {
      */
     function fetch($file = null) {
         if(!$file):
-             $file = $this->file;
+             $__owa_template_file = $this->file;
         else:
-            $file = $this->template_dir.$file;
+            $__owa_template_file = $this->template_dir.$file;
         endif;
 
-        extract($this->vars);          // Extract the vars to local namespace
-        ob_start();                    // Start output buffering
-        include($file);                // Include the file
-        $contents = ob_get_contents(); // Get the contents of the buffer
-        ob_end_clean();                // End buffering and discard
-        return $contents;              // Return the contents
+        // DEPRECATED bare-variable contract, kept for compatibility. Third-party
+        // module templates, site-owner templates/local/ overrides and custom themes
+        // are written against extracted locals ($foo) and $this, and OWA neither
+        // ships nor can migrate them. They keep working; removed at v2.0, alongside
+        // the owa_* class-name bridge. OWA's own templates use $view instead.
+        //
+        // The locals above/below are underscore-prefixed because extract() defaults
+        // to EXTR_OVERWRITE: a template payload with a 'file' or 'contents' key
+        // would otherwise clobber the include path or the captured output.
+        extract($this->vars);
+
+        // The modern, analysable scope: $view->foo for data, $view->out() for
+        // helpers. Built AFTER extract() so a stray 'view' key cannot clobber it.
+        $view = new ViewScope($this);
+
+        ob_start();
+        include($__owa_template_file);
+        $__owa_template_output = ob_get_contents();
+        ob_end_clean();
+        return $__owa_template_output;
     }
 
 }

--- a/Core/TemplateEngine.php
+++ b/Core/TemplateEngine.php
@@ -124,11 +124,20 @@ class TemplateEngine {
         // helpers. Built AFTER extract() so a stray 'view' key cannot clobber it.
         $view = new ViewScope($this);
 
+        // try/finally so the buffer is always discarded, even when the template
+        // throws. ViewScope::__get raises on a view var that was never set, and
+        // that exception unwinds straight out of include() -- without the finally
+        // the ob_start() above would leak. A leaked buffer is nastier than it
+        // sounds: renders nest, so each swallowed template error leaves output
+        // captured in a buffer nobody closes, and a later ob_get_contents()
+        // returns unrelated markup.
         ob_start();
-        include($__owa_template_file);
-        $__owa_template_output = ob_get_contents();
-        ob_end_clean();
-        return $__owa_template_output;
+        try {
+            include($__owa_template_file);
+            return ob_get_contents();
+        } finally {
+            ob_end_clean();
+        }
     }
 
 }

--- a/Core/ViewScope.php
+++ b/Core/ViewScope.php
@@ -1,0 +1,176 @@
+<?php
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+namespace OWA\Core;
+
+/**
+ * The explicit render scope handed to a template as `$view`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Templates historically received their data as bare local variables, produced
+ * by `extract($this->vars)` in TemplateEngine::fetch(), and reached the template
+ * helpers through `$this` (the include happens inside that method, so `$this` is
+ * in scope). That contract has two costs:
+ *
+ *   - A key the controller never set is simply an UNDEFINED VARIABLE. In scalar
+ *     context that is a warning; in `foreach` it is a fatal ("must be of type
+ *     array|object, bool given") because undefined coerces to false. The failure
+ *     surfaces in the template, far from the controller that forgot the key.
+ *   - Nothing declares what a template needs, so neither PHPStan nor an IDE can
+ *     see the contract. Analysing the tree reported ~426 undefined template
+ *     variables plus 562 `$this` false positives (templates are analysed as
+ *     standalone files, where `$this` legitimately does not exist).
+ *
+ * `$view` replaces both: `$view->tabs` for data, `$view->out(...)` for helpers.
+ * Reading a key that was never set throws instead of silently yielding false.
+ *
+ * SEMANTICS ARE DELIBERATELY IDENTICAL TO extract(), EXCEPT FOR THE THROW
+ * ----------------------------------------------------------------------
+ * __isset() uses isset() on the underlying value, so `isset($view->x)` and
+ * `empty($view->x)` behave exactly as `isset($x)` / `empty($x)` did against an
+ * extracted local -- false for a null value, false for a missing key, and NEVER
+ * throwing. 54 isset() and 32 empty() call sites across the templates depend on
+ * that. __get() uses array_key_exists(), so a key set to null returns null
+ * rather than throwing; only a key that was NEVER set is an error. The result is
+ * that the throw fires precisely on the case that used to be a silent fatal.
+ *
+ * BACKWARDS COMPATIBILITY
+ * -----------------------
+ * extract() REMAINS in fetch(). Third-party module templates, site-owner
+ * templates/local/ overrides and custom themes are written against the bare-var
+ * contract, and OWA neither ships nor can migrate them -- Template resolves
+ * templates from four roots (base, module, module local, theme). Those keep
+ * working untouched, and `$this` keeps working there too. Only OWA's own
+ * templates use `$view`. The bare-var path is deprecated and goes away at v2.0,
+ * on the same schedule as the owa_* class-name bridge.
+ *
+ * The @method list below is the TEMPLATE-FACING API surface -- every helper OWA's
+ * own templates actually call, forwarded by __call to the Template. It is declared
+ * rather than left to magic because PHPStan does not infer anything from __call:
+ * without these, each of the 560 helper call sites reports an undefined method.
+ * Declaring them also documents what a template is allowed to reach for.
+ *
+ * @method mixed choose_browser_icon($browser_type)
+ * @method mixed createNonceFormField($action)
+ * @method mixed displaySeriesAsSparkline($name, $result_set_obj, $id = '')
+ * @method mixed escapeForXml($string)
+ * @method mixed formatCurrency($value)
+ * @method mixed get($name)
+ * @method mixed getAvatarImage($email)
+ * @method mixed getBrowserIcon($browser_family, $size = '128x128', $module = 'base')
+ * @method mixed getCurrentUser()
+ * @method mixed getNs()
+ * @method mixed getSiteThumbnail($domain, $width = '200')
+ * @method mixed getTemplatePath($module, $file)
+ * @method mixed getValue($key, $var)
+ * @method mixed getWidget($do, $params = [], $wrapper = true, $add_state = true)
+ * @method mixed headerActions()
+ * @method mixed isValueSet($string)
+ * @method mixed makeAbsoluteLink($params = [], $add_state = false, $url = '', $xml = false)
+ * @method mixed makeApiLink($params = [], $add_state = false, $add_apiKey = false)
+ * @method mixed makeImageLink($path, $absolute = false)
+ * @method mixed makeJson($array)
+ * @method mixed makeLink($params = [], $add_state = false, $url = '', $xml = false, $add_nonce = false)
+ * @method mixed makeNavigationMenu($links, $currentSiteId, $current_action = '')
+ * @method mixed makePagination($pagination, $map = [], $add_state = true, $template = '')
+ * @method mixed makePaginationFromResultSet($pagination, $map = [], $add_state = true, $template = '')
+ * @method mixed makeParamString($params = [], $add_state = false, $format = 'query', $namespace = true)
+ * @method mixed makeWikiLink($page)
+ * @method mixed out($output, $sanitize = true, $decode_special_entities = false)
+ * @method mixed renderDimension($template, $properties)
+ * @method mixed renderKpiInfobox($number, $label, $link = '', $class = '')
+ * @method mixed safeHref($url, $echo = true)
+ * @method mixed setTemplate($file)
+ * @method mixed substituteValue($string, $var_name)
+ * @method mixed truncate($str, $length=10, $trailing='...')
+ */
+class ViewScope {
+
+    /**
+     * @param TemplateEngine $template The template being rendered; supplies both
+     *                                 the view vars and the helper methods.
+     */
+    public function __construct(private TemplateEngine $template) {}
+
+    /**
+     * Read a view var.
+     *
+     * View data ONLY -- deliberately no fallback to a property on the Template. The
+     * two are different things: a template's `$this->config` is the Template's own
+     * config, which is not the same as a view var that happens to be called
+     * 'config'. Conflating them let a view var shadow the property and silently
+     * return the wrong value. Property reads stay as `$this->` in templates.
+     */
+    public function __get(string $name): mixed {
+
+        // array_key_exists, not isset: a var deliberately set to null must read
+        // back as null, exactly as an extracted local would.
+        if (array_key_exists($name, $this->template->vars)) {
+            return $this->template->vars[$name];
+        }
+
+        throw new \OutOfBoundsException(sprintf(
+            'Template "%s" read view var $view->%s, which was never set. '
+            . 'Set it in the controller/view before rendering (initialize it '
+            . 'unconditionally if it is only populated on some branches).',
+            $this->template->file ?? 'unknown',
+            $name
+        ));
+    }
+
+    /**
+     * isset()/empty() support. Mirrors isset() on an extracted local: false for a
+     * null value and false for a missing key. Never throws -- isset() must not.
+     */
+    public function __isset(string $name): bool {
+
+        return isset($this->template->vars[$name]);
+    }
+
+    /**
+     * View data is read-only from inside a template. Nothing in OWA's templates
+     * writes one; this turns a would-be silent dynamic-property creation into a
+     * clear error.
+     */
+    public function __set(string $name, mixed $value): void {
+
+        throw new \LogicException(sprintf(
+            'Template "%s" tried to assign $view->%s. View data is read-only '
+            . 'inside a template; set it in the controller or view instead.',
+            $this->template->file ?? 'unknown',
+            $name
+        ));
+    }
+
+    /**
+     * Template helpers -- out(), makeLink(), getNs(), makeApiLink(), getValue()
+     * and friends -- forwarded to the template. `$this` inside those methods is
+     * still the Template, so behavior is unchanged.
+     */
+    public function __call(string $name, array $arguments): mixed {
+
+        return $this->template->$name(...$arguments);
+    }
+
+    /**
+     * Escape hatch for the rare case a template needs the Template object itself.
+     */
+    public function owaTemplate(): TemplateEngine {
+
+        return $this->template;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ See the [technical requirements](https://github.com/Open-Web-Analytics/Open-Web-
 ## Documentation
 See the wiki for documentation about the OWA Server and the Javascript Tracker client.
 
+Upgrading, or maintaining a third-party module, local template override, or custom theme? See [UPGRADING.md](UPGRADING.md) for the interfaces that are deprecated but still supported, and what replaces each one.
+
 ## Issues & Support
 
 Please read the [troubleshooting](https://github.com/Open-Web-Analytics/Open-Web-Analytics/wiki/Troubleshooting) guide before filing any issue or bug reports. Issue tickets without the necessary debug info will be closed automatically.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,122 @@
+# Upgrading OWA
+
+This file lists the deprecated interfaces third-party code still relies on, what
+replaces each one, and when the old path goes away. It exists because OWA's
+recent modernization work replaced several long-standing conventions while
+keeping the old ones working — so nothing breaks on upgrade, but the old paths
+are on a clock.
+
+**Everything listed here still works today.** Each entry is scheduled for removal
+in **v2.0**, and none of it will be removed in a 1.x release.
+
+Audience: authors of third-party modules, site owners with local template
+overrides, and anyone maintaining a custom theme.
+
+---
+
+## Deprecated in 1.9.x, removed in v2.0
+
+### 1. Bare template variables and `$this` inside templates
+
+**What changed.** OWA's own templates now receive their view data through an
+explicit `$view` object instead of variables materialized by `extract()`, and
+reach the template helpers through `$view` rather than `$this`.
+
+```php
+<!-- Deprecated -->
+<?php $this->out( $headline ); ?>
+<?php foreach ($tabs as $tab): ?>
+
+<!-- Current -->
+<?php $view->out( $view->headline ); ?>
+<?php foreach ($view->tabs as $tab): ?>
+```
+
+**Why.** A key the controller never set was simply an undefined variable — a
+warning in scalar context and a **fatal** in `foreach` (`foreach() argument must
+be of type array|object, bool given`), raised inside the template rather than at
+the controller that forgot the key. Nothing declared what a template required,
+so no tool could check it. Reading a never-set key through `$view` raises an
+`OutOfBoundsException` naming the key and the template instead.
+
+**What still works.** `extract()` is still called, so **bare variables and
+`$this` continue to work** in:
+
+- third-party module templates (`modules/<Module>/templates/`)
+- site-owner overrides (`modules/<Module>/templates/local/`)
+- custom themes (`OWA_THEMES_DIR`)
+
+OWA ships none of those and cannot migrate them, which is why the old path
+remains for the full deprecation window.
+
+**Migrating.** Replace each bare view variable with `$view-><name>` and each
+`$this->helper(...)` call with `$view->helper(...)`. Two things to know:
+
+- **Property reads stay on `$this`.** `$this->config` is the *Template object's*
+  config, not a view variable of the same name. `$view` resolves view data only —
+  it deliberately does **not** fall back to template properties, because letting a
+  view variable shadow a property is a silent wrong-value bug.
+- **`isset()` and `empty()` behave identically** on both paths — false for a null
+  value, false for a missing key, and never throwing. A read guarded by `isset()`
+  or by the `@` operator is safe to leave alone; the `@` form in particular is a
+  signal that the key may legitimately be absent, and `@` suppresses diagnostics
+  but **not** exceptions, so migrating such a read converts a tolerated absence
+  into a 500.
+
+If a variable is only populated on some controller branches, initialize it
+unconditionally in the controller *before* migrating the template read.
+
+The contract on both paths is pinned by `tests/ViewScopeCompatTest.php`.
+
+---
+
+### 2. Legacy `owa_*` class names
+
+**What changed.** OWA's framework classes moved from the global namespace with an
+`owa_` prefix into real PSR-4 namespaces:
+
+| Deprecated | Current |
+| --- | --- |
+| `owa_coreAPI` | `OWA\Core\CoreAPI` |
+| `owa_base` | `OWA\Core\Base` |
+| `owa_entity` | `OWA\Core\Entity` |
+| `owa_module` | `OWA\Core\Module` |
+| `owa_db_mysql` | `OWA\Core\Db\Mysql` |
+
+**What still works.** A lazy alias bridge (`owa_compat_aliases.php`) resolves
+every legacy `owa_*` name to its namespaced class on demand, so `new
+owa_document`, `extends owa_entity`, and `instanceof` in both directions all
+continue to work. The bridge is **on by default**.
+
+**Testing against the v2.0 behavior now.** Define
+`OWA_DISABLE_COMPAT_BRIDGE = true` in your config before OWA boots. With the
+bridge off, only the namespaced names resolve — which is what v2.0 will do. OWA
+itself runs correctly in that mode; if your module does not, it still has legacy
+references to migrate.
+
+---
+
+### 3. Lowercase module directories
+
+**What changed.** Module directories are PascalCase and PSR-4 (`modules/Base/`,
+`modules/MemcachedCache/`), with one class per file.
+
+**What still works.** A module shipped in the old convention — a lowercase
+directory plus an `owa_<name>Module` class in `module.php` — is still discovered
+and loaded. `Lib::moduleDirName()` resolves to the legacy lowercase directory
+when no PascalCase one exists, so the module's entities, controllers, views and
+classes all continue to resolve.
+
+**Migrating.** Rename the module directory to PascalCase and adopt the PSR-4
+layout (`Entity/`, `Controller/`, `View/`, `Classes/`), one class per file, with
+namespaced class names under `OWA\Module\<YourModule>\`.
+
+The shim is pinned by `tests/ThirdPartyModuleCompatTest.php`.
+
+---
+
+## Reporting a problem
+
+If something in your module breaks on upgrade and it is not covered above, that
+is a bug in the compatibility layer rather than something for you to work
+around — please open an issue with the module code that triggers it.

--- a/modules/Base/templates/apiError.php
+++ b/modules/Base/templates/apiError.php
@@ -1,2 +1,3 @@
-<?php if (isset($error_msg['headline'])) : $this->out( $error_msg['headline'] ); endif; ?>
-<?php if (isset($error_msg['message'])) : $this->out( $error_msg['message'] ); endif; ?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if (isset($view->error_msg['headline'])) : $view->out( $view->error_msg['headline'] ); endif; ?>
+<?php if (isset($view->error_msg['message'])) : $view->out( $view->error_msg['message'] ); endif; ?>

--- a/modules/Base/templates/chart_dom.php
+++ b/modules/Base/templates/chart_dom.php
@@ -1,13 +1,14 @@
-<div id="<?php echo $dom_id;?>Container" style="width:; margin:0px; padding:0px;height:<?php echo $height;?>;">
-    <div id="<?php echo $dom_id;?>"></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div id="<?php echo $view->dom_id;?>Container" style="width:; margin:0px; padding:0px;height:<?php echo $view->height;?>;">
+    <div id="<?php echo $view->dom_id;?>"></div>
 </div>
 
 <script>
-OWA.items['<?php echo $dom_id;?>'] = new OWA.chart();
-OWA.items['<?php echo $dom_id;?>'].setDomId('<?php echo $dom_id;?>');
-OWA.items['<?php echo $dom_id;?>'].setData(<?php echo $data;?>);
-OWA.items['<?php echo $dom_id;?>'].config.ofc_version = '<?php echo OWA_OFC_VERSION;?>';
+OWA.items['<?php echo $view->dom_id;?>'] = new OWA.chart();
+OWA.items['<?php echo $view->dom_id;?>'].setDomId('<?php echo $view->dom_id;?>');
+OWA.items['<?php echo $view->dom_id;?>'].setData(<?php echo $view->data;?>);
+OWA.items['<?php echo $view->dom_id;?>'].config.ofc_version = '<?php echo OWA_OFC_VERSION;?>';
 
-OWA.items['<?php echo $dom_id;?>'].render();
-jQuery("#<?php echo $dom_id;?>").addClass('owa_ofcChart');
+OWA.items['<?php echo $view->dom_id;?>'].render();
+jQuery("#<?php echo $view->dom_id;?>").addClass('owa_ofcChart');
 </script>

--- a/modules/Base/templates/cli.php
+++ b/modules/Base/templates/cli.php
@@ -1,8 +1,9 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <?php
 
-if ( $msgs ) {
+if ( $view->msgs ) {
 
-    $this->out( $msgs );
+    $view->out( $view->msgs );
 }
 
 ?>

--- a/modules/Base/templates/dimension_browser.php
+++ b/modules/Base/templates/dimension_browser.php
@@ -1,11 +1,12 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_dimensionDetail" id="">
 
     <div class="icon" style="float:left;">
-        <img src="<?php echo $this->getBrowserIcon($properties['browser_family']);?>">
+        <img src="<?php echo $view->getBrowserIcon($view->properties['browser_family']);?>">
     </div>
     <div>
         <div class="title">
-        <?php $this->out($properties['browser_family'], true, true); ?>
+        <?php $view->out($view->properties['browser_family'], true, true); ?>
         </div>
 
     </div>

--- a/modules/Base/templates/dimension_referral.php
+++ b/modules/Base/templates/dimension_referral.php
@@ -1,21 +1,22 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_dimensionDetail refererDetailPanel" id="">
     <div class="icon" style="float:left;">
-        <img src="<?php echo $this->makeImageLink('base/i/referral_icon_64.png'); ?>">
+        <img src="<?php echo $view->makeImageLink('base/i/referral_icon_64.png'); ?>">
     </div>
     <div>
         <div class="title">
         <?php
-            if ($properties['page_title']) {
-                $this->out($properties['page_title'], true, true);
+            if ($view->properties['page_title']) {
+                $view->out($view->properties['page_title'], true, true);
             } else {
-                $this->out('No Title', false);
+                $view->out('No Title', false);
             }
         ?>
         </div>
         <div class="url">
-            <?php $this->out($properties['url']);?> &nbsp; <span class="moreLink"><a href="<?php $this->safeHref( $properties['url'] );?>">Visit Site &raquo;</a></span>
+            <?php $view->out($view->properties['url']);?> &nbsp; <span class="moreLink"><a href="<?php $view->safeHref( $view->properties['url'] );?>">Visit Site &raquo;</a></span>
         </div>
-        <div class="snippet"><?php $this->out($properties['snippet'], false);?></div>
+        <div class="snippet"><?php $view->out($view->properties['snippet'], false);?></div>
     </div>
     <div style="clear:both;"></div>
 </div>

--- a/modules/Base/templates/documentNavSum.php
+++ b/modules/Base/templates/documentNavSum.php
@@ -1,9 +1,10 @@
-<div style="background-image: url('<?php echo $this->makeImageLink('base/i/document_icon.gif');?>');background-repeat: no-repeat; padding:5px 5px 5px 35px; background-position:13px 5px;">
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div style="background-image: url('<?php echo $view->makeImageLink('base/i/document_icon.gif');?>');background-repeat: no-repeat; padding:5px 5px 5px 35px; background-position:13px 5px;">
     <span class="inline_h4">
-        <a href="<?php $this->safeHref( $row['document_url'] );?>"><?php $this->out( $row['document_page_title'] );?></a> &nbsp;
+        <a href="<?php $view->safeHref( $row['document_url'] );?>"><?php $view->out( $row['document_page_title'] );?></a> &nbsp;
         <?php
 	        
-	        if ( $this->isValueSet( $row['document_page_type'] ) ) {
+	        if ( $view->isValueSet( $row['document_page_type'] ) ) {
 	        
 	        	echo '('. $row['document_page_type'] .')';
 	        	 
@@ -17,7 +18,7 @@
 
         <BR>
         <span class="externalUrl">
-            <?php $this->out( $this->truncate( $row['document_url'], 80, '…') );?>
+            <?php $view->out( $view->truncate( $row['document_url'], 80, '…') );?>
         </span>
     </span>
 </div>

--- a/modules/Base/templates/filter_site.php
+++ b/modules/Base/templates/filter_site.php
@@ -1,10 +1,11 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div id="owa_reportSiteFilter" style="line-height:30px;">
     
     <div style="float:left;">
         <span>Web Site:</span>
         <SELECT name="owa_reportSiteFilterSelect" id="owa_reportSiteFilterSelect" style="height:auto;">
-        <?php  foreach ($sites as $site ):?>
-            <OPTION VALUE="<?php $this->out($site->get('site_id'), false);?>" <?php if ($params['siteId'] === $site->get('site_id')):?>selected="selected" selected <?php endif; ?>><?php $this->out( $site->get('name') );?></OPTION>
+        <?php  foreach ($view->sites as $site ):?>
+            <OPTION VALUE="<?php $view->out($site->get('site_id'), false);?>" <?php if ($view->params['siteId'] === $site->get('site_id')):?>selected="selected" selected <?php endif; ?>><?php $view->out( $site->get('name') );?></OPTION>
         <?php endforeach;?>
         </SELECT>
     </div>
@@ -13,10 +14,10 @@
     <ul>
         <?php if (\OWA\Core\CoreAPI::isCurrentUserCapable("edit_settings")):?>
         <LI>
-            <a href="<?php echo $this->makeLink( array('do' => 'base.sitesProfile', 'siteId' => $params['siteId'], 'edit' => true ) );?>">Settings</a>
+            <a href="<?php echo $view->makeLink( array('do' => 'base.sitesProfile', 'siteId' => $view->params['siteId'], 'edit' => true ) );?>">Settings</a>
         </LI>
         <LI>
-            <a href="<?php echo $this->makeLink( array('do' => 'base.optionsGoals', 'siteId' => $params['siteId'] ) );?>">Goals</a>
+            <a href="<?php echo $view->makeLink( array('do' => 'base.optionsGoals', 'siteId' => $view->params['siteId'] ) );?>">Goals</a>
         </LI>
          <?php endif;?>
     </ul>

--- a/modules/Base/templates/genericAdminPage.php
+++ b/modules/Base/templates/genericAdminPage.php
@@ -1,12 +1,13 @@
-<div id="<?php echo $dom_id;?>" class="owa_reportContainer">
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div id="<?php echo $view->dom_id;?>" class="owa_reportContainer">
 
     <div class="reportSectionContainer">
         <div id="owa_timePeriodControl" class="owa_reportPeriod" style="float:right;"></div>
         <div id="liveViewSwitch" style="width:auto;float:right; padding-right:30px;"></div>
-        <div class="owa_reportTitle"><?php echo $title;?><span class="titleSuffix"><?php echo $this->get('titleSuffix');?></span></div>
+        <div class="owa_reportTitle"><?php echo $view->title;?><span class="titleSuffix"><?php echo $view->get('titleSuffix');?></span></div>
 
         <div class="clear"></div>
-        <?php echo $subview;?>
+        <?php echo $view->subview;?>
 
     </div>
 

--- a/modules/Base/templates/generic_error.php
+++ b/modules/Base/templates/generic_error.php
@@ -1,1 +1,2 @@
-<div class=""><?php if (isset($error_msg)) { echo $error_msg; } else { echo 'no error message'; } ?></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class=""><?php if (isset($view->error_msg)) { echo $view->error_msg; } else { echo 'no error message'; } ?></div>

--- a/modules/Base/templates/generic_table.php
+++ b/modules/Base/templates/generic_table.php
@@ -1,36 +1,37 @@
-<?php if (!empty($rows)): ?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if (!empty($view->rows)): ?>
 
 <script>
 
 jQuery(document).ready(function() { 
-    jQuery("#<?php echo $table_id;?>").tablesorter();
+    jQuery("#<?php echo $view->table_id;?>").tablesorter();
 }); 
     
 </script>
 
-<table class="<?php echo $sort_table_class;?> <?php echo $table_class;?>" summary="" id="<?php echo $table_id;?>">
+<table class="<?php echo $view->sort_table_class;?> <?php echo $view->table_class;?>" summary="" id="<?php echo $view->table_id;?>">
     <?php if (!empty($caption)): ?>
     <caption><?php echo $caption;?></caption>
     <?php endif;?>
     <thead>
         <TR>
-            <?php if (!empty($labels)):?>
-            <?php foreach ($labels as $label): ?>
+            <?php if (!empty($view->labels)):?>
+            <?php foreach ($view->labels as $label): ?>
             <TH scope="<?php echo $th_scope;?>"><?php echo $label;?></TH>
             <?php endforeach;?>
             <?php endif;?>
         </TR>
     </thead>
-    <?php if (!empty($table_footer)): ?>
+    <?php if (!empty($view->table_footer)): ?>
     <tfoot>
-        <td colspan="<?php echo $col_count;?>"><?php echo $table_footer;?></td>
+        <td colspan="<?php echo $view->col_count;?>"><?php echo $view->table_footer;?></td>
     </tfoot>
     <?php endif;?>
     <tbody>
-        <?php foreach ($rows as $row):?>
+        <?php foreach ($view->rows as $row):?>
         <TR>
-            <?php if (!empty($table_row_template)): ?>
-            <?php include($this->setTemplate($table_row_template));?>
+            <?php if (!empty($view->table_row_template)): ?>
+            <?php include($view->setTemplate($view->table_row_template));?>
             <?php else: ?>
             <?php foreach ($row as $item): ?>
             <TD><?php echo $item;?></TD>
@@ -42,7 +43,7 @@ jQuery(document).ready(function() {
 </table>
 
 <?php else: ?>
-    <?php if ($show_error):?>
+    <?php if ($view->show_error):?>
     <div class="owa_status-msg">No data to display.</div>
     <?php endif;?>
 <?php endif;?>

--- a/modules/Base/templates/head.php
+++ b/modules/Base/templates/head.php
@@ -1,12 +1,13 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <!-- HEAD Elements -->
-<?php if(!empty($css)): ?>
-<?php foreach ($css as $cssfile): ?>
+<?php if(!empty($view->css)): ?>
+<?php foreach ($view->css as $cssfile): ?>
 <LINK REL=StyleSheet HREF="<?php echo $cssfile['url'];?>" TYPE="text/css">
 <?php endforeach; ?>
 <?php endif;?>
 
-<?php if(!empty($js)): ?>
-<?php foreach ($js as $jsfile): ?>
+<?php if(!empty($view->js)): ?>
+<?php foreach ($view->js as $jsfile): ?>
 <?php if ($jsfile['ie_only']):?>
  <!--[if IE]><script language="javascript" type="text/javascript" src="<?php echo $jsfile['url'];?>"></script><![endif]-->
 <?php else: ?>

--- a/modules/Base/templates/header.php
+++ b/modules/Base/templates/header.php
@@ -1,14 +1,15 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div id="owa_header">
 
-    <span class="owa_logo"><img src="<?php echo $this->makeImageLink( \OWA\Core\CoreAPI::getSetting( 'base', 'logo_image_path' ) ); ?>" alt="Open Web Analytics"></span>
+    <span class="owa_logo"><img src="<?php echo $view->makeImageLink( \OWA\Core\CoreAPI::getSetting( 'base', 'logo_image_path' ) ); ?>" alt="Open Web Analytics"></span>
      &nbsp
     <span class="owa_navigation">
         <UL>
-            <?php if ($this->getCurrentUser()->isCapable('view_site_list')): ?>
-                <LI><a href="<?php echo $this->makeLink(array('do' => 'base.sites'));?>">Reporting</a></LI>
+            <?php if ($view->getCurrentUser()->isCapable('view_site_list')): ?>
+                <LI><a href="<?php echo $view->makeLink(array('do' => 'base.sites'));?>">Reporting</a></LI>
             <?php endif; ?>
-            <?php if ($this->getCurrentUser()->isCapable('edit_settings')): ?>
-                <LI><a href="<?php echo $this->makeLink(array('do' => 'base.optionsGeneral'));?>">Settings</a></LI>
+            <?php if ($view->getCurrentUser()->isCapable('edit_settings')): ?>
+                <LI><a href="<?php echo $view->makeLink(array('do' => 'base.optionsGeneral'));?>">Settings</a></LI>
             <?php endif; ?>
             <LI><a href="https://github.com/Open-Web-Analytics/Open-Web-Analytics/wiki">Documentation</a></LI>
             <LI><a href="https://github.com/Open-Web-Analytics/Open-Web-Analytics/issues">Report a Bug</a></LI>
@@ -16,15 +17,15 @@
 
         </UL>
     </span>
-    <?php $cu = $this->getCurrentUser(); ?>
+    <?php $cu = $view->getCurrentUser(); ?>
     <span class="user-greating" style="">
-        Hi, <?php $this->out( $cu->getUserData('user_id') );?> ! &bull;
+        Hi, <?php $view->out( $cu->getUserData('user_id') );?> ! &bull;
         <?php if ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ):?>
 
                 <?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ):?>
-                <a class="login" href="<?php echo $this->makeLink(array('do' => 'base.logout'), false);?>">Logout</a>
+                <a class="login" href="<?php echo $view->makeLink(array('do' => 'base.logout'), false);?>">Logout</a>
                 <?php else:?>
-                <a class="login" href="<?php echo $this->makeLink(array('do' => 'base.loginForm'), false);?>">Login</a>
+                <a class="login" href="<?php echo $view->makeLink(array('do' => 'base.loginForm'), false);?>">Login</a>
                 <?php endif;?>
 
             <?php endif;?>
@@ -34,6 +35,6 @@
     <div class="owa_headerServiceMsg"><?php echo $service_msg; ?></div>
     <?php endif;?>
 
-    <?php $this->headerActions(); ?>
+    <?php $view->headerActions(); ?>
 
 </div>

--- a/modules/Base/templates/install.php
+++ b/modules/Base/templates/install.php
@@ -1,8 +1,9 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div style="width:800px; margin: 0px auto -1px auto;">
     <div class="" style="text-align:center;">
         <h1>Open Web Analytics Installer</h1>
     </div>
     <br>
-    <div class="layout_subview" valign="top" style="text-align:left;"><?php echo $subview;?></div>
+    <div class="layout_subview" valign="top" style="text-align:left;"><?php echo $view->subview;?></div>
 
 </div>

--- a/modules/Base/templates/install_check_env.php
+++ b/modules/Base/templates/install_check_env.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <!-- <div class="panel_headline"><?php //echo $headline;?></div> -->
 
 <h2>Uh-oh. We found a few issues.</h2>
@@ -13,7 +14,7 @@
 </style>    
 
 <h3>Problems</h3>
-<?php foreach ($errors as $error): ?>
+<?php foreach ($view->errors as $error): ?>
 <p class="form-row">
     <span class="form-label"><?php echo $error['name'];?></span>
     <span class="form-field form-error"><?php echo $error['value'];?></span>

--- a/modules/Base/templates/install_config_entry.php
+++ b/modules/Base/templates/install_config_entry.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <h2>Configuration Settings</h2>
 <p>
 We could not locate OWA's <code>owa-config.php</code> configuration file. You can use the form below to create the file but this may not work on all hosts. If file generation fails, you can  create the config file manually by renaming <code>owa-config-dist.php</code> to <code>owa-config.php</code> and filling in your database information and public URL.
@@ -9,7 +10,7 @@ We could not locate OWA's <code>owa-config.php</code> configuration file. You ca
         <p class="form-row">
             <span class="form-label">Public URL:</span>
             <span class="form-field">
-                <input type="text"size="50" name="<?php echo $this->getNs();?>public_url" value="<?php echo $public_url;?>">
+                <input type="text"size="50" name="<?php echo $view->getNs();?>public_url" value="<?php echo $view->public_url;?>">
             </span>
             <span class="form-instructions">This is the web URL of OWA's base directory.</span>
         </p>
@@ -18,9 +19,9 @@ We could not locate OWA's <code>owa-config.php</code> configuration file. You ca
         <p class="form-row">
             <span class="form-label">Database Type:</span>
             <span class="form-field">
-                <select name="<?php echo $this->getNs();?>db_type">
+                <select name="<?php echo $view->getNs();?>db_type">
 	                <?php foreach ( $this->config['db_supported_types'] as $db_type => $db_label ): ?>
-                    <option value="<?php $this->out( $db_type );?>"><?php $this->out( $db_label );?></option>
+                    <option value="<?php $view->out( $db_type );?>"><?php $view->out( $db_label );?></option>
                     <?php endforeach;?>
                 </select>
             </span>
@@ -30,7 +31,7 @@ We could not locate OWA's <code>owa-config.php</code> configuration file. You ca
         <p class="form-row">
             <span class="form-label">Database Host:</span>
             <span class="form-field">
-                <input type="text"size="30" name="<?php echo $this->getNs();?>db_host" value="<?php echo $config['db_host'] ?? '';?>">
+                <input type="text"size="30" name="<?php echo $view->getNs();?>db_host" value="<?php echo $view->config['db_host'] ?? '';?>">
             </span>
             <span class="form-instructions">This is the host that your database resides on. Localhost is ok.</span>
         </p>
@@ -38,7 +39,7 @@ We could not locate OWA's <code>owa-config.php</code> configuration file. You ca
         <p class="form-row">
             <span class="form-label">Database Port:</span>
             <span class="form-field">
-                <input type="text"size="30" name="<?php echo $this->getNs();?>db_port" value="<?php echo (!empty($config['db_port']) ? $config['db_port'] : 3306);?>">
+                <input type="text"size="30" name="<?php echo $view->getNs();?>db_port" value="<?php echo (!empty($view->config['db_port']) ? $view->config['db_port'] : 3306);?>">
             </span>
             <span class="form-instructions">(optional) The port of your database. Will default to port 3306 if you leave this empty.</span>
         </p>
@@ -46,7 +47,7 @@ We could not locate OWA's <code>owa-config.php</code> configuration file. You ca
         <p class="form-row">
             <span class="form-label">Database Name:</span>
             <span class="form-field">
-                <input type="text"size="30" name="<?php echo $this->getNs();?>db_name" value="<?php echo $config['db_name'] ?? '';?>">
+                <input type="text"size="30" name="<?php echo $view->getNs();?>db_name" value="<?php echo $view->config['db_name'] ?? '';?>">
             </span>
             <span class="form-instructions">This is the name of the database to install tables into.</span>
         </p>
@@ -54,7 +55,7 @@ We could not locate OWA's <code>owa-config.php</code> configuration file. You ca
         <p class="form-row">
             <span class="form-label">Database User:</span>
             <span class="form-field">
-                <input type="text"size="30" name="<?php echo $this->getNs();?>db_user" value="<?php echo $config['db_user'] ?? '';?>">
+                <input type="text"size="30" name="<?php echo $view->getNs();?>db_user" value="<?php echo $view->config['db_user'] ?? '';?>">
             </span>
             <span class="form-instructions">This is the user name to connect to the database.</span>
         </p>
@@ -62,14 +63,14 @@ We could not locate OWA's <code>owa-config.php</code> configuration file. You ca
         <p class="form-row">
             <span class="form-label">Database Password:</span>
             <span class="form-field">
-                <input type="password"size="30" name="<?php echo $this->getNs();?>db_password" value="<?php echo $config['db_password'] ?? '';?>">
+                <input type="password"size="30" name="<?php echo $view->getNs();?>db_password" value="<?php echo $view->config['db_password'] ?? '';?>">
             </span>
             <span class="form-instructions">This is the password to connect to the database.</span>
         </p>
         <p>
-            <?php echo $this->createNonceFormField('base.installConfig');?>
-            <input type="hidden" value="base.installConfig" name="<?php echo $this->getNs();?>action">
-            <input class="owa-button"type="submit" value="Continue..." name="<?php echo $this->getNs();?>save_button">
+            <?php echo $view->createNonceFormField('base.installConfig');?>
+            <input type="hidden" value="base.installConfig" name="<?php echo $view->getNs();?>action">
+            <input class="owa-button"type="submit" value="Continue..." name="<?php echo $view->getNs();?>save_button">
         <p>
 
     </form>

--- a/modules/Base/templates/install_defaults_entry.php
+++ b/modules/Base/templates/install_defaults_entry.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <h2>Default Site & User Information</h2>
 <div id="configSettings">
     <form method="POST">
@@ -5,11 +6,11 @@
         <p class="form-row">
             <span class="form-label">Site Domain</span>
             <span class="form-field">
-                <select name="<?php echo $this->getNs();?>protocol">
+                <select name="<?php echo $view->getNs();?>protocol">
                     <option value="http://">http://</option>
                     <option value="https://">https://</option>
                 </select>
-                <input type="text"size="30" name="<?php echo $this->getNs();?>domain" value="<?php $this->out( $defaults['domain'] );?>">
+                <input type="text"size="30" name="<?php echo $view->getNs();?>domain" value="<?php $view->out( $view->defaults['domain'] );?>">
             </span>
             <span class="form-instructions">This is the domain of the site to track.</span>
         </p>
@@ -17,7 +18,7 @@
         <p class="form-row">
             <span class="form-label">Your Admin Name</span>
             <span class="form-field">
-                <input type="text"size="30" name="<?php echo $this->getNs();?>user_id" value="<?php $this->out( $defaults['user_id'] );?>">
+                <input type="text"size="30" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( $view->defaults['user_id'] );?>">
             </span>
             <span class="form-instructions">This is name of the admin user.</span>
         </p>
@@ -25,7 +26,7 @@
         <p class="form-row">
             <span class="form-label">Your E-mail Address</span>
             <span class="form-field">
-                <input type="text"size="30" name="<?php echo $this->getNs();?>email_address" value="<?php $this->out( $defaults['email_address'] );?>">
+                <input type="text"size="30" name="<?php echo $view->getNs();?>email_address" value="<?php $view->out( $view->defaults['email_address'] );?>">
             </span>
             <span class="form-instructions">This is the e-mail address of the admin user.</span>
         </p>
@@ -33,15 +34,15 @@
         <p class="form-row">
             <span class="form-label">Your Password</span>
             <span class="form-field">
-                <input type="password"size="30" name="<?php echo $this->getNs();?>password" value="">
+                <input type="password"size="30" name="<?php echo $view->getNs();?>password" value="">
             </span>
             <span class="form-instructions">This will be the password of the admin user.</span>
         </p>
                 
         <p>
-            <?php echo $this->createNonceFormField('base.installBase');?>
-            <input type="hidden" value="base.installBase" name="<?php echo $this->getNs();?>action">
-            <input class="owa-button" type="submit" value="Continue..." name="<?php echo $this->getNs();?>save_button">
+            <?php echo $view->createNonceFormField('base.installBase');?>
+            <input type="hidden" value="base.installBase" name="<?php echo $view->getNs();?>action">
+            <input class="owa-button" type="submit" value="Continue..." name="<?php echo $view->getNs();?>save_button">
         </p>
         
     </form>

--- a/modules/Base/templates/install_finish.php
+++ b/modules/Base/templates/install_finish.php
@@ -1,19 +1,20 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="subview_content">
 
     <h1>Success! That's It. Installation is Complete.</h1>
     <p>Open Web Analytics has been successfully installed. Login using the user name and password below and generate a tracker.</p>
     <p class="form-row">
         <span class="form-label">User Name:</span>
-        <span class="form-field"><?php echo $u;?></span>
+        <span class="form-field"><?php echo $view->u;?></span>
     </p>
     <p class="form-row">
         <span class="form-label">Password:</span>
-        <span class="form-field"><?php echo $p;?></span>
+        <span class="form-field"><?php echo $view->p;?></span>
         <span class="form-instructions"></span>
     </p>
     <BR>
     <p>
-        <a href="<?php echo $this->makeLink(array("action" => "base.sitesInvocation", "siteId" => $site_id), false, \OWA\Core\CoreAPI::getSetting('base','public_url'));?>" target="_blank">
+        <a href="<?php echo $view->makeLink(array("action" => "base.sitesInvocation", "siteId" => $view->site_id), false, \OWA\Core\CoreAPI::getSetting('base','public_url'));?>" target="_blank">
             <span class="owa-button">Login and generate a site tracker!</span>
         </a>
     </p>

--- a/modules/Base/templates/install_start.php
+++ b/modules/Base/templates/install_start.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div id="panel" style="width:800px; margin: 0px auto 20px auto;">
 
     <h2>Welcome to the Installer!</h2>
@@ -6,7 +7,7 @@
     need help, please consult the <a href=<?php echo $this->config['wiki_url'];?>>OWA Documentation Wiki</a>.</P>
     <BR>
     <p>
-        <a href="<?php echo $this->makeLink(array('action' => 'base.installCheckEnv'));?>"><span class="owa-button">Let's Get Started...</span></a>
+        <a href="<?php echo $view->makeLink(array('action' => 'base.installCheckEnv'));?>"><span class="owa-button">Let's Get Started...</span></a>
     </p>
 
 	</div>

--- a/modules/Base/templates/invocation.php
+++ b/modules/Base/templates/invocation.php
@@ -1,11 +1,12 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <fieldset>
     <legend>Javascript</legend>
     <div style="padding:10px;">
-        <P>To track page views using Javascript, cut and paste this tracking tag into the HTML of your web pages. Learn more about how to use OWA's  <a href="<?php echo $this->makeWikiLink('Javascript-Tracker');?>">Javascript tracking API</a> to track your web site and pages.</P>
+        <P>To track page views using Javascript, cut and paste this tracking tag into the HTML of your web pages. Learn more about how to use OWA's  <a href="<?php echo $view->makeWikiLink('Javascript-Tracker');?>">Javascript tracking API</a> to track your web site and pages.</P>
 
         <textarea cols="110" rows="18">
 
-<?php echo $tracking_code; ?>
+<?php echo $view->tracking_code; ?>
 
         </textarea>
     </div>

--- a/modules/Base/templates/item_document.php
+++ b/modules/Base/templates/item_document.php
@@ -1,13 +1,14 @@
-<div class="owa_dimensionDetail" id="<?php echo $properties->get('id');?>">
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="owa_dimensionDetail" id="<?php echo $view->properties->get('id');?>">
     <div class="icon" style="float:left;">
-        <img src="<?php echo $this->makeImageLink('base/i/document_icon_64.png');?>">
+        <img src="<?php echo $view->makeImageLink('base/i/document_icon_64.png');?>">
     </div>
     <div>
-        <div class="title"><?php $this->out( $properties->get('page_title') );?></div>
+        <div class="title"><?php $view->out( $view->properties->get('page_title') );?></div>
         <div class="url">
-            <?php $this->out( $properties->get('url') );?> &nbsp; <span class="moreLink"><a href="<?php $this->safeHref( $properties->get('url') );?>">Visit Site &raquo;</a></span>
+            <?php $view->out( $view->properties->get('url') );?> &nbsp; <span class="moreLink"><a href="<?php $view->safeHref( $view->properties->get('url') );?>">Visit Site &raquo;</a></span>
         </div>
-        <div class="pagetype"><b>Page Type:</B> <?php $this->out( $properties->get('page_type') );?></div>
+        <div class="pagetype"><b>Page Type:</B> <?php $view->out( $view->properties->get('page_type') );?></div>
     </div>
     <div style="clear:both;"></div>
 </div>

--- a/modules/Base/templates/js_helper_tags.php
+++ b/modules/Base/templates/js_helper_tags.php
@@ -1,1 +1,2 @@
-<?php echo $tracking_code; ?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php echo $view->tracking_code; ?>

--- a/modules/Base/templates/js_log_tag.php
+++ b/modules/Base/templates/js_log_tag.php
@@ -1,28 +1,29 @@
-<?php if ( isset($options) && ! $this->getValue( 'no_script_wrapper', $options ) ) { ?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if ( isset($view->options) && ! $view->getValue( 'no_script_wrapper', $view->options ) ) { ?>
 <!-- Start Open Web Analytics Tracker -->
 <script type="text/javascript">
 //<![CDATA[
 <?php } ?>
-var owa_baseUrl = '<?php $this->out( \OWA\Core\CoreAPI::getSetting( 'base', 'public_url' ) ); ?>';
+var owa_baseUrl = '<?php $view->out( \OWA\Core\CoreAPI::getSetting( 'base', 'public_url' ) ); ?>';
 var owa_cmds = owa_cmds || [];
 <?php if (\OWA\Core\CoreAPI::getSetting('base', 'error_handler') === 'development'){ ?>
 owa_cmds.push(['setDebug', true]);
 <?php }?>
-<?php if ( isset($options) && $this->getValue('apiEndpoint', $options ) ) { ?>
-owa_cmds.push(['setApiEndpoint', '<?php echo $options['apiEndpoint'];?>']);
+<?php if ( isset($view->options) && $view->getValue('apiEndpoint', $view->options ) ) { ?>
+owa_cmds.push(['setApiEndpoint', '<?php echo $view->options['apiEndpoint'];?>']);
 <?php } ?>
-owa_cmds.push(['setSiteId', '<?php echo $site_id; ?>']);
+owa_cmds.push(['setSiteId', '<?php echo $view->site_id; ?>']);
 <?php 
-    if ( isset($options) && $this->getValue( 'cmds', $options ) ) {
-        $this->out($this->getValue( 'cmds', $options ), false );
-        $this->out( "\n");
+    if ( isset($view->options) && $view->getValue( 'cmds', $view->options ) ) {
+        $view->out($view->getValue( 'cmds', $view->options ), false );
+        $view->out( "\n");
     }
 ?>
 <?php
-foreach ($cmds as $cmd) {
+foreach ($view->cmds as $cmd) {
 
-    $this->out( $cmd , false);
-    $this->out( "\n");
+    $view->out( $cmd , false);
+    $view->out( "\n");
 }
 ?>
 
@@ -32,7 +33,7 @@ foreach ($cmds as $cmd) {
     _owa.src = owa_baseUrl + 'public/base/dist/owa.tracker.js';
     var _owa_s = document.getElementsByTagName('script')[0]; _owa_s.parentNode.insertBefore(_owa, _owa_s);
 }());
-<?php if ( isset($options) && ! $this->getValue( 'no_script_wrapper', $options ) ) { ?>
+<?php if ( isset($view->options) && ! $view->getValue( 'no_script_wrapper', $view->options ) ) { ?>
 //]]>
 </script>
 <!-- End Open Web Analytics Code -->

--- a/modules/Base/templates/json.php
+++ b/modules/Base/templates/json.php
@@ -1,5 +1,6 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <?php
 
-    echo $json;
+    echo $view->json;
 
 ?>

--- a/modules/Base/templates/kpiInfobox.php
+++ b/modules/Base/templates/kpiInfobox.php
@@ -1,13 +1,14 @@
-<?php if ( $this->get( 'link' ) ): ?>
-<a class="kpiInfoboxLink" href="<?php $this->out($this->get('link'));?>">
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if ( $view->get( 'link' ) ): ?>
+<a class="kpiInfoboxLink" href="<?php $view->out($view->get('link'));?>">
 <?php endif;?>
 
-<div id="<?php $this->out( str_replace(' ', '', (string) $this->get( 'label' ) ) );?>_kpibox" class="owa_metricInfobox kpiInfobox <?php $this->out($this->get('class'));?>">
+<div id="<?php $view->out( str_replace(' ', '', (string) $view->get( 'label' ) ) );?>_kpibox" class="owa_metricInfobox kpiInfobox <?php $view->out($view->get('class'));?>">
 
-    <p class="owa_metricInfoboxLabel"><?php $this->out( $this->get( 'label' ) ); ?></p>
-    <p class="owa_metricInfoboxLargeNumber"><?php $this->out( $this->get( 'number' ), false ); ?></p>
+    <p class="owa_metricInfoboxLabel"><?php $view->out( $view->get( 'label' ) ); ?></p>
+    <p class="owa_metricInfoboxLargeNumber"><?php $view->out( $view->get( 'number' ), false ); ?></p>
 </div>
 
-<?php if ( $this->get( 'link' ) ): ?>
+<?php if ( $view->get( 'link' ) ): ?>
 </a>
 <?php endif;?>

--- a/modules/Base/templates/login_form.php
+++ b/modules/Base/templates/login_form.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div style="width:340px; margin: 0px auto -1px auto;">
     <div class="inline_h1" style="text-align:left;">Login</div><BR>
 
@@ -9,13 +10,13 @@
             <form method="POST">
 
             <div class="inline_h3"><B>User Name:</B></div>
-            <INPUT class="owa_largeFormField" type="text" size="20" name="<?php echo $this->getNs();?>user_id" value="<?php $this->out( $user_id); ?>"><BR><BR>
+            <INPUT class="owa_largeFormField" type="text" size="20" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( $view->user_id); ?>"><BR><BR>
             <div class="inline_h3"><B>Password:</B></div>
-            <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $this->getNs();?>password"><BR><BR>
-            <input type="hidden" size="70" name="<?php echo $this->getNs();?>go" value="<?php echo $go?>">
-            <input name="<?php echo $this->getNs();?>action" value="base.login" type="hidden">
+            <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $view->getNs();?>password"><BR><BR>
+            <input type="hidden" size="70" name="<?php echo $view->getNs();?>go" value="<?php echo $view->go?>">
+            <input name="<?php echo $view->getNs();?>action" value="base.login" type="hidden">
             <div style="text-align:;">
-            <INPUT class="owa_largeFormField" type="submit" name="<?php echo $this->getNs();?>submit_btn" value="Login">
+            <INPUT class="owa_largeFormField" type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Login">
             </div>
             </form>
 
@@ -26,7 +27,7 @@
 
     <BR>
     <span class="info_text">
-    <a href="<?php echo $this->makeLink(array('do' => 'base.passwordResetForm'))?>">Forgot your password?</a>
+    <a href="<?php echo $view->makeLink(array('do' => 'base.passwordResetForm'))?>">Forgot your password?</a>
     </span>
 </div>
 

--- a/modules/Base/templates/metricInfobox.php
+++ b/modules/Base/templates/metricInfobox.php
@@ -1,5 +1,6 @@
-<div id="<?php echo $dom_id;?>" class="owa_metricInfobox">
-    <p class="owa_metricInfoboxLabel"><?php echo $count->getlabel($count->aggregates[$metric_name]['name']);?></p>
-    <p class="owa_metricInfoboxLargeNumber"><?php echo $count->aggregates[$metric_name]['value'];?></p>
-    <p><?php echo $this->displaySeriesAsSparkline($count->aggregates[$metric_name]['name'], $trend, $dom_id);?></p>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div id="<?php echo $view->dom_id;?>" class="owa_metricInfobox">
+    <p class="owa_metricInfoboxLabel"><?php echo $view->count->getlabel($view->count->aggregates[$view->metric_name]['name']);?></p>
+    <p class="owa_metricInfoboxLargeNumber"><?php echo $view->count->aggregates[$view->metric_name]['value'];?></p>
+    <p><?php echo $view->displaySeriesAsSparkline($view->count->aggregates[$view->metric_name]['name'], $view->trend, $view->dom_id);?></p>
 </div>

--- a/modules/Base/templates/msgs.php
+++ b/modules/Base/templates/msgs.php
@@ -1,33 +1,34 @@
-<?php if( ! empty( $status_msg ) ):?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if( ! empty( $view->status_msg ) ):?>
 <div class="status">
-    <?php if (isset($status_msg['headline'])) : ?><b><?php $this->out( $status_msg['headline'] ); ?>!</b><?php endif; ?>
-    <?php if (isset($status_msg['message'])) : $this->out( $status_msg['message'] ); endif; ?>
+    <?php if (isset($view->status_msg['headline'])) : ?><b><?php $view->out( $view->status_msg['headline'] ); ?>!</b><?php endif; ?>
+    <?php if (isset($view->status_msg['message'])) : $view->out( $view->status_msg['message'] ); endif; ?>
 </div>
 <?php endif;?>
 
-<?php if ( isset($error_msg) && !isset($validation_errors)):?>
+<?php if ( isset($view->error_msg) && !isset($view->validation_errors)):?>
 <div class="error">
-    <?php if (isset($error_msg['headline'])) : ?><b><?php $this->out( $error_msg['headline'] ); ?>!</b><?php endif; ?>
-    <?php if (isset($error_msg['message'])) : $this->out( $error_msg['message'] ); endif; ?>
+    <?php if (isset($view->error_msg['headline'])) : ?><b><?php $view->out( $view->error_msg['headline'] ); ?>!</b><?php endif; ?>
+    <?php if (isset($view->error_msg['message'])) : $view->out( $view->error_msg['message'] ); endif; ?>
 </div>
 <?php endif;?>
 
-<?php if ( isset($validation_errors) ):?>
+<?php if ( isset($view->validation_errors) ):?>
 <div class="error">
     <span class="inline_h2">The form that you completed had some errors:</span>
     <ul>
-        <?php foreach ($validation_errors as $validation_error): ?>
+        <?php foreach ($view->validation_errors as $validation_error): ?>
         <li>
-            <?php if (isset($validation_error['headline'])) : ?><b><?php $this->out( $validation_error['headline'] ); ?>!</b><?php endif; ?>
+            <?php if (isset($validation_error['headline'])) : ?><b><?php $view->out( $validation_error['headline'] ); ?>!</b><?php endif; ?>
             <?php 
 	            
 	            if (isset($validation_error['message'])) {
 	            
-	            	$this->out( $validation_error['message'] ); 
+	            	$view->out( $validation_error['message'] ); 
 	             
 	             } else {
 		             // backwards compatabilitiy wth old style msgs used by validators
-		             $this->out( $validation_error );
+		             $view->out( $validation_error );
 	             }
 	        ?>
         </li>

--- a/modules/Base/templates/msgsCli.php
+++ b/modules/Base/templates/msgsCli.php
@@ -1,25 +1,26 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <?php
 	
-if ( isset($msgs) && ! empty($msgs) ) {
+if ( isset($view->msgs) && ! empty($view->msgs) ) {
 	
-	\OWA\Core\CoreAPI::notice( json_encode( $msgs, JSON_PRETTY_PRINT ) );
+	\OWA\Core\CoreAPI::notice( json_encode( $view->msgs, JSON_PRETTY_PRINT ) );
 }
 
-if( isset( $status_msg ) && ! empty( $status_msg ) ) {
+if( isset( $view->status_msg ) && ! empty( $view->status_msg ) ) {
 
-	\OWA\Core\CoreAPI::notice( $status_msg );
+	\OWA\Core\CoreAPI::notice( $view->status_msg );
 
 }
 
-if ( isset( $error ) && ! empty( $error ) ) {
+if ( isset( $view->error ) && ! empty( $view->error ) ) {
 	
-	\OWA\Core\CoreAPI::notice("Command failed. There were some errors:". "\n" . json_encode( $error, JSON_PRETTY_PRINT ) );
+	\OWA\Core\CoreAPI::notice("Command failed. There were some errors:". "\n" . json_encode( $view->error, JSON_PRETTY_PRINT ) );
 	
 } else {
 	
-	if ( isset( $response_data ) && ! empty( $response_data ) ) {
+	if ( isset( $view->response_data ) && ! empty( $view->response_data ) ) {
 	
-		\OWA\Core\CoreAPI::notice( "\n" . json_encode( $response_data, JSON_PRETTY_PRINT ) );
+		\OWA\Core\CoreAPI::notice( "\n" . json_encode( $view->response_data, JSON_PRETTY_PRINT ) );
 	}
 }
 

--- a/modules/Base/templates/new_session_email.php
+++ b/modules/Base/templates/new_session_email.php
@@ -1,20 +1,21 @@
-<p>There was a new visit to site: <?php $this->out( $site['domain'] );?>.</p>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<p>There was a new visit to site: <?php $view->out( $view->site['domain'] );?>.</p>
 
-<p>Visitor ID: <?php $this->out( $session['visitor_id'] );?></p>
+<p>Visitor ID: <?php $view->out( $view->session['visitor_id'] );?></p>
 
-<p>Username (email): <?php $this->out( $session['user_name'] );?>  (<?php if (isset($session['user_email'])) {
-                                                                    $this->out( $session['user_email'] );
+<p>Username (email): <?php $view->out( $view->session['user_name'] );?>  (<?php if (isset($view->session['user_email'])) {
+                                                                    $view->out( $view->session['user_email'] );
                                                                 } else {
                                                                     echo 'not set';
                                                                 }  ?>)
 </p>
-<p>Host: <?php $this->out( $session['host'] );?></p>
+<p>Host: <?php $view->out( $view->session['host'] );?></p>
 
 
-<p>City/Country:  <?php $this->out( $session['city'] );?> <?php $this->out( $session['country'] );?></p>
+<p>City/Country:  <?php $view->out( $view->session['city'] );?> <?php $view->out( $view->session['country'] );?></p>
 
 
-<p>Entry page:  <?php $this->out( $session['page_title'] );?> - <?php $this->out( $session['page_url'] );?></p>
+<p>Entry page:  <?php $view->out( $view->session['page_title'] );?> - <?php $view->out( $view->session['page_url'] );?></p>
 
 
 <hr>

--- a/modules/Base/templates/new_session_email_plain_text.php
+++ b/modules/Base/templates/new_session_email_plain_text.php
@@ -1,7 +1,8 @@
-New Visit to <?php echo $site['domain'];?> from:
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+New Visit to <?php echo $view->site['domain'];?> from:
 
-Visitor: <?php echo $session['visitor_id'];?>
-Email or Username: <?php echo $session['user_email'];?> | <?php echo $session['user_name'];?>
-Host: <?php echo $session['host'];?>
-City/Country:  <?php echo $session['city'];?> <?php echo $session['country'];?>
-Entry page:  <?php echo $session['page_title'];?> (<?php echo $session['page_url'];?>)
+Visitor: <?php echo $view->session['visitor_id'];?>
+Email or Username: <?php echo $view->session['user_email'];?> | <?php echo $view->session['user_name'];?>
+Host: <?php echo $view->session['host'];?>
+City/Country:  <?php echo $view->session['city'];?> <?php echo $view->session['country'];?>
+Entry page:  <?php echo $view->session['page_title'];?> (<?php echo $view->session['page_url'];?>)

--- a/modules/Base/templates/news.php
+++ b/modules/Base/templates/news.php
@@ -1,11 +1,12 @@
-<?php if ($news):?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if ($view->news):?>
 <div style="text-align:left;">
-    <?php foreach ($news as $newsItem): ?>
-    <span class="info_text"><?php $this->out(date_create($newsItem->published_at)->format("M j, Y")); ?></span><br/>
-    <a href="<?php $this->out($newsItem->html_url); ?>"><span class="h_label">Release <?php $this->out($newsItem->name); ?></span></a>
+    <?php foreach ($view->news as $newsItem): ?>
+    <span class="info_text"><?php $view->out(date_create($newsItem->published_at)->format("M j, Y")); ?></span><br/>
+    <a href="<?php $view->out($newsItem->html_url); ?>"><span class="h_label">Release <?php $view->out($newsItem->name); ?></span></a>
     <p>
         <?php foreach (preg_split('/\n|\r\n?/', $newsItem->body) as $line): ?>
-        <?php $this->out($line); ?><br/>
+        <?php $view->out($line); ?><br/>
         <?php endforeach;?>
     </p>
     <?php endforeach;?>

--- a/modules/Base/templates/options.php
+++ b/modules/Base/templates/options.php
@@ -1,31 +1,32 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="section">
 
 <table id="layout_panels" class="layout_panels" cellpadding="0" cellspacing="0">
     <TR>
         <TD colspan="2" class="headline">
-            <?php $this->out( $headline );?>
+            <?php $view->out( $view->headline );?>
         </TD>
     </TR>
     <TR>
         <TD colspan="2" class="introtext">
-            <P>You are using <strong>Open Web Analytics <?php $this->out(OWA_VERSION);?></strong></P>
+            <P>You are using <strong>Open Web Analytics <?php $view->out(OWA_VERSION);?></strong></P>
             <P>Open Web Analytics has several configuration options that can be set using the controls below. Once changes are made click the "save" button to save the configuration to the database. To learn more about configuring OWA, visit the <a href="http://wiki.openwebanalytics.com">OWA Wiki</a></P>
         </TD>
     </TR>
     <TR>
         <TD valign="top" id="nav_left">
 
-            <?php foreach ($panels as $group => $items):?>
+            <?php foreach ($view->panels as $group => $items):?>
 
                 <H4><?php echo $group;?></H4>
                     <UL>
                     <?php foreach ($items as $k => $v):?>
-                        <LI><a href="<?php echo $this->makeLink(array('do' => $v['do']));?>"><?php echo $v['anchortext'];?></a></LI>
+                        <LI><a href="<?php echo $view->makeLink(array('do' => $v['do']));?>"><?php echo $v['anchortext'];?></a></LI>
                     <?php endforeach;?>
                     </UL>
             <?php endforeach;?>
         </TD>
-        <TD class="layout_subview"><?php echo $subview;?></TD>
+        <TD class="layout_subview"><?php echo $view->subview;?></TD>
     </TR>
 
 </table>

--- a/modules/Base/templates/options_general.php
+++ b/modules/Base/templates/options_general.php
@@ -1,4 +1,5 @@
-<div class="panel_headline"><?php echo $headline?></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="panel_headline"><?php echo $view->headline?></div>
 
 <div class="subview_content">
 
@@ -11,9 +12,9 @@
         <div class="title">Resolve Host Names</div>
         <div class="description">Controls the resolution of host names (e.g. verizon.com) from visitor's raw IP addresses.</div>
         <div class="field">
-            <select name="<?php echo $this->getNs();?>config[base.resolve_hosts]">
-                <option value="0" <?php if ($config['resolve_hosts'] == false):?>SELECTED<?php endif;?>>Off</option>
-                <option value="1" <?php if ($config['resolve_hosts'] == true):?>SELECTED<?php endif;?>>On</option>
+            <select name="<?php echo $view->getNs();?>config[base.resolve_hosts]">
+                <option value="0" <?php if ($view->config['resolve_hosts'] == false):?>SELECTED<?php endif;?>>Off</option>
+                <option value="1" <?php if ($view->config['resolve_hosts'] == true):?>SELECTED<?php endif;?>>On</option>
             </select>
         </div>
     </div>
@@ -22,9 +23,9 @@
         <div class="title">Log Requests From Known Robots</div>
         <div class="description">Controls the logging of page requests made by known robots and spiders. Turning this feature on will dramatically increase the number of requests that are processed and logged.</div>
         <div class="field">
-            <SELECT NAME="<?php echo $this->getNs();?>config[base.log_robots]">
-                <OPTION VALUE="0" <?php if ($config['log_robots'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
-                <OPTION VALUE="1" <?php if ($config['log_robots'] == true):?>SELECTED<?php endif;?>>On</OPTION>
+            <SELECT NAME="<?php echo $view->getNs();?>config[base.log_robots]">
+                <OPTION VALUE="0" <?php if ($view->config['log_robots'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
+                <OPTION VALUE="1" <?php if ($view->config['log_robots'] == true):?>SELECTED<?php endif;?>>On</OPTION>
             </SELECT>
         </div>
     </div>
@@ -33,9 +34,9 @@
         <div class="title">Log Requests From Named Users</div>
         <div class="description">Controls the logging of requests made by named users.</div>
         <div class="field">
-            <SELECT NAME="<?php echo $this->getNs();?>config[base.log_named_users]">
-                <OPTION VALUE="0" <?php if ($config['log_named_users'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
-                <OPTION VALUE="1" <?php if ($config['log_named_users'] == true):?>SELECTED<?php endif;?>>On</OPTION>
+            <SELECT NAME="<?php echo $view->getNs();?>config[base.log_named_users]">
+                <OPTION VALUE="0" <?php if ($view->config['log_named_users'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
+                <OPTION VALUE="1" <?php if ($view->config['log_named_users'] == true):?>SELECTED<?php endif;?>>On</OPTION>
             </SELECT>
         </div>
     </div>
@@ -43,16 +44,16 @@
     <div class="setting" id="excluded_ips">
         <div class="title">Excluded IP Addresses</div>
         <div class="description">Enter a comma seperated list of the IP addresses that you wish to exclude from tracking.</div>
-        <div class="field"><input type="text" size="50" name="<?php echo $this->getNs();?>config[base.excluded_ips]" value="<?php $this->out( $config['excluded_ips'] );?>"></div>
+        <div class="field"><input type="text" size="50" name="<?php echo $view->getNs();?>config[base.excluded_ips]" value="<?php $view->out( $view->config['excluded_ips'] );?>"></div>
     </div>
 
     <div class="setting" id="anonymize_ips">
         <div class="title">Anonymize IP Addresses</div>
         <div class="description">Anonymizes the IP addresses of visitors by removing the last octet from their IP address.</div>
         <div class="field">
-            <SELECT NAME="<?php echo $this->getNs();?>config[base.anonymize_ips]">
-                <OPTION VALUE="0" <?php if ($config['anonymize_ips'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
-                <OPTION VALUE="1" <?php if ($config['anonymize_ips'] == true):?>SELECTED<?php endif;?>>On</OPTION>
+            <SELECT NAME="<?php echo $view->getNs();?>config[base.anonymize_ips]">
+                <OPTION VALUE="0" <?php if ($view->config['anonymize_ips'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
+                <OPTION VALUE="1" <?php if ($view->config['anonymize_ips'] == true):?>SELECTED<?php endif;?>>On</OPTION>
             </SELECT>
         </div>
     </div>
@@ -63,10 +64,10 @@
         <div class="title">Fetch Referring Web Page Info</div>
         <div class="description">Controls whether OWA should crawl the web pages that refer visitors to your web site and extract descriptive meta-data that will be used in reporting.</div>
         <div class="field">
-            <select name="<?php echo $this->getNs();?>config[base.fetch_refering_page_info]">
-                <option value="0" <?php if ($config['fetch_refering_page_info'] == false):?>SELECTED<?php endif;?>>
+            <select name="<?php echo $view->getNs();?>config[base.fetch_refering_page_info]">
+                <option value="0" <?php if ($view->config['fetch_refering_page_info'] == false):?>SELECTED<?php endif;?>>
         Off</option>
-                <option value="1" <?php if ($config['fetch_refering_page_info'] == true):?>SELECTED<?php endif;?>>
+                <option value="1" <?php if ($view->config['fetch_refering_page_info'] == true):?>SELECTED<?php endif;?>>
         On</option>
             </select>
         </div>
@@ -75,7 +76,7 @@
     <div class="setting" id="url_params">
         <div class="title">URL Parameters</div>
         <div class="description">This setting controls the URL parameters that OWA should ignore when processing requests. This is useful for avoiding duplicate URLs due to the use of tracking or others state parameters in your URLs. Parameter names should be separated by comma.</div>
-        <div class="field"><input type="text" size="50" name="<?php echo $this->getNs();?>config[base.query_string_filters]" value="<?php $this->out( $config['query_string_filters']);?>"></div>
+        <div class="field"><input type="text" size="50" name="<?php echo $view->getNs();?>config[base.query_string_filters]" value="<?php $view->out( $view->config['query_string_filters']);?>"></div>
     </div>
 
     </fieldset>
@@ -89,9 +90,9 @@
             <div class="title">Announce New Visitors Via E-mail</div>
             <div class="description">Announces each new visitor to your web site via e-mail. If you have a lot of visitors then you probably want to keep this feature turned off.</div>
             <div class="field">
-                <select name="<?php echo $this->getNs();?>config[base.announce_visitors]">
-                    <option value="0" <?php if ($config['announce_visitors'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
-                    <option value="1" <?php if ($config['announce_visitors'] == true):?>SELECTED<?php endif;?>>On</OPTION>
+                <select name="<?php echo $view->getNs();?>config[base.announce_visitors]">
+                    <option value="0" <?php if ($view->config['announce_visitors'] == false):?>SELECTED<?php endif;?>>Off</OPTION>
+                    <option value="1" <?php if ($view->config['announce_visitors'] == true):?>SELECTED<?php endif;?>>On</OPTION>
                 </select>
             </div>
         </div>
@@ -99,7 +100,7 @@
         <div class="setting" id="notice_email">
             <div class="title">Notice E-mail Address</div>
             <div class="description">This is the e-mail address that new visitor e-mails will be sent to.</div>
-            <div class="field"><input size="50" type="text" name="<?php echo $this->getNs();?>config[base.notice_email]" value="<?php $this->out( $config['notice_email']);?>"></div>
+            <div class="field"><input size="50" type="text" name="<?php echo $view->getNs();?>config[base.notice_email]" value="<?php $view->out( $view->config['notice_email']);?>"></div>
 
         </div>
 
@@ -116,9 +117,9 @@
             <div class="title">E-commerce Reporting</div>
             <div class="description">Adds e-commerce metrics/statistics to reports.</div>
             <div class="field">
-                <select name="<?php echo $this->getNs();?>config[base.enableEcommerceReporting]">
-                    <option value="0" <?php if ($config['enableEcommerceReporting'] == false):?>SELECTED<?php endif;?>>Off</option>
-                    <option value="1" <?php if ($config['enableEcommerceReporting'] == true):?>SELECTED<?php endif;?>>On</option>
+                <select name="<?php echo $view->getNs();?>config[base.enableEcommerceReporting]">
+                    <option value="0" <?php if ($view->config['enableEcommerceReporting'] == false):?>SELECTED<?php endif;?>>Off</option>
+                    <option value="1" <?php if ($view->config['enableEcommerceReporting'] == true):?>SELECTED<?php endif;?>>On</option>
                 </select>
             </div>
         </div>
@@ -130,7 +131,7 @@
             <div class="field">
 
 
-                <select id="TIMEZONE" name="<?php echo $this->getNs();?>config[base.timezone]">
+                <select id="TIMEZONE" name="<?php echo $view->getNs();?>config[base.timezone]">
                 <?php
                 require_once(OWA_DIR.'conf/country2Timezones.php');
                 require_once(OWA_DIR.'conf/countryCodes2Names.php');
@@ -152,7 +153,7 @@
 
                            $display_value = str_replace('_', ' ', $value);
                            $selected = '';
-                        if ( ! $selected_already && $config['timezone'] === $value ) {
+                        if ( ! $selected_already && $view->config['timezone'] === $value ) {
                             $selected_already = true;
                             echo sprintf('<option selected="yes" value="%s" >%s</option>', $value, $display_value);
                         } else {
@@ -171,11 +172,11 @@
 
     <BR>
 
-    <?php echo $this->createNonceFormField('base.optionsUpdate');?>
+    <?php echo $view->createNonceFormField('base.optionsUpdate');?>
 
-    <BUTTON class="owa-button" type="submit" name="<?php echo $this->getNs();?>action" value="base.optionsUpdate">Update Configuration</BUTTON>
-    <input type="hidden" name="<?php echo $this->getNs();?>module" value="base">
-    <BUTTON class="owa-button" type="submit" name="<?php echo $this->getNs();?>action" value="base.optionsReset">Reset Configuration to Default Values</BUTTON>
+    <BUTTON class="owa-button" type="submit" name="<?php echo $view->getNs();?>action" value="base.optionsUpdate">Update Configuration</BUTTON>
+    <input type="hidden" name="<?php echo $view->getNs();?>module" value="base">
+    <BUTTON class="owa-button" type="submit" name="<?php echo $view->getNs();?>action" value="base.optionsReset">Reset Configuration to Default Values</BUTTON>
 
 </form>
 </div>

--- a/modules/Base/templates/options_goal_entry.php
+++ b/modules/Base/templates/options_goal_entry.php
@@ -254,7 +254,10 @@ CHECKED
 
 <script>
 var steps = [];
-<?php if (array_key_exists('funnel_steps', $goal['details'])):?>
+<?php // !empty() guard first: $goal['details'] is null for a goal with no details,
+      // and array_key_exists() with a null second argument is a TypeError on PHP 8
+      // (pre-8 it was a warning returning false). ?>
+<?php if (!empty($goal['details']) && array_key_exists('funnel_steps', $goal['details'])):?>
 <?php $view->out(sprintf("steps = %s;", json_encode($goal['details']['funnel_steps'])), false); ?>
 <?php endif;?>
 </script>

--- a/modules/Base/templates/options_goal_entry.php
+++ b/modules/Base/templates/options_goal_entry.php
@@ -1,8 +1,9 @@
-<div class="panel_headline"><?php echo $headline?></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="panel_headline"><?php echo $view->headline?></div>
 
 <div class="subview_content">
 
-<h3>Goal <?php $this->out($goal_number);?> Settings</h3>
+<h3>Goal <?php $view->out($view->goal_number);?> Settings</h3>
 
 <form name="goal-entry" method="POST">
 
@@ -17,7 +18,7 @@
 
                 <th valign="top">Name:</th>
                 <td>
-                    <input name="<?php echo $this->getNs();?>goal[goal_name]" type="text" size="40" value="<?php $this->out($goal['goal_name']);?>">
+                    <input name="<?php echo $view->getNs();?>goal[goal_name]" type="text" size="40" value="<?php $view->out($goal['goal_name']);?>">
                 </td>
             </tr>
             <tr>
@@ -28,26 +29,26 @@
                 </th>
                 <td>
 
-                    <select name="<?php echo $this->getNs();?>goal[goal_group]">
+                    <select name="<?php echo $view->getNs();?>goal[goal_group]">
                         <?php foreach ($goal_groups as $k => $group): ?>
-                        <option value="<?php $this->out($k, false);?>" <?php if ( isset( $goal['goal_group'] ) && $goal['goal_group'] == $k ) { echo 'SELECTED';}?>><?php
+                        <option value="<?php $view->out($k, false);?>" <?php if ( isset( $goal['goal_group'] ) && $goal['goal_group'] == $k ) { echo 'SELECTED';}?>><?php
                         if ( !empty( $group ) ) {
-                            $this->out($k." - $group");
+                            $view->out($k." - $group");
                         } else {
-                            $this->out($k);
+                            $view->out($k);
                         }
                         ?></option>
                         <?php endforeach;?>
                     </select>
                     <BR><BR>Edit the group label:
 
-                    <input name="<?php echo $this->getNs();?>new_goal_group_name" type="text" size="20" value="<?php $this->out(@$goal_groups[$goal['goal_group']]);?>">
+                    <input name="<?php echo $view->getNs();?>new_goal_group_name" type="text" size="20" value="<?php $view->out(@$goal_groups[$goal['goal_group']]);?>">
                 </td>
             </tr>
             <tr>
                 <th valign="top">Status:</th>
                 <td>
-                    <select name="<?php echo $this->getNs();?>goal[goal_status]">
+                    <select name="<?php echo $view->getNs();?>goal[goal_status]">
                         <option value="active" <?php if (isset($goal['goal_status']) && $goal['goal_status'] != 'disabled'){echo 'SELECTED';}?>>
                             Active
                         </option>
@@ -68,7 +69,7 @@
                     </p>
                 </th>
                 <td>
-                    <input name="<?php echo $this->getNs();?>goal[goal_value]" type="text" size="20" value="<?php $this->out(@$goal['goal_value']);?>">
+                    <input name="<?php echo $view->getNs();?>goal[goal_value]" type="text" size="20" value="<?php $view->out(@$goal['goal_value']);?>">
                     <span class="optional">Optional</span>
                 </td>
             </tr>
@@ -81,11 +82,11 @@
                     </p>
                 </th>
                 <td>
-                    <input type="radio" name="<?php echo $this->getNs();?>goal[goal_type]" value="url_destination" <?php if (isset($goal['goal_type']) && $goal['goal_type'] === 'url_destination'){echo 'CHECKED';}?> > URL Destination<BR>
+                    <input type="radio" name="<?php echo $view->getNs();?>goal[goal_type]" value="url_destination" <?php if (isset($goal['goal_type']) && $goal['goal_type'] === 'url_destination'){echo 'CHECKED';}?> > URL Destination<BR>
 
-                    <input type="radio" name="<?php echo $this->getNs();?>goal[goal_type]" value="pages_per_visit" <?php if (isset($goal['goal_type']) && $goal['goal_type'] === 'pages_per_visit'){echo 'CHECKED';}?> > Pages / Visit<BR>
+                    <input type="radio" name="<?php echo $view->getNs();?>goal[goal_type]" value="pages_per_visit" <?php if (isset($goal['goal_type']) && $goal['goal_type'] === 'pages_per_visit'){echo 'CHECKED';}?> > Pages / Visit<BR>
 
-                    <input type="radio" name="<?php echo $this->getNs();?>goal[goal_type]" value="visit_duration" <?php if (isset($goal['goal_type']) && $goal['goal_type'] === 'visit_duration'){echo 'CHECKED';}?> > Visit Duration <BR>
+                    <input type="radio" name="<?php echo $view->getNs();?>goal[goal_type]" value="visit_duration" <?php if (isset($goal['goal_type']) && $goal['goal_type'] === 'visit_duration'){echo 'CHECKED';}?> > Visit Duration <BR>
 
 
                 </td>
@@ -103,7 +104,7 @@
             <tr>
                 <th>Match Type:</th>
                 <td>
-                    <select name="<?php echo $this->getNs();?>goal[details][match_type]">
+                    <select name="<?php echo $view->getNs();?>goal[details][match_type]">
                         <option value="begins" <?php if (isset($goal['details']['match_type']) && $goal['details']['match_type'] === 'begins'){echo 'SELECTED';}?>>
                             Begins With
                         </option>
@@ -125,7 +126,7 @@
                 </p>
                 </th>
                 <td>
-                    <input name="<?php echo $this->getNs();?>goal[details][goal_url]" value="<?php $this->out(@$goal['details']['goal_url']);?>" type="text" size="60" value="<?php $this->out($goal['url']);?>">
+                    <input name="<?php echo $view->getNs();?>goal[details][goal_url]" value="<?php $view->out(@$goal['details']['goal_url']);?>" type="text" size="60" value="<?php $view->out($goal['url']);?>">
                 </td>
             </tr>
         </table>
@@ -157,10 +158,10 @@
         Not implemented yet.
     </div>
 
-    <input type="hidden" name="<?php echo $this->getNs();?>goal[goal_number]" value="<?php $this->out($goal_number, false);?>">
-    <input type="hidden" name="<?php echo $this->getNs();?>siteId" value="<?php $this->out($siteId, false);?>">
-    <input type="hidden" name="<?php echo $this->getNs();?>action" value="base.optionsGoalEdit">
-    <?php echo $this->createNonceFormField('base.optionsGoalEdit');?>
+    <input type="hidden" name="<?php echo $view->getNs();?>goal[goal_number]" value="<?php $view->out($view->goal_number, false);?>">
+    <input type="hidden" name="<?php echo $view->getNs();?>siteId" value="<?php $view->out($view->siteId, false);?>">
+    <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.optionsGoalEdit">
+    <?php echo $view->createNonceFormField('base.optionsGoalEdit');?>
     <BR>
     <input type="submit" value="Submit">
     </form>
@@ -254,6 +255,6 @@ CHECKED
 <script>
 var steps = [];
 <?php if (array_key_exists('funnel_steps', $goal['details'])):?>
-<?php $this->out(sprintf("steps = %s;", json_encode($goal['details']['funnel_steps'])), false); ?>
+<?php $view->out(sprintf("steps = %s;", json_encode($goal['details']['funnel_steps'])), false); ?>
 <?php endif;?>
 </script>

--- a/modules/Base/templates/options_goals.php
+++ b/modules/Base/templates/options_goals.php
@@ -1,4 +1,5 @@
-<div class="panel_headline"><?php echo $headline?></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="panel_headline"><?php echo $view->headline?></div>
 
 <div class="subview_content">
 
@@ -15,23 +16,23 @@
 
         <tbody>
 
-            <?php foreach ($goals as $k => $goal): ?>
+            <?php foreach ($view->goals as $k => $goal): ?>
             <tr>
-                <td>Goal <?php $this->out($k);?> <a class="" href="<?php echo $this->makeLink(array('do' => 'base.optionsGoalEntry', 'goal_number' => $k, 'siteId' => $siteId));?>">Edit</a></p></td>
-                <td><?php $this->out($goal['goal_name']);?></td>
+                <td>Goal <?php $view->out($k);?> <a class="" href="<?php echo $view->makeLink(array('do' => 'base.optionsGoalEntry', 'goal_number' => $k, 'siteId' => $view->siteId));?>">Edit</a></p></td>
+                <td><?php $view->out($goal['goal_name']);?></td>
                 <td>
                 <?php
                     if ( isset( $goal['goal_group'] ) ) {
-                        if ( !empty( $goal_groups[$goal['goal_group']] ) ) {
-                            $this->out($goal_groups[$goal['goal_group']] );
+                        if ( !empty( $view->goal_groups[$goal['goal_group']] ) ) {
+                            $view->out($view->goal_groups[$goal['goal_group']] );
                         } else {
-                            $this->out( $goal['goal_group'] );
+                            $view->out( $goal['goal_group'] );
                         }
                     }
                 ?>
                 </td>
-                <td><?php $this->out($goal['goal_type']);?></td>
-                <td><?php $this->out($goal['goal_status']);?></td>
+                <td><?php $view->out($goal['goal_type']);?></td>
+                <td><?php $view->out($goal['goal_status']);?></td>
             </tr>
             <?php endforeach; ?>
         </tbody>

--- a/modules/Base/templates/options_modules.php
+++ b/modules/Base/templates/options_modules.php
@@ -1,7 +1,8 @@
-<div class="panel_headline"><?php echo $headline?></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="panel_headline"><?php echo $view->headline?></div>
 <div id="panel">
 
-<?php if (!empty($modules)): ?>
+<?php if (!empty($view->modules)): ?>
 
 <table width="100%" id="module_roster" class="management">
     <thead>
@@ -14,7 +15,7 @@
     </TR>
     </thead>
     <tbody>
-    <?php foreach ($modules as $k => $v): ?>
+    <?php foreach ($view->modules as $k => $v): ?>
 
     <TR>
         <TD>
@@ -27,9 +28,9 @@
         <TD class="">
         <?php if ($v['name'] != 'base'): ?>
         <?php if (isset($v['status']) && $v['status'] == 'active'): ?>
-            <a href="<?php echo $this->makeLink( array('do' => 'base.moduleDeactivate', 'module' => $v['name']), false, false, false, true );?>">Deactivate</a>
+            <a href="<?php echo $view->makeLink( array('do' => 'base.moduleDeactivate', 'module' => $v['name']), false, false, false, true );?>">Deactivate</a>
         <?php else: ?>
-            <a href="<?php echo $this->makeLink( array('do' => 'base.moduleActivate', 'module' => $v['name']), false, false, false, true );?>">Activate</a>
+            <a href="<?php echo $view->makeLink( array('do' => 'base.moduleActivate', 'module' => $v['name']), false, false, false, true );?>">Activate</a>
         <?php endif; ?>
         <?php endif;?>
 

--- a/modules/Base/templates/pixel.php
+++ b/modules/Base/templates/pixel.php
@@ -1,1 +1,2 @@
-<?php echo $img;?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php echo $view->img;?>

--- a/modules/Base/templates/player_overlay.php
+++ b/modules/Base/templates/player_overlay.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -5,6 +6,6 @@
     <title>Open Web Analytics - Domstream</title>
 </head>
 <body style="text-align: center">
-<iframe src="<?php $this->safeHref($url); ?>" width="<?php $this->out(($domstream['page_width'] > 0 ? $domstream['page_width'] . 'px' : '100%')); ?>" height="<?php $this->out(($domstream['page_height'] > 0 ? $domstream['page_height'] . 'px' : '100%')); ?>"></iframe>
+<iframe src="<?php $view->safeHref($view->url); ?>" width="<?php $view->out(($view->domstream['page_width'] > 0 ? $view->domstream['page_width'] . 'px' : '100%')); ?>" height="<?php $view->out(($view->domstream['page_height'] > 0 ? $view->domstream['page_height'] . 'px' : '100%')); ?>"></iframe>
 </body>
 </html>

--- a/modules/Base/templates/report.php
+++ b/modules/Base/templates/report.php
@@ -1,12 +1,13 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <script>
-OWA.items['<?php echo $dom_id;?>'] = new OWA.report();
-OWA.items['<?php echo $dom_id;?>'].dom_id = "<?php echo $dom_id;?>";
-OWA.items['<?php echo $dom_id;?>'].page_num = "<?php $this->out( $this->getValue( 'page_num', 'pagination' ),false );?>1";
-OWA.items['<?php echo $dom_id;?>'].max_page_num = "<?php $this->out( $this->getValue( 'max_page_num', 'pagination' ), false );?>";
-OWA.items['<?php echo $dom_id;?>'].max_page_num = "<?php $this->out( $this->getValue( 'more_pages', 'pagination' ), false );?>";
-OWA.items['<?php echo $dom_id;?>'].properties = <?php echo $this->makeJson($params);?>;
+OWA.items['<?php echo $view->dom_id;?>'] = new OWA.report();
+OWA.items['<?php echo $view->dom_id;?>'].dom_id = "<?php echo $view->dom_id;?>";
+OWA.items['<?php echo $view->dom_id;?>'].page_num = "<?php $view->out( $view->getValue( 'page_num', 'pagination' ),false );?>1";
+OWA.items['<?php echo $view->dom_id;?>'].max_page_num = "<?php $view->out( $view->getValue( 'max_page_num', 'pagination' ), false );?>";
+OWA.items['<?php echo $view->dom_id;?>'].max_page_num = "<?php $view->out( $view->getValue( 'more_pages', 'pagination' ), false );?>";
+OWA.items['<?php echo $view->dom_id;?>'].properties = <?php echo $view->makeJson($view->params);?>;
 
-<?php if ( ! $this->get( 'hideReportingNavigation' ) ):?>
+<?php if ( ! $view->get( 'hideReportingNavigation' ) ):?>
 // Bind event handlers
 jQuery(document).ready(function(){   
 	
@@ -31,23 +32,23 @@ jQuery(document).ready(function(){
 <?php endif;?>
 </script>
 
-<div id="<?php echo $dom_id;?>" class="owa_reportContainer">
+<div id="<?php echo $view->dom_id;?>" class="owa_reportContainer">
 
     <table width="100%" cellpadding="0" cellspacing="0">
 
         <TR>
-            <?php if ( ! $this->get( 'hideReportingNavigation' ) ):?>
+            <?php if ( ! $view->get( 'hideReportingNavigation' ) ):?>
             <TD valign="top" class="owa_reportLeftNavColumn">
                 <div>
                     <div id="owa_reportNavPanel">
-                        <?php echo $this->makeNavigationMenu($top_level_report_nav, $currentSiteId, $params['do']);?>
+                        <?php echo $view->makeNavigationMenu($view->top_level_report_nav, $view->currentSiteId, $view->params['do']);?>
                     </div>
                 </div>
             </TD>
             <?php endif;?>
             <TD valign="top" width="*">
 
-                <?php if ( ! $this->get( 'hideSitesFilter' ) ):?>
+                <?php if ( ! $view->get( 'hideSitesFilter' ) ):?>
                 <div class="reportSectionContainer reportSiteFilter" style="margin-bottom:20px;">
                 <?php include('filter_site.php');?>
                 </div>
@@ -55,10 +56,10 @@ jQuery(document).ready(function(){
                 <div class="reportSectionContainer">
                     <div id="owa_timePeriodControl" class="owa_reportPeriod" style="float:right;"></div>
                     <div id="liveViewSwitch" style="width:auto;float:right; padding-right:30px;"></div>
-                    <div class="owa_reportTitle"><?php echo $title;?><span class="titleSuffix"><?php echo $this->get('titleSuffix');?></span></div>
+                    <div class="owa_reportTitle"><?php echo $view->title;?><span class="titleSuffix"><?php echo $view->get('titleSuffix');?></span></div>
 
                     <div class="clear"></div>
-                    <?php echo $subview;?>
+                    <?php echo $view->subview;?>
 
                 </div>
             </TD>
@@ -66,7 +67,7 @@ jQuery(document).ready(function(){
     </table>
 </div>
 <script>
-OWA.items['<?php echo $dom_id;?>'].displayTimePeriodPicker('#owa_timePeriodControl');
-OWA.items['<?php echo $dom_id;?>'].showSiteFilter();
-OWA.items['<?php echo $dom_id;?>'].showAutoRefreshControl({label: 'Live View:', target: '#liveViewSwitch'});
+OWA.items['<?php echo $view->dom_id;?>'].displayTimePeriodPicker('#owa_timePeriodControl');
+OWA.items['<?php echo $view->dom_id;?>'].showSiteFilter();
+OWA.items['<?php echo $view->dom_id;?>'].showAutoRefreshControl({label: 'Live View:', target: '#liveViewSwitch'});
 </script>

--- a/modules/Base/templates/report_actionDetail.php
+++ b/modules/Base/templates/report_actionDetail.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionHeader">Action Metrics</div>
 <div class="owa_reportSectionContent">
 
@@ -48,13 +49,13 @@
 
         if (ui.index === 0) {
 
-            var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+            var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                           'metrics' => 'actions,actionsValue',
                                                           'dimensions' => 'actionLabel',
                                                           'sort' => 'actions-',
                                                           'resultsPerPage' => 25,
                                                           'format' => 'json',
-                                                          'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId').'actionName=='.$actionName)), true);?>';
+                                                          'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId').'actionName=='.$actionName)), true);?>';
 
             rsh = new OWA.resultSetExplorer('actionsByLabelExplorer');
             rsh.load(aurl, 'grid');
@@ -63,13 +64,13 @@
 
         if (ui.index === 1) {
 
-            var aurl2 = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+            var aurl2 = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                           'metrics' => 'actions,actionsValue',
                                                           'dimensions' => 'date',
                                                           'sort' => 'date-',
                                                           'resultsPerPage' => 25,
                                                           'format' => 'json',
-                                                          'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId').'actionName=='.$actionName)), true);?>';
+                                                          'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId').'actionName=='.$actionName)), true);?>';
 
             rsh2 = new OWA.resultSetExplorer('actionsByDateExplorer');
             rsh2.load(aurl2, 'grid');

--- a/modules/Base/templates/report_actionTracking.php
+++ b/modules/Base/templates/report_actionTracking.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <?php include('report_dimensionDetailNoTabs.php');?>
 
 
@@ -9,7 +10,7 @@
                 <div style="min-width:250px;" id="actionsByNameExplorer"></div>
                 <script>
                 
-                var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                   'metrics' => 'actions',
                                                                   'dimensions' => 'actionGroup,actionName',
                                                                   'sort' => 'actions-',
@@ -17,7 +18,7 @@
                                                                   'format' => 'json'), true);?>';
                                                                   
                 rsh = new OWA.resultSetExplorer('actionsByNameExplorer');
-                var link = '<?php echo $this->makeLink(array('do' => 'base.reportActionDetail', 'actionName' => '%s', 'actionGroup' => '%s'), true);?>';
+                var link = '<?php echo $view->makeLink(array('do' => 'base.reportActionDetail', 'actionName' => '%s', 'actionGroup' => '%s'), true);?>';
                 rsh.addLinkToColumn('actionName', link, ['actionName', 'actionGroup']);
                 rsh.asyncQueue.push(['refreshGrid']);
                 rsh.load(aurl, 'grid');
@@ -30,7 +31,7 @@
                 <div class="section_header">Actions By Group</div>
                 <div style="min-width:300px;" id="actionsByGroupExplorer"></div>
                 <script>
-                var url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                var url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                               'metrics' => 'actions',
                                                               'dimensions' => 'actionGroup',
                                                               'sort' => 'actions-',
@@ -38,7 +39,7 @@
                                                               'format' => 'json'), true);?>';
                                                               
                 rshre = new OWA.resultSetExplorer('actionsByGroupExplorer');
-                var link = '<?php echo $this->makeLink(array('do' => 'base.reportActionGroup', 'actionGroup' => '%s'), true);?>';
+                var link = '<?php echo $view->makeLink(array('do' => 'base.reportActionGroup', 'actionGroup' => '%s'), true);?>';
                 rshre.addLinkToColumn('actionGroup', link, ['actionGroup']);
                 rshre.asyncQueue.push(['refreshGrid']);
                 rshre.load(url);

--- a/modules/Base/templates/report_commerce.php
+++ b/modules/Base/templates/report_commerce.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
     <div id="trend-chart" style="height:125px;width:auto;"></div>
     <div class="owa_reportHeadline" id="content-headline"></div>
@@ -21,7 +22,7 @@
                 <div class="owa_genericHorizonalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportProducts'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportProducts'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -37,7 +38,7 @@
                 <div class="owa_genericHorizonalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportSources'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportSources'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -50,12 +51,12 @@
 <script>
 //OWA.setSetting('debug', true);
 
-var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                 'metrics' => 'visits,transactions,transactionRevenue,revenuePerVisit,revenuePerTransaction,ecommerceConversionRate',
                                                 'dimensions' => 'date',
                                                 'sort' => 'date',
                                                 'format' => 'json',
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.rsh = new OWA.resultSetExplorer('trend-chart');
 OWA.items.rsh.options.metricBoxes.width = '125px';
@@ -64,34 +65,34 @@ OWA.items.rsh.asyncQueue.push(['makeMetricBoxes', 'trend-metrics']);
 OWA.items.rsh.asyncQueue.push(['renderTemplate','#headline-template', {data: OWA.items.rsh}, 'replace', 'content-headline']);
 OWA.items.rsh.load(aurl);
 
-var topproductsurl = '<?php echo $this->makeApiLink(array(
+var topproductsurl = '<?php echo $view->makeApiLink(array(
                                                 'do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                 'metrics' => 'lineItemQuantity,lineItemRevenue',
                                                 'dimensions' => 'productName',
                                                 'sort' => 'lineItemRevenue-',
                                                 'format' => 'json',
                                                 'resultsPerPage' => 25,
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.topproducts = new OWA.resultSetExplorer('top-products');
-OWA.items.topproducts.addLinkToColumn('productName', '<?php echo $this->makeLink(array(
+OWA.items.topproducts.addLinkToColumn('productName', '<?php echo $view->makeLink(array(
                                                                         'do' => 'base.reportProductDetail',
                                                                         'productName' => '%s'
                                                                     ),true);?>', ['productName']);
 OWA.items.topproducts.asyncQueue.push(['refreshGrid']);
 OWA.items.topproducts.load(topproductsurl);
 
-var topsourcesurl = '<?php echo $this->makeApiLink(array(
+var topsourcesurl = '<?php echo $view->makeApiLink(array(
                                                 'do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                 'metrics' => 'transactionRevenue',
                                                 'dimensions' => 'source,medium',
                                                 'sort' => 'transactionRevenue-',
                                                 'format' => 'json',
                                                 'resultsPerPage' => 25,
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.topsources = new OWA.resultSetExplorer('top-sources');
-OWA.items.topsources.addLinkToColumn('source', '<?php echo $this->makeLink(array(
+OWA.items.topsources.addLinkToColumn('source', '<?php echo $view->makeLink(array(
                                                                         'do' => 'base.reportSourceDetail',
                                                                         'source' => '%s'
                                                                     ),true);?>', ['source']);

--- a/modules/Base/templates/report_content.php
+++ b/modules/Base/templates/report_content.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
     <div id="trend-chart" style="height:125px;width:auto;"></div>
     <div class="owa_reportHeadline" id="content-headline"></div>
@@ -21,7 +22,7 @@
                 <div class="owa_genericHorizonalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportPages'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportPages'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -34,16 +35,16 @@
                 <div class="relatedReports">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportDomstreams'), true);?>">Domstream Recordings</a></span> - See user mouse movement and keypress recordings.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportDomstreams'), true);?>">Domstream Recordings</a></span> - See user mouse movement and keypress recordings.
                         </LI>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportActionTracking'), true);?>">Actions</a></span> - See which actions your user performed.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportActionTracking'), true);?>">Actions</a></span> - See which actions your user performed.
                         </LI>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportReferringSites'), true);?>">Entry & Exits</a></span> - See which web pages user entered and exited on.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportReferringSites'), true);?>">Entry & Exits</a></span> - See which web pages user entered and exited on.
                         </LI>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportAnchortext'), true);?>">Feeds</a></span> - See trends for feed subscribers and usage.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportAnchortext'), true);?>">Feeds</a></span> - See trends for feed subscribers and usage.
                         </LI>
                     </UL>
                 </div>
@@ -55,7 +56,7 @@
                 <div class="owa_genericHorizonalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportPageTypes'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportPageTypes'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -68,12 +69,12 @@
 <script>
 //OWA.setSetting('debug', true);
 
-var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                 'metrics' => 'visits,pageViews,bounceRate',
                                                 'dimensions' => 'date',
                                                 'sort' => 'date',
                                                 'format' => 'json',
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.rsh = new OWA.resultSetExplorer('trend-chart');
 OWA.items.rsh.options.metricBoxes.width = '125px';
@@ -82,31 +83,31 @@ OWA.items.rsh.asyncQueue.push(['makeMetricBoxes', 'trend-metrics']);
 OWA.items.rsh.asyncQueue.push(['renderTemplate','#content-headline-template', {data: OWA.items.rsh}, 'replace', 'content-headline']);
 OWA.items.rsh.load(aurl);
 
-var toppagesurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var toppagesurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                 'metrics' => 'visits',
                                                 'dimensions' => 'pageTitle,pageUrl',
                                                 'sort' => 'visits-',
                                                 'format' => 'json',
                                                 'resultsPerPage' => 25,
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.toppages = new OWA.resultSetExplorer('top-pages');
-OWA.items.toppages.addLinkToColumn('pageTitle', '<?php echo $this->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => '%s'),true);?>', ['pageUrl']);
+OWA.items.toppages.addLinkToColumn('pageTitle', '<?php echo $view->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => '%s'),true);?>', ['pageUrl']);
 OWA.items.toppages.options.grid.excludeColumns = ['pageUrl'];
 OWA.items.toppages.asyncQueue.push(['refreshGrid']);
 OWA.items.toppages.load(toppagesurl);
 
-var toppagetypesurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var toppagetypesurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                 'metrics' => 'visits',
                                                 'dimensions' => 'pageType',
                                                 'sort' => 'visits-',
                                                 'format' => 'json',
                                                 'resultsPerPage' => 25,
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.toppagetypes = new OWA.resultSetExplorer('top-pagetypes');
 OWA.items.toppagetypes.asyncQueue.push(['refreshGrid']);
-OWA.items.toppagetypes.addLinkToColumn('pageType', '<?php echo $this->makeLink(array('do' => 'base.reportPageTypeDetail', 'pageType' => '%s'),true);?>', ['pageType']);
+OWA.items.toppagetypes.addLinkToColumn('pageType', '<?php echo $view->makeLink(array('do' => 'base.reportPageTypeDetail', 'pageType' => '%s'),true);?>', ['pageType']);
 OWA.items.toppagetypes.load(toppagetypesurl);
 
 

--- a/modules/Base/templates/report_dashboard.php
+++ b/modules/Base/templates/report_dashboard.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent" style="width:auto;">
 <div class="owa_reportSectionHeader">Site Metrics</div>
 
@@ -15,7 +16,7 @@
 
                 <div id="top-pages" style="min-width:350px"></div>
                 <div class="owa_moreLinks">
-                    <a href="<?php echo $this->makeLink(array('do' => 'base.reportPages'), true);?>">View Full Report &raquo;</a>
+                    <a href="<?php echo $view->makeLink(array('do' => 'base.reportPages'), true);?>">View Full Report &raquo;</a>
                 </div>
             </div>
 
@@ -40,7 +41,7 @@
                 <div class="owa_genericHorizontalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportActionTracking'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportActionTracking'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -68,14 +69,14 @@
 
                 <div id="top-referers" style="min-width:350px"></div>
                 <div class="owa_moreLinks">
-                    <a href="<?php echo $this->makeLink(array('do' => 'base.reportReferringSites'), true);?>">View Full Report &raquo;</a>
+                    <a href="<?php echo $view->makeLink(array('do' => 'base.reportReferringSites'), true);?>">View Full Report &raquo;</a>
                 </div>
                 <div id="test"></div>
             </div>
 
             <div class="owa_reportSectionContent">
                 <div class="section_header">OWA News</div>
-                <?php echo $this->getWidget('base.widgetOwaNews','',false);?>
+                <?php echo $view->getWidget('base.widgetOwaNews','',false);?>
             </div>
         </TD>
     </TR>
@@ -85,11 +86,11 @@
 
     var aurl = '<?php
 
-                    echo $this->makeApiLink(array(
+                    echo $view->makeApiLink(array(
                         'module'	=> 'base',
 	    				'version'	=>'v1',
 	    				'do' => 'reports',
-                        'metrics'        => $metrics,
+                        'metrics'        => $view->metrics,
                         'dimensions'     => 'date',
                         'sort'             => 'date',
                         'format'         => 'json'
@@ -103,9 +104,9 @@
     rsh.asyncQueue.push(['makeMetricBoxes' , 'trend-metrics']);
 
     rsh.load(aurl);
-    OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer('rsh', rsh);
+    OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer('rsh', rsh);
 	
-	var burl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+	var burl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                               'metrics' => 'actions', 
                                                               'dimensions' => 'actionGroup,actionName', 
                                                               'sort' => 'actions-', 
@@ -114,13 +115,13 @@
  
 	var bsh = new OWA.resultSetExplorer('actions-trend');
 	bsh.options.grid.showRowNumbers = false;
-	bsh.addLinkToColumn('actionGroup', '<?php echo $this->makeLink(array('do' => 'base.reportActionGroup', 'actionGroup' => '%s'), true);?>', ['actionGroup']);
+	bsh.addLinkToColumn('actionGroup', '<?php echo $view->makeLink(array('do' => 'base.reportActionGroup', 'actionGroup' => '%s'), true);?>', ['actionGroup']);
 	bsh.asyncQueue.push(['refreshGrid']);
 	bsh.load(burl);
-	OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer('bsh', bsh);
+	OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer('bsh', bsh);
 	
 (function() {
-    var tcurl = '<?php echo $this->makeApiLink(array('module'	=> 'base',
+    var tcurl = '<?php echo $view->makeApiLink(array('module'	=> 'base',
 	    											'version'	=>'v1',
 	    											'do' => 'reports',
                                                     'metrics' => 'pageViews',
@@ -133,15 +134,15 @@
 
     OWA.items.tc = new OWA.resultSetExplorer('top-pages');
     OWA.items.tc.options.grid.showRowNumbers = false;
-    OWA.items.tc.addLinkToColumn('pageTitle', '<?php echo $this->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => '%s'), true);?>', ['pageUrl']);
+    OWA.items.tc.addLinkToColumn('pageTitle', '<?php echo $view->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => '%s'), true);?>', ['pageUrl']);
     OWA.items.tc.options.grid.excludeColumns = ['pageUrl'];
     OWA.items.tc.asyncQueue.push(['refreshGrid']);
     OWA.items.tc.load(tcurl);
-    OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer( 'tc', OWA.items.tc );
+    OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer( 'tc', OWA.items.tc );
 })();
 
 (function() {
-    var traurl = '<?php echo $this->makeApiLink(array('module'	=> 'base',
+    var traurl = '<?php echo $view->makeApiLink(array('module'	=> 'base',
 	    											'version'	=>'v1',
 	    											'do' => 'reports',
                                                     'metrics' => 'visits',
@@ -155,16 +156,16 @@
 
     OWA.items.topreferers = new OWA.resultSetExplorer('top-referers');
     OWA.items.topreferers.options.grid.showRowNumbers = false;
-    OWA.items.topreferers.addLinkToColumn('referralPageTitle', '<?php echo $this->makeLink(array('do' => 'base.reportReferralDetail', 'referralPageUrl' => '%s'),true);?>', ['referralPageUrl']);
+    OWA.items.topreferers.addLinkToColumn('referralPageTitle', '<?php echo $view->makeLink(array('do' => 'base.reportReferralDetail', 'referralPageUrl' => '%s'),true);?>', ['referralPageUrl']);
     OWA.items.topreferers.options.grid.excludeColumns = ['referralPageUrl'];
     OWA.items.topreferers.asyncQueue.push(['refreshGrid']);
     OWA.items.topreferers.load(traurl);
-    OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer( 'topreferers', OWA.items.topreferers );
+    OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer( 'topreferers', OWA.items.topreferers );
 
 })();
 
 (function() {
-    var aturl = '<?php echo $this->makeApiLink(array(
+    var aturl = '<?php echo $view->makeApiLink(array(
         'module'	=> 'base',
 	    'version'	=>'v1',
 	    'do' => 'reports',
@@ -173,19 +174,19 @@
         'sort' => 'date',
         'format' => 'json',
         'period' => 'last_seven_days',
-        'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))
+        'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))
     ));?>';
 
     at = new OWA.resultSetExplorer('actions-trend');
     at.options.areaChart.series.push({x:'date',y:'actions'});
     at.setView('areaChart');
-    OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer( 'at', at );
+    OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer( 'at', at );
 
     //at.load(aturl);
 })();
 
 (function() {
-    var vmurl = '<?php echo $this->makeApiLink(array(
+    var vmurl = '<?php echo $view->makeApiLink(array(
 	    															'module'	=> 'base',
 	    															'version'	=>'v1',
 	    															'do' => 'reports',
@@ -193,31 +194,31 @@
                                                                     'dimensions' => 'medium',
                                                                     'sort' => 'visits-',
                                                                     'format' => 'json',
-                                                                    'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))),true);?>';
+                                                                    'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))),true);?>';
 
     var vm = new OWA.resultSetExplorer('visitor-mediums');
     vm.options.pieChart.metric = 'visits';
     vm.options.pieChart.dimension = 'medium';
     vm.setView('pie');
     vm.load(vmurl);
-    OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer( 'vm', vm );
+    OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer( 'vm', vm );
 })();
 
 (function() {
-    var aurl = '<?php echo $this->makeApiLink(array('module'	=> 'base',
+    var aurl = '<?php echo $view->makeApiLink(array('module'	=> 'base',
 	    											'version'	=>'v1',
 	    											'do' => 'reports',
                                                     'metrics' => 'repeatVisitors,newVisitors',
                                                     'dimensions' => '',
                                                     'sort' => 'visits',
                                                     'format' => 'json',
-                                                    'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))),true);?>';
+                                                    'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))),true);?>';
 
     OWA.items.vt = new OWA.resultSetExplorer('visitor-types');
     OWA.items.vt.options.pieChart.metrics = ['repeatVisitors', 'newVisitors'];
     OWA.items.vt.asyncQueue.push(['makePieChart']);
     OWA.items.vt.load(aurl);
-    OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer( 'vt', OWA.items.vt );
+    OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer( 'vt', OWA.items.vt );
 })();
 
 </script>

--- a/modules/Base/templates/report_dimensionDetail.php
+++ b/modules/Base/templates/report_dimensionDetail.php
@@ -1,6 +1,7 @@
-<?php if ($dimension_properties): ?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if ($view->dimension_properties): ?>
 <div class="owa_reportSectionContent">
-    <?php echo $this->renderDimension($dimension_template, $dimension_properties);?>
+    <?php echo $view->renderDimension($view->dimension_template, $view->dimension_properties);?>
 </div>
 <?php endif;?>
 
@@ -10,16 +11,16 @@
     <div id="trend-title" class="owa_reportHeadline"></div>
     <div id="report-tabs">
 
-        <?php foreach ($tabs as $k => $tab): ?>
-        <div id="tab_<?php $this->out($k); ?>">
+        <?php foreach ($view->tabs as $k => $tab): ?>
+        <div id="tab_<?php $view->out($k); ?>">
 
-                <div id="<?php $this->out($k); ?>_trend-metrics" style="height:auto;width:auto;<?php if(isset($pie)) {echo 'float:right';}?>"></div>
+                <div id="<?php $view->out($k); ?>_trend-metrics" style="height:auto;width:auto;<?php if(isset($pie)) {echo 'float:right';}?>"></div>
                 <?php if(isset($pie)): ?>
                 <div id="pie" style="min-width:300px;"></div>
                 <?php endif;?>
                 <div class="spacer" style="clear:both; height:20px;"></div>
-                <?php if (!$this->get('hideGrid')):?>
-                <div id="<?php $this->out($k); ?>_dimension-grid"></div>
+                <?php if (!$view->get('hideGrid')):?>
+                <div id="<?php $view->out($k); ?>_dimension-grid"></div>
                 <?php endif;?>
 
         </div>
@@ -31,33 +32,33 @@
 <script>
 
     // add tabs
-    <?php foreach ($tabs as $k => $tab): ?>
+    <?php foreach ($view->tabs as $k => $tab): ?>
 
-    var tab = new OWA.report.tab('tab_<?php $this->out($k, false);?>');
-    tab.setLabel('<?php $this->out($tab['tab_label']);?>');
+    var tab = new OWA.report.tab('tab_<?php $view->out($k, false);?>');
+    tab.setLabel('<?php $view->out($tab['tab_label']);?>');
     // create trend and aggregate data resultSetExplorer objects
-    var trendurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+    var trendurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                 'metrics' => $tab['metrics'],
                                                                 'dimensions' => 'date',
                                                                 'sort' => 'date',
                                                                 'format' => 'json',
-                                                                'constraints' => $constraints
+                                                                'constraints' => $view->constraints
                                                                 ),true);?>';
 
     var trend = new OWA.resultSetExplorer('trend-chart');
     trend.setDataLoadUrl(trendurl);
     trend.options.sparkline.metric = 'visits';
-    <?php if ($trendTitle):?>
-    trend.asyncQueue.push(['renderTemplate', '<?php echo $trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
+    <?php if ($view->trendTitle):?>
+    trend.asyncQueue.push(['renderTemplate', '<?php echo $view->trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
     <?php endif;?>
-    trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php if ( isset($tab['trendchartmetric'] ) ): echo $tab['trendchartmetric']; else: echo $trendChartMetric; endif; ?>'}], 'trend-chart']);
+    trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php if ( isset($tab['trendchartmetric'] ) ): echo $tab['trendchartmetric']; else: echo $view->trendChartMetric; endif; ?>'}], 'trend-chart']);
     trend.options.metricBoxes.width = '150px';
-    trend.asyncQueue.push(['makeMetricBoxes' , '<?php $this->out($k, false);?>_trend-metrics']);
+    trend.asyncQueue.push(['makeMetricBoxes' , '<?php $view->out($k, false);?>_trend-metrics']);
     tab.addRse('trend', trend);
-    OWA.items['<?php echo $dom_id;?>'].addTab( tab );
+    OWA.items['<?php echo $view->dom_id;?>'].addTab( tab );
     <?php endforeach;?>
     // create report tabs
-    OWA.items['<?php echo $dom_id;?>'].createTabs();
+    OWA.items['<?php echo $view->dom_id;?>'].createTabs();
 
 </script>
 

--- a/modules/Base/templates/report_dimensionDetailNoTabs.php
+++ b/modules/Base/templates/report_dimensionDetailNoTabs.php
@@ -1,6 +1,7 @@
-<?php if (isset($dimension_properties) && $dimension_properties): ?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if (isset($view->dimension_properties) && $view->dimension_properties): ?>
 <div class="owa_reportSectionContent">
-    <?php echo $this->renderDimension($dimension_template, $dimension_properties);?>
+    <?php echo $view->renderDimension($view->dimension_template, $view->dimension_properties);?>
 </div>
 <?php endif;?>
 
@@ -13,16 +14,16 @@
     <?php if(isset($pie) && $pie): ?>
     <div id="pie" style="min-width:300px;"></div>
     <script>
-    var hpurl = '<?php echo $this->makeApiLink(array(
+    var hpurl = '<?php echo $view->makeApiLink(array(
                         'do'             => 'reports', 'module' => 'base', 'version' => 'v1',
                         'metrics'         => 'pageViews,visits,bounceRate',
                         'dimensions'     => 'hostName',
                         'sort'             => 'visits-',
                         'format'         => 'json',
-                        'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))),true);?>';
+                        'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))),true);?>';
 
     hp = new OWA.resultSetExplorer('pie');
-    hp.options.pieChart.dimension = '<?php echo $dimensions;?>';
+    hp.options.pieChart.dimension = '<?php echo $view->dimensions;?>';
     hp.options.pieChart.metric = 'visits';
     hp.setView('pie');
     hp.load(hpurl);
@@ -33,23 +34,23 @@
     <div style="clear:both;"></div>
     <script>
 
-        var trendurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
-                                                                    'metrics' => $metrics,
+        var trendurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                                                                    'metrics' => $view->metrics,
                                                                     'dimensions' => 'date',
                                                                     'sort' => 'date',
                                                                     'format' => 'json',
-                                                                    'constraints' => $constraints
+                                                                    'constraints' => $view->constraints
                                                                     ),true);?>';
 
         var trend = new OWA.resultSetExplorer('trend-chart');
         trend.options.sparkline.metric = 'visits';
 
 
-        <?php if ($trendTitle):?>
-        trend.asyncQueue.push(['renderTemplate', '<?php echo $trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
+        <?php if ($view->trendTitle):?>
+        trend.asyncQueue.push(['renderTemplate', '<?php echo $view->trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
         <?php endif;?>
-        <?php if (isset($trendChartMetric)): ?>
-        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $trendChartMetric; ?>'}], 'trend-chart']);
+        <?php if (isset($view->trendChartMetric)): ?>
+        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $view->trendChartMetric; ?>'}], 'trend-chart']);
         <?php endif; ?>
         trend.options.metricBoxes.width = '150px';
         trend.asyncQueue.push(['makeMetricBoxes' , 'trend-metrics']);
@@ -60,30 +61,30 @@
 
 </div>
 
-<?php if ( $this->get( 'dimensions' ) ):?>
+<?php if ( $view->get( 'dimensions' ) ):?>
 <div class="owa_reportSectionContent">
 
     <div id="dimension-grid"></div>
 
     <script>
-        var dimurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
-                                                                    'metrics' => $metrics,
-                                                                    'dimensions' => $dimensions,
-                                                                    'sort' => $sort,
-                                                                    'resultsPerPage' => $resultsPerPage,
+        var dimurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                                                                    'metrics' => $view->metrics,
+                                                                    'dimensions' => $view->dimensions,
+                                                                    'sort' => $view->sort,
+                                                                    'resultsPerPage' => $view->resultsPerPage,
                                                                     'format' => 'json',
-                                                                    'constraints' => $constraints
+                                                                    'constraints' => $view->constraints
                                                                     ),true);?>';
 
         var dim = new OWA.resultSetExplorer('dimension-grid');
 
-        <?php if (!empty($dimensionLink)):?>
-        var link = '<?php echo $this->makeLink($dimensionLink['template'], true);?>';
-        var values = <?php if (is_array($dimensionLink['valueColumns'])) {
+        <?php if (!empty($view->dimensionLink)):?>
+        var link = '<?php echo $view->makeLink($view->dimensionLink['template'], true);?>';
+        var values = <?php if (is_array($view->dimensionLink['valueColumns'])) {
                         $values = "[";
                         $i = 0;
-                        $count = count($dimensionLink['valueColumns']);
-                        foreach ($dimensionLink['valueColumns'] as $v) {
+                        $count = count($view->dimensionLink['valueColumns']);
+                        foreach ($view->dimensionLink['valueColumns'] as $v) {
                             $values .= "'$v'";
                             if ($i < $count) {
                                 $values .= ', ';
@@ -93,13 +94,13 @@
                         $values .= "]";
                         echo $values;
                     } else {
-                        echo "['".$dimensionLink['valueColumns']."']";
+                        echo "['".$view->dimensionLink['valueColumns']."']";
                     }
                     ?>;
-        dim.addLinkToColumn('<?php echo $dimensionLink['linkColumn'];?>', link, values);
+        dim.addLinkToColumn('<?php echo $view->dimensionLink['linkColumn'];?>', link, values);
         <?php endif; ?>
-        <?php if (!empty($excludeColumns)):?>
-        dim.options.grid.excludeColumns = [<?php echo $excludeColumns;?>];
+        <?php if (!empty($view->excludeColumns)):?>
+        dim.options.grid.excludeColumns = [<?php echo $view->excludeColumns;?>];
         <?php endif; ?>
         dim.asyncQueue.push(['refreshGrid']);
         dim.load(dimurl);

--- a/modules/Base/templates/report_dimensionalTrend.php
+++ b/modules/Base/templates/report_dimensionalTrend.php
@@ -1,19 +1,20 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
     
     <div id="trend-chart"></div>
     <div id="trend-title" class="owa_reportHeadline"></div>
     <div id="report-tabs">
         
-        <?php foreach ($tabs as $k => $tab): ?>
-        <div id="tab_<?php $this->out($k); ?>">
+        <?php foreach ($view->tabs as $k => $tab): ?>
+        <div id="tab_<?php $view->out($k); ?>">
             
-                <div id="<?php $this->out($k); ?>_trend-metrics" style="height:auto;width:auto;<?php if( $this->get( 'pie' ) ) {echo 'float:right';}?>"></div>
-                <?php if ( $this->get('pie' ) ): ?>
+                <div id="<?php $view->out($k); ?>_trend-metrics" style="height:auto;width:auto;<?php if( $view->get( 'pie' ) ) {echo 'float:right';}?>"></div>
+                <?php if ( $view->get('pie' ) ): ?>
                 <div id="pie" style="min-width:300px;"></div>
                 <?php endif;?>
                 <div class="spacer" style="clear:both; height:20px;"></div>
-                <?php if (!$this->get('hideGrid')):?>
-                <div id="<?php $this->out($k); ?>_dimension-grid"></div>
+                <?php if (!$view->get('hideGrid')):?>
+                <div id="<?php $view->out($k); ?>_dimension-grid"></div>
                 <?php endif;?>
             
         </div>
@@ -25,54 +26,54 @@
         
     // add tabs
     
-    <?php foreach ($tabs as $k => $tab): ?>
+    <?php foreach ($view->tabs as $k => $tab): ?>
     
-    // adding tab for <?php $this->out($k, false);?>
+    // adding tab for <?php $view->out($k, false);?>
     
     
-    var tab = new OWA.report.tab('tab_<?php $this->out($k, false);?>');
-    tab.setLabel('<?php $this->out($tab['tab_label']);?>');
+    var tab = new OWA.report.tab('tab_<?php $view->out($k, false);?>');
+    tab.setLabel('<?php $view->out($tab['tab_label']);?>');
     // create trend and aggregate data resultSetExplorer objects
-    var trendurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+    var trendurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                 'metrics' => $tab['metrics'],
                                                                 'dimensions' => 'date',
                                                                 'sort' => 'date',
                                                                 'format' => 'json',
-                                                                'constraints' => $constraints
+                                                                'constraints' => $view->constraints
                                                                 ),true);?>';
                                                                   
     var trend = new OWA.resultSetExplorer('trend-chart');
     trend.setDataLoadUrl(trendurl);
     trend.options.sparkline.metric = 'visits';
-    <?php if ($trendTitle):?>
-    trend.asyncQueue.push(['renderTemplate', '<?php echo $trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
+    <?php if ($view->trendTitle):?>
+    trend.asyncQueue.push(['renderTemplate', '<?php echo $view->trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
     <?php endif;?>
-    trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php if ( isset($tab['trendchartmetric'] ) ): echo $tab['trendchartmetric']; else: echo $trendChartMetric; endif; ?>'}], 'trend-chart']);
+    trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php if ( isset($tab['trendchartmetric'] ) ): echo $tab['trendchartmetric']; else: echo $view->trendChartMetric; endif; ?>'}], 'trend-chart']);
     trend.options.metricBoxes.width = '150px';
-    trend.asyncQueue.push(['makeMetricBoxes' , '<?php $this->out($k, false);?>_trend-metrics']);
+    trend.asyncQueue.push(['makeMetricBoxes' , '<?php $view->out($k, false);?>_trend-metrics']);
     // add rse to tab
     tab.addRse('trend', trend);
     // dimensonal data object
-    var dimurl = '<?php $_sort = $sort ?: $tag['sort'];
+    var dimurl = '<?php $_sort = $view->sort ?: $tag['sort'];
 	    
-	    echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+	    echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                 'metrics' => $tab['metrics'],
-                                                                'dimensions' => $dimensions,
+                                                                'dimensions' => $view->dimensions,
                                                                 'sort' => $_sort,
-                                                                'resultsPerPage' => $resultsPerPage,
+                                                                'resultsPerPage' => $view->resultsPerPage,
                                                                 'format' => 'json',
-                                                                'constraints' => $constraints
+                                                                'constraints' => $view->constraints
                                                                 ),true);?>';
                                                                   
-    var dim = new OWA.resultSetExplorer('<?php $this->out($k, false);?>_dimension-grid');
+    var dim = new OWA.resultSetExplorer('<?php $view->out($k, false);?>_dimension-grid');
     dim.setDataLoadUrl(dimurl);
-    <?php if (!empty($dimensionLink)):?>
-    var link = '<?php echo $this->makeLink($dimensionLink['template'], true);?>';
-    var values = <?php if (is_array($dimensionLink['valueColumns'])) {
+    <?php if (!empty($view->dimensionLink)):?>
+    var link = '<?php echo $view->makeLink($view->dimensionLink['template'], true);?>';
+    var values = <?php if (is_array($view->dimensionLink['valueColumns'])) {
                     $values = "[";
                     $i = 0;
-                    $count = count($dimensionLink['valueColumns']);
-                    foreach ($dimensionLink['valueColumns'] as $v) {
+                    $count = count($view->dimensionLink['valueColumns']);
+                    foreach ($view->dimensionLink['valueColumns'] as $v) {
                         $values .= "'$v'";
                         if ($i < $count) {
                             $values .= ', ';
@@ -82,29 +83,29 @@
                     $values .= "]";
                     echo $values;
                 } else {
-                    echo "['".$dimensionLink['valueColumns']."']";
+                    echo "['".$view->dimensionLink['valueColumns']."']";
                 }
                 ?>;
-    dim.addLinkToColumn('<?php echo $dimensionLink['linkColumn'];?>', link, values);
+    dim.addLinkToColumn('<?php echo $view->dimensionLink['linkColumn'];?>', link, values);
     <?php endif; ?>
     
-    <?php if (isset($gridFormatters) && ! empty($gridFormatters) ):?>
-    <?php foreach ($gridFormatters as $col => $formatter): ?>
-    dim.options.grid.columnFormatters['<?php $this->out($col); ?>'] = <?php $this->out($formatter, false);?>;
+    <?php if (isset($view->gridFormatters) && ! empty($view->gridFormatters) ):?>
+    <?php foreach ($view->gridFormatters as $col => $formatter): ?>
+    dim.options.grid.columnFormatters['<?php $view->out($col); ?>'] = <?php $view->out($formatter, false);?>;
     <?php endforeach;?>
     <?php endif;?>
     
-    <?php if (!empty($excludeColumns)):?>
-    dim.options.grid.excludeColumns = [<?php echo $excludeColumns;?>];
+    <?php if (!empty($view->excludeColumns)):?>
+    dim.options.grid.excludeColumns = [<?php echo $view->excludeColumns;?>];
     <?php endif; ?>
     dim.asyncQueue.push(['refreshGrid']);
     // add dim object to tab
     tab.addRse('dim', dim);
     // add tab
-    OWA.items['<?php echo $dom_id;?>'].addTab( tab );
+    OWA.items['<?php echo $view->dom_id;?>'].addTab( tab );
     <?php endforeach;?>
     // create report tabs
-    OWA.items['<?php echo $dom_id;?>'].createTabs();
+    OWA.items['<?php echo $view->dom_id;?>'].createTabs();
     
 </script>
 

--- a/modules/Base/templates/report_document.php
+++ b/modules/Base/templates/report_document.php
@@ -1,6 +1,7 @@
-<?php if ($dimension_properties): ?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if ($view->dimension_properties): ?>
 <div class="owa_reportSectionContent">
-    <?php echo $this->renderDimension($dimension_template, $dimension_properties);?>
+    <?php echo $view->renderDimension($view->dimension_template, $view->dimension_properties);?>
 </div>
 <?php endif;?>
 
@@ -35,19 +36,19 @@
                     <P>
                         <span class="inline_h3"><a href="<?php 
 	                        echo ( 
-	                        	$this->makeLink(
+	                        	$view->makeLink(
 		                        	[
 			                        	'do' => 'base.overlayLauncher', 
-				                        'document_id' =>$document->get('id'), 
+				                        'document_id' =>$view->document->get('id'), 
 					                    'overlay_params' => base64_encode(
-											$this->makeParamString(
+											$view->makeParamString(
 							                    
 								                [
 								                    'action' 		=> 'loadHeatmap', 
-									                'api_url' 		=> $this->makeApiLink(
+									                'api_url' 		=> $view->makeApiLink(
 									                	
 										                [
-										                	'document_id' 	=> $document->get('id'),
+										                	'document_id' 	=> $view->document->get('id'),
 														    'module' 		=> 'base',
 														    'version'		=> 'v1',
 														    'do'			=> 'reports',
@@ -57,7 +58,7 @@
 											            true
 									                ), 
 										            
-											        'document_id' 	=> $document->get('id')
+											        'document_id' 	=> $view->document->get('id')
 												], 
 												false, 
 												'json'
@@ -69,11 +70,11 @@
                     </P>
 
                     <P>
-                        <span class="inline_h3"><a href="<?php echo $this->makeLink(array('do' => 'base.reportDomstreams', 'document_id' => $document->get('id')), true);?>">Domstreams</a></span> - mouse movement recordings.
+                        <span class="inline_h3"><a href="<?php echo $view->makeLink(array('do' => 'base.reportDomstreams', 'document_id' => $view->document->get('id')), true);?>">Domstreams</a></span> - mouse movement recordings.
                     </P>
 
                     <P>
-                        <span class="inline_h3"><a href="<?php echo $this->makeLink(array('do' => 'base.reportDomClicks', 'document_id' => $document->get('id')), true);?>">Dom Clicks</a></span> - analysis of dom clicks.
+                        <span class="inline_h3"><a href="<?php echo $view->makeLink(array('do' => 'base.reportDomClicks', 'document_id' => $view->document->get('id')), true);?>">Dom Clicks</a></span> - analysis of dom clicks.
                     </P>
                 </div>
             </TD>
@@ -84,44 +85,44 @@
 
 
 <script>
-        var trurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+        var trurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                       'metrics' => 'visits',
                                                       'dimensions' => 'pagePath,pageTitle',
                                                       'sort' => 'visits-',
                                                       'resultsPerPage' => 15,
-                                                      'constraints'            => 'priorPageUrl=='.urlencode((string) $dimension_properties->get('url')),
+                                                      'constraints'            => 'priorPageUrl=='.urlencode((string) $view->dimension_properties->get('url')),
                                                       'format' => 'json'), true);?>';
 
         var trshre = new OWA.resultSetExplorer('nextpages');
-        var link = '<?php echo $this->makeLink(array('do' => 'base.reportDocument', 'pagePath' => '%s'), true);?>';
+        var link = '<?php echo $view->makeLink(array('do' => 'base.reportDocument', 'pagePath' => '%s'), true);?>';
         trshre.addLinkToColumn('pagePath', link, ['pagePath']);
         trshre.asyncQueue.push(['refreshGrid']);
         trshre.load(trurl);
 
-        var prurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+        var prurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                       'metrics' => 'visits',
                                                       'dimensions' => 'priorPagePath,priorPageTitle',
                                                       'sort' => 'visits-',
                                                       'resultsPerPage' => 15,
-                                                      'constraints'            => urlencode('pageUrl=='.(string) $dimension_properties->get('url')),
+                                                      'constraints'            => urlencode('pageUrl=='.(string) $view->dimension_properties->get('url')),
                                                       'format' => 'json'), true);?>';
 
         var prshre = new OWA.resultSetExplorer('priorpages');
-        var link = '<?php echo $this->makeLink(array('do' => 'base.reportDocument', 'pagePath' => '%s'), true);?>';
+        var link = '<?php echo $view->makeLink(array('do' => 'base.reportDocument', 'pagePath' => '%s'), true);?>';
         prshre.addLinkToColumn('priorPagePath', link, ['priorPagePath']);
         prshre.asyncQueue.push(['refreshGrid']);
         prshre.load(prurl);
 
-        var vrurl = '<?php echo $this->makeApiLink(['do' => 'reports', 'module' => 'base', 'version' => 'v1',
+        var vrurl = '<?php echo $view->makeApiLink(['do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                     'metrics'           => 'visits,pageViews',
                                                     'dimensions'        => 'visitorId',
                                                     'sort'              => 'visits-',
                                                     'resultsPerPage'    => 15,
-                                                    'constraints'       => urlencode('pageUrl=='.(string) $dimension_properties->get('url')),
+                                                    'constraints'       => urlencode('pageUrl=='.(string) $view->dimension_properties->get('url')),
                                                     'format'            => 'json'], true);?>';
 
         var vrshre = new OWA.resultSetExplorer('pagevisitors');
-        var link = '<?php echo $this->makeLink(['do' => 'base.reportVisitor', 'visitorId' => '%s'], true);?>';
+        var link = '<?php echo $view->makeLink(['do' => 'base.reportVisitor', 'visitorId' => '%s'], true);?>';
         vrshre.addLinkToColumn('visitorId', link, ['visitorId']);
         vrshre.asyncQueue.push(['refreshGrid']);
         vrshre.load(vrurl);

--- a/modules/Base/templates/report_dom_clicks.php
+++ b/modules/Base/templates/report_dom_clicks.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <?php require('report_trend_section.php');?>
 
 <div class="owa_reportSectionContent">
@@ -10,10 +11,10 @@
                     <div class="section_header">Dom IDs</div>
                     <div style="min-width:300px;" id="topDomIds"></div>
                     <script>
-                    var url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                    var url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                   'metrics' => 'domClicks',
                                                                   'dimensions' => 'domElementId',
-                                                                  'constraints' => $constraints,
+                                                                  'constraints' => $view->constraints,
                                                                   'sort' => 'domClicks-',
                                                                   'resultsPerPage' => 5,
                                                                   'format' => 'json'), true);?>';
@@ -28,10 +29,10 @@
                     <div class="section_header">Name Attributes</div>
                     <div style="min-width:300px;" id="topDomNames"></div>
                     <script>
-                    var url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                    var url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                   'metrics' => 'domClicks',
                                                                   'dimensions' => 'domElementName',
-                                                                  'constraints' => $constraints,
+                                                                  'constraints' => $view->constraints,
                                                                   'sort' => 'domClicks-',
                                                                   'resultsPerPage' => 5,
                                                                   'format' => 'json'), true);?>';
@@ -50,10 +51,10 @@
                     <div class="section_header">HTML Tags</div>
                     <div style="min-width:300px;" id="topHtmlTags"></div>
                     <script>
-                    var url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                    var url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                   'metrics' => 'domClicks',
                                                                   'dimensions' => 'domElementTag',
-                                                                  'constraints' => $constraints,
+                                                                  'constraints' => $view->constraints,
                                                                   'sort' => 'domClicks-',
                                                                   'resultsPerPage' => 5,
                                                                   'format' => 'json'), true);?>';
@@ -68,10 +69,10 @@
                     <div class="section_header">Dom Classes</div>
                     <div style="min-width:300px;" id="topDomClasses"></div>
                     <script>
-                    var url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                    var url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                   'metrics' => 'domClicks',
                                                                   'dimensions' => 'domElementClass',
-                                                                  'constraints' => $constraints,
+                                                                  'constraints' => $view->constraints,
                                                                   'sort' => 'domClicks-',
                                                                   'resultsPerPage' => 5,
                                                                   'format' => 'json'), true);?>';

--- a/modules/Base/templates/report_domstreams.php
+++ b/modules/Base/templates/report_domstreams.php
@@ -1,4 +1,5 @@
-<?php if (!empty($document)): require('item_document.php'); endif;?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if (!empty($view->document)): require('item_document.php'); endif;?>
 
 
 <?php if ( $domstreams ):?>
@@ -20,8 +21,8 @@
                 <?php echo date("F j, Y, g:i a",$ds['timestamp']);?>
             </TD>
             <TD class="data_cell">
-            <a href="<?php $this->safeHref( $ds['page_url'] );?>">
-                <?php $this->out( $this->truncate($ds['page_url'], 150) );?>
+            <a href="<?php $view->safeHref( $ds['page_url'] );?>">
+                <?php $view->out( $view->truncate($ds['page_url'], 150) );?>
             </a>
             </TD>
 
@@ -30,11 +31,11 @@
             </TD>
             <TD class="data_cell">
                 <a class="play" data-overlay="<?php echo trim( base64_encode(
-                                $this->makeParamString(
+                                $view->makeParamString(
                                     [
                                         'action' => 'loadPlayer',
                                         'domstream_guid' => $ds['domstream_guid'],
-	                                    'api_url' 		=> $this->makeApiLink(
+	                                    'api_url' 		=> $view->makeApiLink(
 									                	
 										                [
 										                	'domstream_guid' => $ds['domstream_guid'],
@@ -58,7 +59,7 @@
 								            $ds['page_url'] = $parts[0];
 								        }
 
-	                                    $this->safeHref( $ds['page_url'] );?>"
+	                                    $view->safeHref( $ds['page_url'] );?>"
                                     href="#">Play</a>
             </TD>
         </TR>
@@ -66,7 +67,7 @@
     </tbody>
 </table>
 
-<?php echo $this->makePaginationFromResultSet($d2, array('do' => 'base.reportDomstreams'), true);?>
+<?php echo $view->makePaginationFromResultSet($d2, array('do' => 'base.reportDomstreams'), true);?>
 
 <?php else:?>
     There are no Dom Streams this time period.

--- a/modules/Base/templates/report_ecommerce.php
+++ b/modules/Base/templates/report_ecommerce.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
 
     <div id="trend-chart"></div>
@@ -8,20 +9,20 @@
     <div style="clear:both;"></div>
     <script>
 
-        var trendurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
-                                                                    'metrics' => $metrics,
+        var trendurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                                                                    'metrics' => $view->metrics,
                                                                     'dimensions' => 'date',
                                                                     'sort' => 'date',
                                                                     'format' => 'json',
-                                                                    'constraints' => $constraints
+                                                                    'constraints' => $view->constraints
                                                                     ),true);?>';
 
         var trend = new OWA.resultSetExplorer('trend-chart');
         trend.options.sparkline.metric = 'visits';
-        <?php if ($trendTitle):?>
-        trend.asyncQueue.push(['renderTemplate', '<?php echo $trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
+        <?php if ($view->trendTitle):?>
+        trend.asyncQueue.push(['renderTemplate', '<?php echo $view->trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
         <?php endif;?>
-        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $trendChartMetric; ?>'}], 'trend-chart']);
+        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $view->trendChartMetric; ?>'}], 'trend-chart']);
         trend.options.metricBoxes.width = '150px';
         trend.asyncQueue.push(['makeMetricBoxes' , 'trend-metrics']);
         trend.load(trendurl);
@@ -38,7 +39,7 @@
                 <div style="min-width:250px;" id="productNameExplorer"></div>
                 <script>
 
-                var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                   'metrics' => 'lineItemRevenue',
                                                                   'dimensions' => 'productName',
                                                                   'sort' => 'lineItemRevenue-',
@@ -46,7 +47,7 @@
                                                                   'format' => 'json'), true);?>';
 
                 rsh = new OWA.resultSetExplorer('productNameExplorer');
-                var link = '<?php echo $this->makeLink(array('do' => 'base.reportProductDetail', 'productName' => '%s'), true);?>';
+                var link = '<?php echo $view->makeLink(array('do' => 'base.reportProductDetail', 'productName' => '%s'), true);?>';
                 rsh.addLinkToColumn('productName', link, ['productName']);
                 rsh.asyncQueue.push(['refreshGrid']);
                 rsh.load(aurl, 'grid');
@@ -57,7 +58,7 @@
                 <div class="section_header">Sales Sources</div>
                 <div style="min-width:300px;" id="sourceExplorer"></div>
                 <script>
-                var url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                var url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                               'metrics' => 'transactions,transactionRevenue',
                                                               'dimensions' => 'source',
                                                               'sort' => 'transactionsRevenue-',
@@ -65,7 +66,7 @@
                                                               'format' => 'json'), true);?>';
 
                 rshre = new OWA.resultSetExplorer('sourceExplorer');
-                var link = '<?php echo $this->makeLink(array('do' => 'base.reportSources', 'source' => '%s'), true);?>';
+                var link = '<?php echo $view->makeLink(array('do' => 'base.reportSources', 'source' => '%s'), true);?>';
                 rshre.addLinkToColumn('source', link, ['source']);
                 rshre.asyncQueue.push(['refreshGrid']);
                 rshre.load(url);
@@ -80,20 +81,20 @@
                 <UL>
                     <li>
                         Item Level Analysis:
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportProducts'), true);?>">Product Name</a>,
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportProductSkus'), true);?>">SKU</a>,
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportProductCategories'), true);?>">Categories</a>
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportProducts'), true);?>">Product Name</a>,
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportProductSkus'), true);?>">SKU</a>,
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportProductCategories'), true);?>">Categories</a>
                     </li>
                     <li>
                         Purchase Patterns:
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportVisitsToPurchase'), true);?>">Visits to Purchase</a>,
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportDaysToPurchase'), true);?>">Days to Purchase</a>
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportVisitsToPurchase'), true);?>">Visits to Purchase</a>,
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportDaysToPurchase'), true);?>">Days to Purchase</a>
                     </li>
                     <li>
                         Sales Trends:
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportAvgOrderValue'), true);?>">Average Order Value</a>,
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportRevenue'), true);?>">Total Revenue</a>,
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportEcommerceConversionRate'), true);?>">Conversion Rate</a>
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportAvgOrderValue'), true);?>">Average Order Value</a>,
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportRevenue'), true);?>">Total Revenue</a>,
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportEcommerceConversionRate'), true);?>">Conversion Rate</a>
                     </li>
                 </UL>
                 </div>

--- a/modules/Base/templates/report_goal_funnel.php
+++ b/modules/Base/templates/report_goal_funnel.php
@@ -1,55 +1,56 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 
 <div>
 
     Choose a goal: <select id="goalChooser">
-        <?php for ($i = 1; $i <= $numGoals; $i++):?>
-        <option <?php if ($i == $goal_number): echo 'SELECTED'; endif;?> value="<?php $this->out($i, false); ?>">Goal <?php $this->out($i, false); ?></option>
+        <?php for ($i = 1; $i <= $view->numGoals; $i++):?>
+        <option <?php if ($i == $view->goal_number): echo 'SELECTED'; endif;?> value="<?php $view->out($i, false); ?>">Goal <?php $view->out($i, false); ?></option>
         <?php endfor; ?>
     </select>
 </div>
 
-<?php if ( $this->get('funnel') ):?>
+<?php if ( $view->get('funnel') ):?>
 <table class="funnel" border="0" style="min-width:100%;">
     <tr>
         <td class="funnelLeft">Prior Page Viewed</td>
-        <td class="funnelMiddle"><h2><?php $this->out($goal_conversion_rate);?> conversion rate</h2></td>
+        <td class="funnelMiddle"><h2><?php $view->out($view->goal_conversion_rate);?> conversion rate</h2></td>
         <td class="funnelRight" style="text-align:right;">Next Page Viewed</td>
     </tr>
-    <?php foreach ($funnel as $k => $step):?>
+    <?php foreach ($view->funnel as $k => $step):?>
     <tr>
-        <td width="33%" valign="top" class="funnelLeft" id="entrances_step_<?php $this->out($step['step_number']);?>">
-            <div class="funnelLargeNumber entranceCount" style="text-align: right;" id="prior_page_count_step_<?php $this->out($step['step_number']);?>">
+        <td width="33%" valign="top" class="funnelLeft" id="entrances_step_<?php $view->out($step['step_number']);?>">
+            <div class="funnelLargeNumber entranceCount" style="text-align: right;" id="prior_page_count_step_<?php $view->out($step['step_number']);?>">
 
             </div>
         </td>
-        <td width="33%" valign="top" class="funnelMiddle funnelStep" id="step_<?php $this->out($step['step_number']);?>">
-            <div class="funnelStepName">Step <?php $this->out($step['step_number']);?>: <?php $this->out($step['name']);?></div>
-            <div class="funnelStepCount"><?php $this->out($step['visitors']);?> <span class="visitorCountLabel">visitors</span></div>
-            <div class="funnelStepUrl"><?php $this->out($step['url']);?></div>
+        <td width="33%" valign="top" class="funnelMiddle funnelStep" id="step_<?php $view->out($step['step_number']);?>">
+            <div class="funnelStepName">Step <?php $view->out($step['step_number']);?>: <?php $view->out($step['name']);?></div>
+            <div class="funnelStepCount"><?php $view->out($step['visitors']);?> <span class="visitorCountLabel">visitors</span></div>
+            <div class="funnelStepUrl"><?php $view->out($step['url']);?></div>
             <div class="genericHorizontalList" style="padding-top:10px;font-size:12px;">
                 <ul class="">
 
 
                     <li>
-                        <span class="inline_h4"><a href="<?php echo $this->makeLink(array('do' => 'base.reportDomstreams', 'pagePath' => $step['url']), true);?>">Watch Domstreams</a></span>
+                        <span class="inline_h4"><a href="<?php echo $view->makeLink(array('do' => 'base.reportDomstreams', 'pagePath' => $step['url']), true);?>">Watch Domstreams</a></span>
                     </li>
 
                     <li>
-                        <span class="inline_h4"><a href="<?php echo $this->makeLink(array('do' => 'base.reportDomClicks', 'pagePath' => $step['url']), true);?>">Analyze Dom Clicks</a></span>
+                        <span class="inline_h4"><a href="<?php echo $view->makeLink(array('do' => 'base.reportDomClicks', 'pagePath' => $step['url']), true);?>">Analyze Dom Clicks</a></span>
                     </li>
                 </ul>
             </div>
         </td>
-        <td width="33%" valign="top" class="funnelRight" id="exits_step_<?php $this->out($step['step_number']);?>">
-            <div class="funnelLargeNumber exitCount" id="next_page_count_step_<?php $this->out($step['step_number']);?>"></div>
+        <td width="33%" valign="top" class="funnelRight" id="exits_step_<?php $view->out($step['step_number']);?>">
+            <div class="funnelLargeNumber exitCount" id="next_page_count_step_<?php $view->out($step['step_number']);?>"></div>
         </td>
     </tr>
-    <?php if (array_key_exists($k+1, $funnel)):?>
+    <?php if (array_key_exists($k+1, $view->funnel)):?>
     <tr>
         <td class="funnelLeft"></td>
         <td class="funnelMiddle funnelLargeNumber funnelFlow">
-            <?php $this->out($funnel[$k+1]['visitor_percentage']);?><BR>
-            <span class="secondaryText">Proceeded to step: <?php $this->out($funnel[$k+1]['name']); ?></span>
+            <?php $view->out($view->funnel[$k+1]['visitor_percentage']);?><BR>
+            <span class="secondaryText">Proceeded to step: <?php $view->out($view->funnel[$k+1]['name']); ?></span>
         </td>
         <td class="funnelRight"></td>
     </tr>
@@ -58,7 +59,7 @@
 </table>
 
 <script>
-var funnel_json = <?php $this->out($funnel_json, false);?>;
+var funnel_json = <?php $view->out($view->funnel_json, false);?>;
 var i = 1;
 for (step in funnel_json) {
     step = parseInt(step);
@@ -136,8 +137,8 @@ for (step in funnel_json) {
 </script>
 <?php else: ?>
 No Funnel has been configured for this goal.
-<?php if ($this->getCurrentUser()->isCapable('edit_settings')): ?>
-    <a href="<?php echo $this->makeLink(array('do' => 'base.optionsGoalEntry', 'goal_number' => $goal_number, 'siteId' => $params['siteId']));?>">Add a funnel</a>
+<?php if ($view->getCurrentUser()->isCapable('edit_settings')): ?>
+    <a href="<?php echo $view->makeLink(array('do' => 'base.optionsGoalEntry', 'goal_number' => $view->goal_number, 'siteId' => $view->params['siteId']));?>">Add a funnel</a>
 <?php endif; ?>
 <?php endif;?>
 

--- a/modules/Base/templates/report_goals.php
+++ b/modules/Base/templates/report_goals.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
     
     <div id="trend-chart"></div>
@@ -8,20 +9,20 @@
     <div style="clear:both;"></div>
     <script>
         
-        var trendurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
-                                                                    'metrics' => $metrics,
+        var trendurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                                                                    'metrics' => $view->metrics,
                                                                     'dimensions' => 'date',
                                                                     'sort' => 'date',
                                                                     'format' => 'json',
-                                                                    'constraints' => $constraints
+                                                                    'constraints' => $view->constraints
                                                                     ),true);?>';
                                                                       
         var trend = new OWA.resultSetExplorer('trend-chart');
         trend.options.sparkline.metric = 'goalCompletionsAll';
-        <?php if ($trendTitle):?>
-        trend.asyncQueue.push(['renderTemplate', '<?php echo $trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
+        <?php if ($view->trendTitle):?>
+        trend.asyncQueue.push(['renderTemplate', '<?php echo $view->trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
         <?php endif;?>
-        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $trendChartMetric; ?>'}], 'trend-chart']);
+        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $view->trendChartMetric; ?>'}], 'trend-chart']);
         trend.options.metricBoxes.width = '150px';
         trend.asyncQueue.push(['makeMetricBoxes' , 'trend-metrics']);
         trend.load(trendurl);
@@ -36,11 +37,11 @@
             <div class="owa_reportSectionContent">
                 <div class="section_header">Goal Performance</div>
                 <div style="min-width:250px;" id="goalMetrics"></div>
-                <?php if ($goal_metrics): ?>
+                <?php if ($view->goal_metrics): ?>
                 <script>
                 
-                var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
-                                                                  'metrics' => $goal_metrics,
+                var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                                                                  'metrics' => $view->goal_metrics,
                                                                   'format' => 'json'), true);?>';
                                                                   
                 rsh = new OWA.resultSetExplorer('goalMetrics');
@@ -59,7 +60,7 @@
                 <UL>
                     <li>
                         
-                        <a href="<?php echo $this->makeLink(array('do' => 'base.reportGoalFunnel'), true);?>">Conversion Funnels</a> - Goal funnel Visualization.
+                        <a href="<?php echo $view->makeLink(array('do' => 'base.reportGoalFunnel'), true);?>">Conversion Funnels</a> - Goal funnel Visualization.
                         
                     </li>
                 </UL>

--- a/modules/Base/templates/report_latest_visits.php
+++ b/modules/Base/templates/report_latest_visits.php
@@ -1,6 +1,7 @@
-<?php if(!empty($visits)):?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php if(!empty($view->visits)):?>
 <table style="width:100%;">
-    <?php foreach($visits->resultsRows as $row): 
+    <?php foreach($view->visits->resultsRows as $row): 
 	    $row = (array) $row;?>
         <TR>
         <?php include('row_visitSummary.php'); ?>

--- a/modules/Base/templates/report_nav.php
+++ b/modules/Base/templates/report_nav.php
@@ -1,12 +1,13 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_admin_nav">
 
     <UL>
-        <?php foreach ($links as $kl => $l): ?>
-        <?php if (!$this->getCurrentUser()->isCapable($l['priviledge'], $currentSiteId)) { continue; } ?>
+        <?php foreach ($view->links as $kl => $l): ?>
+        <?php if (!$view->getCurrentUser()->isCapable($l['priviledge'], $view->currentSiteId)) { continue; } ?>
         <LI>
             <div class="owa_admin_nav_topmenu">
 
-                <div class="owa_admin_nav_topmenu_item <?php if ($l['ref'] === $params['do'] || ( array_key_exists('subgroup', $l) && in_array( $params['do'], array_column($l['subgroup'], 'ref')))) { echo ' owa_current';} ?>">
+                <div class="owa_admin_nav_topmenu_item <?php if ($l['ref'] === $view->params['do'] || ( array_key_exists('subgroup', $l) && in_array( $view->params['do'], array_column($l['subgroup'], 'ref')))) { echo ' owa_current';} ?>">
                     <span class="owa_admin_nav_topmenu_toggle 
                     
                     <?php 
@@ -19,7 +20,7 @@
 			      
                     ?>"></span>
               
-                    <span><i class="owa_nav_icon <?php $this->out( $l['icon_class']); ?>"></i><a class=" owa_admin_nav_topmenu_item_text" id="owa_admin_nav_topmenu_item_<?php echo $kl;?>" href="<?php echo $this->makeLink(array('do' => $l['ref']), true);?>"><?php echo $l['anchortext'];?></a></span>
+                    <span><i class="owa_nav_icon <?php $view->out( $l['icon_class']); ?>"></i><a class=" owa_admin_nav_topmenu_item_text" id="owa_admin_nav_topmenu_item_<?php echo $kl;?>" href="<?php echo $view->makeLink(array('do' => $l['ref']), true);?>"><?php echo $l['anchortext'];?></a></span>
                     
 
                 </div>
@@ -29,10 +30,10 @@
                 <div id="owa_admin_nav_subgroup_<?php echo $kl;?>" class="owa_admin_nav_subgroup">
                     <UL>
                         <?php foreach ($l['subgroup'] as $sgl): ?>
-                        <?php if (!$this->getCurrentUser()->isCapable($sgl['priviledge'], $currentSiteId)) continue; ?>
+                        <?php if (!$view->getCurrentUser()->isCapable($sgl['priviledge'], $view->currentSiteId)) continue; ?>
                         <LI>
                             <div class="owa_admin_nav_subgroup_item ">
-                                <a href="<?php echo $this->makeLink(array('do' => $sgl['ref']), true);?>"><?php echo $sgl['anchortext'];?></a>
+                                <a href="<?php echo $view->makeLink(array('do' => $sgl['ref']), true);?>"><?php echo $sgl['anchortext'];?></a>
                             </div>
 
                         </LI>

--- a/modules/Base/templates/report_traffic.php
+++ b/modules/Base/templates/report_traffic.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
     <div id="trend-chart" style="height:125px; min-width:400px;padding-right:30px;"></div>
 </div>
@@ -31,7 +32,7 @@
                 <div class="owa_genericHorizonalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportSources'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportSources'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -44,7 +45,7 @@
                 <div class="owa_genericHorizonalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportKeywords'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportKeywords'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -60,7 +61,7 @@
                 <div class="owa_genericHorizonalList owa_moreLinks">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportReferringSites'), true);?>">View Full Report &raquo;</a>
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportReferringSites'), true);?>">View Full Report &raquo;</a>
                         </LI>
                     </UL>
                 </div>
@@ -70,16 +71,16 @@
                 <div class="relatedReports">
                     <UL>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportSearchEngines'), true);?>">Search Engines</a></span> - See which search engines your visitors are coming from.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportSearchEngines'), true);?>">Search Engines</a></span> - See which search engines your visitors are coming from.
                         </LI>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportKeywords'), true);?>">Keywords</a></span> - See what keywords your visitor are using to find your web site.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportKeywords'), true);?>">Keywords</a></span> - See what keywords your visitor are using to find your web site.
                         </LI>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportReferringSites'), true);?>">Referring Web Sites</a></span> - See which web sites are linking to your web site.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportReferringSites'), true);?>">Referring Web Sites</a></span> - See which web sites are linking to your web site.
                         </LI>
                         <LI>
-                            <a href="<?php echo $this->makeLink(array('do' => 'base.reportAnchortext'), true);?>">Inbound Link Text</a></span> - See what words Referring Web Sites use to describe your web site.
+                            <a href="<?php echo $view->makeLink(array('do' => 'base.reportAnchortext'), true);?>">Inbound Link Text</a></span> - See what words Referring Web Sites use to describe your web site.
                         </LI>
                     </UL>
                 </div>
@@ -95,26 +96,26 @@
 <script>
 //OWA.setSetting('debug', true);
 
-var aurl = '<?php echo $this->makeApiLink(array('module'	=> 'base',
+var aurl = '<?php echo $view->makeApiLink(array('module'	=> 'base',
 	    										'version'	=>'v1',
 	    										'do' => 'reports', 
                                                 'metrics' => 'visits',
                                                 'dimensions' => 'date',
                                                 'sort' => 'date',
                                                 'format' => 'json',
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.rsh = new OWA.resultSetExplorer('trend-chart');
 OWA.items.rsh.asyncQueue.push(['makeAreaChart', [{x:'date',y:'visits'}]]);
 OWA.items.rsh.asyncQueue.push(['renderTemplate','#visits-headline-template', {data: OWA.items.rsh}, 'replace', 'visits-headline']);
 OWA.items.rsh.load(aurl);
 
-var tturl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var tturl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                         'metrics' => 'visits',
                                                         'dimensions' => 'date',
                                                         'sort' => 'date',
                                                         'format' => 'json',
-                                                        'constraints' => urlencode($this->substituteValue('siteId==%s,', 'siteId').',medium==organic-search')),true);?>';
+                                                        'constraints' => urlencode($view->substituteValue('siteId==%s,', 'siteId').',medium==organic-search')),true);?>';
 
 OWA.items.tt = new OWA.resultSetExplorer('trend-metrics');
 //OWA.items.tt.asyncQueue.push(['makeMetricBoxes','','','Visits From Search Engines', '',function(row) {if (row.medium.value === 'organic-search') return true;}]);
@@ -122,36 +123,36 @@ OWA.items.tt.asyncQueue.push(['makeMetricBoxes','','','Visits From Search Engine
 
 OWA.items.tt.load(tturl);
 
-var tt1url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var tt1url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                         'metrics' => 'visits',
                                                         'dimensions' => 'date',
                                                         'sort' => 'date',
                                                         'format' => 'json',
-                                                        'constraints' => urlencode($this->substituteValue('siteId==%s,', 'siteId')).'medium==direct'),true);?>';
+                                                        'constraints' => urlencode($view->substituteValue('siteId==%s,', 'siteId')).'medium==direct'),true);?>';
 
 OWA.items.tt1 = new OWA.resultSetExplorer('trend-metrics');
 OWA.items.tt1.asyncQueue.push(['makeMetricBoxes','','','Visits From Direct Navigation']);
 OWA.items.tt1.load(tt1url);
 
 
-var tt2url = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var tt2url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                         'metrics' => 'visits',
                                                         'dimensions' => 'date',
                                                         'sort' => 'date',
                                                         'format' => 'json',
-                                                        'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId')).'medium==referral'),true);?>';
+                                                        'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId')).'medium==referral'),true);?>';
 
 OWA.items.tt2 = new OWA.resultSetExplorer('trend-metrics');
 
 OWA.items.tt2.asyncQueue.push(['makeMetricBoxes','','','Visits From Referrals']);
 OWA.items.tt2.load(tt2url);
 
-var vmurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var vmurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                                     'metrics' => 'visits',
                                                                     'dimensions' => 'medium',
                                                                     'sort' => 'visits-',
                                                                     'format' => 'json',
-                                                                    'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))),true);?>';
+                                                                    'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))),true);?>';
 
 OWA.items.vm = new OWA.resultSetExplorer('traffic-sources');
 OWA.items.vm.options.pieChart.metric = 'visits';
@@ -161,43 +162,43 @@ OWA.items.vm.asyncQueue.push(['makePieChart']);
 OWA.items.vm.load(vmurl);
 
 
-var topkeywordsurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var topkeywordsurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                 'metrics' => 'visits',
                                                 'dimensions' => 'referralSearchTerms',
                                                 'sort' => 'visits-',
                                                 'format' => 'json',
                                                 'resultsPerPage' => 25,
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId') . 'medium==organic-search')), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId') . 'medium==organic-search')), true);?>';
 
 OWA.items.topkeywords = new OWA.resultSetExplorer('top-keywords');
-OWA.items.topkeywords.addLinkToColumn('referralSearchTerms', '<?php echo $this->makeLink(array('do' => 'base.reportKeywordDetail', 'referralSearchTerms' => '%s'), true);?>', ['referralSearchTerms']);
+OWA.items.topkeywords.addLinkToColumn('referralSearchTerms', '<?php echo $view->makeLink(array('do' => 'base.reportKeywordDetail', 'referralSearchTerms' => '%s'), true);?>', ['referralSearchTerms']);
 OWA.items.topkeywords.asyncQueue.push(['refreshGrid']);
 OWA.items.topkeywords.load(topkeywordsurl);
 
-var topreferralsurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var topreferralsurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                 'metrics' => 'visits',
                                                 'dimensions' => 'referralPageUrl',
                                                 'sort' => 'visits-',
                                                 'format' => 'json',
                                                 'resultsPerPage' => 25,
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.topreferrals = new OWA.resultSetExplorer('top-referrals');
-OWA.items.topreferrals.addLinkToColumn('referralPageUrl', '<?php echo $this->makeLink(array('do' => 'base.reportReferralDetail', 'referralPageUrl' => '%s'),true);?>', ['referralPageUrl']);
+OWA.items.topreferrals.addLinkToColumn('referralPageUrl', '<?php echo $view->makeLink(array('do' => 'base.reportReferralDetail', 'referralPageUrl' => '%s'),true);?>', ['referralPageUrl']);
 OWA.items.topreferrals.asyncQueue.push(['refreshGrid', 'top-referrals']);
 OWA.items.topreferrals.load(topreferralsurl);
 
-var topsources_url = '<?php echo $this->makeApiLink(array(
+var topsources_url = '<?php echo $view->makeApiLink(array(
         'do' => 'reports', 'module' => 'base', 'version' => 'v1',
         'metrics' => 'visits',
         'dimensions' => 'source,medium',
         'sort' => 'visits-',
         'format' => 'json',
         'resultsPerPage' => 25,
-        'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+        'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.topsources = new OWA.resultSetExplorer('top-sources');
-OWA.items.topsources.addLinkToColumn('source', '<?php echo $this->makeLink(array('do' => 'base.reportSourceDetail', 'source' => '%s' , 'medium' => '%s'),true);?>', ['source', 'medium']);
+OWA.items.topsources.addLinkToColumn('source', '<?php echo $view->makeLink(array('do' => 'base.reportSourceDetail', 'source' => '%s' , 'medium' => '%s'),true);?>', ['source', 'medium']);
 OWA.items.topsources.asyncQueue.push(['refreshGrid', 'top-sources']);
 OWA.items.topsources.load(topsources_url);
 

--- a/modules/Base/templates/report_transaction_detail.php
+++ b/modules/Base/templates/report_transaction_detail.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <table class="management">
 
     <thead>
@@ -32,33 +33,33 @@
 
         <tr>
             <th>Order Id</th>
-            <td><?php $this->out( $trans_detail['order_id'] );?></td>
+            <td><?php $view->out( $view->trans_detail['order_id'] );?></td>
         </tr>
         <tr>
             <th>Order Source</th>
-            <td><?php $this->out( $trans_detail['order_source'] );?></td>
+            <td><?php $view->out( $view->trans_detail['order_source'] );?></td>
         </tr>
         <tr>
             <th>Processing Gateway</th>
-            <td><?php $this->out( $trans_detail['gateway'] );?></td>
+            <td><?php $view->out( $view->trans_detail['gateway'] );?></td>
         </tr>
         <tr>
             <th>Total Revenue</th>
-            <td><?php $this->out( $this->formatCurrency( $trans_detail['total_revenue'] ) );?></td>
+            <td><?php $view->out( $view->formatCurrency( $view->trans_detail['total_revenue'] ) );?></td>
         </tr>
         <tr>
             <th>Tax Revenue</th>
-            <td><?php $this->out( $this->formatCurrency( $trans_detail['tax_revenue'] ) );?></td>
+            <td><?php $view->out( $view->formatCurrency( $view->trans_detail['tax_revenue'] ) );?></td>
         </tr>
         <tr>
             <th>Shipping Revenue</th>
-            <td><?php $this->out( $this->formatCurrency( $trans_detail['shipping_revenue'] ) );?></td>
+            <td><?php $view->out( $view->formatCurrency( $view->trans_detail['shipping_revenue'] ) );?></td>
         </tr>
     </tbody>
 </table>
 
 <h3>Transaction Line Items</h3>
-<?php if ( isset( $trans_detail['line_items'] ) ):?>
+<?php if ( isset( $view->trans_detail['line_items'] ) ):?>
 <table class="simpleTable">
     <tr>
         <th>Product Name</th>
@@ -68,13 +69,13 @@
         <th>Item Revenue</th>
     </tr>
 
-    <?php foreach ($trans_detail['line_items'] as $li): $li = (array) $li; ?>
+    <?php foreach ($view->trans_detail['line_items'] as $li): $li = (array) $li; ?>
     <tr>
-        <td><?php $this->out( $li['product_name'] ); ?> (<?php $this->out( $li['category'] ); ?>)</td>
-        <td><?php $this->out( $li['sku'] ); ?></td>
-        <td><?php $this->out( $this->formatCurrency( $li['unit_price'] ) ); ?></td>
-        <td><?php $this->out( $li['quantity'] ); ?></td>
-        <td><?php $this->out( $this->formatCurrency( $li['item_revenue'] ) ); ?></td>
+        <td><?php $view->out( $li['product_name'] ); ?> (<?php $view->out( $li['category'] ); ?>)</td>
+        <td><?php $view->out( $li['sku'] ); ?></td>
+        <td><?php $view->out( $view->formatCurrency( $li['unit_price'] ) ); ?></td>
+        <td><?php $view->out( $li['quantity'] ); ?></td>
+        <td><?php $view->out( $view->formatCurrency( $li['item_revenue'] ) ); ?></td>
     </tr>
     <?php endforeach; ?>
 </table>

--- a/modules/Base/templates/report_transactions.php
+++ b/modules/Base/templates/report_transactions.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
     <div id="trend-chart" style="height:125px;width:auto;"></div>
     <div class="owa_reportHeadline" id="content-headline"></div>
@@ -26,12 +27,12 @@
 <script>
 //OWA.setSetting('debug', true);
 
-var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                 'metrics' => 'visits,transactions,transactionRevenue,revenuePerVisit,revenuePerTransaction,ecommerceConversionRate',
                                                 'dimensions' => 'date',
                                                 'sort' => 'date',
                                                 'format' => 'json',
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.rsh = new OWA.resultSetExplorer('trend-chart');
 OWA.items.rsh.options.metricBoxes.width = '125px';
@@ -40,17 +41,17 @@ OWA.items.rsh.asyncQueue.push(['makeMetricBoxes', 'trend-metrics']);
 OWA.items.rsh.asyncQueue.push(['renderTemplate','#headline-template', {data: OWA.items.rsh}, 'replace', 'content-headline']);
 OWA.items.rsh.load(aurl);
 
-var transactionsurl = '<?php echo $this->makeApiLink(array(
+var transactionsurl = '<?php echo $view->makeApiLink(array(
                                                 'do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                 'metrics' => 'transactionRevenue,shippingRevenue,taxRevenue',
                                                 'dimensions' => 'timestamp,transactionId',
                                                 'sort' => 'timestamp-',
                                                 'format' => 'json',
                                                 'resultsPerPage' => 25,
-                                                'constraints' => urlencode($this->substituteValue('siteId==%s,','siteId'))), true);?>';
+                                                'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))), true);?>';
 
 OWA.items.transactions = new OWA.resultSetExplorer('transactions');
-OWA.items.transactions.addLinkToColumn('transactionId', '<?php echo $this->makeLink(array(
+OWA.items.transactions.addLinkToColumn('transactionId', '<?php echo $view->makeLink(array(
                                                                         'do' => 'base.reportTransactionDetail',
                                                                         'transactionId' => '%s'
                                                                     ),true);?>', ['transactionId']);

--- a/modules/Base/templates/report_trend_section.php
+++ b/modules/Base/templates/report_trend_section.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
 
     <div id="trend-chart"></div>
@@ -8,20 +9,20 @@
     <div style="clear:both;"></div>
     <script>
 
-        var trendurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
-                                                                    'metrics' => $metrics,
+        var trendurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                                                                    'metrics' => $view->metrics,
                                                                     'dimensions' => 'date',
                                                                     'sort' => 'date',
                                                                     'format' => 'json',
-                                                                    'constraints' => $constraints
+                                                                    'constraints' => $view->constraints
                                                                     ),true);?>';
 
         var trend = new OWA.resultSetExplorer('trend-chart');
         trend.options.sparkline.metric = 'visits';
-        <?php if ($trendTitle):?>
-        trend.asyncQueue.push(['renderTemplate', '<?php echo $trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
+        <?php if ($view->trendTitle):?>
+        trend.asyncQueue.push(['renderTemplate', '<?php echo $view->trendTitle;?>', {d: trend}, 'replace', 'trend-title']);
         <?php endif;?>
-        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $trendChartMetric; ?>'}], 'trend-chart']);
+        trend.asyncQueue.push(['makeAreaChart', [{x: 'date', y: '<?php echo $view->trendChartMetric; ?>'}], 'trend-chart']);
         trend.options.metricBoxes.width = '150px';
         trend.asyncQueue.push(['makeMetricBoxes' , 'trend-metrics']);
         trend.load(trendurl);

--- a/modules/Base/templates/report_visit.php
+++ b/modules/Base/templates/report_visit.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionHeader">Visit Summary</div>
 <div class="owa_reportSectionContent">
     <?php include('report_latest_visits.php');?>
@@ -9,11 +10,11 @@
     
     <div class="propertyList">
 
-        <?php foreach($clickstream->resultsRows as $s): $s = (array) $s;?>
+        <?php foreach($view->clickstream->resultsRows as $s): $s = (array) $s;?>
 
-        <dt><?php $this->out(date("H:i:s",$s['timestamp']));?></dt>
+        <dt><?php $view->out(date("H:i:s",$s['timestamp']));?></dt>
         <dd>
-            <a href="<?php echo $this->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => urlencode( $s['url'] ) ), true );?>"><span><?php echo $s['uri'];?></span></a>
+            <a href="<?php echo $view->makeLink(array('do' => 'base.reportDocument', 'pageUrl' => urlencode( $s['url'] ) ), true );?>"><span><?php echo $s['uri'];?></span></a>
         </dd>
         <BR><BR>
         <?php endforeach; ?>

--- a/modules/Base/templates/report_visitor.php
+++ b/modules/Base/templates/report_visitor.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div>
     <div style="display: table-cell; vertical-align: middle">
         <span>
@@ -7,7 +8,7 @@
             $avatar = '';
             if ( isset($row) && is_array( $row ) && array_key_exists('visitor_user_email', $row) ) {
                 
-                $this->getAvatarImage($row['visitor_user_email']);
+                $view->getAvatarImage($row['visitor_user_email']);
             }
             if ( $avatar ) {
         		
@@ -22,11 +23,11 @@
             ?>
         
         </span>
-        <span class="inline_h2"><?php $this->out( $visitor_label );?></span>
+        <span class="inline_h2"><?php $view->out( $view->visitor_label );?></span>
     </div>
     <BR>
     <div>
-        <?php $this->renderKpiInfobox( $first_visit_date, 'First Visit' ); ?>
+        <?php $view->renderKpiInfobox( $view->first_visit_date, 'First Visit' ); ?>
 
     </div>
 </div>
@@ -40,7 +41,7 @@
                 <div class="owa_reportSectionContent" style="min-width:500px;">
                     <div class="owa_reportSectionHeader">Latest Visits</div>
                     <?php include('report_latest_visits.php')?>
-                    <?php echo $this->makePaginationFromResultSet($visits, array('do' => 'base.reportVisitors'), true);?>
+                    <?php echo $view->makePaginationFromResultSet($view->visits, array('do' => 'base.reportVisitors'), true);?>
                 </div>
             </td>
             <td valign="top">
@@ -55,19 +56,19 @@
 
 <script>
 	
-var burl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
+var burl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1', 
                                                           'metrics' => 'actions', 
                                                           'dimensions' => 'actionGroup,actionName', 
-                                                          'constraints' => 'visitorId=='.$this->get('visitor_id'),
+                                                          'constraints' => 'visitorId=='.$view->get('visitor_id'),
                                                           'sort' => 'actions-', 
                                                           'resultsPerPage' => 5,
                                                           'format' => 'json'), true);?>';
 	
 var bsh = new OWA.resultSetExplorer('latest-actions');
 	bsh.options.grid.showRowNumbers = false;
-	bsh.addLinkToColumn('actionGroup', '<?php echo $this->makeLink(array('do' => 'base.reportActionGroup', 'actionGroup' => '%s'), true);?>', ['actionGroup']);
+	bsh.addLinkToColumn('actionGroup', '<?php echo $view->makeLink(array('do' => 'base.reportActionGroup', 'actionGroup' => '%s'), true);?>', ['actionGroup']);
 	bsh.asyncQueue.push(['refreshGrid']);
 	bsh.load(burl);
-	OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer('bsh', bsh);
+	OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer('bsh', bsh);
 
 </script>

--- a/modules/Base/templates/report_visitors.php
+++ b/modules/Base/templates/report_visitors.php
@@ -1,10 +1,11 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent">
     <div id="visitor-trend" style="height:125px;width:auto;"></div>
     <div id="trend-metrics"></div>
 
     <script>
     //OWA.setSetting('debug', true);
-    var aurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+    var aurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                     'metrics' => 'uniqueVisitors,newVisitors,repeatVisitors,visits,visitDuration',
                                                     'dimensions' => 'date',
                                                     'sort' => 'date',
@@ -30,20 +31,20 @@
                 <div class="owa_reportSectionContent" style="">
                     <div class="owa_reportSectionHeader">Latest Visits</div>
                     <?php include('report_latest_visits.php')?>
-                    <?php echo $this->makePaginationFromResultSet($visits, array('do' => 'base.reportVisitors'), true);?>
+                    <?php echo $view->makePaginationFromResultSet($view->visits, array('do' => 'base.reportVisitors'), true);?>
                 </div>
             </td>
             <TD width="50%" valign="top">
                 <div class="owa_reportSectionContent">
                     <div class="section_header inline_h2">Visitor Reports</div>
                     <P>
-                        <span class="inline_h3"><a href="<?php echo $this->makeLink(array('do' => 'base.reportVisitorsLoyalty'), true);?>">Visitor Loyalty</a></span> - See how long ago your visitors first came to your web site.
+                        <span class="inline_h3"><a href="<?php echo $view->makeLink(array('do' => 'base.reportVisitorsLoyalty'), true);?>">Visitor Loyalty</a></span> - See how long ago your visitors first came to your web site.
                     </P>
                     <P>
-                        <span class="inline_h3"><a href="<?php echo $this->makeLink(array('do' => 'base.reportGeolocation'), true);?>">Geo-location</a></span> - See which parts of the world your visitors are coming from.
+                        <span class="inline_h3"><a href="<?php echo $view->makeLink(array('do' => 'base.reportGeolocation'), true);?>">Geo-location</a></span> - See which parts of the world your visitors are coming from.
                     </P>
                     <P>
-                        <span class="inline_h3"><a href="<?php echo $this->makeLink(array('do' => 'base.reportHosts'), true);?>">Domains</a></span> - See which Networks or Internet hosts your visitors are coming from.
+                        <span class="inline_h3"><a href="<?php echo $view->makeLink(array('do' => 'base.reportHosts'), true);?>">Domains</a></span> - See which Networks or Internet hosts your visitors are coming from.
                     </P>
                 </div>
 
@@ -53,7 +54,7 @@
                     <div id="top-browsers"></div>
                     <script>
 
-                        var bturl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                        var bturl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                                 'metrics' => 'visits',
                                                                                 'dimensions' => 'browserType',
                                                                                 'sort' => 'visits-',
@@ -62,7 +63,7 @@
                                                                                 ),true);?>';
 
                         OWA.items.browsertypes = new OWA.resultSetExplorer('top-browsers');
-                        OWA.items.browsertypes.addLinkToColumn('browserType', '<?php echo $this->makeLink(array('do' => 'base.reportBrowserDetail', 'browserType' => '%s'),true); ?>', ['browserType']);
+                        OWA.items.browsertypes.addLinkToColumn('browserType', '<?php echo $view->makeLink(array('do' => 'base.reportBrowserDetail', 'browserType' => '%s'),true); ?>', ['browserType']);
                         OWA.items.browsertypes.asyncQueue.push(['refreshGrid']);
                         OWA.items.browsertypes.load(bturl);
 
@@ -74,7 +75,7 @@
                     <div id="top-visitors"></div>
                     <script>
 
-                        var tvurl = '<?php echo $this->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
+                        var tvurl = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                                                 'metrics' => 'visits,pageViews',
                                                                                 'dimensions' => 'visitorId',
                                                                                 'sort' => 'visits-',
@@ -83,7 +84,7 @@
                                                                                 ),true);?>';
 
                         OWA.items.topvisitors = new OWA.resultSetExplorer('top-visitors');
-                        OWA.items.topvisitors.addLinkToColumn('visitorId', '<?php echo $this->makeLink(array('do' => 'base.reportVisitor', 'visitorId' => '%s'), true); ?>', ['visitorId']);
+                        OWA.items.topvisitors.addLinkToColumn('visitorId', '<?php echo $view->makeLink(array('do' => 'base.reportVisitor', 'visitorId' => '%s'), true); ?>', ['visitorId']);
                         OWA.items.topvisitors.asyncQueue.push(['refreshGrid']);
                         OWA.items.topvisitors.load(tvurl);
 

--- a/modules/Base/templates/report_visitors_roster.php
+++ b/modules/Base/templates/report_visitors_roster.php
@@ -1,17 +1,18 @@
-<H2><?php echo $headline;?>: <?php echo $date_label;?></H2>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<H2><?php echo $view->headline;?>: <?php echo $date_label;?></H2>
 
 <table>
-    <?php if (!empty($visitors)):?>
-    <?php foreach ($visitors as $visitor):?>
+    <?php if (!empty($view->visitors)):?>
+    <?php foreach ($view->visitors as $visitor):?>
     <TR>
-        <TD><img src="<?php echo $this->makeImageLink('base/i/user_icon_small.gif');?>" align="top">
-            <a href="<?php echo $this->makeLink(array('do' => 'base.reportVisitor', 'visitor_id' => $visitor['visitor_id'], 'period' => 'all_time'));?>">
+        <TD><img src="<?php echo $view->makeImageLink('base/i/user_icon_small.gif');?>" align="top">
+            <a href="<?php echo $view->makeLink(array('do' => 'base.reportVisitor', 'visitor_id' => $visitor['visitor_id'], 'period' => 'all_time'));?>">
             <?php if(!empty($visitor['user_name'])):
-                $this->out( $visitor['user_name'] );
+                $view->out( $visitor['user_name'] );
             elseif(!empty($visitor['user_email'])):
-                $this->out( $visitor['user_email'] );
+                $view->out( $visitor['user_email'] );
             else:
-                $this->out( $visitor['visitor_id'] );
+                $view->out( $visitor['visitor_id'] );
             endif;?>
             </a>
         </TD>

--- a/modules/Base/templates/report_visits.php
+++ b/modules/Base/templates/report_visits.php
@@ -1,5 +1,6 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="owa_reportSectionContent" style="width:700px;">
     <div class="owa_reportSectionHeader">Latest Visits</div>
     <?php include('report_latest_visits.php')?>
-    <?php echo $this->makePagination($pagination, array('do' => $params['do']));?>
+    <?php echo $view->makePagination($view->pagination, array('do' => $view->params['do']));?>
 </div>

--- a/modules/Base/templates/restApiResponse.php
+++ b/modules/Base/templates/restApiResponse.php
@@ -1,23 +1,24 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <?php
 	
 $_response = [
 		    
-		    'requestId'			=> $request_id,
-		    'httpResponse'		=> $http_response,
-		    'error'				=> $error,
+		    'requestId'			=> $view->request_id,
+		    'httpResponse'		=> $view->http_response,
+		    'error'				=> $view->error,
 		    'data'				=> null
 
 ];
 
 
-if ( isset( $response_data ) ) {
+if ( isset( $view->response_data ) ) {
 	
-	$_response['data'] = $response_data;
+	$_response['data'] = $view->response_data;
 }
 
-if ( isset( $callback ) && ! empty( $callback) ) {
+if ( isset( $view->callback ) && ! empty( $view->callback) ) {
 	
-	echo sprintf("%s(%s);", $callback, json_encode( $_response ) );	
+	echo sprintf("%s(%s);", $view->callback, json_encode( $_response ) );	
 } else {
 
 	echo json_encode( $_response );

--- a/modules/Base/templates/resultSetHtml.php
+++ b/modules/Base/templates/resultSetHtml.php
@@ -1,10 +1,11 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 
 <table id= "" class="owa_dataGrid<?php //echo $class; ?>" summary="">
-    <!-- <CAPTION>Result set for <?php echo $rs->timePeriod['label'];?>.</CAPTION> -->
+    <!-- <CAPTION>Result set for <?php echo $view->rs->timePeriod['label'];?>.</CAPTION> -->
     <thead>
         <tr>
-<?php if ($rs->resultsRows):?>
-<?php foreach ($rs->resultsRows[0] as $k => $v):?>
+<?php if ($view->rs->resultsRows):?>
+<?php foreach ($view->rs->resultsRows[0] as $k => $v):?>
             <th class="<?php if($v['result_type'] === 'dimension') { echo 'dimensionColumn';} else { echo 'metricColumn';}?>"><?php echo $v['label'];?></th>
 <?php endforeach;?>
 <?php endif;?>
@@ -16,8 +17,8 @@
     </tfoot>
         
     <tbody>
-<?php if ($rs->resultsRows):?>
-<?php foreach ($rs->resultsRows as $row):?>
+<?php if ($view->rs->resultsRows):?>
+<?php foreach ($view->rs->resultsRows as $row):?>
         <tr>
 <?php foreach ($row as $k => $v):?>
             <td class="<?php if($v['result_type'] === 'dimension') { echo 'dimensionColumn';} else { echo 'metricColumn';}?>">

--- a/modules/Base/templates/resultSetXml.php
+++ b/modules/Base/templates/resultSetXml.php
@@ -1,28 +1,29 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <?php echo ("<?xml version='1.0' encoding='UTF-8'?>");?>
 <resultSet>
     <timePeriod>
-<?php foreach ($rs->timePeriod as $k => $v):?>
-        <?php echo sprintf("<%s>%s</%s>\n", $k, $this->escapeForXml($v), $k);?>
+<?php foreach ($view->rs->timePeriod as $k => $v):?>
+        <?php echo sprintf("<%s>%s</%s>\n", $k, $view->escapeForXml($v), $k);?>
 <?php endforeach;?>
     </timePeriod>
 
     <aggregates>
-<?php foreach ($rs->aggregates as $item):?>
-        <?php echo sprintf("<%s name='%s' value='%s' label='%s'/>\n", $item['result_type'], $this->escapeForXml($item['name']), $this->escapeForXml($item['value']), $this->escapeForXml($item['label']));?>
+<?php foreach ($view->rs->aggregates as $item):?>
+        <?php echo sprintf("<%s name='%s' value='%s' label='%s'/>\n", $item['result_type'], $view->escapeForXml($item['name']), $view->escapeForXml($item['value']), $view->escapeForXml($item['label']));?>
 <?php endforeach;?>
     </aggregates>
 
-    <resultsTotal><?php echo $rs->resultsTotal;?></resultsTotal>
+    <resultsTotal><?php echo $view->rs->resultsTotal;?></resultsTotal>
 
-    <resultsReturned><?php echo $rs->resultsReturned;?></resultsReturned>
+    <resultsReturned><?php echo $view->rs->resultsReturned;?></resultsReturned>
 
-    <resultsPerPage><?php echo $rs->resultsPerPage;?></resultsPerPage>
+    <resultsPerPage><?php echo $view->rs->resultsPerPage;?></resultsPerPage>
 
     <resultsRows>
-<?php foreach ($rs->resultsRows as $row):?>
+<?php foreach ($view->rs->resultsRows as $row):?>
         <row>
 <?php foreach ($row as $item):?>
-            <?php echo sprintf("<%s name='%s' value='%s' label='%s'/>\n", $item['result_type'], $this->escapeForXml($item['name']), $this->escapeForXml($item['value']), $this->escapeForXml($item['label']));?>
+            <?php echo sprintf("<%s name='%s' value='%s' label='%s'/>\n", $item['result_type'], $view->escapeForXml($item['name']), $view->escapeForXml($item['value']), $view->escapeForXml($item['label']));?>
 <?php endforeach;?>
         </row>
 <?php endforeach;?>

--- a/modules/Base/templates/row_visitSummary.php
+++ b/modules/Base/templates/row_visitSummary.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <TD>
     <div class="owa_visitInfobox" style="width:auto;">
 
@@ -17,7 +18,7 @@
                             
                             } else { 
 	                            
-	                            $avatar = $this->getAvatarImage($row['visitor_user_email']);
+	                            $avatar = $view->getAvatarImage($row['visitor_user_email']);
 	                            if ( $avatar ) {
 		                    		
 		                    		echo '<img class="owa_avatar" src="'. $avatar.'" width="30" height="30">';        
@@ -36,43 +37,43 @@
                             <span class="inline_h4">
 
                             <?php
-                            if ( $this->isValueSet( $row[ 'session_user_name' ] ) ) {
-                                $this->out( $row[ 'session_user_name' ] );
+                            if ( $view->isValueSet( $row[ 'session_user_name' ] ) ) {
+                                $view->out( $row[ 'session_user_name' ] );
                             } else {
-                                $this->out( $row['visitor_id'] );
+                                $view->out( $row['visitor_id'] );
                             }?></span>
                             <BR>
-                            <?php if ( $this->isValueSet( $row['location_city'] ) || $this->isValueSet( $row['location_country'] ) ):?>
+                            <?php if ( $view->isValueSet( $row['location_city'] ) || $view->isValueSet( $row['location_country'] ) ):?>
                             <span class="owa_userGeoLabel"><?php echo $row['location_city'];?>, <?php echo $row['location_country'];?></span>
                             <?php endif;?>
                             <BR>
-                            <span class="owa_moreLinks"><a href="<?php echo $this->makeLink(array('do' => 'base.reportVisitor', 'visitor_id' => $row['visitor_id'], 'site_id' => $this->get('site_id')),true);?>">Visitor Detail &raquo</a></span>
-                            &nbsp<span class="owa_moreLinks"><a href="<?php echo $this->makeLink(array('session_id' => $row['session_id'], 'do' => 'base.reportVisit'), true);?>">Visit Detail &raquo</a></span>
+                            <span class="owa_moreLinks"><a href="<?php echo $view->makeLink(array('do' => 'base.reportVisitor', 'visitor_id' => $row['visitor_id'], 'site_id' => $view->get('site_id')),true);?>">Visitor Detail &raquo</a></span>
+                            &nbsp<span class="owa_moreLinks"><a href="<?php echo $view->makeLink(array('session_id' => $row['session_id'], 'do' => 'base.reportVisit'), true);?>">Visit Detail &raquo</a></span>
                         </TD>
                     </table>
                 </td>
                 <TD class="owa_visitInfoboxItem">
 
-                    <?php $this->renderKpiInfobox(
-	                        '<i title="'. $row['browser_user_agent'] .'" class=" '. $this->choose_browser_icon($row['browser_type']) . '"></i>',
+                    <?php $view->renderKpiInfobox(
+	                        '<i title="'. $row['browser_user_agent'] .'" class=" '. $view->choose_browser_icon($row['browser_type']) . '"></i>',
                         'Browser Type',
-                        $this->makeLink(array('session_id' => $row['session_id'], 'do' => 'base.reportVisit'), true),
+                        $view->makeLink(array('session_id' => $row['session_id'], 'do' => 'base.reportVisit'), true),
                         'visitSummaryKpi'
                     );?>
 
                 </TD>
                 <TD class="owa_visitInfoboxItem">
 
-                    <?php $this->renderKpiInfobox(
+                    <?php $view->renderKpiInfobox(
                         $row['session_num_pageviews'],
                         'Pages Viewed',
-                        $this->makeLink(array('session_id' => $row['session_id'], 'do' => 'base.reportVisit'), true),
+                        $view->makeLink(array('session_id' => $row['session_id'], 'do' => 'base.reportVisit'), true),
                         'visitSummaryKpi'
                     );?>
 
                 </TD>
                 <TD class="owa_visitInfoboxItem">
-                    <?php $this->renderKpiInfobox(
+                    <?php $view->renderKpiInfobox(
                         date("G:i:s",mktime(0,0,($row['session_last_req'] - $row['session_timestamp']))),
                         'Visit Length',
                         '',
@@ -81,7 +82,7 @@
 
                 </TD>
                 <TD class="owa_visitInfoboxItem">
-                    <?php $this->renderKpiInfobox(
+                    <?php $view->renderKpiInfobox(
                         $row['session_num_prior_visits'],
                         'Prior Visits',
                         '',

--- a/modules/Base/templates/sites.php
+++ b/modules/Base/templates/sites.php
@@ -1,12 +1,13 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 
 <P>Below is the list of web sites that are being tracked.</P>
 
-<?php if ($this->getCurrentUser()->isCapable('edit_sites')): ?>
-    <p class="inline_h2"><a href="<?php echo $this->makeLink(array('do' => 'base.sitesProfile'));?>">Add New</a></p>
+<?php if ($view->getCurrentUser()->isCapable('edit_sites')): ?>
+    <p class="inline_h2"><a href="<?php echo $view->makeLink(array('do' => 'base.sitesProfile'));?>">Add New</a></p>
 <?php endif; ?>
 
-<?php if ($tracked_sites): ?>
-    <?php foreach ($tracked_sites as $site):?>
+<?php if ($view->tracked_sites): ?>
+    <?php foreach ($view->tracked_sites as $site):?>
     <div class="owa_reportSectionContent" style="min-width:500px;">
     <TABLE width="" border="0" class="management">
         <thead></thead>
@@ -14,28 +15,28 @@
             <TR>
 
                 <td style="width:150px;" valign="">
-                    <?php $this->getSiteThumbnail( $site->get( 'domain' ), 150 );?>
+                    <?php $view->getSiteThumbnail( $site->get( 'domain' ), 150 );?>
                 </td>
 
                 <td valign="" style="min-width:300px;">
                     <span style="font-size:14px; font-weight:bold;">
-                        <a href="<?php echo $this->makeLink( array('do' => 'base.reportDashboard', 'siteId' => $site->get('site_id') ), false );?>"><?php $this->out( $site->get('name') );?></a>
+                        <a href="<?php echo $view->makeLink( array('do' => 'base.reportDashboard', 'siteId' => $site->get('site_id') ), false );?>"><?php $view->out( $site->get('name') );?></a>
                     </span><BR>
                     <?php if ($site->get('description') != ''):?>
-                    <span class="info_text"><?php $this->out( $site->get('description') );?></span><BR>
+                    <span class="info_text"><?php $view->out( $site->get('description') );?></span><BR>
                     <?php endif;?>
-                    <span class="externalUrl"><?php $this->out( $site->get('domain') );?></span><BR><BR>
+                    <span class="externalUrl"><?php $view->out( $site->get('domain') );?></span><BR><BR>
                     <div>
-                    <a href="<?php echo $this->makeLink( array('do' => 'base.reportDashboard', 'siteId' => $site->get('site_id') ), true );?>">View Reports</a>
-                    <?php if ($this->getCurrentUser()->isCapable('edit_sites')): ?>
-                        | <a href="<?php echo $this->makeLink( array('do' => 'base.sitesProfile', 'siteId' => $site->get('site_id'), 'edit' => true ) );?>">Edit Profile</a>
-                        | <a href="<?php echo $this->makeLink( array('do' => 'base.sitesInvocation', 'siteId' => $site->get('site_id') ) );?>">Get Tracking Code</a>
+                    <a href="<?php echo $view->makeLink( array('do' => 'base.reportDashboard', 'siteId' => $site->get('site_id') ), true );?>">View Reports</a>
+                    <?php if ($view->getCurrentUser()->isCapable('edit_sites')): ?>
+                        | <a href="<?php echo $view->makeLink( array('do' => 'base.sitesProfile', 'siteId' => $site->get('site_id'), 'edit' => true ) );?>">Edit Profile</a>
+                        | <a href="<?php echo $view->makeLink( array('do' => 'base.sitesInvocation', 'siteId' => $site->get('site_id') ) );?>">Get Tracking Code</a>
                     <?php endif; ?>
-                    <?php if ($this->getCurrentUser()->isCapable('edit_settings')): ?>
-                        <a href="<?php echo $this->makeLink( array('do' => 'base.optionsGoals', 'siteId' => $site->get('site_id') ) );?>">Goals</a>
+                    <?php if ($view->getCurrentUser()->isCapable('edit_settings')): ?>
+                        <a href="<?php echo $view->makeLink( array('do' => 'base.optionsGoals', 'siteId' => $site->get('site_id') ) );?>">Goals</a>
                     <?php endif; ?>
-                    <?php if ($this->getCurrentUser()->isCapable('edit_sites')): ?>
-                        | <a href="<?php echo $this->makeLink( array('do' => 'base.sitesDelete', 'siteId' => $site->get('site_id') ), false, false, false, true );?>">Delete</a>
+                    <?php if ($view->getCurrentUser()->isCapable('edit_sites')): ?>
+                        | <a href="<?php echo $view->makeLink( array('do' => 'base.sitesDelete', 'siteId' => $site->get('site_id') ), false, false, false, true );?>">Delete</a>
                     <?php endif; ?>
                     </div>
                 </td>
@@ -43,7 +44,7 @@
                     <!-- stats -->
                     <div id="trend-metrics-<?php echo $site->get('site_id'); ?>"></div>
                     <script>
-                        var aurl = '<?php echo $this->makeApiLink(array(
+                        var aurl = '<?php echo $view->makeApiLink(array(
                                             'do'            => 'reports', 'module' => 'base', 'version' => 'v1',
                                             'metrics'        => 'visits,pageViews,bounceRate',
                                             'dimensions'     => 'date',
@@ -58,7 +59,7 @@
                         rsh.options.metricBoxes.width = '150px';
                         rsh.asyncQueue.push(['makeMetricBoxes' , 'trend-metrics-<?php echo $site->get('site_id'); ?>']);
                         rsh.load(aurl);
-                        OWA.items['<?php echo $dom_id;?>'].registerResultSetExplorer('rsh-<?php echo $site->get('site_id'); ?>', rsh);
+                        OWA.items['<?php echo $view->dom_id;?>'].registerResultSetExplorer('rsh-<?php echo $site->get('site_id'); ?>', rsh);
                     </script>
 
 
@@ -72,8 +73,8 @@
 <?php else: ?>
 
 There are no tracked sites.
-<?php if ($this->getCurrentUser()->isCapable('edit_sites')): ?>
-    <a href="<?php echo $this->makeLink(array('do' => 'base.sitesProfile'));?>">Add a site</a>.
+<?php if ($view->getCurrentUser()->isCapable('edit_sites')): ?>
+    <a href="<?php echo $view->makeLink(array('do' => 'base.sitesProfile'));?>">Add a site</a>.
 <?php endif; ?>
 </TD>
 

--- a/modules/Base/templates/sites_addoredit.php
+++ b/modules/Base/templates/sites_addoredit.php
@@ -1,4 +1,5 @@
-<DIV class="panel_headline"><?php $this->out( $headline );?></DIV>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<DIV class="panel_headline"><?php $view->out( $view->headline );?></DIV>
 <div id="panel">
 <fieldset>
 
@@ -7,37 +8,37 @@
     <form method="POST">
 
     <table class="management">
-        <?php if ($edit == true):?>
+        <?php if ($view->edit == true):?>
         <TR>
             <TH>Site ID:</TH>
-            <TD><?php $this->out( $site['site_id'] );?></TD>
-            <input type="hidden" name="<?php echo $this->getNs();?>siteId" value="<?php $this->out( $site['site_id'] );?>">
+            <TD><?php $view->out( $site['site_id'] );?></TD>
+            <input type="hidden" name="<?php echo $view->getNs();?>siteId" value="<?php $view->out( $site['site_id'] );?>">
 
         </TR>
         <?php endif;?>
         <TR>
             <TH>Domain:</TH>
-            <?php if ($edit == true):?>
-            <input type="hidden" name="<?php echo $this->getNs();?>domain" value="<?php $this->out( $site['domain'] );?>">
-            <TD><?php $this->out( $site['domain'] );?></TD>
+            <?php if ($view->edit == true):?>
+            <input type="hidden" name="<?php echo $view->getNs();?>domain" value="<?php $view->out( $site['domain'] );?>">
+            <TD><?php $view->out( $site['domain'] );?></TD>
             <?php else:?>
             <TD>  
-                <input type="text" name="<?php echo $this->getNs();?>domain" size="52" maxlength="70" value="<?php $this->out( @$site['domain'] );?>"><BR>
+                <input type="text" name="<?php echo $view->getNs();?>domain" size="52" maxlength="70" value="<?php $view->out( @$site['domain'] );?>"><BR>
                 Example: http://some.domain.com<BR>
-                <span class="validation_error"><?php $this->out( @$validation_errors['domain'] );?></span>
+                <span class="validation_error"><?php $view->out( @$validation_errors['domain'] );?></span>
             </TD>
             <?php endif;?>
         </TR>
         <TR>
             <TH>Site Name:</TH>
-            <TD><input type="text" name="<?php echo $this->getNs();?>name" size="52" maxlength="70" value="<?php $this->out( @$site['name'] );?>">
+            <TD><input type="text" name="<?php echo $view->getNs();?>name" size="52" maxlength="70" value="<?php $view->out( @$site['name'] );?>">
 				<span class="form-instructions">Example: My Website</span>            
             </TD>
         </TR>
         <TR>
             <TH>Description:</TH>
             <TD>
-                <textarea name="<?php echo $this->getNs();?>description" cols="52" rows="3"><?php $this->out( @$site['description'] );?></textarea>
+                <textarea name="<?php echo $view->getNs();?>description" cols="52" rows="3"><?php $view->out( @$site['description'] );?></textarea>
             </TD>
         </TR>
 
@@ -45,9 +46,9 @@
 
     </table>
     <BR>
-    <?php echo $this->createNonceFormField($action);?>
-    <input type="hidden" name="<?php echo $this->getNs();?>action" value="<?php $this->out( $action, false );?>">
-    <input class="owa-button" type="submit" name="<?php echo $this->getNs();?>submit_btn" value="Save Profile">
+    <?php echo $view->createNonceFormField($view->action);?>
+    <input type="hidden" name="<?php echo $view->getNs();?>action" value="<?php $view->out( $view->action, false );?>">
+    <input class="owa-button" type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Save Profile">
 
     </form>
 
@@ -62,63 +63,63 @@
         <div class="setting" id="p3p_policy">
             <div class="title">P3P Compact Privacy Policy</div>
             <div class="description">This setting controls the P3P compact privacy policy that is returned to the browser when OWA sets cookies. Click <a href="https://www.w3.org/P3P/">here</a> for more information on compact privacy policies and choosing the right one for your web site.</div>
-            <div class="field"><input type="text" size="50" name="<?php echo $this->getNs();?>config[p3p_policy]" value="<?php $this->out( @$config['p3p_policy'] );?>"></div>
+            <div class="field"><input type="text" size="50" name="<?php echo $view->getNs();?>config[p3p_policy]" value="<?php $view->out( @$config['p3p_policy'] );?>"></div>
         </div>
 
         <div class="setting" id="domain_aliases">
             <div class="title">Domain Aliases</div>
             <div class="description">This setting allows you to specify additional domain names that you want OWA to treat as the same as the one you are using for this tracked website. For example, if the domain of your website is "www.mydomain.com" you could add an alias here for "mydomain.com". Aliases should be separated by comma.</div>
-            <div class="field"><input type="text" size="50" name="<?php echo $this->getNs();?>config[domain_aliases]" value="<?php $this->out( @$config['domain_aliases'] );?>"></div>
+            <div class="field"><input type="text" size="50" name="<?php echo $view->getNs();?>config[domain_aliases]" value="<?php $view->out( @$config['domain_aliases'] );?>"></div>
         </div>
 
 
         <div class="setting" id="url_params">
             <div class="title">URL Parameters</div>
             <div class="description">This setting controls the URL parameters that OWA should ignore when processing requests. This is useful for avoiding duplicate URLs due to the use of tracking or others state parameters in your URLs. Parameter names should be separated by comma.</div>
-            <div class="field"><input type="text" size="50" name="<?php echo $this->getNs();?>config[query_string_filters]" value="<?php $this->out( @$config['query_string_filters'] );?>"></div>
+            <div class="field"><input type="text" size="50" name="<?php echo $view->getNs();?>config[query_string_filters]" value="<?php $view->out( @$config['query_string_filters'] );?>"></div>
         </div>
 
         <div class="setting" id="default_page">
             <div class="title">Default Page</div>
             <div class="description">This is the page that your web server defaults to when there is no page specified in your URL (e.g. index.html). Use this setting to combine page views for www.domain.com and www.domain.com/index.html.</div>
-            <div class="field"><input type="text" size="50" name="<?php echo $this->getNs();?>config[default_page]" value="<?php $this->out( @$config['default_page'] );?>"></div>
+            <div class="field"><input type="text" size="50" name="<?php echo $view->getNs();?>config[default_page]" value="<?php $view->out( @$config['default_page'] );?>"></div>
         </div>
 
         <div class="setting" id="ecommerce_reporting">
             <div class="title">e-commerce Reporting</div>
             <div class="description">Adds e-commerce metrics/statistics to reports.</div>
             <div class="field">
-                <select name="<?php echo $this->getNs();?>config[enableEcommerceReporting]">
-                    <option value="0" <?php if ( ! $this->getValue( 'enableEcommerceReporting', $config ) ):?>SELECTED<?php endif;?>>Off</option>
-                    <option value="1" <?php if ( $this->getValue( 'enableEcommerceReporting', $config ) ):?>SELECTED<?php endif;?>>On</option>
+                <select name="<?php echo $view->getNs();?>config[enableEcommerceReporting]">
+                    <option value="0" <?php if ( ! $view->getValue( 'enableEcommerceReporting', $config ) ):?>SELECTED<?php endif;?>>Off</option>
+                    <option value="1" <?php if ( $view->getValue( 'enableEcommerceReporting', $config ) ):?>SELECTED<?php endif;?>>On</option>
                 </select>
             </div>
         </div>
 
         <BR>
 
-        <?php echo $this->createNonceFormField('base.sitesEditSettings');?>
-        <input type="hidden" name="<?php echo $this->getNs();?>siteId" value="<?php $this->out( @$site['site_id'] );?>">
-        <input type="hidden" name="<?php echo $this->getNs();?>module" value="base">
-        <input type="hidden" name="<?php echo $this->getNs();?>action" value="base.sitesEditSettings">
-        <input type="submit" name="<?php echo $this->getNs();?>submit_btn" value="Save Settings" class="owa-button">
+        <?php echo $view->createNonceFormField('base.sitesEditSettings');?>
+        <input type="hidden" name="<?php echo $view->getNs();?>siteId" value="<?php $view->out( @$site['site_id'] );?>">
+        <input type="hidden" name="<?php echo $view->getNs();?>module" value="base">
+        <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.sitesEditSettings">
+        <input type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Save Settings" class="owa-button">
     </fieldset>
 </form>
 <form method="post" name="owa-allowedusersform">
     <fieldset name="owa-allowedusers" class="options">
     <legend>Allowed Users</legend>
 
-            <select multiple="multiple" size="10" name="<?php echo $this->getNs();?>allowed_users[]" >
-                <?php foreach ($users as $user):?>
-                <option <?php if( $edit && $siteEntity->isUserAssigned($user['id']) ): echo 'SELECTED="SELECTED" style="background-color:#90ee90"'; endif;?> value="<?php $this->out( $user['id'] );?>"><?php $this->out( $user['user_id']. ' / '.$user['real_name']. ' ('.$user['role'].')' );?></option>
+            <select multiple="multiple" size="10" name="<?php echo $view->getNs();?>allowed_users[]" >
+                <?php foreach ($view->users as $user):?>
+                <option <?php if( $view->edit && $view->siteEntity->isUserAssigned($user['id']) ): echo 'SELECTED="SELECTED" style="background-color:#90ee90"'; endif;?> value="<?php $view->out( $user['id'] );?>"><?php $view->out( $user['user_id']. ' / '.$user['real_name']. ' ('.$user['role'].')' );?></option>
                 <?php endforeach;?>
             </select>
             <br>
-            <?php echo $this->createNonceFormField('base.sitesEditAllowedUsers');?>
-            <input type="hidden" name="<?php echo $this->getNs();?>siteId" value="<?php $this->out( @$site['site_id'] );?>">
-            <input type="hidden" name="<?php echo $this->getNs();?>module" value="base">
-            <input type="hidden" name="<?php echo $this->getNs();?>action" value="base.sitesEditAllowedUsers">
-            <input type="submit" name="<?php echo $this->getNs();?>submit_btn" value="Save Users" class="owa-button">
+            <?php echo $view->createNonceFormField('base.sitesEditAllowedUsers');?>
+            <input type="hidden" name="<?php echo $view->getNs();?>siteId" value="<?php $view->out( @$site['site_id'] );?>">
+            <input type="hidden" name="<?php echo $view->getNs();?>module" value="base">
+            <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.sitesEditAllowedUsers">
+            <input type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Save Users" class="owa-button">
     </fieldset>
 
 </form>

--- a/modules/Base/templates/sites_invocation.php
+++ b/modules/Base/templates/sites_invocation.php
@@ -1,8 +1,9 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="panel_headline">Tracking Tag</div>
 <div id="panel">
 
-<P>The Domain for this web site is: <span class=""><B><?php $this->out( $site->get('domain') );?></B></P>
-<P>The Site ID for this web site is: <span class=""><B><?php $this->out( $site_id ); ?></B></P>
+<P>The Domain for this web site is: <span class=""><B><?php $view->out( $view->site->get('domain') );?></B></P>
+<P>The Site ID for this web site is: <span class=""><B><?php $view->out( $view->site_id ); ?></B></P>
 
 <?php include('invocation.php');?>
 </div>

--- a/modules/Base/templates/sparklineJs.php
+++ b/modules/Base/templates/sparklineJs.php
@@ -1,4 +1,5 @@
-<span id="<?php echo $dom_id;?>Sparkline"><?php echo $values;?></span>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<span id="<?php echo $view->dom_id;?>Sparkline"><?php echo $view->values;?></span>
 <script>
-    jQuery('#<?php echo $dom_id;?>Sparkline').sparkline('html', {width:'<?php echo $width;?>px', height:'<?php echo $height;?>px', spotRadius: 2, fillColor: '', lineColor: '#ffffff'});
+    jQuery('#<?php echo $view->dom_id;?>Sparkline').sparkline('html', {width:'<?php echo $view->width;?>px', height:'<?php echo $view->height;?>px', spotRadius: 2, fillColor: '', lineColor: '#ffffff'});
 </script>

--- a/modules/Base/templates/sparkline_dom.php
+++ b/modules/Base/templates/sparkline_dom.php
@@ -1,11 +1,12 @@
-<!-- Sparkline data for '<?php echo $dom_id;?>' -->
-<span id="<?php echo $dom_id;?>"><?php echo $data;?></span>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<!-- Sparkline data for '<?php echo $view->dom_id;?>' -->
+<span id="<?php echo $view->dom_id;?>"><?php echo $view->data;?></span>
 
 <script>
-/* Sparkline DOM configuration for '<?php echo $dom_id;?>' */
-OWA.items['<?php echo $dom_id;?>'] = new OWA.sparkline();
-OWA.items['<?php echo $dom_id;?>'].setDomId('<?php echo $dom_id;?>');
-OWA.items['<?php echo $dom_id;?>'].setWidth('<?php echo $width;?>');
-OWA.items['<?php echo $dom_id;?>'].setHeight('<?php echo $height;?>');
-OWA.items['<?php echo $dom_id;?>'].render();
+/* Sparkline DOM configuration for '<?php echo $view->dom_id;?>' */
+OWA.items['<?php echo $view->dom_id;?>'] = new OWA.sparkline();
+OWA.items['<?php echo $view->dom_id;?>'].setDomId('<?php echo $view->dom_id;?>');
+OWA.items['<?php echo $view->dom_id;?>'].setWidth('<?php echo $view->width;?>');
+OWA.items['<?php echo $view->dom_id;?>'].setHeight('<?php echo $view->height;?>');
+OWA.items['<?php echo $view->dom_id;?>'].render();
 </script>

--- a/modules/Base/templates/trafficSourceSum.php
+++ b/modules/Base/templates/trafficSourceSum.php
@@ -1,21 +1,22 @@
-<div class="propertyList" style="background-image: url('<?php $this->out( $this->makeImageLink('base/i/referer_icon.gif') );?>');background-repeat: no-repeat; padding:5px 5px 5px 35px; background-position:0px 5px;">
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="propertyList" style="background-image: url('<?php $view->out( $view->makeImageLink('base/i/referer_icon.gif') );?>');background-repeat: no-repeat; padding:5px 5px 5px 35px; background-position:0px 5px;">
     <dl>
     
         <dt>Medium:</dt>
-        <dd><?php $this->out( $row['medium'] );?></dd>
+        <dd><?php $view->out( $row['medium'] );?></dd>
         
         <?php if ( isset( $row['source'] ) && $row['source'] != '(none)' ): ?>
         <dt>Source:</dt>
         <dd>
-            <a href="<?php $this->out( $this->makeLink(
+            <a href="<?php $view->out( $view->makeLink(
             array(
                 'do' => 'base.reportSourceDetail',
                 'source' => urlencode($row['source']),
-                'site_id' => $this->get('site_id')
+                'site_id' => $view->get('site_id')
                 ),
             true
         ) );?>">
-        <?php $this->out( $row['source']);?>
+        <?php $view->out( $row['source']);?>
             </a>
         </dd>
         <?php endif;?>
@@ -25,15 +26,15 @@
         
         <dt>Search Term:</dt>
         <dd>
-            <a href="<?php $this->out( $this->makeLink(
+            <a href="<?php $view->out( $view->makeLink(
             array(
                 'do' => 'base.reportKeywordDetail',
                 'referralSearchTerms' => urlencode($row['search_term']),
-                'site_id' => $this->get('site_id')
+                'site_id' => $view->get('site_id')
                 ),
             true
         ) );?>">
-                <?php $this->out( $row['search_term'] );?>
+                <?php $view->out( $row['search_term'] );?>
             </a>
         </dd>
         <?php endif;?>
@@ -43,13 +44,13 @@
     <?php if ( $row['medium'] === 'referral' ):?>
     <div style="line-height:120%; width:inherit; padding-left:20px; padding-top:15px;">
         <span class="inline_h4">
-            <a href="<?php $this->safeHref( $row['referer_url'] );?>">
-                <?php if (!empty($row['referer_page_title'])):?><?php $this->out( $this->truncate($row['referer_page_title'], 80, '…') );?></span></a><BR><span class="externalUrl"><?php $this->out( $this->truncate($row['referer_url'], 80, '…') );?><?php else:?><?php $this->out( $this->truncate($row['referer_url'], 80, '…') );?><?php endif;?>
+            <a href="<?php $view->safeHref( $row['referer_url'] );?>">
+                <?php if (!empty($row['referer_page_title'])):?><?php $view->out( $view->truncate($row['referer_page_title'], 80, '…') );?></span></a><BR><span class="externalUrl"><?php $view->out( $view->truncate($row['referer_url'], 80, '…') );?><?php else:?><?php $view->out( $view->truncate($row['referer_url'], 80, '…') );?><?php endif;?>
             </a>
         </span>
         
         <?php if ( ! empty( $row['referer_snippet'] ) ):?>
-        <br><span class="snippet_text"><?php $this->out( $row['referer_snippet'] );?></span>
+        <br><span class="snippet_text"><?php $view->out( $row['referer_snippet'] );?></span>
         <?php endif;?>
     </div>
     <?php endif;?>

--- a/modules/Base/templates/updates.php
+++ b/modules/Base/templates/updates.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div id="updates" style="width:800px; margin: 0px auto 20px auto;">
     <div class="" style="text-align:center;">
         <h1>Open Web Analytics Updater</h1>
@@ -12,7 +13,7 @@
         <P>
         <UL>
 
-        <?php foreach ($modules as $k => $module): ?>
+        <?php foreach ($view->modules as $k => $module): ?>
 
             <LI><?php echo $module; ?></LI>
 
@@ -24,7 +25,7 @@
         <BR>
 
         <P>
-        <a href="<?php echo $this->makeLink(array('do' => 'base.updatesApply'));?>"><span class="owa-button">Apply updates</span></a>
+        <a href="<?php echo $view->makeLink(array('do' => 'base.updatesApply'));?>"><span class="owa-button">Apply updates</span></a>
         </P>
 
     </div>

--- a/modules/Base/templates/users.php
+++ b/modules/Base/templates/users.php
@@ -1,12 +1,13 @@
-<div class="panel_headline"><?php echo $headline;?></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="panel_headline"><?php echo $view->headline;?></div>
 <div id="panel">
 <fieldset>
 
     <legend>
-        Users <span class="legend_link">(<a href="<?php echo $this->makeLink(array('do' => 'base.usersProfile'));?>">Add New User</a>)</span>
+        Users <span class="legend_link">(<a href="<?php echo $view->makeLink(array('do' => 'base.usersProfile'));?>">Add New User</a>)</span>
     </legend>
 
-    <?php if($users):?>
+    <?php if($view->users):?>
 
     <table class="management">
         <thead>
@@ -18,14 +19,14 @@
             </TR>
         </thead>
         <tbody>
-            <?php foreach ($users as $user => $value):?>
+            <?php foreach ($view->users as $user => $value):?>
             <TR>
-                <TD><?php $this->out( $value['user_id'] );?></TD>
-                <TD><?php $this->out( $value['real_name'] );?></TD>
-                <TD><?php $this->out( $value['role'] );?></TD>
-                <TD><a href="<?php echo $this->makeLink(array('do' => 'base.usersProfile', 'edit' => true, 'user_id' => $value['user_id']));?>">Edit</a>
+                <TD><?php $view->out( $value['user_id'] );?></TD>
+                <TD><?php $view->out( $value['real_name'] );?></TD>
+                <TD><?php $view->out( $value['role'] );?></TD>
+                <TD><a href="<?php echo $view->makeLink(array('do' => 'base.usersProfile', 'edit' => true, 'user_id' => $value['user_id']));?>">Edit</a>
                 <?php if ($value['id'] != 1):?>
-                | <a href="<?php echo $this->makeLink( array( 'do' => 'base.usersDelete', 'user_id' => $value['user_id'] ), false, false, false, true );?>">Delete</a></TD>
+                | <a href="<?php echo $view->makeLink( array( 'do' => 'base.usersDelete', 'user_id' => $value['user_id'] ), false, false, false, true );?>">Delete</a></TD>
                 <?php endif;?>
             </TR>
             <?php endforeach;?>

--- a/modules/Base/templates/users_addoredit.php
+++ b/modules/Base/templates/users_addoredit.php
@@ -1,4 +1,5 @@
-<div class="panel_headline"><?php $this->out( $headline );?></div>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<div class="panel_headline"><?php $view->out( $view->headline );?></div>
 <div id="panel">
 <fieldset class="options">
 
@@ -10,31 +11,31 @@
         <TR>
             <TH>User Name</TH>
             <TD>
-            <?php if ( $edit === true ):?>
-            <input type="hidden" size="30" name="<?php echo $this->getNs();?>user_id" value="<?php $this->out( $user['user_id'] );?>"><span class="noedit"><?php $this->out( $user['user_id'] )?></span>
+            <?php if ( $view->edit === true ):?>
+            <input type="hidden" size="30" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( $user['user_id'] );?>"><span class="noedit"><?php $view->out( $user['user_id'] )?></span>
             <?php else:?>
-            <input type="text" size="30" name="<?php echo $this->getNs();?>user_id" value="<?php $this->out( @$user['user_id'] );?>">
+            <input type="text" size="30" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( @$user['user_id'] );?>">
             <?php endif;?>
             </TD>
         </TR>
 
-        <?php if ($edit === true):?>
+        <?php if ($view->edit === true):?>
         <TR>
             <TH>API Key</TH>
             <TD><span class="noedit"><?php echo $user['api_key'];?></span></TD>
         </TR>
         <?php endif;?>
 
-        <?php if ( ! $isAdmin ):?>
+        <?php if ( ! $view->isAdmin ):?>
         <TR>
             <TH>Real Name</TH>
-            <TD><input type="text" size="30" name="<?php echo $this->getNs();?>real_name" value="<?php $this->out( $this->getValue( 'real_name', $user ) );?>"></TD>
+            <TD><input type="text" size="30" name="<?php echo $view->getNs();?>real_name" value="<?php $view->out( $view->getValue( 'real_name', $user ) );?>"></TD>
         </TR>
         <TR>
             <TH>Role</TH>
             <TD>
-            <select name="<?php echo $this->getNs();?>role">
-                <?php foreach ($roles as $role):?>
+            <select name="<?php echo $view->getNs();?>role">
+                <?php foreach ($view->roles as $role):?>
                 <option <?php if( isset( $user['role'] ) && $user['role'] === $role): echo "SELECTED"; endif;?> value="<?php echo $role;?>"><?php echo $role;?></option>
                 <?php endforeach;?>
             </select>
@@ -45,15 +46,15 @@
         <?php endif;?>
         <TR>
             <TH>E-mail Address</TH>
-            <TD><input type="text"size="30" name="<?php echo $this->getNs();?>email_address" value="<?php $this->out( @$user['email_address'] );?>"></TD>
+            <TD><input type="text"size="30" name="<?php echo $view->getNs();?>email_address" value="<?php $view->out( @$user['email_address'] );?>"></TD>
         </TR>
 
         <TR>
             <TD>
-                <input type="hidden" name="<?php echo $this->getNs();?>id" value="<?php $this->out( @$user['id'] );?>">
-                <?php echo $this->createNonceFormField($action);?>
-                <input type="hidden" name="<?php echo $this->getNs();?>action" value="<?php echo $action;?>">
-                <input class="owa-button" type="submit" value="Save" name="<?php echo $this->getNs();?>save_button">
+                <input type="hidden" name="<?php echo $view->getNs();?>id" value="<?php $view->out( @$user['id'] );?>">
+                <?php echo $view->createNonceFormField($view->action);?>
+                <input type="hidden" name="<?php echo $view->getNs();?>action" value="<?php echo $view->action;?>">
+                <input class="owa-button" type="submit" value="Save" name="<?php echo $view->getNs();?>save_button">
             </TD>
         </TR>
         </form>
@@ -61,13 +62,13 @@
     </TABLE>
 
 </fieldset>
-<?php if ($edit === true):?>
+<?php if ($view->edit === true):?>
 <P>
 <fieldset class="options">
 
     <legend>Change Password</legend>
     <div style="padding:10px">
-    <a href="<?php echo $this->makeLink(array('do' => 'base.passwordResetForm'))?>">Change password for this user</a>
+    <a href="<?php echo $view->makeLink(array('do' => 'base.passwordResetForm'))?>">Change password for this user</a>
     </div>
 </fieldset>
 <?php endif;?>

--- a/modules/Base/templates/users_change_password.php
+++ b/modules/Base/templates/users_change_password.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div style="width:550px;margin: 0px auto -1px auto;">
     <div class="inline_h1" style="text-align:left;">Password Setup</div><BR>
     <div class="inline_h2" style="text-align:left;">Enter your new password below.</div><BR>
@@ -14,15 +15,15 @@
         <div id="" style="color:#ffffff; padding:30px; height:200px; text-align:left;" >
             <form method="POST">
                 <div class="inline_h2">New Password</div>
-                <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $this->getNs();?>password"><BR><BR>
+                <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $view->getNs();?>password"><BR><BR>
                 <div class="inline_h2">Re-type your Password</div>
-                <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $this->getNs();?>password2"><BR><BR>
-                <?php if ( $is_embedded ) {?>
-		        <input type="hidden" name="<?php echo $this->getNs();?>is_embedded" value="<?php echo $is_embedded;?>">                
+                <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $view->getNs();?>password2"><BR><BR>
+                <?php if ( $view->is_embedded ) {?>
+		        <input type="hidden" name="<?php echo $view->getNs();?>is_embedded" value="<?php echo $view->is_embedded;?>">                
                 <?php } ?>
-                <input type="hidden" name="<?php echo $this->getNs();?>k" value="<?php echo $key;?>">
-                <input name="<?php echo $this->getNs();?>action" value="base.usersChangePassword" type="hidden">
-                <INPUT class="owa_largeFormField" type="submit" size="" name="<?php echo $this->getNs();?>submit_btn" value="Save Your New Password">
+                <input type="hidden" name="<?php echo $view->getNs();?>k" value="<?php echo $view->key;?>">
+                <input name="<?php echo $view->getNs();?>action" value="base.usersChangePassword" type="hidden">
+                <INPUT class="owa_largeFormField" type="submit" size="" name="<?php echo $view->getNs();?>submit_btn" value="Save Your New Password">
             </form>
         </div>
     </div>

--- a/modules/Base/templates/users_new_account_email.php
+++ b/modules/Base/templates/users_new_account_email.php
@@ -1,11 +1,12 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <p>An Open Web Analytics account has been created for you.</p>
 
-<p>Your User Name is: <?php $this->out( $user_id );?></p> 
+<p>Your User Name is: <?php $view->out( $view->user_id );?></p> 
 
 <p>To login you need to set your password by clicking on the link below.</p>
 
-<p><?php echo $this->makeAbsoluteLink(array('do' => 'base.usersPasswordEntry', 'k' => $key));?> </p>
+<p><?php echo $view->makeAbsoluteLink(array('do' => 'base.usersPasswordEntry', 'k' => $view->key));?> </p>
 
 <p>Once your password has been setup you can login to OWA at the following URL:</p>
 
-<p><?php echo $this->makeAbsoluteLink(array('do' => 'base.reportDashboard'));?></p> 
+<p><?php echo $view->makeAbsoluteLink(array('do' => 'base.reportDashboard'));?></p> 

--- a/modules/Base/templates/users_password_reset_request.php
+++ b/modules/Base/templates/users_password_reset_request.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div style="width:550px;margin: 0px auto -1px auto;">
     <div class="inline_h1" style="text-align:left;">Password Reset</div><BR>
     <div class="inline_h2" style="text-align:left;">Enter the e-mail address associated with your account.</div><BR>
@@ -14,15 +15,15 @@
         <div id="" style="color:#ffffff; padding:30px; height:100px; text-align:left;" >
             <form method="POST">
                 <div class="inline_h3">E-mail address:</div>
-                <INPUT class="owa_largeFormField" type="text" size="30" name="<?php echo $this->getNs();?>email_address" value=""></TD>
+                <INPUT class="owa_largeFormField" type="text" size="30" name="<?php echo $view->getNs();?>email_address" value=""></TD>
                 </TR>
 
                 <TR>
                     <TH scope="row"></TH>
                     <TD>
 
-                        <input name="<?php echo $this->getNs();?>action" value="base.passwordResetRequest" type="hidden"><BR><BR>
-                        <INPUT class="owa_largeFormField" type="submit" size="30" name="<?php echo $this->getNs();?>submit" value="Request New Password">
+                        <input name="<?php echo $view->getNs();?>action" value="base.passwordResetRequest" type="hidden"><BR><BR>
+                        <INPUT class="owa_largeFormField" type="submit" size="30" name="<?php echo $view->getNs();?>submit" value="Request New Password">
                     </TD>
                 </TR>
 
@@ -44,7 +45,7 @@
 
     <BR>
     <span class="info_text">
-    <!--<a href="<?php echo $this->makeLink(array('do' => 'base.passwordResetForm'))?>">Forgot your password?</a> -->
+    <!--<a href="<?php echo $view->makeLink(array('do' => 'base.passwordResetForm'))?>">Forgot your password?</a> -->
     </span>
 </div>
 

--- a/modules/Base/templates/users_reset_password_email.php
+++ b/modules/Base/templates/users_reset_password_email.php
@@ -1,6 +1,7 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <P>Someone, hopefully you, has requested a reset of your Open Web Analytics account password.</P>
 
 <p>If this message was generated in error, please disregard. If not, please click on the link below
 to complete the process.</p>
 
-<?php echo $this->makeAbsoluteLink(array('do' => 'base.usersPasswordEntry', 'k' => $key));
+<?php echo $view->makeAbsoluteLink(array('do' => 'base.usersPasswordEntry', 'k' => $view->key));

--- a/modules/Base/templates/users_set_password_email.php
+++ b/modules/Base/templates/users_set_password_email.php
@@ -1,1 +1,2 @@
-Your Open Web Analytics password was successfully changed on <?php echo date("F j, Y, \a\\t g:i a");?> from IP address <?php echo $ip;?>.
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+Your Open Web Analytics password was successfully changed on <?php echo date("F j, Y, \a\\t g:i a");?> from IP address <?php echo $view->ip;?>.

--- a/modules/Base/templates/widget_latestActions.php
+++ b/modules/Base/templates/widget_latestActions.php
@@ -1,8 +1,9 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div class="widget-latestActions">
 
 <?php if ( $items ): ?>
 
-<table border="0" style="width: <?php $this->out( $this->get( 'width' ) ); ?>;">
+<table border="0" style="width: <?php $view->out( $view->get( 'width' ) ); ?>;">
 
     <?php foreach ( $items as $k => $row ):?>
     <tr>
@@ -14,7 +15,7 @@
 
 
 <?php else: ?>
-<?php $this->out('No actions were performed during this time period.'); ?>
+<?php $view->out('No actions were performed during this time period.'); ?>
 <?php endif;?>
 
 </div>

--- a/modules/Base/templates/wrapper_blank.php
+++ b/modules/Base/templates/wrapper_blank.php
@@ -1,1 +1,2 @@
-<?php echo $body;?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php echo $view->body;?>

--- a/modules/Base/templates/wrapper_default.php
+++ b/modules/Base/templates/wrapper_default.php
@@ -1,11 +1,12 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<?php $cu = $this->getCurrentUser(); ?>
+<?php $cu = $view->getCurrentUser(); ?>
 <html xmlns="http://www.w3.org/1999/xhtml">
 
     <head>
-        <title>Open Web Analytics - <?php echo $page_title ?? '';?></title>
+        <title>Open Web Analytics - <?php echo $view->page_title ?? '';?></title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <?php include($this->getTemplatePath('base','head.php'));?>
+        <?php include($view->getTemplatePath('base','head.php'));?>
     </head>
 
     <body class="<?php if ($cu->user->isOWAAdmin()) echo 'owaadmin'; ?>">
@@ -14,13 +15,13 @@
         </style>
 
         <div class="owa">
-        <?php include($this->getTemplatePath('base', 'header.php'));?>
+        <?php include($view->getTemplatePath('base', 'header.php'));?>
 
-        <?php include($this->getTemplatePath('base', 'msgs.php'));?>
+        <?php include($view->getTemplatePath('base', 'msgs.php'));?>
 
-        <?php echo $body;?>
+        <?php echo $view->body;?>
 
-        <?php include($this->getTemplatePath('base', 'footer.php'));?>
+        <?php include($view->getTemplatePath('base', 'footer.php'));?>
         </div>
     </body>
 

--- a/modules/Base/templates/wrapper_email.php
+++ b/modules/Base/templates/wrapper_email.php
@@ -1,3 +1,4 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 -- Open Web Analytics -------------------------------
 
-<?php echo $body;?>
+<?php echo $view->body;?>

--- a/modules/Base/templates/wrapper_public.php
+++ b/modules/Base/templates/wrapper_public.php
@@ -1,10 +1,11 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
-        <title><?php if (isset($page_title)) { $this->out( $page_title . ' - '); } ?>Open Web Analytics</title>
-        <?php include($this->getTemplatePath('base','head.php'));?>
+        <title><?php if (isset($view->page_title)) { $view->out( $view->page_title . ' - '); } ?>Open Web Analytics</title>
+        <?php include($view->getTemplatePath('base','head.php'));?>
     </head>
 
     <body>
@@ -14,16 +15,16 @@
                 <table width="100%">
                     <TR>
                         <TD class="">
-                            <img src="<?php echo $this->makeImageLink('base/i/owa_logo_150w.jpg'); ?>" alt="Open Web Analytics"><BR>
+                            <img src="<?php echo $view->makeImageLink('base/i/owa_logo_150w.jpg'); ?>" alt="Open Web Analytics"><BR>
                         </TD>
                     </TR>
                 </table>
             </div>
             <BR>
-            <?php include($this->setTemplate('msgs.php'));?>
+            <?php include($view->setTemplate('msgs.php'));?>
             <BR>
             <?php if (isset($content)) { echo $content; }?>
-            <?php echo $body;?>
+            <?php echo $view->body;?>
 
             <BR><BR><BR><BR>
             <div style="text-align:center">

--- a/modules/Base/templates/wrapper_subview.php
+++ b/modules/Base/templates/wrapper_subview.php
@@ -1,1 +1,2 @@
-<?php echo $body;?>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php echo $view->body;?>

--- a/modules/Hello/templates/example_settings.php
+++ b/modules/Hello/templates/example_settings.php
@@ -1,3 +1,4 @@
-<h2><?php echo $headline; ?></h2>
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<h2><?php echo $view->headline; ?></h2>
 
 Hello world. This is how you create a settings page.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,13 @@ parameters:
     # Framework uses runtime-defined constants and dynamic class loading; keep
     # the baseline broad so this catches *new* breakage (undefined symbols from
     # deletions) rather than pre-existing legacy noise.
+    # ViewScope hands templates their view data through __get, so any view var is a
+    # legitimate property. Declaring it a universal object crate is how PHPStan is
+    # told that (it infers nothing from __get on its own) -- without this, every
+    # $view->someVar read in a template reports an undefined property.
+    universalObjectCratesClasses:
+        - OWA\Core\ViewScope
+
     bootstrapFiles:
         - tests/phpstan-bootstrap.php
     treatPhpDocTypesAsCertain: false

--- a/tests/ViewScopeCompatTest.php
+++ b/tests/ViewScopeCompatTest.php
@@ -1,0 +1,293 @@
+<?php
+
+use OWA\Core\TemplateEngine;
+use OWA\Core\ViewScope;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the template render contract introduced when OWA's own templates moved
+ * off the extract() bare-variable convention onto an explicit $view scope.
+ *
+ * TWO CONTRACTS ARE PINNED HERE, and they pull in opposite directions:
+ *
+ *  1. The DEPRECATED bare-variable path must keep working. Template resolves
+ *     templates from four roots (base, module, module-local, theme), so bare
+ *     vars and $this are the contract for third-party module templates,
+ *     site-owner templates/local/ overrides and custom themes -- none of which
+ *     OWA ships or can migrate. Breaking extract() breaks those silently, with
+ *     the same fatal-in-foreach the $view work exists to eliminate. Removal is
+ *     a v2.0 task; until then this half of the test is the guard.
+ *
+ *  2. The NEW $view path must be strict about a key that was never set, and
+ *     otherwise indistinguishable from an extracted local. That second half
+ *     matters more than it looks: __isset has to match native isset() exactly
+ *     (false for null, false for missing, NEVER throwing) because 54 isset()
+ *     and 32 empty() call sites across the templates depend on it. A __isset
+ *     that threw, or that reported true for a null value, would turn those into
+ *     500s or silently flip their branches.
+ *
+ * Read together they say: migrated and un-migrated templates observe the same
+ * values, and the only behavioral difference is that reading a never-set var
+ * through $view raises instead of yielding false.
+ *
+ * The suite drives the real TemplateEngine::fetch() against temp template
+ * files rather than unit-testing ViewScope in isolation -- fetch() is where
+ * extract(), the $view construction order, and the include all interact, and
+ * that interaction is the part that can regress.
+ */
+final class ViewScopeCompatTest extends TestCase
+{
+    private string $dir;
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/owa_viewscope_' . getmypid() . '_' . uniqid();
+        mkdir($this->dir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $f) {
+            unlink($f);
+        }
+        @rmdir($this->dir);
+    }
+
+    /** Render template source through the real fetch(), with the given view vars. */
+    private function render(string $source, array $vars = []): string
+    {
+        $file = $this->dir . '/t_' . uniqid() . '.php';
+        file_put_contents($file, $source);
+
+        $t = new TemplateEngine();
+        foreach ($vars as $k => $v) {
+            $t->set($k, $v);
+        }
+        $t->file = $file;
+
+        return $t->fetch();
+    }
+
+    // ---------------------------------------------------------------- contract 1
+    // The deprecated bare-variable path (third-party / local / theme templates).
+
+    public function testExtractStillPopulatesBareVariables(): void
+    {
+        $out = $this->render('<?php echo $headline; ?>', ['headline' => 'Hello']);
+
+        $this->assertSame('Hello', $out, 'extract() must keep populating bare vars for un-migrated templates');
+    }
+
+    public function testBareVariableForeachStillWorks(): void
+    {
+        $out = $this->render('<?php foreach ($tabs as $tab) { echo $tab; } ?>', ['tabs' => ['a', 'b']]);
+
+        $this->assertSame('ab', $out);
+    }
+
+    public function testThisStillResolvesToTheTemplateInsideATemplate(): void
+    {
+        // Templates are included from inside fetch(), so $this is in scope. 69 of
+        // OWA's own templates used it before the migration and third-party ones
+        // still do -- including property reads like $this->config.
+        $out = $this->render('<?php echo get_class($this) . ":" . $this->vars["x"]; ?>', ['x' => 'ok']);
+
+        $this->assertSame(TemplateEngine::class . ':ok', $out);
+    }
+
+    /**
+     * fetch() renames its own locals because extract() defaults to
+     * EXTR_OVERWRITE: a payload key called 'file' would otherwise overwrite the
+     * include path mid-render and a 'contents' key would clobber the captured
+     * output. Nothing sets those keys today, which is exactly why a regression
+     * here would go unnoticed.
+     */
+    public function testPayloadKeyCannotClobberFetchInternals(): void
+    {
+        $out = $this->render(
+            '<?php echo "rendered:" . $file . "|" . $contents; ?>',
+            ['file' => 'PAYLOAD_FILE', 'contents' => 'PAYLOAD_CONTENTS']
+        );
+
+        $this->assertSame('rendered:PAYLOAD_FILE|PAYLOAD_CONTENTS', $out);
+    }
+
+    // ---------------------------------------------------------------- contract 2
+    // The $view scope.
+
+    public function testViewReadsAViewVar(): void
+    {
+        $out = $this->render('<?php echo $view->headline; ?>', ['headline' => 'Hello']);
+
+        $this->assertSame('Hello', $out);
+    }
+
+    public function testViewSupportsArrayIndexingAndInterpolation(): void
+    {
+        $out = $this->render(
+            '<?php echo "id={$view->site[\'site_id\']}"; ?>',
+            ['site' => ['site_id' => 'abc123']]
+        );
+
+        $this->assertSame('id=abc123', $out);
+    }
+
+    /**
+     * array_key_exists, not isset: a var deliberately set to null must read back
+     * as null, exactly as an extracted local would -- not throw.
+     */
+    public function testViewReturnsNullForAVarSetToNull(): void
+    {
+        $out = $this->render('<?php var_export($view->maybe); ?>', ['maybe' => null]);
+
+        $this->assertSame('NULL', $out);
+    }
+
+    public function testViewThrowsForAVarThatWasNeverSet(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessageMatches('/\$view->tabs/');
+
+        $this->render('<?php echo $view->tabs; ?>');
+    }
+
+    /**
+     * The whole point of the strictness: the pre-migration failure was a FATAL
+     * inside foreach ("must be of type array|object, bool given") raised far from
+     * the controller that forgot the key. Now it names the key.
+     */
+    public function testForeachOverANeverSetVarThrowsNamingTheKey(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessageMatches('/never set/');
+
+        $this->render('<?php foreach ($view->tabs as $t) { echo $t; } ?>');
+    }
+
+    // --- isset()/empty() must be indistinguishable from an extracted local ---
+
+    /** @dataProvider issetCases */
+    public function testIssetOnViewMatchesIssetOnAnExtractedLocal(array $vars, string $expected): void
+    {
+        $bare = $this->render('<?php var_export(isset($probe)); ?>', $vars);
+        $view = $this->render('<?php var_export(isset($view->probe)); ?>', $vars);
+
+        $this->assertSame($expected, $view, 'isset($view->probe) should match native isset()');
+        $this->assertSame($bare, $view, 'isset() must agree between the bare and $view paths');
+    }
+
+    /** @dataProvider issetCases */
+    public function testEmptyOnViewMatchesEmptyOnAnExtractedLocal(array $vars, string $unused): void
+    {
+        $bare = $this->render('<?php var_export(empty($probe)); ?>', $vars);
+        $view = $this->render('<?php var_export(empty($view->probe)); ?>', $vars);
+
+        $this->assertSame($bare, $view, 'empty() must agree between the bare and $view paths');
+    }
+
+    public static function issetCases(): array
+    {
+        return [
+            'set to a value' => [['probe' => 'x'], 'true'],
+            'set to null'    => [['probe' => null], 'false'],
+            'never set'      => [[], 'false'],
+        ];
+    }
+
+    /**
+     * isset()/empty() on a never-set var must NOT throw -- they are the guard
+     * expression templates use precisely because a key may be absent.
+     */
+    public function testIssetOnANeverSetVarDoesNotThrow(): void
+    {
+        $out = $this->render('<?php var_export(isset($view->nope)); echo "|reached"; ?>');
+
+        $this->assertSame('false|reached', $out);
+    }
+
+    // --- helper delegation, construction order, write protection ---
+
+    public function testViewDelegatesMethodCallsToTheTemplate(): void
+    {
+        // set_template() is a real TemplateEngine method; reaching it through
+        // $view proves __call forwards to the underlying template object.
+        $out = $this->render('<?php $view->set_template("x.php"); echo $view->owaTemplate()->file; ?>');
+
+        $this->assertStringEndsWith('x.php', $out);
+    }
+
+    /**
+     * $view is built AFTER extract() so a payload key called 'view' cannot
+     * replace the scope object and silently break every migrated template in
+     * the file.
+     */
+    public function testPayloadKeyNamedViewCannotClobberTheScopeObject(): void
+    {
+        $out = $this->render('<?php echo get_class($view); ?>', ['view' => 'PAYLOAD']);
+
+        $this->assertSame(ViewScope::class, $out);
+    }
+
+    /**
+     * View data resolves from the template's vars ONLY -- no fallback to a real
+     * property on the Template. The two are different things: a template's
+     * $this->config is the Template's own config, not a view var of the same
+     * name, and letting __get fall through to properties let a view var shadow
+     * the property. That conflation shipped a broken installer once (an emptied
+     * db_supported_types loop rendering <select> with no options), so the
+     * absence of the fallback is pinned deliberately.
+     */
+    public function testViewDoesNotFallBackToTemplateProperties(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        // template_dir is a declared property on TemplateEngine, never a view var.
+        $this->render('<?php echo $view->template_dir; ?>');
+    }
+
+    /**
+     * A template that throws must not leak fetch()'s output buffer.
+     *
+     * Found by this suite on its first run: making __get throw turned a
+     * previously-fatal condition into a catchable exception that unwinds out of
+     * include(), so the ob_end_clean() after it never ran. Renders nest, so every
+     * swallowed template error left output captured in a buffer nobody closed and
+     * a later ob_get_contents() could return unrelated markup. fetch() now wraps
+     * the include in try/finally; this asserts the buffer level is restored.
+     */
+    public function testAThrowingTemplateDoesNotLeakTheOutputBuffer(): void
+    {
+        $before = ob_get_level();
+
+        try {
+            $this->render('<?php echo $view->never_set_anywhere; ?>');
+            $this->fail('expected the never-set read to throw');
+        } catch (OutOfBoundsException) {
+            // expected
+        }
+
+        $this->assertSame($before, ob_get_level(), 'fetch() must not leave an output buffer open when a template throws');
+    }
+
+    public function testAssigningThroughViewIsRejected(): void
+    {
+        $this->expectException(LogicException::class);
+
+        $this->render('<?php $view->headline = "no"; ?>', ['headline' => 'yes']);
+    }
+
+    /**
+     * Both paths must observe the SAME values in the same render -- this is what
+     * makes the migration safe to do file-by-file rather than all at once, and
+     * what let 28 templates stay on bare vars without behaving differently.
+     */
+    public function testBareAndViewPathsAgreeInTheSameRender(): void
+    {
+        $out = $this->render(
+            '<?php echo ($headline === $view->headline) ? "agree" : "differ"; ?>',
+            ['headline' => 'Hello']
+        );
+
+        $this->assertSame('agree', $out);
+    }
+}

--- a/tests/tools/modernize_template_vars.php
+++ b/tests/tools/modernize_template_vars.php
@@ -1,0 +1,382 @@
+<?php
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * Token-driven rewrite of OWA's own templates off the extract() contract.
+ *
+ * WHAT IT DOES
+ * ------------
+ * Templates historically received view data as bare locals, materialized by
+ * `extract($this->vars)` in TemplateEngine::fetch(), and reached the template
+ * helpers through `$this` (the include happens inside the method, so `$this` is
+ * in scope). Both are invisible to static analysis: a missing key is simply an
+ * undefined variable, which is a warning in scalar context and a FATAL in
+ * foreach ("must be of type array|object, bool given").
+ *
+ * This rewrites OWA's own templates onto an explicit scope object:
+ *     $tabs              ->  $view->tabs
+ *     $this->out(...)    ->  $view->out(...)
+ *
+ * METHOD calls move to $view; PROPERTY reads stay on $this. `$this->config` is the
+ * Template's own property, not a view var of the same name, and routing it through
+ * ViewScope::__get would let the view var shadow it.
+ *
+ * extract() STAYS in fetch() as the deprecated compat path, so third-party
+ * module templates, site-owner templates/local/ overrides and custom themes --
+ * none of which OWA ships or can migrate -- keep working untouched.
+ *
+ * WHY IT IS BIASED TOWARD DOING NOTHING
+ * -------------------------------------
+ * Because extract() stays, a variable we FAIL to rewrite still resolves exactly
+ * as before: harmless. A variable we WRONGLY rewrite hits ViewScope::__get and
+ * throws: a 500. The two error directions are wildly asymmetric, so every rule
+ * below resolves ambiguity by leaving the variable alone. A conservative pass
+ * that misses some vars is a good outcome; an aggressive one is not.
+ *
+ * A variable is rewritten ONLY when ALL of these hold:
+ *   1. It is never an assignment target anywhere in the file -- not `$x =`, not
+ *      `$x['k'] =`, not `$x[] =`, not compound `$x .= ` (accumulators start
+ *      undefined by design), not `foreach (... as $x)`, not `global`/`static`,
+ *      not a function/closure parameter. ANY of those marks it local for the
+ *      whole file, no matter where it appears.
+ *   2. It is not a superglobal.
+ *   3. Its name appears as a `->set('name', ...)` literal somewhere in the tree.
+ *      That is the authoritative set of keys that can ever be in $this->vars,
+ *      so a name absent from it cannot be a view var.
+ *   4. It is not supplied by an INCLUDER's scope. Raw include/require of one
+ *      template by another SHARES scope, so a free variable in a partial may be
+ *      a parent's local rather than a view var. The include graph is walked and
+ *      any name assigned by any transitive includer is treated as local here.
+ *      Variables assigned by included conf/*.php files are handled the same way.
+ *
+ * Interpolation is handled through the token stream, so "$foo" becomes
+ * "{$view->foo}" and "{$foo}" becomes "{$view->foo}" rather than being
+ * corrupted by a textual substitution.
+ *
+ * USAGE
+ *   php tests/tools/modernize_template_vars.php            # analyse, write no files
+ *   php tests/tools/modernize_template_vars.php --apply    # rewrite in place
+ *   php tests/tools/modernize_template_vars.php --file=X    # limit to one file
+ */
+
+$root = dirname(__DIR__, 2);
+$apply = in_array('--apply', $argv, true);
+$only = null;
+foreach ($argv as $a) {
+    if (str_starts_with($a, '--file=')) { $only = substr($a, 7); }
+}
+
+const SUPERGLOBALS = [
+    '$GLOBALS', '$_SERVER', '$_GET', '$_POST', '$_FILES', '$_COOKIE',
+    '$_SESSION', '$_REQUEST', '$_ENV', '$this', '$view',
+];
+
+/** Every key that can ever land in TemplateEngine::$vars: the ->set('literal') surface. */
+function collectSetNames(string $root): array {
+    $names = [];
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . '/Core'));
+    $dirs = [$root . '/Core', $root . '/modules'];
+    foreach ($dirs as $d) {
+        $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($d));
+        foreach ($it as $f) {
+            if (!$f->isFile() || $f->getExtension() !== 'php') { continue; }
+            $src = file_get_contents($f->getPathname());
+            if (preg_match_all('/->set\(\s*[\'"]([A-Za-z_][A-Za-z0-9_]*)[\'"]/', $src, $m)) {
+                foreach ($m[1] as $n) { $names[$n] = true; }
+            }
+        }
+    }
+    return $names;
+}
+
+/**
+ * Classify every variable in a file: which are assigned (=> local) and which are
+ * only ever read (=> candidate view vars). Assignment wins globally per file.
+ */
+function analyseFile(string $path): array {
+    $src = file_get_contents($path);
+    $tokens = token_get_all($src);
+    $assigned = [];
+    $read = [];
+    $suppressed = [];
+
+    $n = count($tokens);
+    for ($i = 0; $i < $n; $i++) {
+        $t = $tokens[$i];
+        if (!is_array($t) || $t[0] !== T_VARIABLE) { continue; }
+        $name = $t[1];
+
+        // `@$foo` -- the author explicitly marked this read as possibly-absent.
+        // The @ operator suppresses DIAGNOSTICS, not EXCEPTIONS, so rewriting such
+        // a read to $view->foo would convert a deliberately-tolerated missing var
+        // into a thrown 500. Treat the whole name as off-limits in this file.
+        for ($b = $i - 1; $b >= 0; $b--) {
+            $p = $tokens[$b];
+            if (is_array($p) && $p[0] === T_WHITESPACE) { continue; }
+            if ($p === '@') { $suppressed[$name] = true; }
+            break;
+        }
+
+        // --- does an assignment-ish construct claim this variable? ---
+        // Look backward for foreach-as / global / static / function-param.
+        $claimed = false;
+        for ($b = $i - 1; $b >= 0; $b--) {
+            $p = $tokens[$b];
+            if (is_array($p) && in_array($p[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) { continue; }
+            if (is_array($p) && in_array($p[0], [T_AS, T_GLOBAL, T_STATIC, T_DOUBLE_ARROW], true)) {
+                // `as $v`, `as $k => $v`, `global $x`, `static $x`
+                if ($p[0] === T_DOUBLE_ARROW) {
+                    // only a claim when this is the value half of `as $k => $v`
+                    $claimed = looksLikeForeachAs($tokens, $b);
+                } else {
+                    $claimed = true;
+                }
+            }
+            if (is_array($p) && in_array($p[0], [T_FUNCTION, T_FN], true)) { $claimed = true; }
+            if ($p === '(' || $p === ',') {
+                // could be a function parameter list; check if a `function` precedes
+                $claimed = $claimed || precededByFunction($tokens, $b);
+            }
+            break;
+        }
+        if ($claimed) { $assigned[$name] = true; continue; }
+
+        // --- forward scan: `$x =`, `$x['k'] =`, `$x[] =`, `$x .= `, `$x++` ---
+        $j = $i + 1;
+        $depth = 0;
+        $isWrite = false;
+        while ($j < $n) {
+            $q = $tokens[$j];
+            if (is_array($q) && in_array($q[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) { $j++; continue; }
+            if ($q === '[') { $depth++; $j++; continue; }
+            if ($q === ']') { $depth--; $j++; continue; }
+            if ($depth > 0) { $j++; continue; }
+            if (is_array($q) && $q[0] === T_OBJECT_OPERATOR) { break; }  // $x->y : read of $x
+            if ($q === '=') { $isWrite = true; break; }
+            if (is_array($q) && in_array($q[0], [
+                T_PLUS_EQUAL, T_MINUS_EQUAL, T_MUL_EQUAL, T_DIV_EQUAL, T_CONCAT_EQUAL,
+                T_MOD_EQUAL, T_AND_EQUAL, T_OR_EQUAL, T_XOR_EQUAL, T_SL_EQUAL, T_SR_EQUAL,
+                T_COALESCE_EQUAL, T_POW_EQUAL, T_INC, T_DEC,
+            ], true)) { $isWrite = true; break; }
+            break;
+        }
+        if ($isWrite) { $assigned[$name] = true; } else { $read[$name] = true; }
+    }
+
+    // assignment anywhere in the file wins
+    foreach (array_keys($assigned) as $a) { unset($read[$a]); }
+    return ['assigned' => $assigned, 'read' => $read, 'suppressed' => $suppressed,
+            'tokens' => $tokens, 'src' => $src];
+}
+
+function looksLikeForeachAs(array $tokens, int $arrowIdx): bool {
+    for ($b = $arrowIdx - 1; $b >= 0 && $b > $arrowIdx - 40; $b--) {
+        $p = $tokens[$b];
+        if (is_array($p) && $p[0] === T_AS) { return true; }
+        if (is_array($p) && $p[0] === T_FOREACH) { return true; }
+        if ($p === ';' || $p === '{') { return false; }
+    }
+    return false;
+}
+
+/** True when `$this` at $i is followed by `->name(` -- a method call, not a property read. */
+function nextIsMethodCall(array $tokens, int $i): bool {
+    $seenArrow = false;
+    for ($j = $i + 1, $n = count($tokens); $j < $n; $j++) {
+        $q = $tokens[$j];
+        if (is_array($q) && $q[0] === T_WHITESPACE) { continue; }
+        if (!$seenArrow) {
+            if (is_array($q) && $q[0] === T_OBJECT_OPERATOR) { $seenArrow = true; continue; }
+            return false;
+        }
+        if (is_array($q) && $q[0] === T_STRING) { continue; }   // the member name
+        return $q === '(';
+    }
+    return false;
+}
+
+function precededByFunction(array $tokens, int $idx): bool {
+    for ($b = $idx - 1; $b >= 0 && $b > $idx - 30; $b--) {
+        $p = $tokens[$b];
+        if (is_array($p) && in_array($p[0], [T_FUNCTION, T_FN], true)) { return true; }
+        if ($p === ';' || $p === '{' || $p === '}') { return false; }
+    }
+    return false;
+}
+
+/** Template-to-template and template-to-conf include edges (raw include shares scope). */
+function collectIncludes(string $path, string $root): array {
+    $src = file_get_contents($path);
+    $out = [];
+    if (preg_match_all('/(?:include|require)(?:_once)?\s*\(?\s*([^;]+);/', $src, $m)) {
+        foreach ($m[1] as $expr) {
+            if (preg_match('/[\'"]([A-Za-z0-9_\/.\-]+\.php)[\'"]/', $expr, $mm)) {
+                $out[] = $mm[1];
+            }
+        }
+    }
+    return $out;
+}
+
+// ---------------------------------------------------------------- main
+
+$setNames = collectSetNames($root);
+$templates = glob($root . '/modules/*/templates/*.php') ?: [];
+sort($templates);
+if ($only) { $templates = array_values(array_filter($templates, fn($t) => str_contains($t, $only))); }
+
+// Pass 1: analyse everything so includer locals are known before rewriting.
+$info = [];
+foreach ($templates as $t) { $info[$t] = analyseFile($t); }
+
+// Build a map of basename -> assigned names, and who includes whom.
+$assignedByBasename = [];
+foreach ($info as $path => $d) { $assignedByBasename[basename($path)] = $d['assigned']; }
+
+$ambient = [];   // path -> names that come from an includer's scope (treat as local)
+foreach ($templates as $t) {
+    foreach (collectIncludes($t, $root) as $inc) {
+        $b = basename($inc);
+        // the INCLUDED file inherits the INCLUDER's locals
+        foreach (array_keys($info[$t]['assigned'] ?? []) as $a) {
+            $ambient[$b][$a] = true;
+        }
+        // and variables the included conf/ file defines become locals in the includer
+        $confPath = $root . '/' . ltrim($inc, '/');
+        if (!str_contains($inc, 'templates') && is_file($confPath)) {
+            $c = analyseFile($confPath);
+            foreach (array_keys($c['assigned']) as $a) { $ambient[basename($t)][$a] = true; }
+        }
+    }
+}
+
+$totalRewrites = 0; $totalThis = 0; $skipped = []; $changedFiles = 0;
+
+foreach ($templates as $path) {
+    $d = $info[$path];
+    $tokens = $d['tokens'];
+    $amb = $ambient[basename($path)] ?? [];
+
+    $rewritable = [];
+    foreach (array_keys($d['read']) as $name) {
+        if (in_array($name, SUPERGLOBALS, true)) { continue; }
+        $bare = ltrim($name, '$');
+        if (isset($d['suppressed'][$name])) { $skipped[$bare]['error-suppressed-read'] = true; continue; }
+        if (isset($amb[$name])) { $skipped[$bare]['includer-scope'] = true; continue; }
+        if (!isset($setNames[$bare])) { $skipped[$bare]['not-in-set-allowlist'] = true; continue; }
+        $rewritable[$name] = true;
+    }
+
+    // ---- emit ----
+    $out = '';
+    $fileRewrites = 0; $fileThis = 0;
+    $n = count($tokens);
+    for ($i = 0; $i < $n; $i++) {
+        $t = $tokens[$i];
+        if (!is_array($t)) { $out .= $t; continue; }
+
+        if ($t[0] !== T_VARIABLE) { $out .= $t[1]; continue; }
+
+        // $this->helper(...) -> $view->helper(...), but ONLY for METHOD CALLS.
+        //
+        // A property read must be left alone: `$this->config` is the TEMPLATE OBJECT's
+        // config, which is a different thing from a view var that happens to also be
+        // called 'config'. Rewriting it to $view->config sends the read through
+        // ViewScope::__get, which serves view vars -- so the view var shadows the
+        // template property and the read silently returns the wrong value. That is
+        // exactly how install_config_entry.php's db_supported_types loop emptied out
+        // and left <select name="owa_db_type"> with no options. Only 2 property reads
+        // exist in the whole corpus, so leaving them as $this-> costs nothing.
+        if ($t[1] === '$this') {
+            if (nextIsMethodCall($tokens, $i)) { $out .= '$view'; $fileThis++; }
+            else { $out .= '$this'; }
+            continue;
+        }
+
+        if (!isset($rewritable[$t[1]])) { $out .= $t[1]; continue; }
+
+        $bare = ltrim($t[1], '$');
+        // Inside a double-quoted string / heredoc, a bare "$foo" must become
+        // "{$view->foo}" -- simple interpolation cannot express ->.
+        if (inInterpolation($tokens, $i)) {
+            $out .= '{$view->' . $bare . '}';
+        } else {
+            $out .= '$view->' . $bare;
+        }
+        $fileRewrites++;
+    }
+
+    // A template is included from inside TemplateEngine::fetch(), so $view is
+    // injected by the includer and looks undefined to any tool analysing the file
+    // on its own -- the same false positive $this used to produce (825 of them).
+    // One declared anchor per template fixes that, and it is the single place a
+    // per-page typed view model would later be named instead of ViewScope.
+    $needsHeader = (str_contains($out, '$view') || $fileRewrites || $fileThis)
+        && !str_contains($out, '@var \OWA\Core\ViewScope');
+    if ($needsHeader) {
+        $out = "<?php /** @var \\OWA\\Core\\ViewScope \$view */ ?>\n" . $out;
+        $headersAdded = true;
+    }
+
+    if ($fileRewrites || $fileThis || $needsHeader) {
+        $changedFiles++;
+        $totalRewrites += $fileRewrites; $totalThis += $fileThis;
+        $GLOBALS['headerCount'] = ($GLOBALS['headerCount'] ?? 0) + ($needsHeader ? 1 : 0);
+        printf("  %-56s vars:%-4d \$this:%-4d hdr:%s\n", str_replace($root . '/', '', $path), $fileRewrites, $fileThis, $needsHeader ? 'y' : 'n');
+        if ($apply) { file_put_contents($path, $out); }
+    }
+}
+
+/**
+ * True when token $i sits inside a double-quoted string or heredoc body, where
+ * `$foo->bar` is NOT parsed as a property access and needs {} braces.
+ * Already-braced ({$foo}) positions are detected via the preceding T_CURLY_OPEN.
+ */
+function inInterpolation(array $tokens, int $i): bool {
+    $inString = false;
+    for ($b = 0; $b < $i; $b++) {
+        $p = $tokens[$b];
+        if ($p === '"') { $inString = !$inString; continue; }
+        if (is_array($p) && $p[0] === T_START_HEREDOC) { $inString = true; }
+        if (is_array($p) && $p[0] === T_END_HEREDOC) { $inString = false; }
+    }
+    if (!$inString) { return false; }
+    // if immediately preceded by {$ (T_CURLY_OPEN) the braces already exist
+    for ($b = $i - 1; $b >= 0; $b--) {
+        $p = $tokens[$b];
+        if (is_array($p) && in_array($p[0], [T_WHITESPACE], true)) { continue; }
+        if (is_array($p) && $p[0] === T_CURLY_OPEN) { return false; }
+        break;
+    }
+    return true;
+}
+
+echo "\n";
+printf("templates scanned : %d\n", count($templates));
+printf("files changed     : %d\n", $changedFiles);
+printf("var rewrites      : %d\n", $totalRewrites);
+printf("\$this -> \$view    : %d\n", $totalThis);
+printf("mode              : %s\n", $apply ? 'APPLIED' : 'dry run (no files written)');
+if ($skipped) {
+    echo "\nleft alone (conservative), by reason:\n";
+    $byReason = [];
+    foreach ($skipped as $name => $reasons) {
+        foreach (array_keys($reasons) as $r) { $byReason[$r][] = $name; }
+    }
+    foreach ($byReason as $r => $names) {
+        sort($names);
+        printf("  %-22s %d: %s\n", $r, count($names), implode(', ', array_slice($names, 0, 12)) . (count($names) > 12 ? ' ...' : ''));
+    }
+}


### PR DESCRIPTION
> **Stacked on #951.** Base is `modernize-phase6`, not `master`, because the templates live at `modules/Base/templates/` (PascalCase) which only exists on that branch. Merge #951 first; this then retargets to `master` cleanly.

## Pull request checklist

- [x] Tested the changes
- [x] Build (`npm run build`) was run locally and any changes were pushed

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

Templates receive view data as bare local variables produced by `extract($this->vars)` in `TemplateEngine::fetch()`, and reach the template helpers through `$this` (the include happens inside that method, so `$this` is in scope). Two costs:

- **A missing key is an undefined variable, not an error.** Warning in scalar context; **fatal** in `foreach` — `foreach() argument must be of type array|object, bool given` — because undefined coerces to `false`. The failure surfaces in the template, far from the controller that forgot the key. Not theoretical: `report_dimensionalTrend.php`'s `foreach ($tabs)` crashed exactly this way when `reportController::pre` set `tabs` only inside its `if ($siteId)` branch (fixed in `b6e030b9` by hoisting the initializer).
- **Nothing declares what a template needs**, so no tool can check it — 0 of 94 templates carry a type annotation. A whole-tree PHPStan run reports 988 undefined template variables.

## What is the new behavior?

OWA's own templates use an explicit scope object: `$view->tabs` for data, `$view->out(...)` for helpers.

**Scope, stated precisely:** the rewrite covers 89 of 94 templates, but **28 of them still read at least one bare variable** and therefore still depend on `extract()`. The tool deliberately left 20 variable names alone (rules below), and most of those are *correct* to leave — `isset()`/`empty()`-guarded optional vars, `foreach` values, and vars supplied by an includer's scope are not debt. So `extract()` is not yet third-party-only; it remains load-bearing for some of OWA's own templates until those names are resolved controller-side.

- **`Core/ViewScope.php`** (new) — `__get` serves view vars and **throws**, naming the key and template, when one was never set. `__isset` mirrors `isset()` on an extracted local (false for null, false for missing, never throws) because 54 `isset()` and 32 `empty()` call sites depend on that. `__call` forwards helpers. The 33 `@method` tags are the real template-facing API surface: PHPStan infers nothing from `__call`, so without them all 560 helper calls report an undefined method.
- **`Core/TemplateEngine.php`** — builds `$view` *after* `extract()` so a stray `view` key can't clobber it, and renames `fetch()`'s own locals. `extract()` defaults to `EXTR_OVERWRITE`, so a payload key named `file` or `contents` could clobber the include path or the captured output — latent today, no longer reachable.
- **`phpstan.neon`** — declares `ViewScope` a universal object crate, which is how PHPStan is told a `__get` bag's properties are legitimate.

Each template gains one `@var \OWA\Core\ViewScope $view` header. `$view` is injected by the includer, so without it every template reports `$view` undefined (825 of them) — the same false positive `$this` used to produce. That header is also the single place a per-page typed view model would later be named, which keeps that follow-up **purely additive**.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

**`extract()` stays** as the deprecated path. `Template` resolves templates from four roots — base, module, `templates/local/`, and theme — so the bare-var contract is used by third-party module templates, **site-owner `templates/local/` overrides and custom themes**. OWA ships none of those and cannot migrate them, so removing `extract()` would break them silently, with the same fatal-in-`foreach` this PR exists to eliminate. They keep working, `$this` keeps working there, and the old path is removed at v2.0 alongside the `owa_*` class-name bridge.

## Docs need to be updated?

- [x] Yes
- [ ] No

Worth a note for template authors: `$view` is the supported contract going forward, bare vars and `$this` are deprecated, v2.0 removes them.

## Other information

### The rewrite is token-driven and biased toward doing nothing

`tests/tools/modernize_template_vars.php`. Because `extract()` stays, the two error directions are wildly asymmetric: a variable **left alone** still resolves exactly as before (harmless), while one **wrongly rewritten** throws a 500. So every rule resolves ambiguity by leaving the variable alone. A name is rewritten only if it:

1. is never an assignment target in the file — including `foreach` values, compound-assign accumulators (`$x .=` starts undefined by design) and params;
2. is not a superglobal;
3. appears as a `->set('name')` literal somewhere — the authoritative set of keys that can reach `$vars` (verified: no dynamic `->set($var, …)` calls exist);
4. is not supplied by an **includer's** scope — raw `include` shares scope, so a partial's free var may be a parent's local;
5. is not read under `@` — the `@` operator suppresses **diagnostics but not exceptions**, so rewriting a deliberately-tolerated missing var would convert it into a 500.

20 names were left alone under those rules, and the tool reports each with its reason.

### One real bug this caught, worth knowing about

Method calls move to `$view`; **property reads stay on `$this`**. `$this->config` is the *Template's own property*, not a view var of the same name — and routing it through `__get` let the view var shadow it. That emptied `install_config_entry.php`'s `db_supported_types` loop and produced `<select name="owa_db_type">` **with no options**, i.e. a broken installer. The install e2e suite caught it. `ViewScope` now resolves view vars only, with no property fallback, so the two can't be conflated again.

### Verification

| Check | Result |
|---|---|
| PHPStan whole-tree, level 2, cold cache | **1890 → 1047** (−843) |
| `variable.undefined` | **988 → 145** |
| files with errors | 295 → 229 |
| any category worse than baseline | **none** |
| PHPUnit | 164/164 (was 142; +22 from the new suite) |
| Jest | 199/199 |
| e2e (full suite) | 75 passed, 1 skipped |
| install-flow e2e | 2/2 |
| authenticated crawl, 55 actions | 0 × 500, 0 ViewScope throws in the error log |
| PHPStan `variable.undefined` | 988 → 145 (73 in templates, 72 pre-existing elsewhere) |
| **55 authenticated pages** | **54 byte-identical**; the 55th is Edit Goal, 7345 truncated bytes -> 12238 complete |
| `ViewScopeCompatTest` | 22 tests pinning both the deprecated and the `$view` path |
| Deprecation notice | `UPGRADING.md`, covering all three v2.0 seams; linked from README |

The byte-identical render comparison is the load-bearing one — it demonstrates output equivalence rather than merely the absence of errors.

### The test found two bugs, both fixed here

**1. `fetch()` leaked its output buffer when a template threw.** Making `__get` throw turned a previously-fatal condition into a catchable exception that unwinds out of `include()`, so the `ob_end_clean()` after it never ran. Renders nest, so each swallowed template error left output captured in a buffer nobody closed. Now `try`/`finally`, with the buffer level asserted restored and mutation-verified against the unfixed version.

**2. `options_goal_entry.php:257` — a pre-existing PHP 8 `TypeError`.** `array_key_exists('funnel_steps', $goal['details'])` receives `null` when a goal has no details; that's a `TypeError` on PHP 8, where pre-8 it was a warning returning `false`. **Not from this migration** — the line is untouched by it. The template threw partway, and the leaked buffer from (1) was flushed at shutdown, so **the Edit Goal screen has been serving a truncated page**, cut off at line 257 with no closing `</body></html>`. Browsers tolerated it. Fixing (1) turned it into a blank page, which is how it surfaced. Now guarded with `!empty()` first, and the page renders complete.

That second one is the argument for the test existing: the byte-comparison in the original commit passed *because both sides were equally truncated*.

### Known residual risk

The throw fires on a direct read of a never-set var. Gate 3 guarantees every rewritten name *is* set somewhere, so the remaining exposure is a var set on only **some** controller branches — the `report_dimensionalTrend` class of bug — on a page no test reaches. The 55-action crawl plus both e2e suites cover the reachable surface; email templates and some option sub-panels are not exercised. That is the tradeoff of `throw` over `warn-and-null`: latent bugs surface loudly instead of silently.
