### PR TITLE
fix(updates): require admin capability and nonce on the apply action

### DIFF
--- a/Core/Update.php
+++ b/Core/Update.php
@@ -134,7 +134,14 @@ class Update extends \OWA\Core\Base {
     /**
      * Rollsback an update
      *
-     * @return boolean
+     * Returns true ONLY when down() ran and succeeded. Refusing an
+     * out-of-sequence rollback and a failing down() both return false, matching
+     * apply()'s contract in this class.
+     *
+     * (This previously returned true unconditionally, so callers could not tell
+     * a completed rollback from one that never ran.)
+     *
+     * @return boolean true if the rollback was applied, false if refused or failed
      */
     function rollback() {
 
@@ -157,14 +164,23 @@ class Update extends \OWA\Core\Base {
                     $this->e->notice("Rollback succeeded to version: $current_version.");
                 }
 
+                return true;
+
             } else {
-                $this->e->notice("Rollback failed.");
+                // down() ran and did not finish. This is the dangerous outcome:
+                // the schema may be partially torn down, and schema_version is
+                // deliberately NOT moved, so the recorded version can now
+                // disagree with the actual schema.
+                $this->e->notice(sprintf('Rollback of update %s FAILED part way through. The schema may be partially rolled back, and the recorded schema version is still %s. Inspect the schema before retrying or re-applying.', $this->schema_version, $current_version));
+
+                return false;
             }
-        } else {
-            $this->e->notice(sprintf('Rollback of update %s cannot be applied because it does not appear that it update %s has been applied to your instance. Your current schema version is only %s', $this->schema_version, $this->schema_version, $current_version));
         }
 
