### PR TITLE
fix(reports): answer isDimensionRelated() instead of warning on a miss

### DIFF
--- a/modules/Base/Classes/ResultSetManager.php
+++ b/modules/Base/Classes/ResultSetManager.php
@@ -499,7 +499,43 @@ if ( ! in_array($item['name'], $this->allMetrics) ) {
 
         $dimension = $this->lookupDimension($dimension_name, $entity);
 
-        if ($dimension['denormalized'] === true) {
+        // lookupDimension() returns null when the name does not resolve AGAINST
+        // THIS ENTITY. That is a routine outcome, not an error case: it looks
+        // for a denormalized dimension on this entity, then the
+        // related_dimensions cache, then the global (non-denormalized)
+        // registry. A denormalized dimension such as productName lives only
+        // under its own entity (base.commerce_line_item_fact), so checking it
+        // against base.request finds nothing in any of the three.
+        //
+        // And the callers do exactly that on purpose -- they loop every
+        // requested dimension against every candidate entity looking for one
+        // that fits them all, so most pairings are expected to miss. Without
+        // this guard each of those misses fell through to the array access
+        // below and logged "Trying to access array offset on value of type
+        // null", which is why the warning appeared on ordinary report
+        // requests rather than only on bad input.
+        //
+        // Not related is the correct answer here, and it is what the callers
+        // already assumed -- they test `if (!$check)`, which treated the
+        // implicit null the same way. Returning false makes the contract match
+        // the method name.
+        //
+        // Strictly this branch is redundant: the isset() below already stops
+        // the warning and the trailing return already yields false, and a
+        // mutation test confirms removing it changes nothing observable. It
+        // stays for the DEBUG LOG. Without it an unregistered name falls
+        // through to "Could not find a foreign key for productName in
+        // base.request", which sends the reader looking for a missing foreign
+        // key when the real problem is that the dimension does not exist.
+        if ( ! $dimension ) {
+            \OWA\Core\CoreAPI::debug("Dimension: $dimension_name did not resolve, so it is not related to $entity_name");
+            return false;
+        }
+
+        // isset() guards a dimension array that has no 'denormalized' key at
+        // all. The strict === true is kept deliberately: only a real boolean
+        // true counts, exactly as before.
+        if ( isset( $dimension['denormalized'] ) && $dimension['denormalized'] === true ) {
             //$this->related_dimensions[$dimension['name']] = $dimension;
             \OWA\Core\CoreAPI::debug("Dimension: $dimension_name is denormalized into $entity_name");
             return true;
@@ -515,6 +551,11 @@ if ( ! in_array($item['name'], $this->allMetrics) ) {
                 \OWA\Core\CoreAPI::debug("Could not find a foreign key for $dimension_name in $entity_name");
             }
         }
+
+        // Was an implicit null before. Every caller tests the result for
+        // truthiness, so this changes no behaviour -- it just stops a method
+        // named is...() from answering a question with null.
+        return false;
     }
 
     function getMetricEntities($metric_name) {

--- a/tests/DimensionResolutionTest.php
+++ b/tests/DimensionResolutionTest.php
@@ -1,0 +1,167 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * isDimensionRelated() must answer, not warn.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * lookupDimension() returns null when a name does not resolve against the entity
+ * being tested, having already recorded why via addError(). isDimensionRelated()
+ * indexed that null directly:
+ *
+ *     $dimension = $this->lookupDimension($dimension_name, $entity);
+ *     if ($dimension['denormalized'] === true) {     // <- null['denormalized']
+ *
+ * so every miss produced "Trying to access array offset on value of type null"
+ * and the method fell out of the bottom returning an implicit NULL from a
+ * predicate named is...().
+ *
+ * This fires on ORDINARY requests, not just bad input. lookupDimension() returns
+ * null when a name does not resolve against THE ENTITY BEING TESTED, and a
+ * denormalized dimension such as productName lives only under its own entity
+ * (base.commerce_line_item_fact). The callers loop every requested dimension
+ * against every candidate entity looking for one that fits them all, so most
+ * pairings are expected to miss -- and every miss logged a warning. That is how
+ * it turned up in a live Apache log, on a perfectly normal e-commerce report.
+ *
+ * Callers all test `if (!$check)`, so null and false were already equivalent to
+ * them. The fix changes no behaviour; it removes the warning and makes the
+ * return type match the method name. These tests pin both halves -- and the
+ * positive case too, because "return false everywhere" would also silence the
+ * warning while breaking every report.
+ */
+final class DimensionResolutionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function manager(): object
+    {
+        return owa_coreAPI::supportClassFactory('base', 'resultSetManager');
+    }
+
+    /**
+     * Capture PHP diagnostics raised during $fn rather than letting them pass
+     * as warnings nothing fails on.
+     */
+    private function diagnosticsFrom(callable $fn, &$result = null): array
+    {
+        $seen = [];
+
+        set_error_handler(static function ($no, $str) use (&$seen) {
+            $seen[] = $str;
+            return true;
+        });
+
+        try {
+            $result = $fn();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $seen;
+    }
+
+    /**
+     * @dataProvider unresolvableDimensions
+     */
+    public function testAnUnresolvableDimensionIsNotRelatedAndDoesNotWarn(string $name): void
+    {
+        $rsm = $this->manager();
+        $result = null;
+
+        $diags = $this->diagnosticsFrom(
+            fn() => $rsm->isDimensionRelated($name, 'base.request'),
+            $result
+        );
+
+        $this->assertSame([], $diags,
+            'a dimension that does not resolve against this entity raised a PHP diagnostic');
+        $this->assertFalse($result,
+            'an unresolvable dimension is "not related" -- and must say so with false, not null');
+    }
+
+    public static function unresolvableDimensions(): array
+    {
+        return [
+            // Denormalized onto base.commerce_line_item_fact, so it does not
+            // resolve against base.request. The exact name from the live log.
+            'productName'       => ['productName'],
+            'zz_not_a_thing'    => ['zz_not_a_thing'],
+            'empty string'      => [''],
+            'sql-ish'           => ["1' OR '1'='1"],
+        ];
+    }
+
+    /**
+     * The guard must not swallow the real answer. Without this, replacing the
+     * body with `return false;` would pass every other test in this file.
+     */
+    public function testAResolvableDimensionIsStillRelated(): void
+    {
+        $rsm = $this->manager();
+        $result = null;
+
+        $diags = $this->diagnosticsFrom(
+            fn() => $rsm->isDimensionRelated('pageTitle', 'base.request'),
+            $result
+        );
+
+        $this->assertSame([], $diags);
+        $this->assertTrue($result,
+            'pageTitle resolves via the global registry and has a foreign key to base.request');
+    }
+
+    /**
+     * A dimension that RESOLVES but has no foreign key to the entity. This is
+     * the ordinary case in the callers, which loop dimensions against candidate
+     * entities looking for one that fits them all -- most pairings do not.
+     *
+     * Covered explicitly because it is the only path that reaches the trailing
+     * return. Without it, deleting that return re-introduced the implicit null
+     * and every other test here still passed.
+     */
+    public function testAResolvableDimensionWithNoForeignKeyIsNotRelated(): void
+    {
+        $rsm = $this->manager();
+        $result = null;
+
+        // pageTitle resolves fine, but base.session has no foreign key to it.
+        $diags = $this->diagnosticsFrom(
+            fn() => $rsm->isDimensionRelated('pageTitle', 'base.session'),
+            $result
+        );
+
+        $this->assertSame([], $diags);
+        $this->assertFalse($result,
+            'no foreign key means not related -- and must be false, not an implicit null');
+    }
+
+    /**
+     * The method is a predicate. Returning null from the failure path made
+     * `$check === false` quietly untrue, so any caller tightening its test from
+     * `!$check` to `=== false` would have silently changed meaning.
+     */
+    public function testTheReturnIsAlwaysBoolean(): void
+    {
+        $rsm = $this->manager();
+
+        $cases = [
+            ['pageTitle',      'base.request'],   // true
+            ['pageTitle',      'base.session'],   // false via the no-fk path
+            ['productName',    'base.request'],   // false via the unresolvable path
+            ['zz_not_a_thing', 'base.request'],
+        ];
+
+        foreach ($cases as [$name, $entity]) {
+            $this->assertIsBool(
+                @$rsm->isDimensionRelated($name, $entity),
+                $name . ' / ' . $entity . ': is...() must answer with a boolean'
+            );
+        }
+    }
+}


### PR DESCRIPTION
`lookupDimension()` returns null for a name that is not in the registry, having already recorded why via `addError()`. `isDimensionRelated()` indexed that null directly:

```php
$dimension = $this->lookupDimension($dimension_name, $entity);
if ($dimension['denormalized'] === true) {     // <- null['denormalized']
```

So every unresolvable name logged `Trying to access array offset on value of type null`, and the method then fell out of the bottom returning an implicit **NULL** from a predicate named `is...()`.

## This fires on ordinary requests

`lookupDimension()` looks for a denormalized dimension **on this entity**, then the `related_dimensions` cache, then the global non-denormalized registry. A denormalized dimension lives only under its own entity:

| | `getDimension` | `getDenormalizedDimension` |
|---|---|---|
| `productName` vs `commerce_line_item_fact` | no | **yes** |
| `productName` vs `base.request` | no | no |
| `pageTitle` vs `base.request` | **yes** | no |

And the callers do exactly that on purpose — they loop every requested dimension against every candidate entity looking for one that fits them all. **Most pairings are expected to miss**, and every miss logged a warning.

Found in a live Apache error log on a normal e-commerce report request (`owa_dimensions=productName`).

Worth stating plainly, because my first reading of this was wrong: **e-commerce reporting is not disabled on that install.** The per-site setting is on; the global one has been `false` since it was introduced, carrying a `// move to site settings` note. Nothing was misconfigured — the warning is simply what a routine lookup miss looked like.

## The fix

| | |
|---|---|
| `isset()` guards the array access | strict `=== true` kept, so only a real boolean true counts as denormalized |
| early return when the lookup fails | see the note below |
| explicit `return false` on the no-foreign-key path | replaces the implicit null |

**Behaviour-preserving.** Every caller tests `if (!$check)`, so null and false were already equivalent to them. Verified by diffing a fixed dimension/entity matrix before and after — the only differences are `NULL → false` and `warnings 1 → 0`, with the positive case still `true`:

```
BASELINE                              FIXED
pageTitle   -> true   warnings=0      pageTitle   -> true   warnings=0
browser     -> NULL   warnings=1      browser     -> false  warnings=0
productName -> NULL   warnings=1      productName -> false  warnings=0
```

## Tests

`DimensionResolutionTest` (7). Mutation-verified:

- restoring the unguarded array access → **4** failures
- dropping the trailing `return false` → **2** failures
- gutting the method to `return false` → positive case fails

That last one matters: "return false everywhere" would otherwise silence the warning while breaking every report.

Finding the second case took a probe — the no-foreign-key path isn't reachable with the dimensions I first tried against `base.request` (they all have FKs). `pageTitle` against `base.session` reaches it, and that pairing is ordinary in the callers, which loop dimensions against candidate entities looking for one that fits them all.

## One guard deliberately not mutation-covered

The early return for a failed lookup is **redundant for behaviour**, and a mutation test confirms removing it changes nothing observable — the `isset()` already stops the warning and the trailing return already yields false.

It stays for the **debug log**. Without it, an unregistered name falls through to `Could not find a foreign key for productName in base.request`, which sends the reader hunting a missing foreign key when the dimension does not exist at all. That is noted in the code so it doesn't read as an oversight.

## Gates

PHPUnit **281 tests, 2567 assertions OK**; `phpstan` / `phpstan:migration` / `phpstan:templates` all `[OK]`.
