### PR TITLE
chore(phpstan): cap analysis at a single worker process

### DIFF
--- a/phpstan-migration.neon
+++ b/phpstan-migration.neon
@@ -21,6 +21,8 @@ includes:
     - phpstan-migration-baseline.neon
 
 parameters:
+    parallel:
+        maximumNumberOfProcesses: 1
     level: 0
     paths:
         - .

--- a/phpstan-templates.neon
+++ b/phpstan-templates.neon
@@ -40,6 +40,8 @@ includes:
     - phpstan-templates-baseline.neon
 
 parameters:
+    parallel:
+        maximumNumberOfProcesses: 1
     level: 1
     paths:
         - modules/Base/templates

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,8 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
+    parallel:
+        maximumNumberOfProcesses: 1
     level: 3
     paths:
         - Core/Lib.php


### PR DESCRIPTION
PHPStan defaults to one worker per detected CPU core, so a single `analyse` run saturates every core it finds. On a constrained host that is enough to starve everything else running alongside it.

Pins all three configs to one process to bound the CPU cost of an analysis run. The three together still complete in well under a minute, so the lost parallelism is not worth the contention.

Applied to each config separately because `phpstan-migration.neon` and `phpstan-templates.neon` do not include `phpstan.neon`.

No analysis behaviour changes — worker count only. All three gates verified locally:

| gate | result |
|---|---|
| `composer phpstan` | `[OK]` |
| `composer phpstan:migration` | `[OK]` |
| `composer phpstan:templates` | `[OK]` |