-        return true;
+        // Refused: nothing ran, the schema is untouched.
+        $this->e->notice(sprintf('Rollback of update %s cannot be applied because it does not appear that it update %s has been applied to your instance. Your current schema version is only %s', $this->schema_version, $this->schema_version, $current_version));
+
+        return false;
     }
 
     /**

--- a/modules/Base/Controller/Updates.php
+++ b/modules/Base/Controller/Updates.php
@@ -23,7 +23,17 @@ namespace OWA\Module\Base\Controller;
 
 
 class Updates extends \OWA\Core\Controller {
-    
+
+    // DELIBERATELY has no required capability. Core\Controller::updateAction()
+    // redirects here (setRedirectAction('base.updates')) whenever an admin
+    // request is intercepted because the schema is out of date -- and that
+    // interception runs BEFORE the capability check, for a request that may not
+    // be authenticated yet. Gating this controller would put a login wall in
+    // front of the very page the interception exists to display.
+    //
+    // It only lists which modules have pending updates. base.updatesApply, the
+    // action that actually mutates the schema, is gated instead.
+
     function action() {
         
         $data = array();

--- a/modules/Base/Controller/UpdatesApply.php
+++ b/modules/Base/Controller/UpdatesApply.php
@@ -33,6 +33,30 @@ namespace OWA\Module\Base\Controller;
 
 class UpdatesApply extends \OWA\Core\Controller {
 
+    function __construct($params) {
+
+        // Applying schema updates is an admin operation. Without a declared
+        // capability the base controller performs no authentication at all,
+        // which left this action reachable unauthenticated.
+        //
+        // 'install_schema' would NOT work here -- it is granted to the
+        // "everyone" role, so isEveryoneCapable() short-circuits the check.
+        //
+        // Note the sibling base.updates is deliberately NOT gated: it is the
+        // target of the pre-auth update interception. Gating only this action
+        // keeps that notice reachable while requiring an admin to actually
+        // mutate the schema.
+        //
+        // If a future update ever breaks authentication itself (new code
+        // querying a column an old schema lacks), the web path here cannot
+        // complete. That is recoverable, not a lockout: `php cli.php cmd=update`
+        // (base.updatesApplyCli, registered in Base/Module.php) applies updates
+        // without web auth, and updates 005/006/007/010 already require it.
+        $this->setRequiredCapability('edit_modules');
+
+        parent::__construct($params);
+    }
+
     function action() {
 
         // fetch list of modules that require updates

--- a/modules/Base/Controller/UpdatesApply.php
+++ b/modules/Base/Controller/UpdatesApply.php
@@ -54,6 +54,18 @@ class UpdatesApply extends \OWA\Core\Controller {
         // without web auth, and updates 005/006/007/010 already require it.
         $this->setRequiredCapability('edit_modules');
 
+        // Capability alone still allowed a logged-in admin to be induced into
+        // applying updates via a crafted link (CSRF). The "Apply updates" link
+        // in base.updates now carries a nonce (makeLink's 5th arg).
+        //
+        // Ordering matters and is in our favour: doAction() runs the capability
+        // check BEFORE the nonce check, so an unauthenticated visitor is sent to
+        // login rather than failing on a nonce. And because createNonce() binds
+        // to user_id, the nonce minted for an anonymous view of base.updates
+        // will not verify -- after logging in the interception re-renders the
+        // page, minting one bound to the real user.
+        $this->setNonceRequired();
+
         parent::__construct($params);
     }
 

--- a/modules/Base/Controller/UpdatesApplyCli.php
+++ b/modules/Base/Controller/UpdatesApplyCli.php
@@ -123,8 +123,17 @@ class UpdatesApplyCli extends \OWA\Core\Controller\Cli {
     function rollback($update) {
         list($module, $seq) = explode('.', $update);
         $u = \OWA\Core\CoreAPI::updateFactory($module, $seq);
-        $u->rollback();
-        \OWA\Core\CoreAPI::notice("Rollback completed.");
+
+        // rollback() returns false when it refuses an out-of-sequence rollback
+        // and when down() fails part way. Reporting "completed" regardless told
+        // operators the schema had moved when nothing had happened.
+        $ret = $u->rollback();
+
+        if ($ret) {
+            \OWA\Core\CoreAPI::notice("Rollback completed.");
+        } else {
+            \OWA\Core\CoreAPI::notice("Rollback did NOT complete. See the messages above for whether it was refused or failed part way.");
+        }
     }
     
 }

--- a/modules/Base/templates/updates.php
+++ b/modules/Base/templates/updates.php
@@ -25,7 +25,9 @@
         <BR>
 
         <P>
-        <a href="<?php echo $view->makeLink(array('do' => 'base.updatesApply'));?>"><span class="owa-button">Apply updates</span></a>
+        <?php // 5th arg = $add_nonce. base.updatesApply mutates the schema, so
+              // the link must carry a nonce or its setNonceRequired() check fails. ?>
+        <a href="<?php echo $view->makeLink(array('do' => 'base.updatesApply'), false, '', false, true);?>"><span class="owa-button">Apply updates</span></a>
         </P>
 
     </div>

--- a/tests/ControllerCapabilityContractTest.php
+++ b/tests/ControllerCapabilityContractTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * "Every non-public controller declares a capability" contract test.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Core/Controller::checkCapabilityAndAuthenticateUser() is the ONLY
+ * authorization gate in the controller layer, and it is opt-in:
+ *
+ *     if ( ( !empty($capability) && ! isEveryoneCapable($capability) )
+ *          || ( getStateParam('u') && getStateParam('p') ) ) { ...authenticate... }
+ *     return true;
+ *
+ * A controller that never calls setRequiredCapability() has $capability === null,
+ * so the whole block is skipped and the action runs unauthenticated. That is
+ * correct and necessary for the tracker, login and install endpoints -- but it
+ * means forgetting the declaration on an admin controller silently ships an
+ * unauthenticated admin action, with nothing to catch it.
+ *
+ * That is exactly what happened to base.updatesApply, which executed module
+ * schema updates with no capability, no nonce and no auth check of any kind.
+ *
+ * This test freezes the set of controllers with no effective capability. Adding
+ * a controller without a declaration turns it red.
+ *
+ * Being on that list is not automatically a bug -- the update-notice page
+ * (base.updates) has to stay reachable pre-auth because the schema-out-of-date
+ * interception redirects to it before any capability check runs. The point is
+ * that every entry is a deliberate, written-down decision rather than an
+ * omission nobody noticed.
+ *
+ * NOTE ON 'install_schema': it is granted to the "everyone" role, so declaring
+ * it does NOT gate anything -- isEveryoneCapable() short-circuits the check.
+ * It is the correct choice for the install flow and the wrong choice anywhere
+ * else. Controllers that declare it are therefore out of scope here.
+ *
+ * Maintenance contract: this list may only SHRINK, or grow with a written
+ * justification for why the new controller must be reachable unauthenticated.
+ * Never add an entry merely to make the test pass.
+ */
+final class ControllerCapabilityContractTest extends TestCase
+{
+    /**
+     * Controllers that are legitimately reachable without authentication.
+     * Every entry needs a reason.
+     */
+    private const INTENTIONALLY_PUBLIC = [
+        // Tracker / ingestion -- hit directly by visitors' browsers.
+        'ProcessEvent',
+        'ProcessRequest',
+        'ProcessFirstRequest',
+        'NotifyNewSession',
+
+        // Authentication entry points -- must be reachable while logged out.
+        'Login',
+        'LoginForm',
+        'Logout',
+
+        // Password reset / account setup. Guarded by the emailed temp_passkey
+        // (Auth::authenticateUserTempPasskey), which is the credential -- a
+        // capability check would make the flow impossible.
+        'PasswordResetForm',
+        'PasswordResetRequest',
+        'UsersChangePassword',
+        'UsersResetPassword',
+        'UsersSetPassword',
+        'UsersPasswordEntry',
+        'UsersNewAccount',
+
+        // REST plumbing. ApiRequest runs the same capability check itself
+        // before dispatching; CorsPreflight answers OPTIONS only.
+        'ApiRequest',
+        'CorsPreflight',
+
+        // CLI-only. Core\Controller\Cli::__construct() exits unless
+        // request_mode === 'cli', so these are not web-reachable.
+        'FlushCacheCli',
+        'InstallCli',
+        'UpdatesApplyCli',
+
+        // Public/embeddable UI surfaces.
+        'OverlayLauncher',
+        'WidgetOwaNews',
+
+        // The "your schema is out of date" notice. Core\Controller::updateAction()
+        // redirects here, and that interception happens BEFORE the capability
+        // check on a possibly-unauthenticated request -- so gating this would
+        // put a login wall in front of the page the interception exists to
+        // show. It only lists module names; base.updatesApply, which actually
+        // mutates the schema, is gated instead.
+        'Updates',
+
+        // Not a controller at all -- a View (extends Core\View\RestApi)
+        // misfiled into a Controller/ directory. Harmless here; worth
+        // relocating on its own merits.
+        'DomstreamsRestView',
+    ];
+
+    public function testEveryControllerEitherDeclaresACapabilityOrIsKnownPublic(): void
+    {
+        $classes = $this->scanClasses();
+
+        $undeclared = [];
+        foreach ($classes as $name => $meta) {
+            if (! $meta['is_controller']) {
+                continue;
+            }
+            if ($this->effectiveCapability($name, $classes) === null) {
+                $undeclared[] = $name;
+            }
+        }
+        sort($undeclared);
+
+        $expected = self::INTENTIONALLY_PUBLIC;
+        sort($expected);
+
+        $this->assertSame(
+            $expected,
+            $undeclared,
+            "A controller's authorization is declared by setRequiredCapability().\n"
+            . "Controllers with no declaration run UNAUTHENTICATED.\n\n"
+            . "If you added a controller, either declare a capability in its\n"
+            . "constructor (see ModuleActivate) or add it to INTENTIONALLY_PUBLIC\n"
+            . "with a reason. Do not use 'install_schema' as a gate -- the\n"
+            . "'everyone' role holds it, so it authorizes nothing."
+        );
+    }
+
+    /**
+     * base.updatesApply executes module schema updates. Pinned explicitly
+     * because it is the case that motivated this test.
+     *
+     * Its sibling base.updates is intentionally left ungated -- see the entry
+     * in INTENTIONALLY_PUBLIC. Only the mutating action is gated, so the
+     * pre-auth update notice still renders.
+     */
+    public function testUpdatesApplyRequiresAnAdminOnlyCapability(): void
+    {
+        $classes = $this->scanClasses();
+
+        // Capabilities held ONLY by the admin role (Settings.php 'capabilities').
+        // 'install_schema' is excluded on purpose: the 'everyone' role holds it.
+        $adminOnly = ['edit_settings', 'edit_sites', 'edit_users', 'edit_modules'];
+
+        $cap = $this->effectiveCapability('UpdatesApply', $classes);
+
+        $this->assertNotNull($cap, 'UpdatesApply must declare a capability.');
+        $this->assertContains(
+            $cap,
+            $adminOnly,
+            "UpdatesApply must require an admin-only capability; '$cap' is "
+            . 'held by a non-admin role, so it would not gate the action.'
+        );
+    }
+
+    /**
+     * Static scan: class name => [parent, declared capability, is_controller].
+     * No framework boot -- this is a source-level contract.
+     */
+    private function scanClasses(): array
+    {
+        $root = dirname(__DIR__);
+        $files = array_merge(
+            glob($root . '/modules/*/Controller/*.php') ?: [],
+            glob($root . '/Core/*.php') ?: [],
+            glob($root . '/Core/Controller/*.php') ?: []
+        );
+
+        $classes = [];
+        foreach ($files as $file) {
+            $src = file_get_contents($file);
+            if ($src === false) {
+                continue;
+            }
+
+            if (! preg_match('/^\s*(?:abstract\s+)?class\s+(\w+)(?:\s+extends\s+([\\\\\w]+))?/m', $src, $m)) {
+                continue;
+            }
+
+            $name   = $m[1];
+            $parent = isset($m[2]) ? substr(strrchr('\\' . $m[2], '\\'), 1) : '';
+
+            // Only real CALLS on $this -- never the method definition in the
+            // base class, and never a variable argument.
+            $capability = null;
+            if (preg_match_all('/->setRequiredCapability\(\s*[\'"]([^\'"]+)[\'"]\s*\)/', $src, $calls)) {
+                $capability = $calls[1][0];
+            }
+
+            $classes[$name] = [
+                'parent'        => $parent,
+                'capability'    => $capability,
+                'is_controller' => strpos($file, '/Controller/') !== false
+                                   && strpos($file, '/modules/') !== false,
+            ];
+        }
+
+        // The base class defines setRequiredCapability(); it grants nothing.
+        if (isset($classes['Controller'])) {
+            $classes['Controller']['capability'] = null;
+        }
+
+        return $classes;
+    }
+
+    /** Walk the inheritance chain for the first declared capability. */
+    private function effectiveCapability(string $name, array $classes, array $seen = []): ?string
+    {
+        if (! isset($classes[$name]) || isset($seen[$name])) {
+            return null;
+        }
+        $seen[$name] = true;
+
+        return $classes[$name]['capability']
+            ?? $this->effectiveCapability($classes[$name]['parent'], $classes, $seen);
+    }
+}

