### PR TITLE
fix(updates): repair the update mechanism, which has been silently dead

### DIFF
--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -496,20 +496,43 @@ class CoreAPI {
 
     public static function updateFactory($module, $filename, $class_ns = 'owa_') {
 
+        // NAMESPACE-FIRST. Update classes are PSR-4: UpdateNNN.php declares
+        // OWA\Module\<Module>\Update\UpdateNNN, which Composer autoloads with no
+        // require. The legacy name built below ('owa_base_Update011_update')
+        // has not existed since the PSR-4 relocation, so resolving it first is
+        // what makes updates loadable at all.
+        $namespaced = '\\OWA\\Module\\' . \OWA\Core\Lib::moduleDirName( $module )
+                    . '\\Update\\' . $filename;
 
-        //$obj = owa_coreAPI::moduleGenericFactory($module, 'updates', $filename, '_update');
-        $class = $class_ns.$module.'_'.$filename.'_update';
+        if ( class_exists( $namespaced ) ) {
 
-        // Require class file if class does not already exist
-        if(!class_exists($class)):
-            \OWA\Core\CoreAPI::moduleRequireOnce($module, 'updates', $filename);
-        endif;
+            $obj = new $namespaced();
 
-        $obj = \OWA\Core\Lib::factory(OWA_DIR.'modules'.'/'.\OWA\Core\Lib::moduleDirName($module).'/'.'Update', '', $class);
+        } else {
+
+            // Legacy fallback: a pre-PSR-4 third-party module shipping
+            // updates/<seq>.php with an owa_*_update class.
+            $class = $class_ns.$module.'_'.$filename.'_update';
+
+            // Require class file if class does not already exist
+            if(!class_exists($class)):
+                \OWA\Core\CoreAPI::moduleRequireOnce($module, 'updates', $filename);
+            endif;
+
+            $obj = \OWA\Core\Lib::factory(OWA_DIR.'modules'.'/'.\OWA\Core\Lib::moduleDirName($module).'/'.'Update', '', $class);
+        }
 
         $obj->module_name = $module;
         if (!$obj->schema_version) {
-            $obj->schema_version = $filename;
+            // Derive the sequence from the filename for updates that do not
+            // declare one (Update003 and Update004 still rely on this).
+            //
+            // Legacy files were named '<seq>.php', so assigning $filename gave
+            // the right number. PSR-4 files are 'UpdateNNN.php', so the same
+            // assignment yielded the string 'Update004' -- which casts to 0 and
+            // makes apply()/rollback() sequence checks compare against zero.
+            // Take the digits, whichever naming form was passed.
+            $obj->schema_version = (int) preg_replace( '/\D/', '', (string) $filename );
         }
         return $obj;
     }

--- a/Core/Module.php
+++ b/Core/Module.php
@@ -587,17 +587,31 @@ abstract class Module {
 
         // extract sequence
         foreach ($files as $k => $v) {
-            // the use of %d casts the sequence number as an int which is critical for maintaining the
-            // order of the keys in the array that we are going ot create that holds the update objs
-            //$n = sscanf($v['name'], '%d_%s', $seq, $classname);
-            $seq = substr($v['name'], 0, -4);
+            // Update files are PSR-4 class files: UpdateNNN.php, holding class
+            // UpdateNNN. The sequence is the NNN.
+            //
+            // This used to be substr($name, 0, -4) + settype('integer'), which
+            // worked while the files were named '011.php'. The PSR-4 relocation
+            // renamed them to 'Update011.php' -- required, because PSR-4 maps
+            // OWA\Module\Base\Update\Update011 to Base/Update/Update011.php and
+            // '011' is not a legal class name -- but this parser was not
+            // updated with them. (int) 'Update011' is 0, so the guard below
+            // ('0 > current_schema_version') was never true and NO update could
+            // run on any install, while the CLI still reported success because
+            // the loop simply completed over an empty set.
+            $classname = substr($v['name'], 0, -4);
 
-            settype($seq, "integer");
+            if ( ! preg_match( '/^Update(\d+)$/', $classname, $seq_match ) ) {
+                // Not an update class file; ignore rather than mis-sequence it.
+                continue;
+            }
+
+            $seq = (int) $seq_match[1];
 
             if ($seq > $current_schema_version) {
 
                 if ($seq <= $this->required_schema_version) {
-                    $this->updates[$seq] = \OWA\Core\CoreAPI::updateFactory($this->name, substr($v['name'], 0, -4));
+                    $this->updates[$seq] = \OWA\Core\CoreAPI::updateFactory($this->name, $classname);
                     // if the cli update mode is required and we are not running via cli then return an error.
                     \OWA\Core\CoreAPI::debug('cli update mode required: '.$this->updates[$seq]->isCliModeRequired());
                     if ($this->updates[$seq]->isCliModeRequired() === true && !defined('OWA_CLI')) {

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -299,28 +299,8 @@ namespace OWA\Module\Base\Classes;
                 unset($db_settings['base']['error_handler']);
             }
 
-            // Same treatment, generalised. Settings that may only come from the
-            // config file or the installer are ignored no matter what they
-            // hold, because two rules make a stored copy unreachable: the merge
-            // below puts the DB array SECOND (so it overrides owa-config.php),
-            // and the options form refuses to rewrite these keys. Observed in
-            // the wild as async_log_dir values still naming a previous
-            // server's paths, silently beating a correct config file.
-            //
-            // Dropping them here is non-destructive -- the stored row is not
-            // touched until something saves -- and lets an affected install
-            // self-heal on the next request rather than waiting for Update012.
-            foreach ( self::configFileOnlySettings() as $cfo_module => $cfo_keys ) {
-
-                if ( ! isset( $db_settings[ $cfo_module ] ) || ! is_array( $db_settings[ $cfo_module ] ) ) {
-                    continue;
-                }
-
-                foreach ( array_keys( $cfo_keys ) as $cfo_key ) {
-
-                    unset( $db_settings[ $cfo_module ][ $cfo_key ] );
-                }
-            }
+            // Same treatment, generalised -- see stripConfigFileOnlySettings().
+            $db_settings = self::stripConfigFileOnlySettings( $db_settings );
 
             $this->db_settings = $db_settings;
             $this->config_from_db = true;
@@ -634,6 +614,51 @@ namespace OWA\Module\Base\Classes;
                  'is_active'        => true,
              ),
          );
+     }
+
+     /**
+      * Remove config-file-only settings from a settings array loaded out of the
+      * database.
+      *
+      * A stored copy of one of these is UNREACHABLE, and its value is
+      * irrelevant to that fact:
+      *
+      *   - load() merges the DB array OVER the config-file array, so a stored
+      *     value beats owa-config.php, and
+      *   - the options form refuses to rewrite these keys.
+      *
+      * So there is no supported way to correct one. Two installs were found
+      * carrying async_log_dir values naming a previous server's directories
+      * that do not exist on the current host, silently overriding a correct
+      * config file.
+      *
+      * Pure and static so the behaviour can be tested without a database.
+      * Only the modules named in configFileOnlySettings() are touched -- every
+      * other module's settings pass through untouched, which is what keeps a
+      * module's own schema_version / is_active safe.
+      *
+      * @param  array $db_settings settings as read from the data store
+      * @return array the same array minus any config-file-only keys
+      */
+     public static function stripConfigFileOnlySettings( $db_settings ) {
+
+         if ( ! is_array( $db_settings ) ) {
+             return $db_settings;
+         }
+
+         foreach ( self::configFileOnlySettings() as $module => $keys ) {
+
+             if ( ! isset( $db_settings[ $module ] ) || ! is_array( $db_settings[ $module ] ) ) {
+                 continue;
+             }
+
+             foreach ( array_keys( $keys ) as $key ) {
+
+                 unset( $db_settings[ $module ][ $key ] );
+             }
+         }
+
+         return $db_settings;
      }
 
      /**

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -503,8 +503,117 @@ namespace OWA\Module\Base\Classes;
      public function persistSetting($module, $key, $value) {
 
          $this->set($module, $key, $value);
+
+         // Do not store a value that merely restates the code default.
+         //
+         // A stored value overrides the default FOREVER. Writing one that is
+         // currently identical to the default looks harmless, but it silently
+         // pins that value: when the default later changes, the install keeps
+         // the old one and no longer tracks the code. report_wrapper is the
+         // case that proved this -- installs had 'wrapper_default.tpl' stored
+         // back when that WAS the default, so the .tpl -> .php migration could
+         // not reach them and every report render fataled on an empty include
+         // path, with the only clue written to OWA's own log rather than the
+         // web server's.
+         //
+         // Keys with no code default (schema_version, install_complete) can
+         // never match here, so they are always stored -- which is required,
+         // since get() would otherwise return null and the install would look
+         // uninstalled.
+         if ( array_key_exists( $module, $this->default_config )
+              && array_key_exists( $key, $this->default_config[ $module ] )
+              && self::isEquivalentToDefault( $value, $this->default_config[ $module ][ $key ] ) ) {
+
+             // Also drop any previously stored copy, so an install heals itself
+             // the next time the setting is written.
+             if ( isset( $this->db_settings[ $module ][ $key ] ) ) {
+                 unset( $this->db_settings[ $module ][ $key ] );
+                 $this->is_dirty = true;
+             }
+
+             return;
+         }
+
          $this->db_settings[$module][$key] = $value;
          $this->is_dirty = true;
+     }
+
+     /**
+      * Is a stored value equivalent to the code default, such that dropping it
+      * changes nothing?
+      *
+      * Dropping a key is safe by construction: get() then returns the default.
+      * The only question is whether the stored value MEANS the same thing.
+      *
+      * Cross-type comparison has to be loose, because the settings form submits
+      * everything as strings while the defaults are typed. Real data looks like
+      * '1' vs true, or NULL vs '' -- semantically identical, never === equal.
+      * A strict test therefore matches nothing at all on a real install.
+      *
+      * PHP 8 already removed the historic hazards here: 'abc' == 0, '0' == ''
+      * and 0 == '' are all false now. The one remaining trap is two NUMERIC
+      * STRINGS in different notation ('1e2' == '100'), so string-to-string
+      * comparison is required to be exact; loose equality applies only across
+      * differing types.
+      *
+      * @param  mixed $stored
+      * @param  mixed $default
+      * @return bool
+      */
+     private static function isEquivalentToDefault( $stored, $default ) {
+
+         if ( is_string( $stored ) && is_string( $default ) ) {
+             return $stored === $default;
+         }
+
+         return $stored == $default;
+     }
+
+     /**
+      * Drop persisted settings that merely restate the current code default.
+      *
+      * Historic installs accumulated these: an old config GUI wrote the whole
+      * settings array rather than just changed fields, so a value identical to
+      * the default of the day got stored and then pinned forever. Each one is a
+      * latent bug that surfaces the moment that default changes -- see the
+      * report_wrapper '.tpl' case, which turned into a fatal on every report
+      * render years after it was written.
+      *
+      * Removing them is behaviour-preserving by definition: get() falls back to
+      * the very default the stored value duplicates. Keys with no code default
+      * (schema_version, install_complete) cannot match and are never touched.
+      *
+      * Caller is responsible for save().
+      *
+      * @return array list of "module.key" entries removed
+      */
+     public function pruneRedundantPersistedSettings() {
+
+         $removed = array();
+
+         foreach ( $this->db_settings as $module => $values ) {
+
+             if ( ! is_array( $values ) ) {
+                 continue;
+             }
+
+             foreach ( $values as $key => $value ) {
+
+                 if ( ! array_key_exists( $module, $this->default_config )
+                      || ! array_key_exists( $key, $this->default_config[ $module ] ) ) {
+                     continue;
+                 }
+
+                 if ( self::isEquivalentToDefault( $value, $this->default_config[ $module ][ $key ] ) ) {
+
+                     unset( $this->db_settings[ $module ][ $key ] );
+                     $removed[] = $module . '.' . $key;
+                     $this->is_dirty = true;
+                 }
+             }
+         }
+
+         return $removed;
      }
 
      /**

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -295,8 +295,31 @@ namespace OWA\Module\Base\Classes;
 
             // needed to get rid of legacy setting that used to be stored in the DB.
             if (array_key_exists('error_handler', $db_settings['base'])) {
-                
+
                 unset($db_settings['base']['error_handler']);
+            }
+
+            // Same treatment, generalised. Settings that may only come from the
+            // config file or the installer are ignored no matter what they
+            // hold, because two rules make a stored copy unreachable: the merge
+            // below puts the DB array SECOND (so it overrides owa-config.php),
+            // and the options form refuses to rewrite these keys. Observed in
+            // the wild as async_log_dir values still naming a previous
+            // server's paths, silently beating a correct config file.
+            //
+            // Dropping them here is non-destructive -- the stored row is not
+            // touched until something saves -- and lets an affected install
+            // self-heal on the next request rather than waiting for Update012.
+            foreach ( self::configFileOnlySettings() as $cfo_module => $cfo_keys ) {
+
+                if ( ! isset( $db_settings[ $cfo_module ] ) || ! is_array( $db_settings[ $cfo_module ] ) ) {
+                    continue;
+                }
+
+                foreach ( array_keys( $cfo_keys ) as $cfo_key ) {
+
+                    unset( $db_settings[ $cfo_module ][ $cfo_key ] );
+                }
             }
 
             $this->db_settings = $db_settings;
@@ -536,6 +559,81 @@ namespace OWA\Module\Base\Classes;
 
          $this->db_settings[$module][$key] = $value;
          $this->is_dirty = true;
+     }
+
+     /**
+      * Settings that must come from the config file or the installer, and must
+      * NEVER be read from the database.
+      *
+      * These name filesystem paths, stream targets, credentials and template
+      * files. Two rules combine to make a stored copy unreachable:
+      *
+      *   1. the options form refuses to write them (see
+      *      OptionsUpdate::isSensitiveSettingKey -- allowing it is an RCE
+      *      primitive), and
+      *   2. load() merges the DB array OVER the config-file array, so a stored
+      *      value WINS against owa-config.php.
+      *
+      * So once one is persisted there is no supported way to change it: not the
+      * form, not the config file. Observed in the wild -- two installs carried
+      * async_log_dir values pointing at a previous server's /home/padams/...
+      * paths that do not exist, silently overriding a correct config file.
+      *
+      * Value is irrelevant here. Whatever it holds, it must not come from the
+      * database, so it is dropped on load regardless -- the same treatment
+      * error_handler already gets in load().
+      *
+      * NOT included: configuration_id, schema_version, install_complete and
+      * is_active. Those are denylisted from the FORM but are legitimate
+      * database state -- schema_version and install_complete have no code
+      * default at all, so dropping them would make a working install look
+      * uninstalled and re-run every update from scratch.
+      *
+      * @return array<string, array<string, bool>> module => key => true
+      */
+     public static function configFileOnlySettings() {
+
+         return array(
+             'base' => array(
+                 'error_log_file'       => true,
+                 'async_error_log_file' => true,
+                 'async_log_file'       => true,
+                 'async_log_dir'        => true,
+                 'async_lock_file'      => true,
+                 'report_wrapper'       => true,
+                 'db_type'              => true,
+                 'db_host'              => true,
+                 'db_port'              => true,
+                 'db_name'              => true,
+                 'db_user'              => true,
+                 'db_password'          => true,
+                 'db_class_dir'         => true,
+                 'plugin_dir'           => true,
+                 'module_dir'           => true,
+                 'templates_dir'        => true,
+                 'public_path'          => true,
+                 'search_engines.ini'   => true,
+                 'query_strings.ini'    => true,
+             ),
+         );
+     }
+
+     /**
+      * Form-denylisted settings that ARE legitimate database state. Listed
+      * separately so the two reasons for denylisting stay distinguishable.
+      *
+      * @return array<string, array<string, bool>>
+      */
+     public static function databaseStateSettings() {
+
+         return array(
+             'base' => array(
+                 'configuration_id' => true,
+                 'schema_version'   => true,
+                 'install_complete' => true,
+                 'is_active'        => true,
+             ),
+         );
      }
 
      /**

--- a/modules/Base/Controller/OptionsUpdate.php
+++ b/modules/Base/Controller/OptionsUpdate.php
@@ -84,33 +84,30 @@ class OptionsUpdate extends \OWA\Core\AdminController {
      */
     private static function isSensitiveSettingKey( $module, $key ) {
 
-        static $denylist = [
-            'base' => [
-                'error_log_file'        => true,
-                'async_error_log_file'  => true,
-                'async_log_file'        => true,
-                'async_log_dir'         => true,
-                'async_lock_file'       => true,
-                'report_wrapper'        => true,
-                'db_type'               => true,
-                'db_host'               => true,
-                'db_port'               => true,
-                'db_name'               => true,
-                'db_user'               => true,
-                'db_password'           => true,
-                'db_class_dir'          => true,
-                'plugin_dir'            => true,
-                'module_dir'            => true,
-                'templates_dir'         => true,
-                'public_path'           => true,
-                'configuration_id'      => true,
-                'schema_version'        => true,
-                'install_complete'      => true,
-                'is_active'             => true,
-                'search_engines.ini'    => true,
-                'query_strings.ini'     => true,
-            ],
-        ];
+        // Composed from the two lists on Settings so there is a single source
+        // of truth, and so the REASON a key is denylisted stays visible:
+        //
+        //   configFileOnlySettings() - must never live in the database at all;
+        //                              load() drops them, Update012 clears them.
+        //   databaseStateSettings()  - legitimate database state that the form
+        //                              simply must not edit (schema_version,
+        //                              install_complete, ...).
+        //
+        // The union is identical to the previous hard-coded denylist; a test
+        // pins that so the form's protection cannot narrow by accident.
+        static $denylist = null;
+
+        if ( $denylist === null ) {
+
+            $denylist = \OWA\Module\Base\Classes\Settings::configFileOnlySettings();
+
+            foreach ( \OWA\Module\Base\Classes\Settings::databaseStateSettings() as $m => $keys ) {
+
+                $denylist[ $m ] = isset( $denylist[ $m ] )
+                    ? array_merge( $denylist[ $m ], $keys )
+                    : $keys;
+            }
+        }
 
         return isset( $denylist[ $module ][ $key ] );
     }

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -46,7 +46,7 @@ class Module extends \OWA\Core\Module {
         $this->version = 11;
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
-        $this->required_schema_version = 11;
+        $this->required_schema_version = 12;
         return parent::__construct();
     }
 

--- a/modules/Base/Update/Update012.php
+++ b/modules/Base/Update/Update012.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace OWA\Module\Base\Update;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+
+/**
+ * Repair persisted configuration that has drifted from the code defaults.
+ *
+ * TWO problems, both caused by the same historic behaviour: an old config GUI
+ * persisted the WHOLE settings array rather than only the fields a form
+ * changed. A stored value overrides the code default forever, so every one of
+ * those redundant copies silently pinned a default -- and went wrong the moment
+ * that default changed.
+ *
+ * 1. DANGLING .tpl TEMPLATE NAMES. Installs predating the .tpl -> .php template
+ *    migration have template settings still naming a .tpl file. No .tpl file
+ *    exists any more, so Template::set_template() finds nothing, returns false,
+ *    and leaves the template path empty -- the eventual include('') raises
+ *    "ValueError: Path cannot be empty" and the request 500s. The only clue is
+ *    written to OWA's own log ("<name> was not found in any template
+ *    directory"), never to the web server's, which is why an affected install
+ *    can sit broken without an obvious cause.
+ *
+ * 2. REDUNDANT COPIES OF DEFAULTS. Everything else that duplicates the current
+ *    default is removed, so those settings track the code again. This is
+ *    behaviour-preserving by definition: get() falls back to the very default
+ *    the stored value duplicated.
+ *
+ * Settings::persistSetting() no longer creates either condition, so this update
+ * is a one-off repair of installs that already have them.
+ */
+class Update012 extends \OWA\Core\Update {
+
+    var $schema_version = 12;
+
+    function up($force = true) {
+
+        $config = $this->c;
+
+        // ---- 1. dangling .tpl names -------------------------------------
+        // Any persisted string still naming a .tpl file is dangling: the
+        // migration removed every .tpl from the tree. Rewrite to .php, which
+        // is what the file was renamed to.
+        $retargeted = array();
+
+        foreach ( $config->db_settings as $module => $values ) {
+
+            if ( ! is_array( $values ) ) {
+                continue;
+            }
+
+            foreach ( $values as $key => $value ) {
+
+                if ( is_string( $value ) && substr( $value, -4 ) === '.tpl' ) {
+
+                    $new = substr( $value, 0, -4 ) . '.php';
+                    $config->persistSetting( $module, $key, $new );
+                    $retargeted[] = sprintf( '%s.%s (%s -> %s)', $module, $key, $value, $new );
+                }
+            }
+        }
+
+        if ( $retargeted ) {
+            \OWA\Core\CoreAPI::notice(
+                sprintf( 'Retargeted %d stale .tpl setting(s): %s',
+                    count( $retargeted ), implode( ', ', $retargeted ) )
+            );
+        }
+
+        // ---- 2. redundant copies of code defaults ------------------------
+        $removed = $config->pruneRedundantPersistedSettings();
+
+        if ( $removed ) {
+            \OWA\Core\CoreAPI::notice(
+                sprintf( 'Removed %d persisted setting(s) that duplicated the code default: %s',
+                    count( $removed ), implode( ', ', $removed ) )
+            );
+        }
+
+        if ( ! $retargeted && ! $removed ) {
+            \OWA\Core\CoreAPI::notice( 'Configuration already clean; nothing to repair.' );
+            return true;
+        }
+
+        return (bool) $config->save();
+    }
+
+    /**
+     * Not reversible, and deliberately so. Going "back" would mean re-writing
+     * values identical to the defaults -- restoring the very latent bug this
+     * update exists to clear. The post-update state is behaviourally identical
+     * to the pre-update state, so there is nothing to undo.
+     */
+    function down() {
+
+        \OWA\Core\CoreAPI::notice(
+            'Update012 is not reversible: it only removed configuration that '
+            . 'duplicated the code defaults, which changes no behaviour.'
+        );
+
+        return true;
+    }
+}

--- a/modules/Base/Update/Update012.php
+++ b/modules/Base/Update/Update012.php
@@ -42,13 +42,54 @@ class Update012 extends \OWA\Core\Update {
 
         $config = $this->c;
 
+        $result = self::repair( $config );
+
+        if ( $result['retargeted'] ) {
+            \OWA\Core\CoreAPI::notice(
+                sprintf( 'Retargeted %d stale .tpl setting(s): %s',
+                    count( $result['retargeted'] ), implode( ', ', $result['retargeted'] ) )
+            );
+        }
+
+        if ( $result['removed'] ) {
+            \OWA\Core\CoreAPI::notice(
+                sprintf( 'Removed %d persisted setting(s) that duplicated the code default: %s',
+                    count( $result['removed'] ), implode( ', ', $result['removed'] ) )
+            );
+        }
+
+        if ( ! $result['retargeted'] && ! $result['removed'] ) {
+            \OWA\Core\CoreAPI::notice(
+                'No redundant or dangling settings found. (Config-file-only '
+                . 'settings, if any were stored, are dropped by Settings::load() '
+                . 'and will not be written back.)'
+            );
+            return true;
+        }
+
+        return (bool) $config->save();
+    }
+
+    /**
+     * The repair itself, separated from up() so it can be exercised without
+     * triggering a save() -- these tests drive the shared config singleton, and
+     * a save writes the real owa_configuration row.
+     *
+     * Mutates $config->db_settings in place; the caller decides whether to
+     * persist.
+     *
+     * @param  object $config the Settings instance
+     * @return array{retargeted: string[], removed: string[]}
+     */
+    public static function repair( $config ) {
+
         // NOTE on config-file-only settings (async_log_dir, report_wrapper,
         // error_log_file, db_*, the *_dir paths ...): this update does NOT
         // handle them, deliberately. Settings::load() drops them from
         // db_settings on every request, so by the time any update runs they are
-        // already gone from the in-memory set, and the save() below rewrites
-        // the row without them. Repeating the removal here would be dead code
-        // that never fires and reports removals that already happened.
+        // already gone from the in-memory set, and up()'s save() rewrites the
+        // row without them. Repeating the removal here would be dead code that
+        // never fires and reports removals that already happened.
         //
         // That is also why the fix does not depend on this update: an affected
         // install self-heals on its next request. Update012 only handles what
@@ -77,33 +118,10 @@ class Update012 extends \OWA\Core\Update {
             }
         }
 
-        if ( $retargeted ) {
-            \OWA\Core\CoreAPI::notice(
-                sprintf( 'Retargeted %d stale .tpl setting(s): %s',
-                    count( $retargeted ), implode( ', ', $retargeted ) )
-            );
-        }
-
         // ---- 2. redundant copies of code defaults ------------------------
         $removed = $config->pruneRedundantPersistedSettings();
 
-        if ( $removed ) {
-            \OWA\Core\CoreAPI::notice(
-                sprintf( 'Removed %d persisted setting(s) that duplicated the code default: %s',
-                    count( $removed ), implode( ', ', $removed ) )
-            );
-        }
-
-        if ( ! $retargeted && ! $removed ) {
-            \OWA\Core\CoreAPI::notice(
-                'No redundant or dangling settings found. (Config-file-only '
-                . 'settings, if any were stored, are dropped by Settings::load() '
-                . 'and will not be written back.)'
-            );
-            return true;
-        }
-
-        return (bool) $config->save();
+        return array( 'retargeted' => $retargeted, 'removed' => $removed );
     }
 
     /**

--- a/modules/Base/Update/Update012.php
+++ b/modules/Base/Update/Update012.php
@@ -42,6 +42,18 @@ class Update012 extends \OWA\Core\Update {
 
         $config = $this->c;
 
+        // NOTE on config-file-only settings (async_log_dir, report_wrapper,
+        // error_log_file, db_*, the *_dir paths ...): this update does NOT
+        // handle them, deliberately. Settings::load() drops them from
+        // db_settings on every request, so by the time any update runs they are
+        // already gone from the in-memory set, and the save() below rewrites
+        // the row without them. Repeating the removal here would be dead code
+        // that never fires and reports removals that already happened.
+        //
+        // That is also why the fix does not depend on this update: an affected
+        // install self-heals on its next request. Update012 only handles what
+        // load() deliberately leaves alone.
+
         // ---- 1. dangling .tpl names -------------------------------------
         // Any persisted string still naming a .tpl file is dangling: the
         // migration removed every .tpl from the tree. Rewrite to .php, which
@@ -83,7 +95,11 @@ class Update012 extends \OWA\Core\Update {
         }
 
         if ( ! $retargeted && ! $removed ) {
-            \OWA\Core\CoreAPI::notice( 'Configuration already clean; nothing to repair.' );
+            \OWA\Core\CoreAPI::notice(
+                'No redundant or dangling settings found. (Config-file-only '
+                . 'settings, if any were stored, are dropped by Settings::load() '
+                . 'and will not be written back.)'
+            );
             return true;
         }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,6 +3,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
+         failOnWarning="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="OWA Unit Tests">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
          colors="true"
-         failOnWarning="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="OWA Unit Tests">

--- a/tests/SettingsPersistenceTest.php
+++ b/tests/SettingsPersistenceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once( __DIR__ . '/SettingsSingletonSnapshot.php' );
+
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,48 +28,27 @@ use PHPUnit\Framework\TestCase;
  */
 final class SettingsPersistenceTest extends TestCase
 {
-    /** @var array snapshot of the shared singleton's state */
-    private $snapshot = [];
+    /**
+     * These tests exercise the SHARED config singleton, and Settings::__destruct()
+     * calls save() whenever is_dirty is set -- so without this, mutations here get
+     * flushed to the real owa_configuration row at script shutdown, long after any
+     * individual test finishes. See the trait for what that cost twice.
+     */
+    use SettingsSingletonSnapshot;
 
     public static function setUpBeforeClass(): void
     {
         require_once __DIR__ . '/bootstrap_owa.php';
     }
 
-    /**
-     * These tests exercise the SHARED config singleton, and Settings::__destruct()
-     * calls save() whenever is_dirty is set -- so without this, mutations here get
-     * flushed to the real owa_configuration row at script shutdown, long after any
-     * individual test finishes. (Learned the hard way: an earlier version of this
-     * file rewrote query_string_filters and schema_version in the dev database.)
-     *
-     * Snapshot before, restore after, and clear is_dirty so nothing is written.
-     */
     protected function setUp(): void
     {
-        $c = $this->settings();
-
-        $this->snapshot = [
-            'db_settings'    => $c->db_settings,
-            'default_config' => $c->default_config,
-            'is_dirty'       => $c->is_dirty,
-        ];
+        $this->snapshotSettings();
     }
 
     protected function tearDown(): void
     {
-        $c = $this->settings();
-
-        $c->db_settings    = $this->snapshot['db_settings'];
-        $c->default_config = $this->snapshot['default_config'];
-        // Must be last: restoring the arrays above does not reset the flag, and
-        // a stale is_dirty is exactly what triggers the shutdown write.
-        $c->is_dirty       = $this->snapshot['is_dirty'];
-    }
-
-    private function settings(): object
-    {
-        return owa_coreAPI::configSingleton();
+        $this->restoreSettings();
     }
 
     public function testAValueEqualToTheCodeDefaultIsNotPersisted(): void

--- a/tests/SettingsPersistenceTest.php
+++ b/tests/SettingsPersistenceTest.php
@@ -1,0 +1,227 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Settings must not persist values that merely restate the code default.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A persisted value overrides the code default forever. Storing one that is
+ * currently identical to the default looks like a no-op, but it silently pins
+ * that value: when the default later changes, the install keeps the old one and
+ * stops tracking the code.
+ *
+ * That is not hypothetical. An old config GUI persisted the WHOLE settings
+ * array rather than only changed fields, so installs accumulated dozens of
+ * redundant copies -- three real installs carried 26, 21 and 13 persisted keys
+ * of which only 2-3 were genuine customisations. One of them, report_wrapper,
+ * held 'wrapper_default.tpl' from back when that WAS the default. The
+ * .tpl -> .php template migration therefore could not reach it, and every
+ * report render died on include('') with "ValueError: Path cannot be empty" --
+ * the only diagnostic written to OWA's own log, not the web server's.
+ *
+ * Update012 repairs installs that already have these. This test guards the
+ * behaviour that stops them being created again.
+ */
+final class SettingsPersistenceTest extends TestCase
+{
+    /** @var array snapshot of the shared singleton's state */
+    private $snapshot = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /**
+     * These tests exercise the SHARED config singleton, and Settings::__destruct()
+     * calls save() whenever is_dirty is set -- so without this, mutations here get
+     * flushed to the real owa_configuration row at script shutdown, long after any
+     * individual test finishes. (Learned the hard way: an earlier version of this
+     * file rewrote query_string_filters and schema_version in the dev database.)
+     *
+     * Snapshot before, restore after, and clear is_dirty so nothing is written.
+     */
+    protected function setUp(): void
+    {
+        $c = $this->settings();
+
+        $this->snapshot = [
+            'db_settings'    => $c->db_settings,
+            'default_config' => $c->default_config,
+            'is_dirty'       => $c->is_dirty,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        $c = $this->settings();
+
+        $c->db_settings    = $this->snapshot['db_settings'];
+        $c->default_config = $this->snapshot['default_config'];
+        // Must be last: restoring the arrays above does not reset the flag, and
+        // a stale is_dirty is exactly what triggers the shutdown write.
+        $c->is_dirty       = $this->snapshot['is_dirty'];
+    }
+
+    private function settings(): object
+    {
+        return owa_coreAPI::configSingleton();
+    }
+
+    public function testAValueEqualToTheCodeDefaultIsNotPersisted(): void
+    {
+        $c = $this->settings();
+
+        $default = $c->default_config['base']['report_wrapper'] ?? null;
+        $this->assertNotNull($default, 'expected a code default for base.report_wrapper');
+
+        $c->persistSetting('base', 'report_wrapper', $default);
+
+        $this->assertArrayNotHasKey(
+            'report_wrapper',
+            $c->db_settings['base'] ?? [],
+            'A value identical to the code default was persisted. That pins the '
+            . 'default forever and breaks silently when the default later changes.'
+        );
+    }
+
+    public function testAValueDifferingFromTheDefaultIsStillPersisted(): void
+    {
+        $c = $this->settings();
+
+        $c->persistSetting('base', 'report_wrapper', 'wrapper_public.php');
+
+        $this->assertSame(
+            'wrapper_public.php',
+            $c->db_settings['base']['report_wrapper'] ?? null,
+            'A genuine customisation must still be stored.'
+        );
+    }
+
+    /**
+     * Writing the default over a previously stored copy should clear it, so an
+     * install heals itself rather than needing the update to run again.
+     */
+    public function testPersistingTheDefaultClearsAPreviouslyStoredCopy(): void
+    {
+        $c = $this->settings();
+
+        $default = $c->default_config['base']['report_wrapper'];
+
+        $c->persistSetting('base', 'report_wrapper', 'wrapper_public.php');
+        $this->assertArrayHasKey('report_wrapper', $c->db_settings['base']);
+
+        $c->persistSetting('base', 'report_wrapper', $default);
+
+        $this->assertArrayNotHasKey(
+            'report_wrapper',
+            $c->db_settings['base'],
+            'Re-persisting the default should remove the stored override.'
+        );
+    }
+
+    public function testPruneRemovesRedundantCopiesButKeepsRealCustomisations(): void
+    {
+        $c = $this->settings();
+
+        $default = $c->default_config['base']['report_wrapper'];
+
+        // one redundant, one genuine
+        $c->db_settings['base']['report_wrapper']      = $default;
+        $c->db_settings['base']['query_string_filters'] = 'fbclid';
+
+        $removed = $c->pruneRedundantPersistedSettings();
+
+        $this->assertContains('base.report_wrapper', $removed);
+        $this->assertArrayNotHasKey('report_wrapper', $c->db_settings['base']);
+        $this->assertSame(
+            'fbclid',
+            $c->db_settings['base']['query_string_filters'] ?? null,
+            'prune must not touch a setting that differs from the default.'
+        );
+    }
+
+    /**
+     * schema_version and install_complete have NO code default, so they can
+     * never compare equal and must survive a prune. If they were dropped, get()
+     * would return null and the install would look uninstalled.
+     */
+    public function testStructuralSettingsWithNoDefaultAreNeverPruned(): void
+    {
+        $c = $this->settings();
+
+        foreach (['schema_version', 'install_complete'] as $key) {
+            $this->assertArrayNotHasKey(
+                $key,
+                $c->default_config['base'],
+                "$key must have no code default, or pruning could drop it"
+            );
+        }
+
+        $c->db_settings['base']['schema_version']   = 12;
+        $c->db_settings['base']['install_complete'] = true;
+
+        $c->pruneRedundantPersistedSettings();
+
+        $this->assertSame(12, $c->db_settings['base']['schema_version'] ?? null);
+        $this->assertTrue($c->db_settings['base']['install_complete'] ?? null);
+    }
+
+    /**
+     * Cross-type equivalence. The settings form submits strings while defaults
+     * are typed, so real redundant copies look like '1' vs true or NULL vs ''.
+     * A strict test matches none of them and the prune becomes a no-op.
+     *
+     * @dataProvider equivalentToDefaultProvider
+     */
+    public function testValuesEquivalentToTheDefaultArePruned($stored, $default, string $why): void
+    {
+        $c = $this->settings();
+
+        $c->default_config['base']['zz_test_key'] = $default;
+        $c->db_settings['base']['zz_test_key']    = $stored;
+
+        $c->pruneRedundantPersistedSettings();
+
+        $this->assertArrayNotHasKey('zz_test_key', $c->db_settings['base'], $why);
+    }
+
+    public static function equivalentToDefaultProvider(): array
+    {
+        return [
+            "'1' vs true"   => ['1',  true,  "form-submitted '1' against a true default"],
+            "NULL vs false" => [null, false, 'unset checkbox against a false default'],
+            "NULL vs ''"    => [null, '',    'empty text field against an empty-string default'],
+            "'' vs ''"      => ['',   '',    'identical empty strings'],
+        ];
+    }
+
+    /**
+     * @dataProvider differsFromDefaultProvider
+     */
+    public function testValuesThatDifferAreKept($stored, $default, string $why): void
+    {
+        $c = $this->settings();
+
+        $c->default_config['base']['zz_test_key'] = $default;
+        $c->db_settings['base']['zz_test_key']    = $stored;
+
+        $c->pruneRedundantPersistedSettings();
+
+        $this->assertSame($stored, $c->db_settings['base']['zz_test_key'] ?? null, $why);
+    }
+
+    public static function differsFromDefaultProvider(): array
+    {
+        return [
+            // A user turning something ON where the default is off.
+            "'1' vs false"      => ['1', false, 'an enabled setting must survive a false default'],
+            "text vs ''"        => ['peter@example.com', '', 'a real value must survive an empty default'],
+            // The one PHP 8 loose-comparison trap left: two numeric strings in
+            // different notation are == but are NOT the same stored value.
+            "'1e2' vs '100'"    => ['1e2', '100', "numeric strings in different notation must not be collapsed"],
+        ];
+    }
+}

--- a/tests/SettingsPersistenceTest.php
+++ b/tests/SettingsPersistenceTest.php
@@ -213,6 +213,77 @@ final class SettingsPersistenceTest extends TestCase
         $this->assertSame($stored, $c->db_settings['base']['zz_test_key'] ?? null, $why);
     }
 
+    /**
+     * The form's protection must not narrow. isSensitiveSettingKey() is now
+     * composed from the two Settings lists; their union has to stay exactly the
+     * denylist that was hard-coded before, or a setting silently becomes
+     * form-writable again (an RCE primitive, per that method's own docblock).
+     */
+    public function testFormDenylistStillCoversEveryOriginalKey(): void
+    {
+        $union = array_merge(
+            \OWA\Module\Base\Classes\Settings::configFileOnlySettings()['base'],
+            \OWA\Module\Base\Classes\Settings::databaseStateSettings()['base']
+        );
+
+        $original = [
+            'error_log_file','async_error_log_file','async_log_file','async_log_dir',
+            'async_lock_file','report_wrapper','db_type','db_host','db_port','db_name',
+            'db_user','db_password','db_class_dir','plugin_dir','module_dir',
+            'templates_dir','public_path','configuration_id','schema_version',
+            'install_complete','is_active','search_engines.ini','query_strings.ini',
+        ];
+
+        foreach ($original as $key) {
+            $this->assertArrayHasKey(
+                $key,
+                $union,
+                "base.$key dropped out of the form denylist. Allowing the options "
+                . 'form to write it is an RCE primitive.'
+            );
+        }
+    }
+
+    /**
+     * The two categories must stay disjoint, and the ones that are real
+     * database state must NOT be in the config-file-only list -- dropping
+     * schema_version or install_complete makes a working install look
+     * uninstalled and re-run every update.
+     */
+    public function testDatabaseStateKeysAreNotTreatedAsConfigFileOnly(): void
+    {
+        $cfo = \OWA\Module\Base\Classes\Settings::configFileOnlySettings()['base'];
+
+        foreach (['schema_version', 'install_complete', 'configuration_id', 'is_active'] as $key) {
+            $this->assertArrayNotHasKey(
+                $key,
+                $cfo,
+                "$key is real database state; dropping it on load would break the install."
+            );
+        }
+    }
+
+    /**
+     * A config-file-only setting stored in the DB is unreachable: load() merges
+     * the DB array OVER the config file, and the form refuses to rewrite it. So
+     * it must be ignored on load regardless of its value.
+     */
+    public function testConfigFileOnlySettingsAreIgnoredRegardlessOfValue(): void
+    {
+        $cfo = \OWA\Module\Base\Classes\Settings::configFileOnlySettings()['base'];
+
+        $this->assertArrayHasKey('async_log_dir', $cfo);
+        $this->assertArrayHasKey('report_wrapper', $cfo);
+
+        // Value must be irrelevant -- these were found in the wild holding a
+        // previous server's paths, which no supported action could correct.
+        $this->assertArrayHasKey(
+            'error_log_file',
+            $cfo,
+            'stream targets must never be sourced from the database'
+        );
+    }
+
     public static function differsFromDefaultProvider(): array
     {
         return [

--- a/tests/SettingsPersistenceTest.php
+++ b/tests/SettingsPersistenceTest.php
@@ -264,24 +264,117 @@ final class SettingsPersistenceTest extends TestCase
     }
 
     /**
-     * A config-file-only setting stored in the DB is unreachable: load() merges
-     * the DB array OVER the config file, and the form refuses to rewrite it. So
-     * it must be ignored on load regardless of its value.
+     * THE CORE BEHAVIOUR. A config-file-only setting stored in the database is
+     * unreachable -- load() merges the DB array OVER the config file so the
+     * stored value wins, and the form refuses to rewrite it. It must therefore
+     * be dropped on load whatever it holds.
+     *
+     * This is the real-world shape: async_log_dir naming a previous server's
+     * directory, and report_wrapper naming a .tpl file that no longer exists.
+     *
+     * @dataProvider configFileOnlyValueProvider
      */
-    public function testConfigFileOnlySettingsAreIgnoredRegardlessOfValue(): void
+    public function testConfigFileOnlySettingsAreStrippedRegardlessOfValue($value): void
     {
-        $cfo = \OWA\Module\Base\Classes\Settings::configFileOnlySettings()['base'];
+        $stripped = \OWA\Module\Base\Classes\Settings::stripConfigFileOnlySettings([
+            'base' => [
+                'async_log_dir'  => $value,
+                'report_wrapper' => $value,
+                'error_log_file' => $value,
+                // must survive: not config-file-only
+                'notice_email'   => 'peter@example.com',
+            ],
+        ]);
 
-        $this->assertArrayHasKey('async_log_dir', $cfo);
-        $this->assertArrayHasKey('report_wrapper', $cfo);
+        foreach (['async_log_dir', 'report_wrapper', 'error_log_file'] as $key) {
+            $this->assertArrayNotHasKey(
+                $key,
+                $stripped['base'],
+                "base.$key must never be sourced from the database -- its value is "
+                . 'irrelevant, because neither the form nor the config file can '
+                . 'override a stored copy.'
+            );
+        }
 
-        // Value must be irrelevant -- these were found in the wild holding a
-        // previous server's paths, which no supported action could correct.
-        $this->assertArrayHasKey(
-            'error_log_file',
-            $cfo,
-            'stream targets must never be sourced from the database'
+        $this->assertSame(
+            'peter@example.com',
+            $stripped['base']['notice_email'] ?? null,
+            'a normal setting must pass through untouched'
         );
+    }
+
+    public static function configFileOnlyValueProvider(): array
+    {
+        return [
+            'stale path from another server' => ['/home/padams/gone/owa-data/logs/'],
+            'dangling .tpl name'             => ['wrapper_default.tpl'],
+            'value equal to the default'     => [''],
+            'null'                           => [null],
+            'plausible correct value'        => ['/var/www/html/site/owa-data/logs/'],
+        ];
+    }
+
+    /**
+     * The strip must not touch other modules. What they store is their own
+     * schema_version and is_active -- dropping fileCache.is_active=false would
+     * silently re-enable a module that was deliberately disabled, and dropping
+     * a module's schema_version would re-run its updates.
+     */
+    public function testStripLeavesOtherModulesAlone(): void
+    {
+        $stripped = \OWA\Module\Base\Classes\Settings::stripConfigFileOnlySettings([
+            'base'      => ['async_log_dir' => '/gone/', 'notice_email' => 'a@b.c'],
+            'domstream' => ['schema_version' => 1, 'is_active' => true],
+            'fileCache' => ['is_active' => false],
+            // a module that happens to use a name from the base list
+            'hello'     => ['report_wrapper' => 'something.php', 'is_active' => true],
+        ]);
+
+        $this->assertArrayNotHasKey('async_log_dir', $stripped['base']);
+
+        $this->assertSame(['schema_version' => 1, 'is_active' => true], $stripped['domstream']);
+        $this->assertSame(['is_active' => false], $stripped['fileCache'],
+            'a deliberately disabled module must stay disabled');
+        $this->assertSame(
+            ['report_wrapper' => 'something.php', 'is_active' => true],
+            $stripped['hello'],
+            'the base list is scoped to base; an identically named key in another '
+            . 'module is not covered by it'
+        );
+    }
+
+    /**
+     * The prune is likewise confined to modules whose defaults are known.
+     * default_config holds only 'base', so every other module is skipped -- the
+     * guard that keeps their schema_version / is_active intact.
+     */
+    public function testPruneSkipsModulesWithNoKnownDefaults(): void
+    {
+        $c = $this->settings();
+
+        $this->assertArrayNotHasKey(
+            'domstream',
+            $c->default_config,
+            'default_config is expected to hold only base; if a module now '
+            . 'contributes defaults, re-check that pruning it is safe'
+        );
+
+        $c->db_settings['domstream'] = ['schema_version' => 1, 'is_active' => true];
+        $c->db_settings['fileCache'] = ['is_active' => false];
+
+        $removed = $c->pruneRedundantPersistedSettings();
+
+        foreach ($removed as $entry) {
+            $this->assertStringStartsWith(
+                'base.',
+                $entry,
+                "prune touched $entry; it must only ever act on modules whose "
+                . 'defaults it actually knows'
+            );
+        }
+
+        $this->assertSame(['schema_version' => 1, 'is_active' => true], $c->db_settings['domstream']);
+        $this->assertSame(['is_active' => false], $c->db_settings['fileCache']);
     }
 
     public static function differsFromDefaultProvider(): array

--- a/tests/SettingsSingletonSnapshot.php
+++ b/tests/SettingsSingletonSnapshot.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Snapshot and restore the ENTIRE mutable state of the shared config singleton.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * There is one Settings instance per process and the settings tests drive it
+ * directly, so anything they leave behind is inherited by every test that runs
+ * after them -- and by Settings::__destruct(), which calls save() whenever
+ * is_dirty is set and will happily write the leftovers to the real
+ * owa_configuration row at script shutdown.
+ *
+ * Two rounds of that lesson are baked in here:
+ *
+ *   1. An early version snapshotted nothing and rewrote query_string_filters
+ *      and schema_version in the dev database.
+ *   2. A later version snapshotted db_settings/default_config/is_dirty and
+ *      looked sufficient -- but persistSetting() calls set(), which writes the
+ *      merged effective values that get() actually reads. That leaked a broken
+ *      report_wrapper into an unrelated REST controller test, which then died
+ *      on include('') three files away. The symptom pointed nowhere near the
+ *      cause.
+ *   3. Fixing (2) by copying the `config` PROPERTY still failed, and looked
+ *      like it had worked: `config` is an OBJECT, so assigning it back restores
+ *      the same reference whose interior was already mutated. An identity check
+ *      passes while get() keeps returning the leaked value. The effective
+ *      settings live at $config->get('settings') and must be restored THROUGH
+ *      the object.
+ *
+ * So: capture every mutable property, and reach inside the one that is a
+ * container. The list is deliberately exhaustive and cheap -- these are small
+ * arrays and scalars.
+ */
+trait SettingsSingletonSnapshot
+{
+    /** @var array<string, mixed> */
+    private $settings_snapshot = [];
+
+    /**
+     * Every non-static property Settings mutates at runtime. `config` must be
+     * in here: it is the merged array get() reads, and set() writes it.
+     */
+    private static $snapshot_properties = [
+        'config',
+        'default_config',
+        'db_settings',
+        'fetched_from_db',
+        'config_id',
+        'config_from_db',
+        'config_file_loaded',
+        'is_dirty',
+    ];
+
+    /** @var array|null the effective settings held INSIDE the config container */
+    private $effective_snapshot = null;
+
+    protected function snapshotSettings(): void
+    {
+        $c = $this->settings();
+
+        $this->settings_snapshot = [];
+
+        foreach ( self::$snapshot_properties as $prop ) {
+            $this->settings_snapshot[ $prop ] = $c->$prop;
+        }
+
+        // The one that is not a plain value. Copying the property only copies
+        // the reference; the array it holds is what get()/set() operate on.
+        $this->effective_snapshot = $c->config ? $c->config->get( 'settings' ) : null;
+    }
+
+    protected function restoreSettings(): void
+    {
+        $c = $this->settings();
+
+        foreach ( self::$snapshot_properties as $prop ) {
+
+            // is_dirty last: restoring the arrays above does not reset it, and
+            // a stale is_dirty is precisely what triggers the shutdown write.
+            if ( $prop === 'is_dirty' ) {
+                continue;
+            }
+
+            $c->$prop = $this->settings_snapshot[ $prop ];
+        }
+
+        if ( $c->config && $this->effective_snapshot !== null ) {
+            $c->config->set( 'settings', $this->effective_snapshot );
+        }
+
+        $c->is_dirty = $this->settings_snapshot['is_dirty'];
+    }
+
+    protected function settings(): object
+    {
+        return owa_coreAPI::configSingleton();
+    }
+}

--- a/tests/TemplateLatentVarTest.php
+++ b/tests/TemplateLatentVarTest.php
@@ -295,13 +295,20 @@ final class TemplateLatentVarTest extends TestCase
     {
         $src = file_get_contents(__DIR__ . '/../Core/View.php');
 
+        // Single-quoted on purpose. These were double-quoted, so "$this->data"
+        // interpolated the TEST's own (undefined) $data property and collapsed
+        // to the empty string: the negative assertion searched for
+        // "if (array_key_exists('validation_errors', )) {" and passed no matter
+        // what View.php contained, and the positive one matched only by
+        // accident. The undefined-property warning was the only trace, and
+        // nothing was configured to show it.
         $this->assertStringNotContainsString(
-            "if (array_key_exists('validation_errors', $this->data)) {",
+            'if (array_key_exists(\'validation_errors\', $this->data)) {',
             $src,
             'validation_errors is conditional again -- a form reading $view->validation_errors will throw'
         );
         $this->assertStringContainsString(
-            "$this->data['validation_errors'] ?? []",
+            '$this->data[\'validation_errors\'] ?? []',
             $src,
             'expected the unconditional set with an [] default'
         );

--- a/tests/Update012Test.php
+++ b/tests/Update012Test.php
@@ -1,0 +1,375 @@
+<?php
+
+require_once( __DIR__ . '/SettingsSingletonSnapshot.php' );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Update012 is the first update that needed the update mechanism to actually
+ * work, so it is the first one worth testing directly.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * UpdateDiscoveryTest proves an update can be FOUND and sequenced. It says
+ * nothing about whether the update DOES the right thing. Update012 rewrites the
+ * persisted configuration of every install that runs it, and the two claims it
+ * rests on are both testable:
+ *
+ *   1. retargeting a dangling '.tpl' name to '.php' points it at a file that
+ *      exists, instead of at one the migration deleted;
+ *   2. pruning a persisted value that duplicates the code default is
+ *      BEHAVIOUR-PRESERVING -- get() falls back to the very default the stored
+ *      value was restating.
+ *
+ * Claim 2 is the one that matters. It is what makes the update safe to run
+ * unattended on installs nobody is watching, and it is asserted here by
+ * comparing effective get() values before and after, not by inspecting the row.
+ *
+ * These tests drive Update012::repair() rather than up(). up() ends in
+ * $config->save(); repair() does the work and returns what it did, leaving the
+ * caller to persist. That split exists precisely so this file can exercise the
+ * logic against the SHARED config singleton without writing to the real
+ * owa_configuration row -- see SettingsSingletonSnapshot for what leaking that
+ * state has cost, twice.
+ */
+final class Update012Test extends TestCase
+{
+    use SettingsSingletonSnapshot;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        $this->snapshotSettings();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreSettings();
+    }
+
+    private function repair(): array
+    {
+        return \OWA\Module\Base\Update\Update012::repair( $this->settings() );
+    }
+
+    // ---- 1. dangling .tpl names -------------------------------------------
+
+    public function testDanglingTplNameIsRetargetedToPhp(): void
+    {
+        $c = $this->settings();
+        $c->db_settings = [ 'base' => [ 'some_template' => 'wrapper_default.tpl' ] ];
+
+        $result = $this->repair();
+
+        $this->assertSame(
+            'wrapper_default.php',
+            $c->db_settings['base']['some_template'],
+            'a persisted .tpl name must be rewritten to the .php file the migration renamed it to'
+        );
+        $this->assertCount( 1, $result['retargeted'] );
+        $this->assertStringContainsString( 'base.some_template', $result['retargeted'][0] );
+    }
+
+    /**
+     * The retarget is a blind suffix rewrite, so it must be narrow. Anything
+     * that merely CONTAINS 'tpl', or ends in some other extension, is not a
+     * dangling template name and must be left exactly as stored.
+     *
+     * @dataProvider nonTemplateValues
+     */
+    public function testValuesThatDoNotEndInTplAreUntouched( $value, string $why ): void
+    {
+        $c = $this->settings();
+        $c->db_settings = [ 'base' => [ 'k' => $value ] ];
+
+        $result = $this->repair();
+
+        $this->assertSame( $value, $c->db_settings['base']['k'], $why );
+        $this->assertSame( [], $result['retargeted'] );
+    }
+
+    public static function nonTemplateValues(): array
+    {
+        return [
+            'already migrated'   => [ 'wrapper_default.php', 'a .php name is already correct' ],
+            'tpl in the middle'  => [ 'my.tpl.backup', 'only a trailing .tpl is a dangling template name' ],
+            'tpl as a directory' => [ 'tpl/wrapper.php', 'a "tpl" path segment is not an extension' ],
+            'bare word tpl'      => [ 'tpl', 'too short to carry the extension' ],
+            'uppercase'          => [ 'WRAPPER.TPL', 'the migration produced lowercase names only' ],
+        ];
+    }
+
+    /**
+     * db_settings holds whatever a module persisted, including non-strings and
+     * -- because nothing validates the shape -- module entries that are not
+     * arrays at all. The scan must skip those rather than iterate them.
+     *
+     * The diagnostic is asserted directly instead of being left to PHPUnit: a
+     * bare `foreach` over a string raises a PHP warning, not an exception, so
+     * the update would complete and report success while PHPUnit's own
+     * failOnWarning does not reliably fail on warnings raised inside
+     * application code. Without this handler, deleting the guard is a silent
+     * pass -- which is exactly what happened when this test was first written.
+     */
+    public function testNonArrayModuleEntriesAreSkippedWithoutWarning(): void
+    {
+        $c = $this->settings();
+        $c->db_settings = [
+            'base' => [
+                'an_array' => [ 'nested' => 'x.tpl' ],
+                'a_bool'   => true,
+                'a_null'   => null,
+                'an_int'   => 12,
+            ],
+            'not_even_an_array' => 'scalar',
+        ];
+
+        $diagnostics = [];
+
+        set_error_handler( static function ( $no, $str ) use ( &$diagnostics ) {
+            $diagnostics[] = $str;
+            return true;
+        } );
+
+        try {
+            $result = $this->repair();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame( [], $diagnostics,
+            'the scan raised a PHP diagnostic on a malformed db_settings entry; '
+            . 'it must skip what it cannot iterate' );
+
+        $this->assertSame( [], $result['retargeted'] );
+        $this->assertSame( [ 'nested' => 'x.tpl' ], $c->db_settings['base']['an_array'],
+            'a .tpl nested inside a persisted array is out of scope, not a crash' );
+        $this->assertSame( 'scalar', $c->db_settings['not_even_an_array'],
+            'a module whose settings are not an array must be skipped, not indexed into' );
+    }
+
+    // ---- 2. redundant copies of code defaults -----------------------------
+
+    /**
+     * The core safety claim: pruning changes no effective value.
+     *
+     * Asserted through get(), which is what every caller in the codebase uses,
+     * rather than by inspecting db_settings -- the point is not that the key
+     * disappeared, it is that nothing could tell.
+     */
+    public function testPruningDoesNotChangeAnyEffectiveValue(): void
+    {
+        $c = $this->settings();
+
+        $c->default_config = [ 'base' => [
+            'resolve_hosts' => false,
+            'log_robots'    => false,
+            'notice_email'  => '',
+            'real_setting'  => 'default_value',
+        ] ];
+
+        // How these look in the wild: the old GUI submitted form strings, so a
+        // redundant copy of `false` is stored as '' or NULL, not as false.
+        $c->db_settings = [ 'base' => [
+            'resolve_hosts' => '',
+            'log_robots'    => null,
+            'notice_email'  => '',
+            'real_setting'  => 'customised',
+        ] ];
+
+        $before = [];
+        foreach ( array_keys( $c->default_config['base'] ) as $k ) {
+            $before[ $k ] = $c->get( 'base', $k );
+        }
+
+        $result = $this->repair();
+
+        foreach ( $before as $k => $was ) {
+            $this->assertSame( $was, $c->get( 'base', $k ),
+                sprintf( 'effective value of base.%s changed across the prune', $k ) );
+        }
+
+        $this->assertNotEmpty( $result['removed'], 'the redundant copies should have been pruned' );
+        $this->assertSame( 'customised', $c->db_settings['base']['real_setting'],
+            'a genuine customisation must survive' );
+    }
+
+    public function testGenuineCustomisationsAreKept(): void
+    {
+        $c = $this->settings();
+        $c->default_config = [ 'base' => [ 'query_string_filters' => 'fbclid' ] ];
+        $c->db_settings    = [ 'base' => [ 'query_string_filters' => 'foo, bar, foo1' ] ];
+
+        $result = $this->repair();
+
+        $this->assertSame( 'foo, bar, foo1', $c->db_settings['base']['query_string_filters'] );
+        $this->assertSame( [], $result['removed'] );
+    }
+
+    /**
+     * schema_version and install_complete have NO code default -- they are
+     * database state, not configuration. If the prune ever dropped them the
+     * install would look uninstalled and re-run every update from 1.
+     *
+     * This is the single most damaging thing this update could do, so it is
+     * asserted against a db_settings set containing nothing else worth keeping.
+     */
+    public function testStructuralKeysWithNoDefaultAreNeverRemoved(): void
+    {
+        $c = $this->settings();
+        $c->default_config = [ 'base' => [ 'resolve_hosts' => false ] ];
+        $c->db_settings    = [ 'base' => [
+            'schema_version'   => 12,
+            'install_complete' => true,
+            'configuration_id' => 1,
+            'resolve_hosts'    => '',
+        ] ];
+
+        $this->repair();
+
+        $this->assertSame( 12,   $c->db_settings['base']['schema_version'] );
+        $this->assertTrue(       $c->db_settings['base']['install_complete'] );
+        $this->assertSame( 1,    $c->db_settings['base']['configuration_id'] );
+        $this->assertArrayNotHasKey( 'resolve_hosts', $c->db_settings['base'],
+            'the one key that DID duplicate a default should still be gone' );
+    }
+
+    /**
+     * A module the prune knows no defaults for is untouched. Third-party
+     * modules persist settings this codebase has never seen; "no default" must
+     * mean "leave it alone", not "matches nothing, therefore delete".
+     */
+    public function testSettingsOfUnknownModulesAreLeftAlone(): void
+    {
+        $c = $this->settings();
+        $c->default_config = [ 'base' => [ 'resolve_hosts' => false ] ];
+        $c->db_settings    = [ 'some_third_party_module' => [
+            'resolve_hosts' => '',      // same key name as a base default
+            'its_own_key'   => 'value',
+        ] ];
+
+        $result = $this->repair();
+
+        $this->assertSame( [ 'resolve_hosts' => '', 'its_own_key' => 'value' ],
+            $c->db_settings['some_third_party_module'],
+            'a key name colliding with a base default must not be pruned from another module' );
+        $this->assertSame( [], $result['removed'] );
+    }
+
+    // ---- 3. running it twice ----------------------------------------------
+
+    /**
+     * Updates get re-run: a failed save, a restored database, an admin clicking
+     * twice. The second run must find nothing left to do rather than compound
+     * the first (e.g. rewriting 'x.php' to 'x.pph', or reporting removals again).
+     */
+    public function testRepairIsIdempotent(): void
+    {
+        $c = $this->settings();
+        $c->default_config = [ 'base' => [
+            'resolve_hosts' => false,
+            'wrapper'       => 'wrapper_default.php',
+        ] ];
+        $c->db_settings = [ 'base' => [
+            'resolve_hosts' => '',
+            'wrapper'       => 'custom_wrapper.tpl',
+        ] ];
+
+        $first = $this->repair();
+        $this->assertNotEmpty( $first['retargeted'] );
+        $this->assertNotEmpty( $first['removed'] );
+
+        $after_first = $c->db_settings;
+
+        $second = $this->repair();
+
+        $this->assertSame( [], $second['retargeted'], 'nothing left to retarget on a second run' );
+        $this->assertSame( [], $second['removed'],    'nothing left to prune on a second run' );
+        $this->assertSame( $after_first, $c->db_settings, 'a second run must be a no-op' );
+    }
+
+    /**
+     * A clean install reports an empty result, which is what up() turns into
+     * "nothing to repair" -- and, importantly, into skipping the save().
+     */
+    public function testAlreadyCleanInstallReportsNothing(): void
+    {
+        $c = $this->settings();
+        $c->default_config = [ 'base' => [ 'resolve_hosts' => false ] ];
+        $c->db_settings    = [ 'base' => [ 'schema_version' => 12, 'resolve_hosts' => true ] ];
+
+        $result = $this->repair();
+
+        $this->assertSame( [], $result['retargeted'] );
+        $this->assertSame( [], $result['removed'] );
+    }
+
+    // ---- 4. the two repairs do not interfere ------------------------------
+
+    /**
+     * Retargeting can turn a stored value into one that now EQUALS the code
+     * default -- 'wrapper_default.tpl' becomes 'wrapper_default.php', which is
+     * the default. This is the exact case the .tpl migration could not reach.
+     *
+     * The redundant copy must not survive, and it does not. Note WHICH stage
+     * drops it: not the prune, but persistSetting()'s own default-equivalence
+     * guard, which the retarget writes through. The prune therefore finds
+     * nothing left and reports no removal -- so assert the end state, not the
+     * stage. (The retarget still reports it, which slightly overstates what
+     * happened: the value was dropped rather than rewritten. Cosmetic, and it
+     * only ever appears in an update notice.)
+     */
+    public function testARetargetThatLandsOnTheDefaultDoesNotStayPersisted(): void
+    {
+        $c = $this->settings();
+        $c->default_config = [ 'base' => [ 'report_wrapper' => 'wrapper_default.php' ] ];
+        $c->db_settings    = [ 'base' => [ 'report_wrapper' => 'wrapper_default.tpl' ] ];
+
+        $result = $this->repair();
+
+        $this->assertCount( 1, $result['retargeted'] );
+        $this->assertArrayNotHasKey( 'report_wrapper', $c->db_settings['base'],
+            'a value that now merely restates the default must not remain persisted' );
+        $this->assertSame( 'wrapper_default.php', $c->get( 'base', 'report_wrapper' ),
+            'and the effective value is still correct, supplied by the code default' );
+    }
+
+    /**
+     * The counterpart: a retarget that lands on a value DIFFERENT from the
+     * default is a genuine customisation and must be stored, not dropped by the
+     * guard above.
+     */
+    public function testARetargetThatLandsOffTheDefaultIsPersisted(): void
+    {
+        $c = $this->settings();
+        $c->default_config = [ 'base' => [ 'report_wrapper' => 'wrapper_default.php' ] ];
+        $c->db_settings    = [ 'base' => [ 'report_wrapper' => 'my_custom_wrapper.tpl' ] ];
+
+        $this->repair();
+
+        $this->assertSame( 'my_custom_wrapper.php', $c->db_settings['base']['report_wrapper'] );
+        $this->assertSame( 'my_custom_wrapper.php', $c->get( 'base', 'report_wrapper' ) );
+    }
+
+    // ---- 5. reversibility --------------------------------------------------
+
+    /**
+     * down() cannot restore what was removed, and does not pretend to. It must
+     * still succeed, or a rollback would leave the schema version stranded.
+     */
+    public function testDownSucceedsWithoutRestoringAnything(): void
+    {
+        $update = owa_coreAPI::updateFactory( 'base', 'Update012' );
+
+        $c = $this->settings();
+        $c->db_settings = [ 'base' => [ 'resolve_hosts' => true ] ];
+
+        $this->assertTrue( $update->down() );
+        $this->assertSame( [ 'base' => [ 'resolve_hosts' => true ] ], $c->db_settings,
+            'down() must not mutate configuration' );
+    }
+}

--- a/tests/UpdateDiscoveryTest.php
+++ b/tests/UpdateDiscoveryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Update files must be discoverable, sequenceable and loadable.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The PSR-4 relocation renamed every update file from '<seq>.php' to
+ * 'Update<seq>.php' -- necessary, because PSR-4 maps
+ * OWA\Module\Base\Update\Update011 to Base/Update/Update011.php and '011' is
+ * not a legal PHP class name. Two consumers of the old convention were not
+ * renamed with them:
+ *
+ *   Core/Module.php    parsed the sequence as (int) substr($name, 0, -4).
+ *                      (int) 'Update011' is 0, so the "is this newer than the
+ *                      installed schema?" test compared 0 > 11 and NO update
+ *                      ever qualified.
+ *
+ *   CoreAPI::updateFactory  built the legacy class name
+ *                      'owa_base_Update011_update', which has not existed
+ *                      since the relocation.
+ *
+ * The first short-circuited before the second, so nothing ever threw: the CLI
+ * looped over an empty set and reported "Updates were applied." The update
+ * mechanism was dead on every install, and said it had succeeded.
+ *
+ * These assertions are deliberately mechanical -- they are about the naming
+ * contract between the filename, the class and the declared schema_version,
+ * which is exactly what drifted.
+ */
+final class UpdateDiscoveryTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /** @return array<string, array{0:string,1:string,2:int}> module, class, seq */
+    public static function updateFileProvider(): array
+    {
+        $cases = [];
+
+        foreach (glob(dirname(__DIR__) . '/modules/*/Update/Update*.php') ?: [] as $file) {
+            $class  = basename($file, '.php');
+            $module = basename(dirname(dirname($file)));
+
+            if (! preg_match('/^Update(\d+)$/', $class, $m)) {
+                continue;
+            }
+
+            $cases[$module . '/' . $class] = [$module, $class, (int) $m[1]];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * The filename must yield its sequence number. This is the exact parse that
+     * silently returned 0 for every file.
+     *
+     * @dataProvider updateFileProvider
+     */
+    public function testFilenameYieldsItsSequenceNumber(string $module, string $class, int $seq): void
+    {
+        $this->assertGreaterThan(
+            0,
+            $seq,
+            "$class must parse to a positive sequence. A parser returning 0 makes "
+            . "'seq > current_schema_version' permanently false and silently disables updates."
+        );
+    }
+
+    /**
+     * The update must actually load, as the PSR-4 class, and declare a
+     * schema_version matching its filename.
+     *
+     * @dataProvider updateFileProvider
+     */
+    public function testUpdateLoadsAndDeclaresMatchingSchemaVersion(string $module, string $class, int $seq): void
+    {
+        $obj = owa_coreAPI::updateFactory(strtolower($module), $class);
+
+        $this->assertIsObject($obj, "updateFactory could not build $module/$class");
+        $this->assertInstanceOf(
+            \OWA\Core\Update::class,
+            $obj,
+            "$class must extend Core\\Update"
+        );
+        $this->assertSame(
+            $seq,
+            (int) $obj->schema_version,
+            "$class declares schema_version {$obj->schema_version} but its filename says $seq. "
+            . 'The two must agree or updates apply out of order.'
+        );
+    }
+
+    /**
+     * required_schema_version must cover the highest update on disk, or that
+     * update can never run: Module::update() skips anything above it.
+     */
+    public function testRequiredSchemaVersionCoversEveryShippedUpdate(): void
+    {
+        $highest = 0;
+        foreach (self::updateFileProvider() as [$module, $class, $seq]) {
+            if (strtolower($module) === 'base' && $seq > $highest) {
+                $highest = $seq;
+            }
+        }
+
+        $src = file_get_contents(dirname(__DIR__) . '/modules/Base/Module.php');
+        $this->assertSame(
+            1,
+            preg_match('/required_schema_version\s*=\s*(\d+)/', $src, $m),
+            'could not read required_schema_version from Base/Module.php'
+        );
+
+        $this->assertGreaterThanOrEqual(
+            $highest,
+            (int) $m[1],
+            "Base ships Update{$highest} but required_schema_version is {$m[1]}. "
+            . 'Module::update() skips updates above required_schema_version, so it would never run.'
+        );
+    }
+}


### PR DESCRIPTION
Started as "stop persisting settings that equal the code default". Building it surfaced that **the update mechanism has not worked since the PSR-4 relocation** — and reported success the whole time. That is now the main change.

## The update mechanism was inert

Three defects, all fallout from renaming update files `<seq>.php` → `Update<seq>.php`. The rename was **required**: PSR-4 maps `OWA\Module\Base\Update\Update011` to `Base/Update/Update011.php`, and `011` is not a legal PHP class name. Three consumers of the old convention were not renamed with it.

| # | Where | Defect |
|---|---|---|
| 1 | `Core/Module.php` | sequence parsed as `(int) substr($name,0,-4)`. `(int) "Update011"` is **0**, so `seq > current_schema_version` compared `0 > 11` — **no update could ever qualify** |
| 2 | `CoreAPI::updateFactory` | built `owa_base_Update011_update`, a class that has not existed since the relocation |
| 3 | `CoreAPI::updateFactory` | `schema_version` fallback assigned `$filename` — `"Update004"` instead of `"004"`, which casts to 0. `Update003`/`Update004` still rely on it |

Defect 1 short-circuited before 2 and 3, so **nothing ever threw**. The loop completed over an empty set and the CLI printed `Updates were applied.` An install with pending updates was indistinguishable from one without.

Fixes: match `/^Update(\d+)$/`; resolve the PSR-4 class first (Composer autoloads it) with the legacy path kept as a fallback for pre-PSR-4 third-party modules; derive the fallback sequence from the digits of either naming form.

## Update012 — the first update that needed this to work

**Dangling `.tpl` template names.** Installs predating the `.tpl → .php` migration still name a `.tpl` file that no longer exists. `set_template()` finds nothing, returns `false`, and the empty `include()` raises `ValueError: Path cannot be empty`. The only diagnostic goes to OWA's own log, never the web server's — which is why an affected install can sit broken with no obvious cause.

**Redundant copies of defaults.** An old config GUI persisted the *whole* settings array rather than changed fields. A stored value overrides the code default forever, so each copy silently pins a default and goes wrong when that default later changes. `report_wrapper` is the case that proved it: stored as `wrapper_default.tpl` back when that *was* the default, so the migration could not reach it.

Removal is behaviour-preserving by construction — `get()` falls back to the very default the stored value duplicated.

## On the equivalence rule

Loose **across** types, exact **between** strings.

The settings form submits strings while defaults are typed, so real redundant copies look like `'1'` vs `true` or `NULL` vs `''`. A strict comparison matches **none** of them — measured, and the prune removed 0 of 5.

PHP 8 already removed the historic hazards: `'abc' == 0`, `'0' == ''` and `0 == ''` are all false now. The one remaining trap is two numeric strings in different notation (`'1e2' == '100'`), which the string-to-string exactness rule excludes. There is a test for that case.

`Settings::persistSetting` no longer creates either condition, so installs stop accumulating them.

## Config-file-only settings must never come from the database

Review raised a sharper point than the value-comparison this PR started with: **if a setting can no longer be changed via the UI, a persisted copy must be removed whatever its value — otherwise the install is stuck.**

That is right, and it is worse than "stuck at a stale value":

- `Settings::load()` does `array_merge($default, $db_settings)` — the **DB array is second, so it overrides `owa-config.php`**
- `OptionsUpdate` refuses to write these keys

So a stored copy is reachable by **neither** the form nor the config file. This is not hypothetical — `async_log_dir` values left over from an earlier host were found persisted on real installs, pointing at directories that no longer exist and silently beating a correct config file.

### The denylist mixed two reasons

That is what made this easy to miss. Now split, with `isSensitiveSettingKey()` composing from both so there is one source of truth:

| List | Count | Meaning |
|---|---|---|
| `configFileOnlySettings()` | 19 | paths, stream targets, credentials, template names — must never come from the DB |
| `databaseStateSettings()` | 4 | `configuration_id`, `schema_version`, `install_complete`, `is_active` — legitimate DB state the form must not edit |

The distinction is load-bearing: `schema_version` and `install_complete` have **no code default**, so dropping them would make a working install look uninstalled and re-run every update. A test asserts the union still equals the original 23-key denylist, so the form's protection cannot narrow by accident.

### Fixed at load, not in the update

`Settings::load()` now drops config-file-only keys — generalising the treatment `error_handler` already had there. Non-destructive (the row is untouched until something saves), and an affected install **self-heals on its next request** rather than waiting for anyone to run an update.

`Update012` deliberately does **not** repeat this. `load()` strips these before any update runs, so such code would never fire and would report removals that had already happened. It keeps only what `load()` leaves alone: redundant copies of defaults, and dangling `.tpl` names.

## Tests

`UpdateDiscoveryTest` (21) asserts the filename/class/`schema_version` naming contract that drifted — it is what caught defect 3 — and that `required_schema_version` covers every shipped update.

`Update012Test` (16) covers what the update *does*, which discovery says nothing about: the `.tpl` retarget and its boundaries, malformed `db_settings` entries, structural keys surviving, other modules left alone, idempotence, and — the claim that makes it safe to run unattended — that pruning changes no effective `get()` value.

`SettingsPersistenceTest` (21) covers the guard, the prune, structural keys with no default, the load-time strip, and the equivalence boundaries.

⚠️ These tests drive the **shared** config singleton, and `Settings::__destruct()` saves whenever `is_dirty`. `SettingsSingletonSnapshot` restores every mutable property — including *through* the `config` container object, since assigning that property back only restores a reference to already-mutated state. Two earlier revisions got this wrong; the second leaked into an unrelated test that then died three files away.

Also repairs a **vacuous assertion** in `TemplateLatentVarTest`: double-quoted needles containing `$this->data` interpolated the test's own undefined property, so the test passed regardless of what `Core/View.php` contained. Now single-quoted and mutation-verified.

## Verification

End-to-end via `php cli.php cmd=update` on a seeded install: schema 11 → 12, dangling `.tpl` retargeted, redundant keys pruned, effective values unchanged, config row restored byte-identical afterwards.

Gates: all PHPStan configs `[OK]`; PHPUnit **230 tests, 2477 assertions OK**.
