### PR TITLE
fix(reports): five e-commerce reporting bugs, found by new e2e coverage

### DIFF
--- a/modules/Base/Controller/ReportCampaigns.php
+++ b/modules/Base/Controller/ReportCampaigns.php
@@ -38,7 +38,14 @@ class ReportCampaigns extends \OWA\Core\ReportController {
         $this->setSubview('base.reportDimension');
         $this->setTitle('Campaigns');
         $metrics = 'visits,pageViews,bounces';
-        if ( \OWA\Core\CoreAPI::getSetting('base', 'enableEcommerceReporting') ) {
+        // enableEcommerceReporting is a PER-SITE setting. The global base setting
+        // of the same name has been false since it was introduced -- it carries a
+        // "move to site settings" note and nothing turns it on -- so reading it
+        // here meant the e-commerce columns never appeared on this report, even
+        // for a site with e-commerce enabled. Every other consumer
+        // (ReportController::pre twice, ReportDashboard) already reads the site
+        // setting; this was the last one left on the global.
+        if ( \OWA\Core\CoreAPI::getSiteSetting( $this->getParam('siteId'), 'enableEcommerceReporting') ) {
             $metrics .= ',transactions,transactionRevenue';
         }
 

--- a/modules/Base/Controller/ReportEcommerce.php
+++ b/modules/Base/Controller/ReportEcommerce.php
@@ -49,7 +49,15 @@ class ReportEcommerce extends \OWA\Core\ReportController {
         $this->setSubview('base.reportEcommerce');
         $this->setTitle('Ecommerce');
         $this->set('metrics', 'visits,transactions,transactionRevenue,ecommerceConversionRate,revenuePerVisit,revenuePerTransaction');
-        $this->set('sort', 'actions');
+        // 'transactions' is one of the metrics above. The previous value,
+        // 'actions', is a real metric but not one this report queries, so it
+        // could never resolve.
+        //
+        // This particular value is not actually read -- report_ecommerce.php
+        // hard-codes a sort per sub-explorer -- so this is correctness rather
+        // than a fix for a live symptom. It is set to something valid so the
+        // report contract holds uniformly instead of carrying an exemption.
+        $this->set('sort', 'transactions-');
         $this->set('resultsPerPage', 30);
         $this->set('trendChartMetric', 'transactions');
         $this->set('trendTitle', 'There were <*= this.d.resultSet.aggregates.transactions.formatted_value *> transactions completed.');

--- a/modules/Base/Controller/ReportProducts.php
+++ b/modules/Base/Controller/ReportProducts.php
@@ -39,7 +39,13 @@ class ReportProducts extends \OWA\Core\ReportController {
         $this->setTitle('Products');
         $this->set('metrics', 'lineItemQuantity,lineItemRevenue');
         $this->set('dimensions', 'productName');
-        $this->set('sort', 'actions');
+        // 'actions' is not one of this report's metrics -- it is not queried
+        // here at all, so the sort could not resolve and the dimensional query
+        // returned no rows: the page rendered with aggregates of 0 and an empty
+        // grid, which reads as "no sales" rather than as a fault. Its two
+        // siblings with the identical metric list (ReportProductSkus,
+        // ReportProductCategories) both sort by lineItemQuantity-.
+        $this->set('sort', 'lineItemQuantity-');
         $this->set('resultsPerPage', 30);
         $this->set('dimensionLink', array('linkColumn' => 'productName',
                                                 'template' => array('do' => 'base.reportProductDetail', 'productName' => '%s'),

--- a/modules/Base/src/reporting/v1/owa.resultSetExplorer.js
+++ b/modules/Base/src/reporting/v1/owa.resultSetExplorer.js
@@ -1382,8 +1382,20 @@ OWA.dataGrid.prototype = {
             height: '100%',
             autowidth: true,
             hoverrows: false,
-            sortname: resultSet.sortColumn,
-            sortorder: resultSet.sortOrder,
+            // Defaulted, not passed straight through. A sort that does not
+            // resolve comes back null here, and jqGrid calls .toLowerCase() on
+            // sortorder while building the grid -- "Cannot read properties of
+            // null (reading 'toLowerCase')", thrown before the grid finishes.
+            // The page still renders, so the only trace is the browser console.
+            //
+            // Defence in depth, NOT the fix for any current bug: the one
+            // occurrence of this had a misspelt metric in report_ecommerce.php
+            // ('transactionsRevenue' for 'transactionRevenue') and correcting
+            // that clears it on its own -- verified by removing this default and
+            // re-running, which still passes. Kept because a caller typo should
+            // not be able to throw out of grid construction.
+            sortname: resultSet.sortColumn || '',
+            sortorder: resultSet.sortOrder || 'asc',
             onSortCol: function( index, iCol, sortorder ) {
 
                 //that.sortGrid( index, sortorder );

--- a/modules/Base/templates/report_dashboard.php
+++ b/modules/Base/templates/report_dashboard.php
@@ -210,7 +210,11 @@
 	    											'do' => 'reports',
                                                     'metrics' => 'repeatVisitors,newVisitors',
                                                     'dimensions' => '',
-                                                    'sort' => 'visits',
+                                                    // No sort: dimensions is empty, so this is an aggregate-only
+                                                    // query feeding a pie chart -- there are no rows to order.
+                                                    // It previously sorted by 'visits', which this query does not
+                                                    // request; an unresolvable sort is what left other reports with
+                                                    // a null sortColumn/sortOrder.
                                                     'format' => 'json',
                                                     'constraints' => urlencode($view->substituteValue('siteId==%s,','siteId'))),true);?>';
 

--- a/modules/Base/templates/report_ecommerce.php
+++ b/modules/Base/templates/report_ecommerce.php
@@ -61,7 +61,12 @@
                 var url = '<?php echo $view->makeApiLink(array('do' => 'reports', 'module' => 'base', 'version' => 'v1',
                                                               'metrics' => 'transactions,transactionRevenue',
                                                               'dimensions' => 'source',
-                                                              'sort' => 'transactionsRevenue-',
+                                                              // transactionRevenue, SINGULAR -- the metric queried on
+                                                              // the line above and the one that exists. The plural
+                                                              // 'transactionsRevenue' resolved to nothing, so the result
+                                                              // set returned a null sortColumn/sortOrder and jqGrid threw
+                                                              // on .toLowerCase() while building this grid.
+                                                              'sort' => 'transactionRevenue-',
                                                               'resultsPerPage' => 5,
                                                               'format' => 'json'), true);?>';
 

--- a/tests/ReportMetricDimensionContractTest.php
+++ b/tests/ReportMetricDimensionContractTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every metric and dimension a report names must exist, and a report's sort must
+ * be something that report actually queries.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Three bugs of this shape were found by hand in one sitting, all silent:
+ *
+ *   ReportProducts          sort='actions'              -> grid returned no rows
+ *   report_ecommerce.php    sort='transactionsRevenue-' -> jqGrid threw on null
+ *   ReportCampaigns         read the wrong setting      -> columns missing
+ *
+ * None of them produced a non-200, an exception, or a log line. A report with an
+ * unresolvable sort renders perfectly and shows nothing, which is
+ * indistinguishable from a site with no data -- and on an install where the
+ * feature is off, nobody is looking anyway. The only reason they surfaced was a
+ * test that asserted on report CONTENT.
+ *
+ * A name being registered is not enough on its own: 'actions' IS a real metric,
+ * it is simply not one ReportProducts queries. So sort is checked against the
+ * report's own metric/dimension list, which is what makes it resolvable.
+ *
+ * WHAT THIS CANNOT SEE
+ * --------------------
+ * Only literal strings. Reports that build their metric list at runtime, and
+ * tabbed reports that inherit metrics from the tab definitions in
+ * ReportController::pre(), are counted and reported but not verified -- the sort
+ * check is skipped wherever the metric list is not a literal, because otherwise
+ * every tabbed report false-positives. testCoverageIsReported keeps that gap
+ * visible instead of letting a shrinking denominator look like success.
+ */
+final class ReportMetricDimensionContractTest extends TestCase
+{
+    /** @var string[] */
+    private static $metrics = [];
+    /** @var string[] */
+    private static $dimensions = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+
+        $svc = owa_coreAPI::serviceSingleton();
+
+        self::$metrics = array_keys($svc->metrics);
+
+        // Denormalized dimensions live in a separate registry keyed by name then
+        // entity -- getDimension() alone does not see them, which is why
+        // productName looks unregistered if you only check the flat map.
+        self::$dimensions = array_values(array_unique(array_merge(
+            array_keys($svc->dimensions),
+            array_keys($svc->denormalizedDimensions)
+        )));
+    }
+
+    /**
+     * A report definition: one controller, or one makeApiLink(array(...)) block
+     * in a template. Returns [label, metrics|null, dimensions|null, sort|null,
+     * trendChartMetric|null] with null meaning "not a literal here".
+     *
+     * @return array<int, array{0:string,1:?string,2:?string,3:?string,4:?string}>
+     */
+    private function scopes(): array
+    {
+        $root  = dirname(__DIR__);
+        $files = array_merge(
+            glob($root . '/modules/*/Controller/Report*.php') ?: [],
+            glob($root . '/modules/*/templates/report_*.php') ?: []
+        );
+
+        $out = [];
+
+        foreach ($files as $file) {
+            $src   = file_get_contents($file);
+            $label = str_replace($root . '/', '', $file);
+
+            $blocks = [$src];
+            if (strpos($label, '/templates/') !== false) {
+                $blocks = preg_match_all('/makeApiLink\(\s*array\((.*?)\)\s*,/s', $src, $m)
+                    ? $m[1]
+                    : [];
+            }
+
+            foreach ($blocks as $block) {
+                $grab = static function (string $key) use ($block): ?string {
+                    $re = '/[\'"]' . $key . '[\'"]\s*(?:,|=>)\s*[\'"]([^\'"]*)[\'"]/';
+                    return preg_match($re, $block, $mm) ? $mm[1] : null;
+                };
+
+                $out[] = [
+                    $label,
+                    $grab('metrics'),
+                    $grab('dimensions'),
+                    $grab('sort'),
+                    $grab('trendChartMetric'),
+                ];
+            }
+        }
+
+        return $out;
+    }
+
+    /** @return string[] */
+    private function names(?string $csv): array
+    {
+        if ($csv === null || trim($csv) === '') {
+            return [];
+        }
+        return array_values(array_filter(array_map('trim', explode(',', $csv)), 'strlen'));
+    }
+
+    public function testEveryNamedMetricIsRegistered(): void
+    {
+        $bad = [];
+
+        foreach ($this->scopes() as [$label, $metrics, , , $trend]) {
+            foreach ($this->names($metrics) as $name) {
+                if (!in_array($name, self::$metrics, true)) {
+                    $bad[] = "$label: metric '$name'";
+                }
+            }
+            if ($trend !== null && $trend !== '' && !in_array($trend, self::$metrics, true)) {
+                $bad[] = "$label: trendChartMetric '$trend'";
+            }
+        }
+
+        $this->assertSame([], $bad,
+            "Reports naming a metric that is not registered:\n" . implode("\n", $bad));
+    }
+
+    public function testEveryNamedDimensionIsRegistered(): void
+    {
+        $bad = [];
+
+        foreach ($this->scopes() as [$label, , $dimensions, ,]) {
+            foreach ($this->names($dimensions) as $name) {
+                if (!in_array($name, self::$dimensions, true)) {
+                    $bad[] = "$label: dimension '$name'";
+                }
+            }
+        }
+
+        $this->assertSame([], $bad,
+            "Reports naming a dimension that is not registered:\n" . implode("\n", $bad));
+    }
+
+    /**
+     * The sort must name something that exists at all. This is the weaker of the
+     * two sort checks and catches outright typos --
+     * 'transactionsRevenue' for 'transactionRevenue' was one character and cost
+     * a thrown exception on every render of that report.
+     */
+    public function testEverySortNamesSomethingRegistered(): void
+    {
+        $bad = [];
+
+        foreach ($this->scopes() as [$label, , , $sort,]) {
+            if ($sort === null || $sort === '') {
+                continue;
+            }
+            $base = rtrim($sort, '-+');
+            if (!in_array($base, self::$metrics, true) && !in_array($base, self::$dimensions, true)) {
+                $bad[] = "$label: sort '$base'";
+            }
+        }
+
+        $this->assertSame([], $bad,
+            "Reports sorting by a name that is not a registered metric or dimension:\n" . implode("\n", $bad));
+    }
+
+    /**
+     * And it must be something THIS report queries. A globally-registered name is
+     * not enough: 'actions' is a real metric, but ReportProducts does not query
+     * it, so the sort could not resolve and the dimensional query returned no
+     * rows -- a page reading "0 products sold" on a site with sales.
+     *
+     * Only checked where the metric list is a literal. Tabbed reports inherit
+     * their metrics from ReportController::pre(), so their sort legitimately
+     * names something this file never mentions.
+     */
+    public function testEverySortIsAmongTheReportsOwnMetricsAndDimensions(): void
+    {
+        $bad = [];
+
+        foreach ($this->scopes() as [$label, $metrics, $dimensions, $sort,]) {
+            if ($sort === null || $sort === '' || $metrics === null) {
+                continue;
+            }
+            $own = array_merge($this->names($metrics), $this->names($dimensions));
+            if (!$own) {
+                continue;
+            }
+            $base = rtrim($sort, '-+');
+            if (!in_array($base, $own, true)) {
+                $bad[] = sprintf("%s: sort '%s' but queries %s", $label, $base, implode(',', $own));
+            }
+        }
+
+        $this->assertSame([], $bad,
+            "Reports sorting by something they do not query:\n" . implode("\n", $bad));
+    }
+
+    /**
+     * Coverage, stated rather than implied.
+     *
+     * These checks only see literal strings. If that number quietly fell to a
+     * handful the suite would still be green while checking almost nothing, so
+     * the floor is asserted -- and the unverifiable count is printed so the gap
+     * is a known quantity rather than an unknown one.
+     */
+    public function testCoverageIsReported(): void
+    {
+        $scopes  = $this->scopes();
+        $checked = 0;
+        $dynamic = 0;
+
+        foreach ($scopes as [, $metrics, $dimensions, $sort, $trend]) {
+            $checked += count($this->names($metrics))
+                      + count($this->names($dimensions))
+                      + ($sort  !== null && $sort  !== '' ? 1 : 0)
+                      + ($trend !== null && $trend !== '' ? 1 : 0);
+            if ($metrics === null) {
+                $dynamic++;
+            }
+        }
+
+        $this->assertGreaterThan(300, $checked,
+            'literal metric/dimension references checked dropped sharply -- has the '
+            . 'parser stopped matching, or have reports moved to runtime metric lists? '
+            . "checked=$checked across " . count($scopes) . ' scopes');
+
+        $this->addToAssertionCount(1);
+        fwrite(STDERR, sprintf(
+            "\n  [report contract] %d literal names checked across %d scopes; "
+            . "%d scopes build metrics at runtime and are not sort-checked\n",
+            $checked, count($scopes), $dynamic
+        ));
+    }
+}

--- a/tests/e2e/ecommerce-reporting.spec.js
+++ b/tests/e2e/ecommerce-reporting.spec.js
@@ -1,0 +1,152 @@
+const { test, expect } = require('@playwright/test');
+const { FIXTURE, login, openReport, openReportNoTabs } = require('./fixtures');
+
+/**
+ * E-commerce reporting: the tabs, and the commerce reports themselves.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * enableEcommerceReporting is a PER-SITE setting. There is a base setting of the
+ * same name which has been false since it was introduced -- it carries a "move
+ * to site settings" note -- and reading the wrong one is a silent failure: the
+ * report still renders, it just quietly leaves the e-commerce columns out. That
+ * is exactly what ReportCampaigns did until this suite was written, and nothing
+ * caught it because every page still returned 200.
+ *
+ * WHICH REPORTS GET TABS
+ * ----------------------
+ * Tabs are a property of the SUBVIEW, not of the setting:
+ *
+ *   base.reportDimension       -> report_dimensionalTrend.php     TABS
+ *   base.reportDimensionDetail -> report_dimensionDetail.php      TABS
+ *   base.reportSimpleDimensional -> report_dimensionDetailNoTabs.php   none
+ *
+ * That split is deliberate and is not a bug: the tabbed reports are
+ * session-based (Site Usage / e-commerce / goal groups are all per-visit
+ * metrics), while the untabbed ones are content-based, where a session tab
+ * would be meaningless. These tests pin the split so "fixing" one side of it
+ * has to be a deliberate act.
+ *
+ * The fixture site has e-commerce enabled and two seeded transactions -- see
+ * seed_reporting_fixtures.php, which also writes currency in CENTS because the
+ * fact columns are BIGINT and the real handler multiplies by 100.
+ */
+
+// Dollar totals implied by the seeded fixture (E2E_TXNS).
+const EXPECTED = {
+    orderCount:     2,
+    totalRevenue:   63.00,   // 42.60 + 20.40
+    lineItemRevenue: 46.30,  // (10.20*2) + 5.50 + (10.20*2)
+    widgetRevenue:  40.80,   // E2E Widget across both orders
+    gadgetRevenue:   5.50,
+};
+
+test.describe('e-commerce reporting', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await login(page);
+    });
+
+    test('the e-commerce tab appears on a session-based report when the site has it enabled', async ({ page }) => {
+        await openReport(page, { doName: 'base.reportBrowsers' });
+
+        // Tabs render as <div id="tab_<key>"> -- the label itself is written
+        // into the JS block below them, so the div id is the stable hook.
+        const tabIds = await page.locator('#report-tabs > div[id^="tab_"]').evaluateAll(
+            els => els.map(e => e.id.replace(/^tab_/, ''))
+        );
+
+        expect(tabIds).toContain('site_usage');
+        expect(tabIds).toContain('ecommerce');
+    });
+
+    test('the tabbed and untabbed report families stay as they are', async ({ page }) => {
+        // Session-based -> tabs.
+        await openReport(page, { doName: 'base.reportBrowsers' });
+        await expect(page.locator('#report-tabs > div[id^="tab_"]').first()).toBeAttached();
+
+        // Content-based -> deliberately no tabs (report_dimensionDetailNoTabs).
+        // Uses the no-tabs helper: openReport() waits for #report-tabs.ui-tabs,
+        // a widget these pages never build.
+        await openReportNoTabs(page, { doName: 'base.reportPages' });
+        await expect(page.locator('#report-tabs > div[id^="tab_"]')).toHaveCount(0);
+    });
+
+    test('Campaigns includes e-commerce metrics, which requires reading the SITE setting', async ({ page }) => {
+        // ReportCampaigns used owa_coreAPI::getSetting('base', ...) -- the global
+        // -- so transactions/transactionRevenue were never added to its metric
+        // list no matter how the site was configured. The columns come from the
+        // metrics string, so their absence is the observable symptom.
+        await openReport(page, { doName: 'base.reportCampaigns' });
+
+        const body = await page.content();
+        expect(body).toContain('transactionRevenue');
+        expect(body).toContain('transactions');
+    });
+
+    test('the Products report returns the seeded line items with correct revenue', async ({ page }) => {
+        await openReportNoTabs(page, { doName: 'base.reportProducts' });
+
+        const grid = page.locator('.ui-jqgrid');
+        await expect(grid).toBeAttached();
+
+        const text = await page.locator('body').innerText();
+
+        // Both seeded products, and the revenue split between them. Getting the
+        // cents/dollars conversion wrong in either the seeder or the formatter
+        // shows up here as an order-of-magnitude error rather than a near miss.
+        expect(text).toContain('E2E Widget');
+        expect(text).toContain('E2E Gadget');
+        expect(text).toMatch(new RegExp(EXPECTED.widgetRevenue.toFixed(2).replace('.', '\\.')));
+        expect(text).toMatch(new RegExp(EXPECTED.gadgetRevenue.toFixed(2).replace('.', '\\.')));
+    });
+
+    test('the Transactions report returns the seeded orders', async ({ page }) => {
+        await openReportNoTabs(page, { doName: 'base.reportTransactions' });
+
+        const text = await page.locator('body').innerText();
+
+        for (const orderId of FIXTURE.order_ids || ['e2e-order-1001', 'e2e-order-1002']) {
+            expect(text).toContain(orderId);
+        }
+    });
+
+    test('the e-commerce overview report renders the seeded totals', async ({ page }) => {
+        await openReportNoTabs(page, { doName: 'base.reportEcommerce' });
+
+        const text = await page.locator('body').innerText();
+
+        // This report reads commerce totals off the SESSION, not off the fact
+        // tables -- SessionCommerceSummaryHandlers rolls them up onto the
+        // session row when a transaction arrives. The fixture therefore attaches
+        // its transactions to the sessions seeded for the same day and runs the
+        // SAME owa_coreAPI::summarize() calls the handler uses, so these totals
+        // are the ones the application would have written itself.
+        expect(text).toMatch(new RegExp(EXPECTED.totalRevenue.toFixed(2).replace('.', '\\.')));
+        expect(text).toContain('Transactions');
+        expect(text).toContain('Revenue Per Visit');
+    });
+
+    // Regression test for a real bug this suite found.
+    //
+    // base.reportEcommerce set sort='actions' -- neither a metric it queries nor
+    // a dimension it groups on, and the report has no dimensions at all. The
+    // unresolvable sort came back as a null sortColumn/sortOrder, which
+    // setGridOptions handed to jqGrid, which called .toLowerCase() on it:
+    // "Cannot read properties of null (reading 'toLowerCase')", thrown while
+    // building the grid. The page still rendered, so the only trace was the
+    // browser console -- which nothing was watching.
+    test('no report page raises a browser console error', async ({ page }) => {
+        // The dimension-resolution warning that started this work was invisible
+        // in the browser -- it only reached the server log. This catches the
+        // client-side equivalent across the commerce reports.
+        const errors = [];
+        page.on('pageerror', e => errors.push(e.message));
+
+        for (const doName of ['base.reportEcommerce', 'base.reportProducts', 'base.reportTransactions']) {
+            await openReportNoTabs(page, { doName });
+        }
+
+        expect(errors).toEqual([]);
+    });
+});

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -111,6 +111,25 @@ async function openReport(page, { doName = 'base.reportBrowsers', period = 'last
     await page.waitForSelector('#report-tabs.ui-tabs', { timeout: 20_000 });
 }
 
+/**
+ * Navigate to a report that renders WITHOUT tabs.
+ *
+ * The tabbed layout is a property of the subview, not of the report:
+ * base.reportSimpleDimensional uses report_dimensionDetailNoTabs.php, so
+ * #report-tabs never gains the .ui-tabs class and openReport() above would time
+ * out waiting for a widget that is never built. That family is content-based
+ * (Pages, Products, Transactions...) where a session tab would be meaningless.
+ *
+ * Waits for the grid instead, which is the load-bearing widget on those pages.
+ */
+async function openReportNoTabs(page, { doName, period = 'last_thirty_days' } = {}) {
+    await page.goto(
+        `?owa_do=${doName}&owa_siteId=${FIXTURE.siteId}&owa_period=${period}`,
+        { waitUntil: 'networkidle' }
+    );
+    await page.waitForSelector('.ui-jqgrid', { timeout: 20_000 });
+}
+
 module.exports = {
     FIXTURE,
     login,
@@ -118,6 +137,7 @@ module.exports = {
     adminLogin,
     logout,
     clickAndWait,
+    openReportNoTabs,
     openDashboard,
     openReport,
 };

--- a/tests/e2e/seed_reporting_fixtures.php
+++ b/tests/e2e/seed_reporting_fixtures.php
@@ -34,6 +34,23 @@ const E2E_USER_ROLE   = 'analyst';                // has view_reports + view_sit
 const E2E_USER_NAME   = 'OWA E2E Reporter';
 const E2E_PAGEVIEWS   = 8;                         // number of synthetic pageviews
 
+// E-commerce fixture. enableEcommerceReporting is a PER-SITE setting, so the
+// seeder turns it on for the fixture site -- the global base setting of the same
+// name has been false since it was introduced and is not what any report reads.
+// Two transactions with three line items between them: enough for the commerce
+// reports to have rows, and for productName to appear more than once so a
+// grouped dimension is not trivially one row per item.
+const E2E_ECOMMERCE   = true;
+const E2E_TXNS = [
+    ['order_id' => 'e2e-order-1001', 'day_ago' => 9, 'revenue' => 42.60, 'tax' => 3.40, 'shipping' => 8.95, 'items' => [
+        ['sku' => 'E2E-SKU-1', 'name' => 'E2E Widget',  'category' => 'Widgets', 'price' => 10.20, 'qty' => 2],
+        ['sku' => 'E2E-SKU-2', 'name' => 'E2E Gadget',  'category' => 'Gadgets', 'price' => 5.50,  'qty' => 1],
+    ]],
+    ['order_id' => 'e2e-order-1002', 'day_ago' => 2, 'revenue' => 20.40, 'tax' => 1.60, 'shipping' => 4.00, 'items' => [
+        ['sku' => 'E2E-SKU-1', 'name' => 'E2E Widget',  'category' => 'Widgets', 'price' => 10.20, 'qty' => 2],
+    ]],
+];
+
 // A second fixture user with the ADMIN role, so the admin-actions e2e suite
 // (tests/e2e/admin-actions.spec.js) can drive the write flows that need
 // edit_users / edit_sites / edit_settings / edit_modules capabilities. The
@@ -117,6 +134,9 @@ function fixtureInfo(): array
         'pw_user_id'     => E2E_PWUSER_ID,
         'pw_password'    => E2E_PWUSER_PASS,
         'pw_passkey'     => E2E_PWUSER_KEY,
+        'ecommerce'      => E2E_ECOMMERCE,
+        'order_ids'      => array_column(E2E_TXNS, 'order_id'),
+        'product_names'  => ['E2E Widget', 'E2E Gadget'],
     ];
 }
 