--- a/tests/UpdatesCliTest.php
+++ b/tests/UpdatesCliTest.php
@@ -1,0 +1,222 @@
+<?php
+
+require_once __DIR__ . '/CliControllerTestCase.php';
+
+/**
+ * Probe update. Extends the real Core\Update so the guard logic under test is
+ * the production code, but replaces up()/down() so no schema is ever touched --
+ * including on the paths where a guard fails to hold, which is exactly when a
+ * naive test would start mutating the developer's database.
+ */
+final class UpdateGuardProbe extends \OWA\Core\Update
+{
+    public static bool $upCalled   = false;
+    public static bool $downCalled = false;
+
+    public static function reset(): void
+    {
+        self::$upCalled   = false;
+        self::$downCalled = false;
+    }
+
+    function up($force = false)
+    {
+        self::$upCalled = true;
+
+        return true;
+    }
+
+    function down()
+    {
+        self::$downCalled = true;
+
+        return true;
+    }
+}
+
+/**
+ * The CLI update path: `php cli.php cmd=update [listpending|apply=|rollback=]`
+ *
+ * This path matters more than it looks. base.updatesApply (web) is gated on the
+ * edit_modules capability, so if a future update ever breaks authentication
+ * itself -- new code querying a column an old schema lacks -- the web route
+ * cannot complete. The CLI is the documented escape hatch, and updates
+ * 005/006/007/010 already REQUIRE it via isCliModeRequired(). If the CLI
+ * command stops being wired up, an operator in that state has no way out.
+ *
+ * The sequencing guards in Core\Update are tested through a probe subclass:
+ * a guard that fails open would otherwise run real migrations against whatever
+ * database the suite is pointed at.
+ */
+final class UpdatesCliTest extends CliControllerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        UpdateGuardProbe::reset();
+    }
+
+    private function currentSchemaVersion(): int
+    {
+        return (int) owa_coreAPI::getSetting('base', 'schema_version');
+    }
+
+    private function makeProbe(int $schemaVersion): UpdateGuardProbe
+    {
+        $probe = new UpdateGuardProbe();
+        $probe->module_name    = 'base';
+        $probe->schema_version = $schemaVersion;
+
+        return $probe;
+    }
+
+    // -----------------------------------------------------------------
+    // Command wiring -- the escape hatch has to actually exist
+    // -----------------------------------------------------------------
+
+    public function testUpdateCommandIsRegistered(): void
+    {
+        $this->assertSame(
+            'base.updatesApplyCli',
+            $this->commandClass('update'),
+            'The `update` CLI command is the only way to apply updates when the '
+            . 'web path is unavailable. It must stay registered.'
+        );
+    }
+
+    public function testCliUpdateControllerIsGatedToCliOnly(): void
+    {
+        $src = file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/UpdatesApplyCli.php'
+        );
+
+        // Its protection is the SAPI gate in Core\Controller\Cli::__construct
+        // (which exits unless request_mode === 'cli'), NOT a capability. If it
+        // ever stops extending that base it becomes web-reachable with no gate
+        // at all.
+        $this->assertMatchesRegularExpression(
+            '/class\s+UpdatesApplyCli\s+extends\s+\\\\OWA\\\\Core\\\\Controller\\\\Cli/',
+            $src,
+            'UpdatesApplyCli must extend Core\\Controller\\Cli -- that base is '
+            . 'what confines it to the command line.'
+        );
+    }
+
+    public function testRollbackIsReachableFromTheCli(): void
+    {
+        $src = file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/UpdatesApplyCli.php'
+        );
+
+        $this->assertStringContainsString(
+            "getParam('rollback')",
+            $src,
+            'The CLI must keep exposing rollback (`cmd=update rollback=base.UpdateNNN`); '
+            . 'it is the only rollback interface OWA has.'
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // apply() sequencing guards
+    // -----------------------------------------------------------------
+
+    public function testApplyRefusesWhenSchemaVersionIsUnset(): void
+    {
+        $probe = $this->makeProbe(0);
+        $probe->schema_version = null;
+
+        $this->assertFalse(
+            $probe->apply(),
+            'apply() must refuse when schema_version is unset, or updates '
+            . 'silently drift out of sequence.'
+        );
+        $this->assertFalse(
+            UpdateGuardProbe::$upCalled,
+            'up() ran despite schema_version being unset.'
+        );
+    }
+
+    public function testApplyRefusesAnAlreadyAppliedUpdate(): void
+    {
+        $current = $this->currentSchemaVersion();
+        $probe   = $this->makeProbe($current);
+
+        $this->assertFalse(
+            $probe->apply(),
+            'apply() must refuse an update already recorded as applied.'
+        );
+        $this->assertFalse(
+            UpdateGuardProbe::$upCalled,
+            're-applying an already-applied update executed up() -- this is how '
+            . 'a schema gets double-migrated.'
+        );
+    }
+
+    public function testApplyWithForceBypassesTheAlreadyAppliedGuard(): void
+    {
+        $current = $this->currentSchemaVersion();
+        $probe   = $this->makeProbe($current);
+
+        $probe->apply(true);
+
+        $this->assertTrue(
+            UpdateGuardProbe::$upCalled,
+            '--force must bypass the already-applied guard; that is its purpose.'
+        );
+
+        // Restore: apply() persists schema_version on success. Value is
+        // unchanged here (we forced the CURRENT version), but be explicit.
+        owa_coreAPI::setSetting('base', 'schema_version', $current);
+        $this->assertSame($current, $this->currentSchemaVersion());
+    }
+
+    // -----------------------------------------------------------------
+    // rollback() sequencing guards
+    // -----------------------------------------------------------------
+
+    public function testRollbackRefusesAnOutOfSequenceUpdate(): void
+    {
+        $current = $this->currentSchemaVersion();
+
+        // Far ahead of the installed schema: this update was never applied.
+        $probe = $this->makeProbe($current + 5);
+
+        $probe->rollback();
+
+        $this->assertFalse(
+            UpdateGuardProbe::$downCalled,
+            'down() ran for an update that was never applied. Rolling back out '
+            . 'of sequence tears down schema the instance still depends on.'
+        );
+        $this->assertSame(
+            $current,
+            $this->currentSchemaVersion(),
+            'A refused rollback still moved schema_version.'
+        );
+    }
+
+    /**
+     * NOTE: Core\Update::rollback() returns true unconditionally -- including
+     * on the refusal branch above -- and UpdatesApplyCli::rollback() ignores
+     * the return value and always prints "Rollback completed."
+     *
+     * So an operator rolling back out of sequence is told it worked when
+     * nothing happened. This test pins the CURRENT behaviour so the
+     * discrepancy is visible and deliberate rather than assumed; the misleading
+     * report is worth fixing separately, and when it is, this expectation
+     * should be inverted.
+     */
+    public function testRollbackReturnValueIsCurrentlyUninformative(): void
+    {
+        $current = $this->currentSchemaVersion();
+        $probe   = $this->makeProbe($current + 5);
+
+        $this->assertTrue(
+            $probe->rollback(),
+            'If rollback() now reports refusal properly, invert this test and '
+            . 'update UpdatesApplyCli::rollback() to stop printing '
+            . '"Rollback completed." unconditionally.'
+        );
+        $this->assertFalse(UpdateGuardProbe::$downCalled);
+    }
+}

