### PR TITLE
fix(controllers): initialise view vars read outside the branch that sets them

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,7 +14,7 @@ overrides, and anyone maintaining a custom theme.
 
 ---
 
-## Deprecated in 1.9.x, removed in v2.0
+## Deprecated in 1.10.0, removed in v2.0
 
 ### 1. Bare template variables and `$this` inside templates
 

--- a/modules/Base/Controller/Login.php
+++ b/modules/Base/Controller/Login.php
@@ -65,7 +65,11 @@ class Login extends \OWA\Core\Controller {
 
         // return login form with error msg
         $this->setView('base.loginForm');
-        $this->set('go', $go);
+        // $go is a local of action(); reading it here silently yielded null, so a
+        // failed login dropped the redirect target and sent the user to the
+        // default landing page instead of back where they were headed. Re-derive
+        // it from the request, sanitised the same way action() does.
+        $this->set('go', \OWA\Module\Base\Classes\Sanitize::cleanUrl( $this->getParam('go') ));
         //$this->set('error_code', 2002);
         $this->set('user_id', $this->getParam('user_id'));
     }

--- a/modules/Base/Controller/ReportDomClicks.php
+++ b/modules/Base/Controller/ReportDomClicks.php
@@ -51,6 +51,9 @@ class ReportDomClicks extends \OWA\Core\ReportController {
             $title_slug = $pagePath;
         }
         
+        // Only assigned inside the branch below, but read by setTitle() after it.
+        $title_slug = '';
+
         if ($this->getParam('document_id')) {
             $did = $this->getParam('document_id');
             $d->load( $did );

--- a/modules/Base/Controller/ReportDomstreams.php
+++ b/modules/Base/Controller/ReportDomstreams.php
@@ -36,6 +36,9 @@ class ReportDomstreams extends \OWA\Core\ReportController {
     function action() {
 
         $document_id = '';
+        // Only assigned inside the document branch below, but read
+        // unconditionally in the API call.
+        $pageUrl = '';
 
         // get period
         $p = $this->getPeriod();

--- a/modules/Base/Controller/ReportGoals.php
+++ b/modules/Base/Controller/ReportGoals.php
@@ -44,8 +44,11 @@ class ReportGoals extends \OWA\Core\ReportController {
         $gm = \OWA\Core\CoreAPI::supportClassFactory('base', 'goalManager', $this->getParam( 'siteId' ) );
         $goals = $gm->getActiveGoals();
 
+        // Read by set() after the branch, so it must exist even when a site has
+        // no active goals.
+        $goal_metrics = '';
+
         if ($goals) {
-            $goal_metrics = '';
             $goal_count = count($goals);
             $i = 1;
             foreach ($goals as $goal) {

--- a/modules/Base/Controller/ReportTransactionDetail.php
+++ b/modules/Base/Controller/ReportTransactionDetail.php
@@ -49,7 +49,9 @@ class ReportTransactionDetail extends \OWA\Core\ReportController {
 		$trans_detail = (array) $trans_detail;
         $this->set('trans_detail', $trans_detail);
         $this->setSubview('base.reportTransactionDetail');
-        $this->setTitle('Transaction Detail for: ', $transaction_id);
+        // Was $transaction_id -- a typo for the $transactionId set above, so the
+        // report heading rendered with null instead of the transaction id.
+        $this->setTitle('Transaction Detail for: ', $transactionId);
     }
 
 }

--- a/modules/Base/Controller/ReportVisits.php
+++ b/modules/Base/Controller/ReportVisits.php
@@ -44,6 +44,12 @@ class ReportVisits extends \OWA\Core\ReportController {
         $v = \OWA\Core\CoreAPI::entityFactory('base.visitor');
         $v->load($visitorId);
 
+        // Both are read unconditionally by the API call below. Without a date
+        // param the request falls back to 'period', so null is the correct
+        // default -- but they still have to exist.
+        $startDate = null;
+        $endDate = null;
+
         if ($this->getParam('date')) {
             $startDate = $this->getParam('date');
             $endDate = $this->getParam('date');

--- a/modules/Base/Controller/UpdatesApply.php
+++ b/modules/Base/Controller/UpdatesApply.php
@@ -81,6 +81,10 @@ class UpdatesApply extends \OWA\Core\Controller {
         // foreach do update in order
 
         $error = false;
+        // Set alongside $error inside the loop below, so at runtime it is always
+        // defined by the time it is read. Initialised anyway: the correlation is
+        // not visible to a reader (or to static analysis) at the point of use.
+        $cli_update_required = false;
 
         foreach ($modules as $k => $v) {
 

--- a/modules/Base/Controller/UsersSetPassword.php
+++ b/modules/Base/Controller/UsersSetPassword.php
@@ -58,6 +58,11 @@ class UsersSetPassword extends \OWA\Core\Controller {
 	        	\OWA\Core\CoreAPI::setSetting('base', 'is_embedded_admin_user_password_reset', true, true);
 		}
 
+        // Returned unconditionally below, but only populated when the user
+        // loaded. Returning an undefined variable made the failure path hand
+        // back null instead of an empty payload.
+        $data = [];
+
         if ($u !== false) {
             $data['view'] = 'base.usersSetPassword';
             $data['view_method'] = 'email';


### PR DESCRIPTION
A live error log showed `Undefined variable $pageUrl` in `ReportDomstreams`. Sweeping `modules/` with PHPStan at level 1 found **nine** reads of a variable nothing guarantees is set — two are real bugs, seven emit a warning and pass `null` onward.

## Real bugs

| File | Variable | Effect |
|---|---|---|
| `Login.php:68` | `$go` | a local of `action()`, read in `errorAction()` — a **separate scope**. A failed login dropped the redirect target and returned the user to the default landing page instead of where they were headed. |
| `ReportTransactionDetail.php:52` | `$transaction_id` | typo for the `$transactionId` set ten lines above, so the report heading rendered with `null` instead of the transaction id. |

## Conditional initialisation

Assigned inside a branch, read after it:

| File | Variable | When it bites |
|---|---|---|
| `ReportDomstreams` | `$pageUrl` | the one that showed up in the error log |
| `ReportDomClicks` | `$title_slug` | no `document_id` param |
| `ReportGoals` | `$goal_metrics` | site has no active goals |
| `ReportVisits` | `$startDate`, `$endDate` | no `date` param — falls back to `period`, so `null` is correct, but they must exist |
| `UpdatesApply` | `$cli_update_required` | always set at runtime on the error path, but the correlation is invisible at the point of use |
| `UsersSetPassword` | `$data` | failure path returned an undefined variable rather than an empty payload |

## Why these shipped

No gate covers controllers:

- `phpstan.neon` — level 3, but only 8 `Core/` files
- `phpstan-migration.neon` — whole tree, but **level 0**, which does not report undefined variables
- `phpstan-templates.neon` — level 1, but scoped to `modules/*/templates`

Same class as #955, #958 and #964, which is what prompted checking the rest of the tree.

`modules/` now analyses clean for `variable.undefined` at level 1. Turning that into a standing gate needs a baseline for the unrelated findings it also surfaces (`staticMethod.void` and friends), so it is left as a follow-up rather than bundled here.

## Verification

- 286 tests, 2,573 assertions — pass
- `php -l` clean on all 8 changed files
- PHPStan `variable.undefined` across all of `modules/`: **0**