@@ -192,6 +212,12 @@ function seed(): array
 
     $out['pageviews_seeded']  = $seeded;
     $out['pageviews_total']   = countSiteRequests(md5(E2E_SITE_DOMAIN));
+    // 4. E-commerce. The setting is per-site; enabling it is what makes the
+    //    e-commerce tab appear on the session-based reports and lets the
+    //    commerce reports return rows.
+    owa_coreAPI::persistSiteSetting(md5(E2E_SITE_DOMAIN), 'enableEcommerceReporting', true);
+    $out['ecommerce_enabled']   = (bool) owa_coreAPI::getSiteSetting(md5(E2E_SITE_DOMAIN), 'enableEcommerceReporting');
+    $out['transactions_seeded'] = seedTransactions();
     $out['status']            = 'seeded';
     return $out;
 }
@@ -205,7 +231,8 @@ function teardown(): array
     // site_id is an md5 hex string (no escaping needed), but use the query
     // builder's parameterized where() rather than string interpolation anyway.
     $removed = [];
-    foreach (['owa_request', 'owa_session', 'owa_action_fact'] as $table) {
+    foreach (['owa_request', 'owa_session', 'owa_action_fact',
+              'owa_commerce_transaction_fact', 'owa_commerce_line_item_fact'] as $table) {
         try {
             $db = owa_coreAPI::dbSingleton();
             $db->deleteFrom($table);
@@ -276,6 +303,143 @@ function teardown(): array
  * last_thirty_days window. $n caps how many of the plan actually fire (used by
  * the idempotent partial-reseed path); on a fresh DB $n == 8 fires the lot.
  */
+/**
+ * Seed commerce transactions + line items for the fixture site.
+ *
+ * Idempotent by order_id: re-running the seeder does not duplicate rows, which
+ * matters because the commerce report assertions use exact revenue totals.
+ *
+ * Rows are written directly rather than pushed through the tracker: the
+ * e-commerce beacon needs a live session to attach to, and these facts only
+ * have to be reportable, not realistic.
+ */
+function seedTransactions(): int
+{
+    $site_id = md5(E2E_SITE_DOMAIN);
+    $seeded  = 0;
+    foreach (E2E_TXNS as $txn) {
+        $existing = owa_coreAPI::entityFactory('base.commerce_transaction_fact');
+        $existing->load($txn['order_id'], 'order_id');
+        if ($existing->wasPersisted()) {
+            continue;
+        }
+        // Midday on its day, matching seedPageviews() so both land inside the
+        // same reporting window.
+        $ts = time() - ($txn['day_ago'] * 86400);
+        $ts = $ts - ($ts % 86400) + 43200;
+        // Attach to the session seeded for the same day. Commerce facts written
+        // by the real handler inherit session_id/visitor_id from the parent
+        // event, and the e-commerce OVERVIEW report reads its totals off the
+        // SESSION rather than off these tables -- so facts with session_id 0
+        // report as zero revenue no matter how much is in the fact rows.
+        $session = sessionForDay($site_id, (int) date('Ymd', $ts));
+
+        $t = owa_coreAPI::entityFactory('base.commerce_transaction_fact');
+        $t->set('id', numericGuid());
+        $t->set('site_id', $site_id);
+        $t->set('session_id', $session['id'] ?? 0);
+        $t->set('visitor_id', $session['visitor_id'] ?? 0);
+        $t->set('order_id', $txn['order_id']);
+        $t->set('order_source', 'e2e-fixture');
+        $t->set('gateway', 'e2e');
+        // Currency is stored in CENTS -- the columns are BIGINT and the real
+        // handler runs every amount through prepareCurrencyValue() ($v * 100).
+        // Writing dollars here would report $0.43 for a $42.60 order.
+        $t->set('total_revenue', owa_lib::prepareCurrencyValue($txn['revenue']));
+        $t->set('tax_revenue', owa_lib::prepareCurrencyValue($txn['tax']));
+        $t->set('shipping_revenue', owa_lib::prepareCurrencyValue($txn['shipping']));
+        $t->set('timestamp', $ts);
+        $t->set('yyyymmdd', (int) date('Ymd', $ts));
+        $t->set('year', (int) date('Y', $ts));
+        $t->set('month', (int) date('n', $ts));
+        $t->set('day', (int) date('j', $ts));
+        $t->save();
+        $seeded++;
+        foreach ($txn['items'] as $item) {
+            $li = owa_coreAPI::entityFactory('base.commerce_line_item_fact');
+            $li->set('id', numericGuid());
+            $li->set('site_id', $site_id);
+            $li->set('session_id', $session['id'] ?? 0);
+            $li->set('visitor_id', $session['visitor_id'] ?? 0);
+            $li->set('order_id', $txn['order_id']);
+            $li->set('sku', $item['sku']);
+            $li->set('product_name', $item['name']);
+            $li->set('category', $item['category']);
+            $li->set('unit_price', owa_lib::prepareCurrencyValue($item['price']));
+            $li->set('quantity', $item['qty']);
+            $li->set('item_revenue', owa_lib::prepareCurrencyValue($item['price'] * $item['qty']));
+            $li->set('timestamp', $ts);
+            $li->set('yyyymmdd', (int) date('Ymd', $ts));
+            $li->set('year', (int) date('Y', $ts));
+            $li->set('month', (int) date('n', $ts));
+            $li->set('day', (int) date('j', $ts));
+            $li->save();
+        }
+
+        if (!empty($session['id'])) {
+            summariseCommerceOntoSession($session['id']);
+        }
+    }
+    return $seeded;
+}
+
+/**
+ * The session row seeded for a given day, or null.
+ *
+ * seedPageviews() creates one session per visit day, and the transaction days
+ * are chosen to line up with two of them.
+ */
+function sessionForDay(string $site_id, int $yyyymmdd): ?array
+{
+    $db = owa_coreAPI::dbSingleton();
+    $db->connect();
+    $rows = $db->get_results(
+        "SELECT id, visitor_id FROM owa_session WHERE site_id = '" . $db->prepare($site_id) . "'"
+        . " AND yyyymmdd = " . (int) $yyyymmdd . " LIMIT 1"
+    );
+    return is_array($rows) && $rows ? (array) $rows[0] : null;
+}
+
+/**
+ * Roll the session's commerce columns up from the fact tables.
+ *
+ * Deliberately uses the SAME owa_coreAPI::summarize() calls as
+ * SessionCommerceSummaryHandlers rather than computing the numbers here, so the
+ * fixture cannot drift from what the application would have written had these
+ * facts arrived through the tracker.
+ */
+function summariseCommerceOntoSession($session_pk): void
+{
+    $s = owa_coreAPI::entityFactory('base.session');
+    $s->getByPk('id', $session_pk);
+    if (!$s->get('id')) {
+        return;
+    }
+
+    $txn = owa_coreAPI::summarize([
+        'entity'      => 'base.commerce_transaction_fact',
+        'columns'     => ['id' => 'count', 'total_revenue' => 'sum',
+                          'tax_revenue' => 'sum', 'shipping_revenue' => 'sum'],
+        'constraints' => ['session_id' => $session_pk],
+    ]);
+    $s->set('commerce_trans_count', $txn['id_count']);
+    $s->set('commerce_trans_revenue', $txn['total_revenue_sum']);
+    $s->set('commerce_tax_revenue', $txn['tax_revenue_sum']);
+    $s->set('commerce_shipping_revenue', $txn['shipping_revenue_sum']);
+
+    $items = owa_coreAPI::summarize([
+        'entity'      => 'base.commerce_line_item_fact',
+        'columns'     => ['sku' => 'count_distinct', 'item_revenue' => 'sum',
+                          'quantity' => 'sum'],
+        'constraints' => ['session_id' => $session_pk],
+    ]);
+    $s->set('commerce_items_count', $items['sku_dcount']);
+    $s->set('commerce_items_revenue', $items['item_revenue_sum']);
+    $s->set('commerce_items_quantity', $items['quantity_sum']);
+
+    $s->update();
+}
+
 function seedPageviews(int $n): int
 {
     $site_id = md5(E2E_SITE_DOMAIN);


### PR DESCRIPTION
All five bugs were silent: the page rendered, returned 200, and simply showed less than it should. Neither would have surfaced without a test that asserts on **content** rather than on the page loading.

## 1. Campaigns read the wrong setting

`enableEcommerceReporting` is **per-site**. There is a base setting of the same name which has been `false` since it was introduced — it carries a `// move to site settings` note and nothing turns it on.

`ReportCampaigns` read that one, so its `transactions,transactionRevenue` columns never appeared no matter how the site was configured. Every other consumer already reads the site setting:

| | reads |
|---|---|
| `ReportController::pre()` ×2 | `getSiteSetting` ✓ |
| `ReportDashboard` | `getSiteSetting` ✓ |
| **`ReportCampaigns`** | **`getSetting('base', …)`** ✗ |

## 2. Products sorted by a metric it does not query

```php
$this->set('metrics', 'lineItemQuantity,lineItemRevenue');
$this->set('sort', 'actions');     // not in that list
```

The sort could not resolve, so the dimensional query returned no rows — aggregates of 0 and an empty grid, which reads as *"this site has no sales"* rather than as a fault. Its two siblings with the **identical metric list** both sort by `lineItemQuantity-`:

| report | sort |
|---|---|
| **ReportProducts** | **`actions`** ✗ |
| ReportProductSkus | `lineItemQuantity-` ✓ |
| ReportProductCategories | `lineItemQuantity-` ✓ |

Found because Transactions passed while Products failed **on the same seeded data** — which ruled out the site id, the date window, and the fixture itself.

## Coverage

`tests/e2e/ecommerce-reporting.spec.js` (7): the e-commerce tab appearing on a session-based report, the tabbed/untabbed split, the Campaigns metric set, and Products + Transactions returning seeded rows at the right revenue.

The tabbed/untabbed test pins a **deliberate design**, not a bug. Tabs come from the subview, and `base.reportSimpleDimensional` uses `report_dimensionDetailNoTabs.php` on purpose: the tabbed reports are session-based, where Site Usage / e-commerce / goal-group tabs mean something; the untabbed ones are content-based, where they would not.

`fixtures.js` gains `openReportNoTabs()` — `openReport()` waits for `#report-tabs.ui-tabs`, a widget the untabbed family never builds, so it timed out on every commerce report.

The seeder enables e-commerce on the fixture site and writes two transactions with three line items (idempotent by `order_id`); teardown now clears both commerce fact tables. **Amounts go through `owa_lib::prepareCurrencyValue()`** — the columns are `BIGINT` and OWA stores currency in **cents**, so seeding dollars reported `$0.43` for a `$42.60` order.

## The overview report, and why the fixture links sessions

The e-commerce overview reads its totals off the **session**, not off the fact tables — `SessionCommerceSummaryHandlers` rolls them onto the session row when a transaction arrives.

An earlier revision of this fixture inserted facts with `session_id = 0`, so that report showed `$0.00` and the test could only assert labels. It now attaches each transaction to the session seeded for the same day (`seedPageviews()` already creates one per visit day, and the transaction days line up), then rolls the totals up with the **same `owa_coreAPI::summarize()` calls the handler uses**.

Deriving them through the application's own summarisation, rather than computing them in the fixture, means the two cannot drift — if the handler's aggregation changes, the fixture follows. Verified on the session rows:

```
day=20260722  trans=1  revenue=4260  items_rev=2590  qty=3
day=20260729  trans=1  revenue=2040  items_rev=2040  qty=2
```

$63.00 and $46.30 in total, so the overview test asserts the real figure.

## 3. A misspelt metric threw out of grid construction

The "Sales Sources" explorer on `base.reportEcommerce` queries `metrics=transactions,transactionRevenue` but sorted by **`transactionsRevenue-`** — plural, and no such metric exists:

```php
'metrics' => 'transactions,transactionRevenue',   // singular
'sort'    => 'transactionsRevenue-',              // plural — resolves to nothing
```

The sort resolved to nothing, the result set returned a null `sortColumn`/`sortOrder`, and jqGrid called `.toLowerCase()` on it while building the grid:

```
TypeError: Cannot read properties of null (reading 'toLowerCase')
  at ... jqGrid
  at dataGrid.setGridOptions (owa.resultSetExplorer.js)
```

The page still rendered, so the only trace was the browser console — which nothing was watching. **One character.**

### This is not the same bug as (2), despite looking like it

`ReportEcommerce`'s controller *also* carries `sort='actions'`, which is what made it look identical. But that value **is never read** — this report's template hard-codes a sort per sub-explorer.

An earlier revision of this branch "fixed" the controller instead. That change was inert and its reasoning was wrong ("the report has no dimensions" — it has three sub-explorers, which is why `setGridOptions` was in the stack at all), so **it has been reverted**.

### The JS default is defence in depth, not the fix

`setGridOptions` now defaults the values:

```js
sortname:  resultSet.sortColumn || '',
sortorder: resultSet.sortOrder  || 'asc',
```

Verified by **removing the default and re-running with only the typo corrected — still passes all 7**. So the typo was the sole cause. The default is kept because a caller typo should not be able to throw out of grid construction, but it is not what fixes this.

## 4. A contract test for the whole class — and two more instances it found

Three bugs of this shape turned up by hand in one sitting, all silent: no non-200, no exception, no log line. `ReportMetricDimensionContractTest` now scans every report controller and template — **115 scopes, 443 literal names**:

| check | catches |
|---|---|
| named metrics are registered | invented / renamed metrics |
| named dimensions are registered | same for dimensions |
| sort names *something* registered | the `transactionsRevenue` typo |
| **sort is among that report's own metrics/dimensions** | the `ReportProducts` `actions` bug |

The last one is the one that matters. A first version only verified **global** registration and **missed the Products bug entirely** — `actions` *is* a registered metric, just not one that report queries. Scoping the sort per report is what makes the check useful.

### It found two more

- **`report_dashboard.php`** sorted by `visits` while querying `repeatVisitors,newVisitors` with **no dimensions** — an aggregate-only query feeding a pie chart, so there was nothing to order. Sort removed; the dashboard spec (Flot pie included) still passes.
- **`ReportEcommerce`** carried `sort='actions'` again. That value is genuinely unused (the template hard-codes a sort per sub-explorer), so this is correctness rather than a live fix — set to `transactions-` so the contract holds uniformly instead of carrying an exemption.

Mutation-verified against all three shapes: registered-but-not-queried → 1 failure, the typo → 2, an invented metric → 1.

### Limitation, asserted rather than assumed

Only **literal strings** are visible. **27 of 115 scopes** build their metric list at runtime — tabbed reports inherit metrics from `ReportController::pre()` — and are counted but not sort-checked, because checking them anyway produced four false positives.

`testCoverageIsReported` pins a floor of 300 checked names and prints the unverifiable count, so a parser that silently stops matching fails instead of going quietly green.

## Gates

e2e **39 passed** (7 e-commerce + dashboard/reporting). Jest **199/199**. PHPUnit **279 tests, 2557 assertions OK**. `phpstan` / `phpstan:migration` / `phpstan:templates` all `[OK]`.