--- a/tests/UpdatesCliTest.php
+++ b/tests/UpdatesCliTest.php
@@ -13,10 +13,14 @@ final class UpdateGuardProbe extends \OWA\Core\Update
     public static bool $upCalled   = false;
     public static bool $downCalled = false;
 
+    /** Simulate a down() that runs but does not finish. */
+    public static bool $downShouldFail = false;
+
     public static function reset(): void
     {
-        self::$upCalled   = false;
-        self::$downCalled = false;
+        self::$upCalled       = false;
+        self::$downCalled     = false;
+        self::$downShouldFail = false;
     }
 
     function up($force = false)
@@ -30,7 +34,7 @@ final class UpdateGuardProbe extends \OWA\Core\Update
     {
         self::$downCalled = true;
 
-        return true;
+        return ! self::$downShouldFail;
     }
 }
 
@@ -196,27 +200,92 @@ final class UpdatesCliTest extends CliControllerTestCase
     }
 
     /**
-     * NOTE: Core\Update::rollback() returns true unconditionally -- including
-     * on the refusal branch above -- and UpdatesApplyCli::rollback() ignores
-     * the return value and always prints "Rollback completed."
-     *
-     * So an operator rolling back out of sequence is told it worked when
-     * nothing happened. This test pins the CURRENT behaviour so the
-     * discrepancy is visible and deliberate rather than assumed; the misleading
-     * report is worth fixing separately, and when it is, this expectation
-     * should be inverted.
+     * rollback() must report refusal, not success. It previously returned true
+     * unconditionally, so UpdatesApplyCli printed "Rollback completed." even
+     * when nothing had run.
      */
