### PR TITLE
chore(test): fail the build on warnings, and silence the one that blocked it

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,7 @@
          bootstrap="tests/bootstrap.php"
          colors="true"
          displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnWarning="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="OWA Unit Tests">

--- a/tests/bootstrap_owa.php
+++ b/tests/bootstrap_owa.php
@@ -45,14 +45,29 @@ if (!defined('OWA_TEST_BOOTSTRAPPED')) {
  * (rather than error) in environments without DB access. Uses a real
  * SELECT round-trip: mysqli_report is OFF and mysqli_init() leaves a truthy
  * handle even on a failed connect, so connection_status alone is unreliable.
+ *
+ * A FAILED probe is the expected, healthy path on a runner with no database --
+ * it is how 143 tests know to skip. But mysqli_real_connect() reports failure
+ * by raising a PHP warning, not by throwing, so the catch below never sees it
+ * and the warning surfaces attributed to whichever test happened to probe
+ * first. That one unavoidable warning is what kept failOnWarning off, which in
+ * turn let real warnings accumulate unnoticed.
+ *
+ * So the probe swallows diagnostics for its own duration only. This suppresses
+ * nothing else: the handler is installed immediately before the round-trip and
+ * restored immediately after, including on the throw path.
  */
 function owa_test_db_available(): bool
 {
+    set_error_handler(static function () { return true; });
+
     try {
         $db = owa_coreAPI::dbSingleton();
         $row = $db->get_row('SELECT 1 AS ok');
         return is_array($row) && isset($row['ok']) && $row['ok'] == 1;
     } catch (\Throwable $e) {
         return false;
+    } finally {
+        restore_error_handler();
     }
 }


### PR DESCRIPTION
A PHP warning has never failed CI, so warnings accumulated where nobody looked. Two real defects were sitting in that log:

- `options_goal_entry.php` warned on **every** render of the New Goal form (#964)
- a `TemplateLatentVarTest` assertion had interpolated itself into something that **could not fail** (#963)

Both are fixed. This stops the next pair hiding the same way.

## What was blocking it

The one warning that is *correct*. A runner with no database is the normal case in CI — **143 tests skip on it** — and they know to skip because `owa_test_db_available()` probes with a real `SELECT` round-trip.

`mysqli_real_connect()` reports failure by **raising a PHP warning rather than throwing**, and OWA sets `mysqli_report(MYSQLI_REPORT_OFF)` (`Core/Db/Mysql.php:123`), so the `catch (\Throwable)` never sees it. The warning then surfaced attributed to whichever test happened to probe first — `ActionIngestionTest`, which has nothing to do with it.

## The fix

The probe swallows diagnostics **for its own duration only**. The handler is installed immediately before the round-trip and restored in a `finally`, so it cannot leak past the probe or hide anything else.

Verified against a deliberately refused connection with `mysqli_report` OFF, which reproduces the CI warning exactly:

| | |
|---|---|
| unsuppressed | `PHP Warning: mysqli_real_connect(): (HY000/2002)` — the CI warning verbatim |
| inside the probe's handler | captured, none escapes |
| next connect attempt | warns again — proving the restore works |

## Note on what `failOnWarning` does and does not catch

It reliably fails on warnings raised in **test** code. Warnings raised inside **application** code are less consistent — I found a case (a `foreach` over a non-array in an update) that PHPUnit did not fail on even with this enabled.

So this is a safety net, not a guarantee. Where a specific diagnostic matters, the tests assert its absence directly with their own error handler rather than relying on this flag — see `Update012Test::testNonArrayModuleEntriesAreSkippedWithoutWarning` and `TemplateLatentVarTest::testAdminFormsRenderOnTheAddPath`.

## Gates

CI's warning count went **5 → 1** as the four real ones were fixed; this takes it to **0** and makes the next one fail the build rather than print.

Local suite: **253 tests, 2521 assertions OK**.
