### PR TITLE
fix(templates): guard the last 2 unguarded goal reads on the add path

### DIFF
--- a/modules/Base/templates/options_goal_entry.php
+++ b/modules/Base/templates/options_goal_entry.php
@@ -18,7 +18,7 @@
 
                 <th valign="top">Name:</th>
                 <td>
-                    <input name="<?php echo $view->getNs();?>goal[goal_name]" type="text" size="40" value="<?php $view->out($view->goal['goal_name']);?>">
+                    <input name="<?php echo $view->getNs();?>goal[goal_name]" type="text" size="40" value="<?php $view->out($view->goal['goal_name'] ?? '');?>">
                 </td>
             </tr>
             <tr>
@@ -126,7 +126,7 @@
                 </p>
                 </th>
                 <td>
-                    <input name="<?php echo $view->getNs();?>goal[details][goal_url]" value="<?php $view->out($view->goal['details']['goal_url'] ?? '');?>" type="text" size="60" value="<?php $view->out($view->goal['url']);?>">
+                    <input name="<?php echo $view->getNs();?>goal[details][goal_url]" value="<?php $view->out($view->goal['details']['goal_url'] ?? '');?>" type="text" size="60">
                 </td>
             </tr>
         </table>

--- a/tests/TemplateLatentVarTest.php
+++ b/tests/TemplateLatentVarTest.php
@@ -231,7 +231,27 @@ final class TemplateLatentVarTest extends TestCase
      */
     public function testAdminFormsRenderOnTheAddPath(string $template, array $vars, array $expected): void
     {
-        $out = $this->render($this->formSpy(), $template, $vars);
+        // The add path renders with an EMPTY record, so every read of a record
+        // field has to be guarded. An unguarded one is only a PHP warning --
+        // the form still renders and the assertions below still pass -- so the
+        // diagnostics are captured explicitly. Without this the template can
+        // warn on every render and nothing goes red: options_goal_entry.php did
+        // exactly that for $goal['goal_name'] and $goal['url'], visible only in
+        // a CI log nobody reads.
+        $diagnostics = [];
+
+        set_error_handler(static function ($no, $str, $file, $line) use (&$diagnostics) {
+            $diagnostics[] = sprintf('%s (%s:%d)', $str, basename((string) $file), $line);
+            return true;
+        });
+
+        try {
+            $out = $this->render($this->formSpy(), $template, $vars);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $diagnostics, "$template raised PHP diagnostics on the add path");
 
         foreach ($expected as $needle) {
             $this->assertStringContainsString($needle, $out, "$template: missing $needle");


### PR DESCRIPTION
The New Goal form warned twice on every render. Both were the only unguarded reads left in the file — the other twelve reads of `$view->goal[...]` already use `isset()` or `?? ''`.

| line | read | fix |
|---|---|---|
| 21 | `$view->goal['goal_name']` | `?? ''` |
| 129 | `$view->goal['url']` | deleted |

## Line 129 is not a missing guard

The input carried **two `value=` attributes**:

```php
<input name="...goal[details][goal_url]"
       value="<?php $view->out($view->goal['details']['goal_url'] ?? '');?>"
       type="text" size="60"
       value="<?php $view->out($view->goal['url']);?>">
```

Someone added the guarded `goal['details']['goal_url'] ?? ''` and left the old attribute in place. A browser honours the first, so the stray one never rendered anything — it only emitted a warning.

There is no `url` key on a goal at any point. The destination URL lives at `goal['details']['goal_url']`, which the surviving attribute already renders. Verified against `OptionsGoalEdit`, `ConversionHandlers` and `ReportGoalFunnel` — nothing reads or writes `goal['url']`. So it is deleted rather than guarded.

## Why nothing caught this

The add path renders with an empty record (`'goal' => []`), so both were **pure warnings**: the form rendered correctly and every existing assertion passed. `phpstan-templates` is `[OK]` on this file. Nothing was going to go red — the warnings were only ever visible in a CI log.

`testAdminFormsRenderOnTheAddPath` now installs its own error handler and fails on any diagnostic, which covers the other three form templates in that provider too.

Mutation-verified: restoring either read fails the test.

## Gates

PHPUnit **172 tests / 2,319 assertions OK**; `phpstan`, `phpstan:migration`, `phpstan:templates` all `[OK]`.