-    public function testRollbackReturnValueIsCurrentlyUninformative(): void
+    public function testRollbackReturnsFalseWhenItRefuses(): void
     {
         $current = $this->currentSchemaVersion();
         $probe   = $this->makeProbe($current + 5);
 
-        $this->assertTrue(
+        $this->assertFalse(
             $probe->rollback(),
-            'If rollback() now reports refusal properly, invert this test and '
-            . 'update UpdatesApplyCli::rollback() to stop printing '
-            . '"Rollback completed." unconditionally.'
+            'A refused rollback reported success. The CLI relies on this return '
+            . 'value to decide what to tell the operator.'
         );
         $this->assertFalse(UpdateGuardProbe::$downCalled);
+    }
+
+    /**
+     * The success path, exercised WITHOUT mutating anything: when
+     * current === schema_version - 1 (rolling back an update that failed part
+     * way), rollback() runs down() and reports success but does not move
+     * schema_version -- there is nothing to move.
+     */
+    public function testRollbackReturnsTrueWhenDownSucceeds(): void
+    {
+        $current = $this->currentSchemaVersion();
+        $probe   = $this->makeProbe($current + 1);
+
+        $this->assertTrue(
+            $probe->rollback(),
+            'A rollback whose down() succeeded must report success.'
+        );
+        $this->assertTrue(UpdateGuardProbe::$downCalled, 'down() never ran.');
+        $this->assertSame(
+            $current,
+            $this->currentSchemaVersion(),
+            'schema_version moved on a branch that should not persist it.'
+        );
+    }
+
+    /**
+     * The dangerous outcome: down() ran and did NOT finish. The schema may be
+     * partially torn down, so schema_version must stay put and the caller must
+     * be told it failed -- silently reporting success here is how an operator
+     * ends up believing a rollback happened that did not.
+     */
+    public function testRollbackReturnsFalseWhenDownFailsPartWay(): void
+    {
+        $current = $this->currentSchemaVersion();
+        UpdateGuardProbe::$downShouldFail = true;
+
+        $probe = $this->makeProbe($current + 1);
+
+        $this->assertFalse(
+            $probe->rollback(),
+            'A rollback whose down() failed reported success.'
+        );
+        $this->assertTrue(UpdateGuardProbe::$downCalled, 'down() never ran.');
+        $this->assertSame(
+            $current,
+            $this->currentSchemaVersion(),
+            'schema_version was moved despite down() failing -- the recorded '
+            . 'version would then disagree with the actual schema.'
+        );
+    }
+
+    /**
+     * The CLI must branch on that return value rather than announcing success
+     * unconditionally.
+     */
+    public function testCliReportsAFailedRollbackHonestly(): void
+    {
+        $src = file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/UpdatesApplyCli.php'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/\$ret\s*=\s*\$u->rollback\(\)\s*;/',
+            $src,
+            'UpdatesApplyCli::rollback() must capture the return value.'
+        );
+        $this->assertStringContainsString(
+            'did NOT complete',
+            $src,
+            'UpdatesApplyCli must tell the operator when a rollback did not '
+            . 'complete instead of always printing "Rollback completed."'
+        );
     }
 }

