### PR TITLE
fix(queue): let a remote sender set event payload, not queue bookkeeping

### DIFF
--- a/Core/EventQueue.php
+++ b/Core/EventQueue.php
@@ -96,13 +96,61 @@ class EventQueue  {
     }
 
     function prepareMessage( $msg ) {
-        
+
         return serialize( $msg );
     }
-    
+
     function decodeMessage ( $msg ) {
-        
-        return unserialize( $msg );
+
+        return unserialize( $msg, array( 'allowed_classes' => self::allowedEventClasses() ) );
+    }
+
+    /**
+     * The only classes a queued message is allowed to reconstruct.
+     *
+     * A queue blob is written by prepareMessage() from an object this instance
+     * built, so nothing an HTTP caller sends can name a class here -- their
+     * input lands in the event's PROPERTIES, and a string that looks like a
+     * serialized object stays a string through the round trip.
+     *
+     * The allowlist exists for the case where the blob is no longer trustworthy:
+     * anyone who can write to owa_queue_item (a SQL-injection foothold, stolen
+     * database credentials, a restored-from-elsewhere table) would otherwise
+     * have a straight path from "can write a row" to "can instantiate arbitrary
+     * classes on the next queue run". This turns that into a decode failure.
+     *
+     * Resolved through the support-class factory rather than hardcoded, because
+     * a module may substitute its own event class -- pinning
+     * Base\Classes\Event would silently break such an install by decoding its
+     * events into __PHP_Incomplete_Class.
+     *
+     * @return string[]
+     */
+    protected static function allowedEventClasses() {
+
+        static $classes = null;
+
+        if ( $classes === null ) {
+
+            $classes = array( 'OWA\Module\Base\Classes\Event' );
+
+            try {
+                $event = \OWA\Core\CoreAPI::supportClassFactory( 'base', 'event' );
+
+                if ( is_object( $event ) ) {
+                    $classes[] = get_class( $event );
+                }
+
+            } catch ( \Throwable $e ) {
+                // Fall back to the base class. A decode that then fails is
+                // visible as an unprocessable queue item, not a silent
+                // widening of what may be instantiated.
+            }
+
+            $classes = array_values( array_unique( $classes ) );
+        }
+
+        return $classes;
     }
     
     function pruneArchive ( $interval ) {

--- a/modules/Base/Classes/Event.php
+++ b/modules/Base/Classes/Event.php
@@ -262,20 +262,74 @@ class Event {
      }
 
     /**
-     * Loads Event class variables from an array
+     * Properties a remote sender is allowed to set on an incoming event.
      *
-     * @param     array $properties
+     * This is an ALLOWLIST because loadFromArray()'s only caller is queue.php,
+     * which is fed straight from an unauthenticated HTTP request. Everything
+     * absent from this list is queue bookkeeping that belongs to the RECEIVING
+     * instance, not to whoever posted the event.
+     *
+     * Letting a sender set those was a real (if narrow) problem. sendMessage()
+     * uses the event's guid as the queue-item PRIMARY KEY, and the retry
+     * machinery reads receive_count / do_not_receive_before_timestamp. A caller
+     * that could set them could collide with an existing queue item, park an
+     * event arbitrarily far in the future, or arrive pre-loaded with a receive
+     * count that trips the retry limits.
+     *
+     * Dropping them is also more correct on the merits: a freshly received
+     * event SHOULD start with fresh queue state, which is exactly what the
+     * constructor already gives it.
+     *
+     * guid and timestamp stay settable on purpose -- the remote-queue forwarder
+     * (HttpEventQueue) relays both, the guid is what makes a retried forward
+     * idempotent rather than duplicating the queue item, and the timestamp is
+     * the real event time from the upstream instance rather than the moment the
+     * forward happened to arrive. Both are validated below instead.
+     *
+     * @var string[]
+     */
+    private static $remote_settable = array(
+        'eventType',
+        'properties',
+        'guid',
+        'timestamp',
+    );
+
+    /**
+     * Loads Event class variables from an array.
+     *
+     * @param  array $vars
      */
      function loadFromArray ( $vars ) {
+
+        if ( ! is_array( $vars ) ) {
+            return;
+        }
 
          $has = get_object_vars( $this );
 
         foreach ($has as $name => $oldValue ) {
-        
-            if ( isset( $vars[$name] ) ) {
 
-                $this->$name = $vars[ $name ];
+            if ( ! in_array( $name, self::$remote_settable, true ) ) {
+                continue;
             }
+
+            if ( ! isset( $vars[ $name ] ) ) {
+                continue;
+            }
+
+            $value = $vars[ $name ];
+
+            // guid and timestamp are numeric by construction -- generateRandomUid()
+            // returns time().rand(6).serverId(3) and the guid column is a BIGINT.
+            // A non-numeric value here is not a valid event identifier, and the
+            // guid reaches the queue item's primary key.
+            if ( ( $name === 'guid' || $name === 'timestamp' )
+                 && ! ( is_int( $value ) || is_string( $value ) && ctype_digit( $value ) ) ) {
+                continue;
+            }
+
+            $this->$name = $value;
         }
     }
 

--- a/modules/Base/Classes/FileEventQueue.php
+++ b/modules/Base/Classes/FileEventQueue.php
@@ -354,7 +354,12 @@ class FileEventQueue extends \OWA\Core\EventQueue {
         if ($row) {
             $raw_event = explode("|*|", $row);
             $row_array = array( 'timestamp' => $raw_event[0], 'event_obj' => $raw_event[3]);
-            $event = unserialize(urldecode($row_array['event_obj']));
+            // Same allowlist as the db queue -- a log file anyone can append to
+            // must not be able to name the class that gets instantiated here.
+            $event = unserialize(
+                urldecode($row_array['event_obj']),
+                array( 'allowed_classes' => self::allowedEventClasses() )
+            );
             return $event;
         }
     }

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -287,7 +287,11 @@ namespace OWA\Module\Base\Classes;
 
         $db_config = \OWA\Core\CoreAPI::entityFactory('base.configuration');
         $db_config->getByPk('id', $id);
-        $db_settings = unserialize($db_config->get('settings'));
+        // The settings blob is a nested array of scalars and nothing else --
+        // save() writes serialize($this->db_settings). Refusing objects here
+        // costs nothing and means a tampered-with row cannot instantiate a
+        // class during unserialize.
+        $db_settings = unserialize($db_config->get('settings'), ['allowed_classes' => false]);
 
         //print $db_settings;
         // store copy of config for use with updates and set a flag
@@ -377,7 +381,8 @@ namespace OWA\Module\Base\Classes;
 
             if (!empty($settings)) {
 
-                $settings = unserialize($settings);
+                // Array data only, same as load() -- see the note there.
+                $settings = unserialize($settings, ['allowed_classes' => false]);
 
                 $new_config = array();
 

--- a/modules/Base/Entity/Site.php
+++ b/modules/Base/Entity/Site.php
@@ -66,7 +66,10 @@ class Site extends \OWA\Core\Entity {
 
     function settingsGetFilter($value) {
         if ($value) {
-            return unserialize($value);
+            // Site settings are an array of scalars -- settingsSetFilter()
+            // writes serialize($value) for exactly that. Refusing objects means
+            // a tampered-with column cannot instantiate a class on read.
+            return unserialize($value, ['allowed_classes' => false]);
         }
     }
 

--- a/tests/EventQueueHardeningTest.php
+++ b/tests/EventQueueHardeningTest.php
@@ -1,0 +1,233 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The remote event-queue ingress: what a sender may set, and what a queue blob
+ * may reconstruct.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * queue.php is fed straight from an unauthenticated HTTP request and is
+ * loadFromArray()'s ONLY caller. Two separate concerns meet there:
+ *
+ *   1. WHICH PROPERTIES a sender may set. Previously every property was
+ *      settable, including the queue bookkeeping the receiving instance owns.
+ *      sendMessage() uses the event guid as the queue item's PRIMARY KEY, and
+ *      the retry machinery reads receive_count and
+ *      do_not_receive_before_timestamp -- so a sender could collide with an
+ *      existing queue item, park an event arbitrarily far in the future, or
+ *      arrive pre-loaded with a receive count that trips the retry limits.
+ *
+ *   2. WHAT A QUEUE BLOB MAY INSTANTIATE. A blob is written by this instance
+ *      from its own object, so HTTP input cannot name a class -- see
+ *      testAHostileStringInAPropertyStaysAString, which pins that. The
+ *      allowlist is for when the blob itself is no longer trustworthy: anyone
+ *      who can write to owa_queue_item would otherwise have a path from "can
+ *      write a row" to "can instantiate arbitrary classes on the next queue
+ *      run".
+ *
+ * The allowlist must not be over-tightened either: pinning the concrete Event
+ * class would break an install whose module substitutes its own, by decoding
+ * every event into __PHP_Incomplete_Class. testALegitimateEventSurvives guards
+ * that direction.
+ */
+final class EventQueueHardeningTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function event(): object
+    {
+        return new \OWA\Module\Base\Classes\Event();
+    }
+
+    private function queue(): object
+    {
+        return new \OWA\Core\EventQueue();
+    }
+
+    // ---- 1. which properties a remote sender may set -----------------------
+
+    public function testEventTypeAndPropertiesAreAccepted(): void
+    {
+        $e = $this->event();
+
+        $e->loadFromArray([
+            'eventType'  => 'track.action',
+            'properties' => ['page_url' => 'https://example.com/x'],
+        ]);
+
+        $this->assertSame('track.action', $e->getEventType());
+        $this->assertSame('https://example.com/x', $e->get('page_url'),
+            'the event payload is the whole point of the endpoint and must still arrive');
+    }
+
+    /**
+     * The forwarder (HttpEventQueue) relays guid and timestamp, and both matter:
+     * the guid is what makes a retried forward idempotent instead of duplicating
+     * the queue item, and the timestamp is the real event time from upstream
+     * rather than whenever the forward arrived.
+     */
+    public function testNumericGuidAndTimestampAreAccepted(): void
+    {
+        $e = $this->event();
+
+        $e->loadFromArray(['guid' => '1753930000123456789', 'timestamp' => '1753930000']);
+
+        $this->assertSame('1753930000123456789', $e->getGuid());
+        // Asserted on the property, not get(): the constructor seeds BOTH
+        // $this->timestamp and $this->properties['timestamp'], and loadFromArray
+        // writes the property. A real forward also relays `properties` (export()
+        // returns every var), so both carry the upstream value in practice --
+        // see testARelayedEventCarriesTheUpstreamTimestampThroughProperties.
+        $this->assertSame('1753930000', $e->timestamp);
+    }
+
+    /**
+     * The realistic forward: HttpEventQueue sends export(), which includes the
+     * `properties` array, so the upstream timestamp arrives by that route too.
+     */
+    public function testARelayedEventCarriesTheUpstreamTimestampThroughProperties(): void
+    {
+        $e = $this->event();
+
+        $e->loadFromArray([
+            'eventType'  => 'track.action',
+            'timestamp'  => '1753930000',
+            'properties' => ['timestamp' => '1753930000', 'page_url' => 'https://example.com/x'],
+        ]);
+
+        $this->assertSame('1753930000', $e->timestamp);
+        $this->assertSame('1753930000', $e->get('timestamp'),
+            'the upstream event time must survive the relay, not be replaced by arrival time');
+    }
+
+    /**
+     * generateRandomUid() returns time().rand(6).serverId(3) and the guid column
+     * is a BIGINT, so a non-numeric guid is not a valid identifier -- and it
+     * reaches the queue item's primary key.
+     *
+     * @dataProvider nonNumericValues
+     */
+    public function testNonNumericGuidIsRejected($hostile): void
+    {
+        $e = $this->event();
+        $original = $e->getGuid();
+
+        $e->loadFromArray(['guid' => $hostile]);
+
+        $this->assertSame($original, $e->getGuid(),
+            'a non-numeric guid must not reach the queue item primary key');
+    }
+
+    public static function nonNumericValues(): array
+    {
+        return [
+            'sql-ish'        => ["1' OR '1'='1"],
+            'serialized'     => ['O:8:"stdClass":0:{}'],
+            'array'          => [['nested' => 'x']],
+            'negative'       => ['-1'],
+            'float'          => ['1.5'],
+            'empty string'   => [''],
+            'leading spaces' => ['  123'],
+        ];
+    }
+
+    /**
+     * Everything the receiving instance owns. A freshly received event has to
+     * start with fresh queue state -- which is what the constructor gives it.
+     *
+     * @dataProvider queueBookkeepingProperties
+     */
+    public function testQueueBookkeepingCannotBeSetByTheSender(string $property, $hostile): void
+    {
+        $e = $this->event();
+        $before = $e->$property ?? null;
+
+        $e->loadFromArray([$property => $hostile]);
+
+        $this->assertSame($before, $e->$property ?? null,
+            $property . ' is queue state owned by the receiver and must ignore sender input');
+    }
+
+    public static function queueBookkeepingProperties(): array
+    {
+        return [
+            // Would let a sender park an event arbitrarily far in the future.
+            'do_not_receive_before_timestamp' => ['do_not_receive_before_timestamp', 99999999999],
+            // Would let a sender arrive pre-loaded against the retry limits.
+            'receive_count'                   => ['receive_count', 9999],
+            // Would let a sender declare its own event already handled.
+            'status'                          => ['status', 'handled'],
+            'last_receive_timestamp'          => ['last_receive_timestamp', 123],
+            'first_receive_timestamp'         => ['first_receive_timestamp', 123],
+            'last_error_msg'                  => ['last_error_msg', 'spoofed'],
+            'old_queue_id'                    => ['old_queue_id', 42],
+        ];
+    }
+
+    public function testNonArrayInputIsIgnored(): void
+    {
+        $e = $this->event();
+        $type = $e->getEventType();
+
+        $e->loadFromArray('not an array');
+        $e->loadFromArray(null);
+
+        $this->assertSame($type, $e->getEventType());
+    }
+
+    // ---- 2. what a queue blob may reconstruct ------------------------------
+
+    public function testALegitimateEventSurvivesTheRoundTrip(): void
+    {
+        $q = $this->queue();
+        $e = $this->event();
+        $e->setEventType('track.action');
+        $e->set('page_url', 'https://example.com/x');
+
+        $back = $q->decodeMessage($q->prepareMessage($e));
+
+        $this->assertNotInstanceOf(__PHP_Incomplete_Class::class, $back,
+            'the allowlist is too tight -- real events no longer decode');
+        $this->assertInstanceOf(\OWA\Module\Base\Classes\Event::class, $back);
+        $this->assertSame('track.action', $back->getEventType());
+        $this->assertSame($e->getGuid(), $back->getGuid());
+        $this->assertSame('https://example.com/x', $back->get('page_url'));
+    }
+
+    public function testAForeignClassInAQueueBlobIsRefused(): void
+    {
+        $q = $this->queue();
+
+        $decoded = $q->decodeMessage('O:8:"stdClass":1:{s:1:"x";s:3:"pwn";}');
+
+        $this->assertInstanceOf(__PHP_Incomplete_Class::class, $decoded,
+            'a tampered queue row must not instantiate an arbitrary class');
+        $this->assertNotInstanceOf(\stdClass::class, $decoded);
+    }
+
+    /**
+     * The claim in the original report was that HTTP input reaches unserialize()
+     * as an object. It does not: superglobals hold strings and arrays, the value
+     * is stored as a property of an object THIS instance constructs, and
+     * serialize() length-prefixes it. It comes back as the same string.
+     */
+    public function testAHostileStringInAPropertyStaysAString(): void
+    {
+        $q = $this->queue();
+        $e = $this->event();
+
+        $hostile = 'O:8:"stdClass":1:{s:1:"x";s:3:"pwn";}';
+        $e->loadFromArray(['eventType' => 'track.action', 'properties' => ['evil' => $hostile]]);
+
+        $back = $q->decodeMessage($q->prepareMessage($e));
+
+        $this->assertSame($hostile, $back->get('evil'));
+        $this->assertIsString($back->get('evil'),
+            'a serialized-looking string is data, not a nested object');
+    }
+}


### PR DESCRIPTION
Prompted by the analysis in #960, reported by @Practice100101. The deserialization conclusion in that report does not hold — see the note below — but reviewing it surfaced the property-handling issue fixed here, and the credit for that is theirs.

---

`Event::loadFromArray()` copied any property present in the caller's array, and its only caller is `queue.php` — fed straight from an unauthenticated HTTP request. So a sender could set fields that belong to the receiving instance's queue bookkeeping, not just the event it was sending.

Not remote code execution, and it needs an operator to have enabled the endpoint (`queue.php` ships in `disabledEndpoints`, and `allowed_queued_event_types` defaults to `[]`). But none of that state is the sender's to decide, and some of it feeds the queue's own identity and retry accounting.

## Now an allowlist

`eventType`, `properties`, `guid`, `timestamp`. Everything else keeps the value the receiving instance gave it.

`guid` and `timestamp` stay settable **deliberately** — `HttpEventQueue` relays both, the guid is what makes a retried forward idempotent instead of duplicating the queue item, and the timestamp is the upstream event time rather than whenever the forward arrived. They are validated instead: `generateRandomUid()` returns `time().rand(6).serverId(3)` and the guid column is a `BIGINT`, so a non-numeric value is not a valid identifier.

Dropping the rest is also more correct on the merits: a freshly received event should start with fresh queue state, which the constructor already provides.

## unserialize() now declares what it may reconstruct

| site | allowlist | why |
|---|---|---|
| Settings (×2), Site settings | `false` | nested arrays of scalars; writers are `serialize($array)` |
| db + file event queues | the event class | resolved via the support-class factory, **not hardcoded** |
| FileCache | *untouched* | legitimately caches objects |

The factory resolution matters: a module may substitute its own event class, and pinning `Base\Classes\Event` would decode such an install's events into `__PHP_Incomplete_Class`. There is a test for that direction specifically.

FileCache is deliberately left alone — the live cache contained `UAParser\Result\Client` and OWA entities (`AdDim`, `CampaignDim`), so an allowlist there is open-ended and would break entity caching.

## On the deserialization report

**No attacker path reaches those `unserialize()` calls today.** Every blob is written by `serialize()` on this side, so HTTP input lands in an event's *properties*, and a serialized-looking string comes back as the same string — `testAHostileStringInAPropertyStaysAString` pins exactly that.

The allowlists are for when the blob itself is no longer trustworthy: anyone who can write to `owa_queue_item` or the settings row (a SQL-injection foothold, stolen credentials, a table restored from elsewhere) would otherwise have a path from "can write a row" to "can instantiate arbitrary classes on the next queue run". This turns that into a decode failure.

## Tests

`EventQueueHardeningTest` (21). Mutation-verified in **both** directions:

- disabling the property allowlist → **7** failures
- removing the numeric guid/timestamp validation → **7** failures
- dropping the unserialize allowlist → **1** failure
- over-tightening it to a wrong class → round-trip test fails

That last one is the point: it guards against "hardening" this into a silently broken queue.

## Gates

PHPUnit **274 tests, 2551 assertions OK**; `phpstan` / `phpstan:migration` / `phpstan:templates` all `[OK]`.