--- a/tests/UpdatesWebAccessTest.php
+++ b/tests/UpdatesWebAccessTest.php
@@ -1,0 +1,256 @@
+<?php
+
+require_once __DIR__ . '/RestControllerTestCase.php';
+
+/**
+ * Probe subclass: inherits UpdatesApply's constructor (and therefore its
+ * setRequiredCapability + setNonceRequired declarations) but replaces action()
+ * so a passing gate never actually runs a schema migration against the test
+ * database. We are testing the gates, not the migrations.
+ */
+final class UpdatesApplyGateProbe extends \OWA\Module\Base\Controller\UpdatesApply
+{
+    public static bool $reached = false;
+
+    public static function reset(): void
+    {
+        self::$reached = false;
+    }
+
+    function action()
+    {
+        self::$reached = true;
+
+        return ['view' => 'base.blank'];
+    }
+}
+
+/**
+ * Access control on the web update flow.
+ *
+ * base.updatesApply mutates the schema. It is guarded by two independent
+ * checks in Core\Controller::doAction(), in this order:
+ *
+ *   1. line 222 -- checkCapabilityAndAuthenticateUser('edit_modules')
+ *   2. line 230 -- the nonce check, only when request_mode === 'web_app'
+ *
+ * Before this was fixed it had NEITHER, so an unauthenticated request could
+ * run pending module updates.
+ *
+ * The ordering is deliberate and asserted below: an anonymous visitor is
+ * stopped by the capability gate, not by a confusing nonce failure.
+ *
+ * Its sibling base.updates is intentionally ungated -- updateAction() redirects
+ * there when an out-of-date schema is detected, before any capability check, so
+ * requiring auth would hide the notice behind a login wall. That is asserted
+ * here too, so nobody "hardens" it by mistake.
+ */
+final class UpdatesWebAccessTest extends RestControllerTestCase
+{
+    private const APPLY_CLASS = \OWA\Module\Base\Controller\UpdatesApply::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The nonce check only engages for the web app; the REST base sets
+        // 'rest_api', which takes a different branch entirely.
+        owa_coreAPI::setSetting('base', 'request_mode', 'web_app');
+
+        UpdatesApplyGateProbe::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        owa_coreAPI::setSetting('base', 'request_mode', 'rest_api');
+
+        parent::tearDown();
+    }
+
+    /**
+     * Authenticate as a user with a caller-chosen label. The base
+     * authenticateAs() hardcodes 'auth', so it cannot produce two distinct
+     * accounts within one test -- which matters for the user-bound nonce.
+     *
+     * @return array{id:mixed, user_id:string}
+     */
+    private function authenticateAsDistinct(string $role, string $label): array
+    {
+        $fixture = $this->makeUser($role, $label);
+
+        $entity = owa_coreAPI::entityFactory('base.user');
+        $entity->load($fixture['id'], 'id');
+
+        $cu = owa_coreAPI::getCurrentUser();
+        $cu->loadNewUserByObject($entity);
+        $cu->setAuthStatus(true);
+
+        return $fixture;
+    }
+
+    /** Run the probe through the real doAction() pipeline. */
+    private function runProbe(array $params): bool
+    {
+        $ctrl = new UpdatesApplyGateProbe($params);
+        $ctrl->doAction();
+
+        return UpdatesApplyGateProbe::$reached;
+    }
+
+    public function testAnonymousRequestCannotApplyUpdates(): void
+    {
+        $this->resetCurrentUser();
+
+        $this->assertFalse(
+            $this->runProbe(['do' => 'base.updatesApply']),
+            'An unauthenticated request reached the update action. '
+            . 'base.updatesApply must require the edit_modules capability.'
+        );
+    }
+
+    public function testNonAdminRoleCannotApplyUpdates(): void
+    {
+        // 'viewer' holds install_schema/view_site_list/view_reports -- notably
+        // NOT edit_modules.
+        $this->authenticateAs('viewer');
+
+        $this->assertFalse(
+            $this->runProbe(['do' => 'base.updatesApply']),
+            'A viewer reached the update action; edit_modules is admin-only.'
+        );
+    }
+
+    public function testAdminWithoutANonceCannotApplyUpdates(): void
+    {
+        $this->authenticateAs('admin');
+
+        $this->assertFalse(
+            $this->runProbe(['do' => 'base.updatesApply']),
+            'An admin applied updates with no nonce. This is the CSRF path: a '
+            . 'crafted link would make a logged-in admin migrate the schema.'
+        );
+    }
+
+    public function testAdminWithAnInvalidNonceCannotApplyUpdates(): void
+    {
+        $this->authenticateAs('admin');
+
+        $this->assertFalse(
+            $this->runProbe([
+                'do'    => 'base.updatesApply',
+                'nonce' => 'not-a-real-nonce',
+            ]),
+            'A forged nonce was accepted.'
+        );
+    }
+
+    public function testAdminWithAValidNonceCanApplyUpdates(): void
+    {
+        $this->authenticateAs('admin');
+
+        // Must be minted AFTER authenticating: createNonce() binds to user_id.
+        $nonce = owa_coreAPI::createNonce('base.updatesApply');
+
+        $this->assertTrue(
+            $this->runProbe([
+                'do'    => 'base.updatesApply',
+                'nonce' => $nonce,
+            ]),
+            'A properly authenticated admin with a valid nonce was blocked. '
+            . 'The gates are too strict and the update flow is broken.'
+        );
+    }
+
+    /**
+     * The nonce is user-bound, which is what makes it a CSRF defence rather
+     * than a shared secret. A nonce minted for one user must not work for
+     * another.
+     */
+    public function testANonceMintedForAnotherUserIsRejected(): void
+    {
+        // NB: the base authenticateAs() always uses the label 'auth', so calling
+        // it twice re-creates the SAME user_id and the nonces match trivially.
+        // These must be two genuinely different accounts.
+        $this->authenticateAsDistinct('admin', 'nonce-owner');
+        $otherUsersNonce = owa_coreAPI::createNonce('base.updatesApply');
+
+        $this->resetCurrentUser();
+        $this->authenticateAsDistinct('admin', 'nonce-thief');
+
+        $this->assertFalse(
+            $this->runProbe([
+                'do'    => 'base.updatesApply',
+                'nonce' => $otherUsersNonce,
+            ]),
+            "Another user's nonce was accepted; the nonce is not user-bound."
+        );
+    }
+
+    /**
+     * Guards the deliberate asymmetry. base.updates is the target of the
+     * pre-auth schema-out-of-date interception -- see
+     * Core\Controller::updateAction(), which does
+     * setRedirectAction('base.updates') BEFORE the capability check runs.
+     */
+    public function testUpdatesNoticeStaysReachableWithoutAuthentication(): void
+    {
+        $this->resetCurrentUser();
+
+        $data = $this->runControllerData(
+            \OWA\Module\Base\Controller\Updates::class,
+            '/' . OWA_BASE_MODULE_DIR . 'Controller/Updates.php',
+            ['do' => 'base.updates']
+        );
+
+        $this->assertSame(
+            'base.updates',
+            $data['view'] ?? null,
+            'base.updates no longer renders for an unauthenticated request. '
+            . 'The update interception redirects here before any capability '
+            . 'check, so gating it hides the notice behind a login wall.'
+        );
+    }
+
+    /**
+     * Belt and braces: the declarations themselves, independent of the
+     * pipeline above.
+     */
+    public function testUpdatesApplyDeclaresBothGuards(): void
+    {
+        $src = file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/UpdatesApply.php'
+        );
+
+        $this->assertStringContainsString(
+            "setRequiredCapability('edit_modules')",
+            $src,
+            'UpdatesApply must require edit_modules. Note install_schema would '
+            . 'NOT work -- the "everyone" role holds it, so isEveryoneCapable() '
+            . 'short-circuits the check straight back off.'
+        );
+        $this->assertStringContainsString(
+            'setNonceRequired()',
+            $src,
+            'UpdatesApply must require a nonce (CSRF).'
+        );
+    }
+
+    /**
+     * The nonce is only useful if the link that drives the flow carries one.
+     * makeLink()'s 5th argument is $add_nonce.
+     */
+    public function testApplyUpdatesLinkCarriesANonce(): void
+    {
+        $tpl = file_get_contents(
+            dirname(__DIR__) . '/modules/Base/templates/updates.php'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/makeLink\(\s*array\(\s*[\'"]do[\'"]\s*=>\s*[\'"]base\.updatesApply[\'"]\s*\)\s*,[^)]*true\s*\)/',
+            $tpl,
+            'The "Apply updates" link must pass $add_nonce (makeLink 5th arg), '
+            . 'otherwise UpdatesApply::setNonceRequired() makes the flow '
+            . 'permanently fail.'
+        );
+    }
+}


### PR DESCRIPTION
Brings `base.updatesApply` in line with the other mutating admin actions: it applies module schema updates, so it should require an admin capability and a nonce like every other action that changes state.

## Capability

Now requires `edit_modules`, which only the admin role holds.

`install_schema` would **not** work as a gate: the `everyone` role holds it, so `isEveryoneCapable()` short-circuits the check straight back off. That is why the install controllers declare it and remain reachable — and it is the trap anyone matching on the surrounding pattern would fall into.

## Nonce

`setNonceRequired()` is set, and the "Apply updates" link passes `makeLink()`'s 5th argument (`$add_nonce`). **Both halves are required** — the flag alone makes the flow permanently fail; the link alone enforces nothing.

Ordering works in our favour: the capability check (line 222) precedes the nonce check (line 230), so a visitor without a session gets the login redirect rather than a confusing nonce failure.

## Why `base.updates` is deliberately left alone

`Core\Controller::updateAction()` does `setRedirectAction('base.updates')` when an out-of-date schema is detected, and **that interception runs before the capability check** (`doAction()` returns at 216, never reaching 222). Gating it would put a login wall in front of the notice the interception exists to show. It only lists module names; the mutating half is what is gated here.

## Recovery path

**Residual risk, stated plainly:** a future update that breaks authentication would leave the web path unable to complete. Recoverable, not a lockout — `php cli.php cmd=update` (`base.updatesApplyCli`, `Base/Module.php:540`) applies updates without web auth, and updates 005/006/007/010 already *require* CLI mode. That is why this PR also tests the CLI path.

## Also fixed here: rollback reported success when it had not run

`Core\Update::rollback()` returned `true` unconditionally — on success, on a failing `down()`, and on refusing an out-of-sequence rollback alike. Its only caller ignored the value and printed "Rollback completed." regardless, so an operator rolling back an update that was never applied was told it worked when nothing had happened.

It now returns `true` only when `down()` ran and succeeded, matching `apply()`'s contract in the same class. The CLI branches on it.

The two failure modes stay distinguishable in the messages, because they differ sharply:

- **refused** — nothing ran, schema untouched, the operator asked for something that does not apply.
- **failed** — `down()` ran and did not finish, so the schema may be **partially torn down** while `schema_version` deliberately stays put. The recorded version can then disagree with the actual schema, and the message now says so instead of a bare "Rollback failed."

Contract change, but the blast radius is one call site that discarded the value. Third-party updates implement `down()`; they do not call `rollback()`.

## Tests (+17)

**`UpdatesWebAccessTest` (9)** drives the real `doAction()` pipeline through a probe subclass that replaces `action()`, so a passing gate never runs a migration against the test database. No session / under-privileged role / missing nonce / forged nonce / valid nonce / another user's nonce — plus that `base.updates` stays reachable so the notice still renders.

**`UpdatesCliTest` (8)** covers the escape hatch that matters exactly when the web path cannot work: `update` still registered, `UpdatesApplyCli` confined to CLI by extending `Core\Controller\Cli`, rollback still exposed, and the `apply()`/`rollback()` sequencing guards — again via a probe, because a guard that fails open would migrate a real schema.

**`ControllerCapabilityContractTest` (2)** freezes the set of controllers with no declared capability so a new one cannot silently ship without one. Every entry carries a written reason.

**Mutation-verified throughout:** removing the capability fails 2 tests; removing `setNonceRequired()` fails 4; dropping `$add_nonce` from the link fails 1.

## Note on verification

I could not confirm the end state with a live request: `index.php?owa_do=...` returns HTTP 200 with zero bytes on my install for both gated and ungated controllers, and I did not chase down why. The reasoning is source-level; the tests exercise the controller pipeline directly rather than over HTTP.

## Gates

`phpstan` / `phpstan:migration` / `phpstan:templates` all `[OK]`; PHPUnit **191 tests, 2348 assertions OK**.
