### PR TITLE
fix(tracker): deliver the first beacon, and stop asserting undelivered sessions

### DIFF
--- a/modules/Base/src/common/StateManager.js
+++ b/modules/Base/src/common/StateManager.js
@@ -10,6 +10,62 @@ class StateManager {
 		this.stores = {};
 		this.storeFormats = {};
 		this.storeMeta = {};
+
+		/*
+		 * Session identity is written to memory immediately (so every event on
+		 * this page reads the same values) but withheld from the COOKIE until a
+		 * request carrying it has actually been accepted for delivery.
+		 *
+		 * Persisting these before delivery is what strands a session: the cookie
+		 * asserts session X, the server was never told about X, and every later
+		 * page takes sessionHandlers::logSessionUpdate() -- which correctly
+		 * aborts, because on a multi-server setup an update can legitimately
+		 * arrive before its create. Nothing then reconciles it.
+		 *
+		 * Only these two keys wait. Everything else -- referer, campaign keys,
+		 * custom vars -- persists immediately, because they are facts observable
+		 * ONLY on the landing hit and are unrecoverable if dropped.
+		 */
+		this.deferPersistence = false;
+		this.deferredKeys = { 's': [ 'sid', 'last_req' ] };
+	}
+
+	/**
+	 * Withhold the deferred keys from the cookie until a send is accepted.
+	 * Memory is unaffected -- this only filters what gets serialized.
+	 */
+	beginDeferredPersistence() {
+
+		this.deferPersistence = true;
+	}
+
+	/**
+	 * A request carrying the session identity was accepted for delivery, so the
+	 * cookie may now assert it. Re-persists the affected stores.
+	 */
+	commitDeferredPersistence() {
+
+		if ( ! this.deferPersistence ) {
+			return;
+		}
+
+		this.deferPersistence = false;
+
+		for ( var store_name in this.deferredKeys ) {
+			if ( this.isPresent( store_name ) ) {
+				this.persist( store_name );
+			}
+		}
+	}
+
+	/**
+	 * The send was refused or never completed. Leave the cookie as it was: the
+	 * next page then finds no sid/last_req, treats the request as a new session,
+	 * and the server creates it properly.
+	 */
+	abandonDeferredPersistence() {
+
+		this.deferPersistence = false;
 	}
         
     registerStore( name, expiration, length, format ) {
@@ -60,26 +116,65 @@ class StateManager {
         } else {
             this.stores[store_name] = value;
         }
-        
-        format = this.getFormat(store_name);
-        
+
+        // Memory is now current for every event on this page. Persistence is a
+        // separate concern -- see persist().
+        this.persist( store_name, is_perminant );
+    }
+
+    /**
+     * Serialize a store to its cookie.
+     *
+     * While deferPersistence is on, the store's deferred keys are filtered OUT
+     * of the serialized snapshot. The filter lives here rather than in set() so
+     * that a write to any OTHER key in the same store (referer, campaign, dsps)
+     * cannot smuggle an undelivered sid into the cookie as a side effect -- the
+     * cookie is per-store, not per-key.
+     */
+    persist( store_name, is_perminant ) {
+
+        if ( ! this.isPresent( store_name ) ) {
+            return;
+        }
+
+        var snapshot = this.stores[store_name];
+
+        if ( this.deferPersistence
+             && this.deferredKeys.hasOwnProperty( store_name )
+             && snapshot
+             && typeof snapshot === 'object' )
+        {
+            var withheld = this.deferredKeys[ store_name ];
+            var filtered = {};
+
+            for ( var k in snapshot ) {
+                if ( snapshot.hasOwnProperty( k ) && withheld.indexOf( k ) === -1 ) {
+                    filtered[k] = snapshot[k];
+                }
+            }
+
+            snapshot = filtered;
+        }
+
+        var format = this.getFormat(store_name);
+
         if ( ! format ) {
-            
+
             // check the orginal format that the state store was loaded from.
             if (this.storeFormats.hasOwnProperty(store_name)) {
                 format = this.storeFormats[store_name];
             }
         }
-        
+
         var state_value = '';
-        
+
         if (format === 'json') {
-            state_value = JSON.stringify(this.stores[store_name]);
+            state_value = JSON.stringify(snapshot);
         } else {
-            state_value = Util.assocStringFromJson(this.stores[store_name]);
+            state_value = Util.assocStringFromJson(snapshot);
         }
-        
-        expiration_days = this.getExpirationDays( store_name );
+
+        var expiration_days = this.getExpirationDays( store_name );
         
         if ( ! expiration_days ) {
             
@@ -103,27 +198,18 @@ class StateManager {
         if ( store_name ) {
         
             if (value) {
-                
+
                 format = this.getFormat(store_name);
                 this.stores[store_name] = value;
                 this.storeFormats[store_name] = format;
-                
-                var cookie_value = '';
-                
-                if (format === 'json') {
-                    cookie_value = JSON.stringify(value);
-                } else {
-                    cookie_value = Util.assocStringFromJson(value);
-                }
             }
-        
-            var domain = OWA.getSetting('cookie_domain') || document.domain;
-            
-            expiration_days = this.getExpirationDays( store_name );
-            
-            OWA.debug('About to replace state store (%s) with: %s', store_name, cookie_value);
-            Util.setCookie( OWA.getSetting('ns') + store_name, cookie_value, expiration_days, '/', domain );
-            
+
+            // Route through persist() rather than writing the cookie here, so a
+            // replace (notably clear(store, key), which rebuilds the store minus
+            // one key) honours the deferred-key filter. Writing directly would
+            // serialize an undelivered sid straight back into the cookie.
+            OWA.debug('About to replace state store (%s)', store_name);
+            this.persist( store_name, is_perminant );
         }
     }
         

--- a/modules/Base/src/common/owa.js
+++ b/modules/Base/src/common/owa.js
@@ -117,9 +117,27 @@ class OWA {
     }
     
     setStateStoreFormat(store_name, format) {
-    
+
         this.initializeStateManager();
         return this.state.setStoreFormat(store_name, format);
+    }
+
+    beginDeferredStatePersistence() {
+
+        this.initializeStateManager();
+        return this.state.beginDeferredPersistence();
+    }
+
+    commitDeferredStatePersistence() {
+
+        this.initializeStateManager();
+        return this.state.commitDeferredPersistence();
+    }
+
+    abandonDeferredStatePersistence() {
+
+        this.initializeStateManager();
+        return this.state.abandonDeferredPersistence();
     }
     
     debug() {

--- a/modules/Base/src/tracker/Tracker.js
+++ b/modules/Base/src/tracker/Tracker.js
@@ -576,23 +576,80 @@ class OWATracker  {
                 //this.cdPost( this.prepareRequestData( properties ) );
                 var data = this.prepareRequestData( properties );
                 this.cdPost( data );
+
+                /*
+                 * The hidden-iframe POST gives us no delivery signal, so commit
+                 * optimistically -- exactly the behaviour this path has always
+                 * had. Withholding here would mean a site whose payloads always
+                 * exceed getRequestCharacterLimit could never persist a session
+                 * at all, minting a new one on every page view. That is a worse
+                 * failure than the one this deferral exists to prevent.
+                 */
+                OWA.commitDeferredStatePersistence();
             } else {
 
                 OWA.debug('url : %s', url);
-                   var image = new Image(1, 1);
-                   //expireDateTime = now.getTime() + delay;
-                   image.onLoad = function () { };
-                image.src = url;
-                if (block) {
-                    //OWA.debug(' blocking...');
-                }
-                OWA.debug('Inserted web bug for %s', properties['event_type']);
+                this.sendRequest( url, properties['event_type'] );
             }
 
             if (callback && (typeof(callback) === "function")) {
                 callback();
             }
         }
+    }
+
+    /**
+     * Hands a request URL to the browser for delivery.
+     *
+     * Prefers navigator.sendBeacon: it is the only transport that survives page
+     * unload, which is the dominant way a first page view is lost -- the visitor
+     * clicks through (including an in-page anchor) while the pixel is still in
+     * flight and the browser cancels it. Called with no body it issues a POST
+     * with the query string intact, so log.php keeps reading $_GET unchanged.
+     *
+     * sendBeacon returns false when the browser refuses to queue the payload
+     * (size caps, disabled by policy); in that case, and on older browsers, fall
+     * back to the historical 1x1 pixel.
+     *
+     * The return value drives whether session identity may be persisted:
+     * accepted -> commit; refused/errored -> abandon; neither (the page was torn
+     * down mid-flight) -> nothing is committed, and the next page correctly
+     * starts a new session.
+     */
+    sendRequest( url, event_type ) {
+
+        var that = this;
+        var queued = false;
+
+        if ( typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function' ) {
+
+            try {
+                queued = navigator.sendBeacon( url );
+            } catch ( e ) {
+                // Some browsers throw on a cross-origin or oversized payload
+                // rather than returning false.
+                queued = false;
+            }
+        }
+
+        if ( queued ) {
+
+            OWA.debug( 'Beacon queued for %s', event_type );
+            OWA.commitDeferredStatePersistence();
+            return true;
+        }
+
+        var image = new Image(1, 1);
+
+        // NOTE: 'onload', not 'onLoad'. The latter is not a DOM property and
+        // never fires -- it sat here unnoticed for years because nothing hung
+        // off the success path until now.
+        image.onload  = function () { OWA.commitDeferredStatePersistence(); };
+        image.onerror = function () { OWA.abandonDeferredStatePersistence(); };
+        image.src = url;
+
+        OWA.debug('Inserted web bug for %s', event_type);
+        return false;
     }
         
     /**
@@ -1959,6 +2016,19 @@ class OWATracker  {
 
         var that = this;
         if ( ! this.stateInit ) {
+
+            /*
+             * Withhold session identity (s.sid / s.last_req) from the cookie
+             * until this event is accepted for delivery. Memory still receives
+             * the values immediately, so every event on this page reads the same
+             * session. See StateManager.beginDeferredPersistence().
+             *
+             * This runs only on the FIRST tracked event of a page, which makes
+             * the deferral one-shot: if that event's send fails, a later event
+             * on the same page finds the flag already cleared and so cannot
+             * commit a session the server was never told about.
+             */
+            OWA.beginDeferredStatePersistence();
 
             this.setVisitorId( event, function(event) {
 

--- a/tests/e2e/session-lifecycle.spec.js
+++ b/tests/e2e/session-lifecycle.spec.js
@@ -1,0 +1,276 @@
+// @ts-check
+/**
+ * Session lifecycle: does a session actually LAND?
+ *
+ * tracker-beacon.spec.js proves beacons leave the browser. Nothing until now
+ * proved rows arrive -- that one page view yields one session, that a second
+ * page view extends it rather than minting another, and (the case this suite
+ * exists for) that a lost FIRST beacon does not strand every later hit.
+ *
+ * The failure being guarded against: the tracker used to write s.sid / s.last_req
+ * to the cookie the moment they were derived, before the request carrying them
+ * was transmitted. When that first beacon died -- typically cancelled by the
+ * browser when the visitor clicked through while the 1x1 pixel was in flight --
+ * the cookie asserted a session the server had never been told about. Every later
+ * page then read that sid, sent is_new_session UNSET, and the server took
+ * sessionHandlers::logSessionUpdate(), which correctly aborts (on a multi-server
+ * setup an update can legitimately precede its create) and requeued the event.
+ * Nothing reconciled it, so one lost beacon stranded the whole session.
+ *
+ * Scenario 4 asserts a dangling fact row as the CORRECT current outcome, not a
+ * bug: a click fired after a lost page view reaches only clickHandlers and the
+ * dimension handlers, never sessionHandlers, so no session is created and nothing
+ * is queued. Fixing that needs the server to be able to establish a session
+ * thinly from any event type -- deliberately out of scope here. The test pins the
+ * behaviour so a future change to handler registration cannot alter what lands in
+ * the fact tables silently.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { test, expect } = require('@playwright/test');
+
+const HARNESS_SITE_ID = 'e2e-tracker-harness';
+const HELPER = path.join(__dirname, 'session_e2e_helper.php');
+const HARNESS_HTML = fs.readFileSync(path.join(__dirname, 'tracker_harness.html'), 'utf8');
+
+function installRoot(baseURL) {
+    return baseURL.replace(/index\.php.*$/, '');
+}
+
+function helper(...args) {
+    return JSON.parse(execFileSync('php', [HELPER, ...args], { encoding: 'utf8' }));
+}
+
+/**
+ * Serve the harness doc from disk at `url`. The injected tracker and its log.php
+ * beacon fall through to the php -S server, same-origin.
+ */
+async function serveHarness(page, url) {
+    await page.route(url, (route) =>
+        route.fulfill({ contentType: 'text/html', body: HARNESS_HTML })
+    );
+}
+
+const SELFHOST = process.env.OWA_E2E_SELFHOST === '1';
+
+test.describe('a session lands, extends, and survives a lost first beacon @selfhost-only', () => {
+
+    test.skip(!SELFHOST,
+        'Reads and truncates the fact tables; runs only under the self-host e2e runner (OWA_E2E_SELFHOST=1).');
+
+    test.beforeEach(() => {
+        helper('reset', `site=${HARNESS_SITE_ID}`);
+    });
+
+    /** Wait until log.php has been hit for the given event type. */
+    async function awaitBeacon(beacons, eventType) {
+        await expect
+            .poll(() => beacons.filter((u) => u.includes(eventType)).length, { timeout: 20_000 })
+            .toBeGreaterThan(0);
+    }
+
+    /** Poll the DB, since the beacon is answered before the write completes. */
+    async function awaitSessions(count) {
+        await expect
+            .poll(() => helper('session-state', `site=${HARNESS_SITE_ID}`).session_count,
+                  { timeout: 20_000 })
+            .toBe(count);
+        return helper('session-state', `site=${HARNESS_SITE_ID}`);
+    }
+
+    test('1 - a single page view yields exactly one session', async ({ page }) => {
+        const beacons = [];
+        page.on('request', (r) => { if (r.url().includes('log.php')) beacons.push(r.url()); });
+
+        const root = installRoot(test.info().project.use.baseURL);
+        const url = root + 'tests/e2e/tracker_harness.html?base=' + encodeURIComponent(root);
+        await serveHarness(page, url);
+        await page.goto(url, { waitUntil: 'load' });
+        await awaitBeacon(beacons, 'owa_event_type=base.page_request');
+
+        const state = await awaitSessions(1);
+        expect(state.request_count).toBe(1);
+        expect(Number(state.sessions[0].num_pageviews)).toBe(1);
+        expect(Number(state.sessions[0].is_bounce)).toBe(1);
+        expect(state.queue_depth).toBe(0);
+        expect(state.dangling_total).toBe(0);
+    });
+
+    test('2 - a second page view extends the session rather than minting another', async ({ page }) => {
+        const beacons = [];
+        page.on('request', (r) => { if (r.url().includes('log.php')) beacons.push(r.url()); });
+
+        const root = installRoot(test.info().project.use.baseURL);
+        const a = root + 'tests/e2e/tracker_harness.html?base=' + encodeURIComponent(root) + '&p=a';
+        const b = root + 'tests/e2e/tracker_harness.html?base=' + encodeURIComponent(root) + '&p=b';
+        await serveHarness(page, a);
+        await serveHarness(page, b);
+
+        await page.goto(a, { waitUntil: 'load' });
+        await awaitBeacon(beacons, 'owa_event_type=base.page_request');
+        await awaitSessions(1);
+
+        /*
+         * logSessionUpdate() only applies an update when the event timestamp is
+         * strictly GREATER than the session's stored last_req -- the idempotency
+         * guard that makes out-of-order arrivals safe on a multi-server setup.
+         * OWA timestamps are whole seconds, so two page views inside the same
+         * second are correctly suppressed. Space them.
+         */
+        await page.waitForTimeout(1100);
+
+        const beforeB = beacons.length;
+        await page.goto(b, { waitUntil: 'load' });
+        // Wait for B's own beacon to leave before inspecting the DB, otherwise
+        // the poll races the request rather than the write.
+        await expect.poll(() => beacons.length, { timeout: 20_000 }).toBeGreaterThan(beforeB);
+
+        // Poll num_pageviews, not request_count: the request row lands first and
+        // sessionHandlers updates the session on a LATER write.
+        await expect.poll(
+            () => {
+                const st = helper('session-state', `site=${HARNESS_SITE_ID}`);
+                // Surface the shape on failure -- a second session here would mean
+                // B minted its own rather than continuing A's.
+                return { sessions: st.session_count,
+                         pageviews: st.sessions[0] ? Number(st.sessions[0].num_pageviews) : 0 };
+            },
+            { timeout: 20_000 }
+        ).toEqual({ sessions: 1, pageviews: 2 });
+
+        const state = helper('session-state', `site=${HARNESS_SITE_ID}`);
+        // The regression this guards: if deferral ever discarded sid/last_req on a
+        // SUCCESSFUL send, every page would start a new session.
+        expect(state.session_count).toBe(1);
+        expect(Number(state.sessions[0].num_pageviews)).toBe(2);
+        expect(Number(state.sessions[0].is_bounce)).toBe(0);
+        expect(state.queue_depth).toBe(0);
+        expect(state.dangling_total).toBe(0);
+
+        // The second hit continues the session -- it must NOT re-declare a new one.
+        const second = beacons.filter((u) => u.includes('owa_event_type=base.page_request'))[1];
+        expect(second).toBeTruthy();
+        expect(second).not.toContain('owa_is_new_session');
+    });
+
+    test('3 - a lost first page view does not strand the session', async ({ page }) => {
+        const beacons = [];
+        page.on('request', (r) => { if (r.url().includes('log.php')) beacons.push(r.url()); });
+
+        const root = installRoot(test.info().project.use.baseURL);
+        // OWA's default campaignKeys are owa_* , not utm_* (utm_ requires an
+        // explicit remap via setCampaignSourceKey and friends).
+        const a = root + 'tests/e2e/tracker_harness.html?base=' + encodeURIComponent(root)
+                + '&p=a&owa_campaign=spring&owa_source=newsletter&owa_medium=email';
+        const b = root + 'tests/e2e/tracker_harness.html?base=' + encodeURIComponent(root) + '&p=b';
+        await serveHarness(page, a);
+        await serveHarness(page, b);
+
+        /*
+         * Force the pixel transport for this scenario.
+         *
+         * route.abort() kills the request at the NETWORK layer, but
+         * navigator.sendBeacon() has already returned true by then -- it reports
+         * "the browser accepted this for delivery", not "it arrived". So under
+         * sendBeacon an aborted request still commits session identity, and the
+         * loss is undetectable client-side. That is a real limitation of the
+         * transport, not of this test.
+         *
+         * The pixel path is the one where failure IS observable (onerror), so it
+         * is what this asserts. Removing sendBeacon also mirrors the browsers
+         * that fall back to it for real.
+         */
+        await page.addInitScript(() => {
+            try { delete Object.getPrototypeOf(navigator).sendBeacon; } catch (e) { /* ignore */ }
+            try { delete navigator.sendBeacon; } catch (e) { /* ignore */ }
+            Object.defineProperty(navigator, 'sendBeacon', {
+                configurable: true, get() { return undefined; },
+            });
+        });
+
+        // --- page A: the beacon never reaches the server --------------------
+        await page.route('**/log.php*', (route) => route.abort());
+        await page.goto(a, { waitUntil: 'load' });
+        await page.waitForTimeout(1000);
+
+        let state = helper('session-state', `site=${HARNESS_SITE_ID}`);
+        expect(state.session_count, 'page A must leave nothing behind').toBe(0);
+        expect(state.request_count).toBe(0);
+        expect(state.queue_depth).toBe(0);
+
+        // --- page B: delivery restored --------------------------------------
+        await page.unroute('**/log.php*');
+        await page.goto(b, { waitUntil: 'load' });
+        await awaitBeacon(beacons, 'owa_event_type=base.page_request');
+
+        state = await awaitSessions(1);
+
+        // Only B's view exists -- A's was genuinely lost, and we do not invent it.
+        expect(state.request_count).toBe(1);
+        // The whole point: no stranded update, so nothing was requeued.
+        expect(state.queue_depth, 'a stranded session requeues page_request_logged').toBe(0);
+        expect(state.dangling_total).toBe(0);
+
+        // B had to declare a NEW session, because A's identity was never persisted.
+        const pageviews = beacons.filter((u) => u.includes('owa_event_type=base.page_request'));
+        expect(pageviews[pageviews.length - 1]).toContain('owa_is_new_session');
+
+        // Arrival facts captured on A survive: they are observable only on the
+        // landing hit and are unrecoverable if dropped. B's URL carries no utm_*.
+        const attribs = state.sessions[0].latest_attributions;
+        expect(attribs, 'campaign attribution from page A was lost').toBeTruthy();
+        expect(JSON.stringify(attribs)).toContain('spring');
+        expect(JSON.stringify(attribs)).toContain('newsletter');
+    });
+
+    test('4 - a click after a lost page view still dangles (accepted, pending server-side fix)', async ({ page }) => {
+        const beacons = [];
+        page.on('request', (r) => { if (r.url().includes('log.php')) beacons.push(r.url()); });
+
+        const root = installRoot(test.info().project.use.baseURL);
+        const a = root + 'tests/e2e/tracker_harness.html?base=' + encodeURIComponent(root) + '&p=a';
+        await serveHarness(page, a);
+
+        // Same reason as scenario 3: under sendBeacon an aborted request still
+        // reports success, so the pixel path is the one where a lost hit is
+        // observable at all.
+        await page.addInitScript(() => {
+            Object.defineProperty(navigator, 'sendBeacon', {
+                configurable: true, get() { return undefined; },
+            });
+        });
+
+        await page.route('**/log.php*', (route) => route.abort());
+        await page.goto(a, { waitUntil: 'load' });
+        await page.waitForTimeout(500);
+
+        // Delivery comes back, then the visitor clicks WITHOUT leaving the page.
+        await page.unroute('**/log.php*');
+        await page.waitForFunction(() => typeof window.OWATracker !== 'undefined',
+            null, { timeout: 20_000 });
+        await page.evaluate(() => window.OWATracker.trackClicks());
+        await page.locator('#tracked-btn').click();
+        await awaitBeacon(beacons, 'owa_event_type=dom.click');
+
+        await page.waitForTimeout(1500);
+        const state = helper('session-state', `site=${HARNESS_SITE_ID}`);
+
+        /*
+         * The click carries the in-memory sid and is_new_session, but dom.click is
+         * registered to clickHandlers + the dimension handlers only -- never
+         * sessionHandlers -- so no session is created and every handler succeeds.
+         * The row lands referencing a session that does not exist, and nothing is
+         * queued to flag it.
+         *
+         * This is the CURRENT, accepted outcome. Closing it requires the server to
+         * establish a session thinly from any event type, which is a separate
+         * change. Asserted here so that altering handler registration or the
+         * globals lifecycle cannot change what reaches the fact tables silently.
+         */
+        expect(state.session_count).toBe(0);
+        expect(state.dangling_total).toBeGreaterThan(0);
+        expect(state.queue_depth, 'the dangling click is invisible to the queue').toBe(0);
+    });
+});

--- a/tests/e2e/session_e2e_helper.php
+++ b/tests/e2e/session_e2e_helper.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * Session lifecycle inspector for the self-host e2e runner.
+ *
+ * The tracker specs can prove a beacon left the browser, but nothing until now
+ * asserted that a session actually LANDS -- that one page view yields one
+ * session, that a second extends it rather than minting another, and that a lost
+ * first beacon does not strand every later hit in that session.
+ *
+ * Commands:
+ *
+ *   session-state site=<id>   sessions, request_count, queue_depth, queued_types,
+ *                             dangling  (fact rows whose session_id has no row in
+ *                             owa_session -- the silent failure the queue never
+ *                             reveals, because dom.click_logged and friends reach
+ *                             only the dimension handlers, never sessionHandlers)
+ *
+ *   reset site=<id>           delete this site's rows so a spec starts clean
+ *
+ * Queries go through the Db fluent builder rather than raw SQL: getAllRows()
+ * executes the builder's accumulated state, so handing it a SQL string fatals in
+ * generateSelectQuerySql(). Dangling rows are therefore computed as a set
+ * difference in PHP rather than with a LEFT JOIN.
+ *
+ * Like queue_e2e_helper.php this writes, so it HARD-REFUSES unless booted against
+ * the throwaway scratch DB the self-host harness provisions. Reading the name
+ * from the booted config rather than the environment means a stray
+ * OWA_E2E_DB_NAME cannot point it at anything real.
+ */
+
+// owa boots expecting a request context.
+if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+    $_SERVER['HTTP_USER_AGENT'] =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+        . '(KHTML, like Gecko) Chrome/120.0 Safari/537.36';
+}
+$_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '203.0.113.10';
+
+const SCRATCH_DB_SENTINEL = 'owa_e2e_selfhost';
+
+$owa_root = dirname(__DIR__, 2) . '/';
+require_once($owa_root . 'owa.php');
+new owa(['tracking_mode' => true, 'instance_role' => 'logger']);
+
+$connected_db = (string) owa_coreAPI::getSetting('base', 'db_name');
+$allowed_db   = getenv('OWA_E2E_DB_NAME') ?: SCRATCH_DB_SENTINEL;
+
+if ($connected_db !== $allowed_db) {
+    fwrite(STDERR, "[session_e2e_helper] REFUSING to run: connected DB '$connected_db' "
+        . "is not the scratch sentinel '$allowed_db'. This helper only runs under "
+        . "the self-host e2e runner.\n");
+    exit(3);
+}
+
+$cmd = $argv[1] ?? '';
+
+switch ($cmd) {
+    case 'session-state': out(sessionState(argSite($argv))); break;
+    case 'reset':         out(resetSite(argSite($argv)));    break;
+    default:
+        fwrite(STDERR, "Unknown command '$cmd'. Use: session-state site=<id> | reset site=<id>\n");
+        exit(2);
+}
+
+function out(array $result): void
+{
+    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+}
+
+function argSite(array $argv): string
+{
+    foreach ($argv as $arg) {
+        if (strpos($arg, 'site=') === 0) {
+            return substr($arg, 5);
+        }
+    }
+    fwrite(STDERR, "Missing required argument: site=<id>\n");
+    exit(2);
+}
+
+function db()
+{
+    return owa_coreAPI::dbSingleton();
+}
+
+/**
+ * Fact tables carrying a session_id. A dangling row in ANY of these is a session
+ * the server was never told to create -- and only page_request_logged surfaces
+ * that as a queue item, so the rest fail silently.
+ */
+function factTables(): array
+{
+    return ['owa_request', 'owa_click', 'owa_domstream', 'owa_commerce_transaction_fact'];
+}
+
+/** Every value of $column in $table for this site. */
+function columnValues(string $table, string $column, string $site_id): array
+{
+    $db = db();
+    $db->selectFrom($table);
+    $db->selectColumn($column);
+    $db->where('site_id', $site_id);
+    $rows = $db->getAllRows();
+
+    $out = [];
+    foreach ((array) $rows as $r) {
+        if (isset($r[$column]) && $r[$column] !== '') {
+            $out[] = (string) $r[$column];
+        }
+    }
+
+    return $out;
+}
+
+function countRows(string $table, string $site_id): int
+{
+    $db = db();
+    $db->selectFrom($table);
+    $db->selectColumn('COUNT(*) AS c');
+    $db->where('site_id', $site_id);
+    $row = $db->getOneRow();
+
+    return is_array($row) ? (int) $row['c'] : 0;
+}
+
+function sessionState(string $site_id): array
+{
+    $db = db();
+
+    $db->selectFrom('owa_session');
+    $db->selectColumn('id, num_pageviews, is_bounce, first_page_id, last_page_id, referer_id, '
+        . 'medium, campaign_id, source_id, latest_attributions, cv1_name, cv1_value');
+    $db->where('site_id', $site_id);
+    $rows = $db->getAllRows();
+
+    $sessions   = [];
+    $session_ids = [];
+
+    foreach ((array) $rows as $r) {
+        $session_ids[(string) $r['id']] = true;
+        $r['latest_attributions'] = $r['latest_attributions']
+            ? json_decode($r['latest_attributions'], true)
+            : null;
+        $sessions[] = $r;
+    }
+
+    // Queue depth is global: the scratch install runs one spec at a time, and a
+    // spec that starts with a dirty queue cannot assert queue_depth == 0.
+    $db2 = db();
+    $db2->selectFrom('owa_queue_item');
+    $db2->selectColumn('event_type, COUNT(*) AS c');
+    $db2->groupBy('event_type');
+    $qrows = $db2->getAllRows();
+
+    $queued_types = [];
+    foreach ((array) $qrows as $q) {
+        $queued_types[$q['event_type']] = (int) $q['c'];
+    }
+
+    $dangling = [];
+    foreach (factTables() as $t) {
+        $n = 0;
+        foreach (columnValues($t, 'session_id', $site_id) as $sid) {
+            if (!isset($session_ids[$sid])) {
+                $n++;
+            }
+        }
+        $dangling[$t] = $n;
+    }
+
+    return [
+        'site_id'        => $site_id,
+        'sessions'       => $sessions,
+        'session_count'  => count($sessions),
+        'request_count'  => countRows('owa_request', $site_id),
+        'queue_depth'    => array_sum($queued_types),
+        'queued_types'   => $queued_types,
+        'dangling'       => $dangling,
+        'dangling_total' => array_sum($dangling),
+    ];
+}
+
+function resetSite(string $site_id): array
+{
+    $deleted = [];
+
+    foreach (array_merge(factTables(), ['owa_session']) as $t) {
+        $db = db();
+        $db->deleteFrom($t);
+        $db->where('site_id', $site_id);
+        $db->executeQuery();
+        $deleted[] = $t;
+    }
+
+    $db = db();
+    $db->deleteFrom('owa_queue_item');
+    $db->executeQuery();
+
+    return ['site_id' => $site_id, 'reset' => $deleted, 'queue_cleared' => true];
+}

--- a/tests/js/BeaconDelivery.test.js
+++ b/tests/js/BeaconDelivery.test.js
@@ -1,0 +1,236 @@
+import { OWATracker } from '../../modules/Base/src/tracker/Tracker.js';
+import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
+
+/**
+ * Transport selection and the delivery signal it produces.
+ *
+ * The tracker historically sent every event as `new Image(1,1); image.src = url`
+ * -- fire and forget, with no way to learn whether the request survived. That is
+ * the dominant way a first page view is lost: the visitor clicks through (an
+ * outbound link, or even an in-page anchor) while the pixel is still in flight
+ * and the browser cancels it. The `block` parameter threaded from
+ * trackCustomEvent -> trackEvent -> logEvent was meant to guard against exactly
+ * that, but its body had been commented out for years, so it did nothing.
+ *
+ * navigator.sendBeacon is the modern replacement: the browser takes ownership of
+ * delivery and completes it across unload. Called with no body it issues a POST
+ * with the query string intact, so log.php keeps reading $_GET unchanged.
+ *
+ * Its boolean return is also the first delivery signal this code has ever had,
+ * and it drives whether session identity may be committed to the cookie:
+ *
+ *   accepted            -> commit  (the server will hear about this session)
+ *   refused / errored   -> abandon (leave the cookie clean; next page starts new)
+ *   neither (page torn  -> nothing is committed, which is the correct outcome
+ *   down mid-flight)
+ */
+
+function installImageSpy() {
+    const sent = [];
+    const Orig = global.Image;
+    global.Image = class {
+        constructor() {}
+        set src(v) { sent.push(v); }
+        get src() { return this._src; }
+    };
+    return { sent, restore: () => { global.Image = Orig; } };
+}
+
+/** Replace navigator.sendBeacon with a stub; returns the recorded calls. */
+function installBeacon(impl) {
+    const sent = [];
+    const had = Object.prototype.hasOwnProperty.call(navigator, 'sendBeacon');
+    const orig = navigator.sendBeacon;
+    Object.defineProperty(navigator, 'sendBeacon', {
+        configurable: true,
+        writable: true,
+        value: (url) => { sent.push(url); return impl(url); },
+    });
+    return {
+        sent,
+        restore: () => {
+            if (had) { navigator.sendBeacon = orig; }
+            else { delete navigator.sendBeacon; }
+        },
+    };
+}
+
+function removeBeacon() {
+    const had = Object.prototype.hasOwnProperty.call(navigator, 'sendBeacon');
+    const orig = navigator.sendBeacon;
+    delete navigator.sendBeacon;
+    return { restore: () => { if (had) { navigator.sendBeacon = orig; } } };
+}
+
+const BASE_URL = 'https://owa.example.test/';
+const URL_UNDER_TEST = BASE_URL + 'log.php?owa_event_type=base.page_request';
+
+function newTracker() {
+    window.owa_baseUrl = BASE_URL;
+    const t = new OWATracker({ cookie_domain_set: true });
+    t.setSiteId('beacon-site');
+    return t;
+}
+
+afterEach(() => {
+    delete window.owa_baseUrl;
+    jest.restoreAllMocks();
+});
+
+describe('transport selection', () => {
+
+    test('prefers navigator.sendBeacon when it accepts the payload', () => {
+        const beacon = installBeacon(() => true);
+        const pixel = installImageSpy();
+
+        const queued = newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        expect(queued).toBe(true);
+        expect(beacon.sent).toEqual([URL_UNDER_TEST]);
+        expect(pixel.sent).toEqual([]);          // no duplicate hit
+
+        pixel.restore();
+        beacon.restore();
+    });
+
+    test('falls back to the 1x1 pixel when sendBeacon is unavailable', () => {
+        const gone = removeBeacon();
+        const pixel = installImageSpy();
+
+        const queued = newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        expect(queued).toBe(false);
+        expect(pixel.sent).toEqual([URL_UNDER_TEST]);
+
+        pixel.restore();
+        gone.restore();
+    });
+
+    test('falls back to the pixel when sendBeacon refuses the payload', () => {
+        // Returns false for an oversized body or when disabled by policy.
+        const beacon = installBeacon(() => false);
+        const pixel = installImageSpy();
+
+        const queued = newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        expect(queued).toBe(false);
+        expect(beacon.sent).toEqual([URL_UNDER_TEST]);
+        expect(pixel.sent).toEqual([URL_UNDER_TEST]);   // the hit is not dropped
+
+        pixel.restore();
+        beacon.restore();
+    });
+
+    test('falls back to the pixel when sendBeacon throws', () => {
+        // Some browsers throw rather than returning false.
+        const beacon = installBeacon(() => { throw new Error('refused'); });
+        const pixel = installImageSpy();
+
+        const queued = newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        expect(queued).toBe(false);
+        expect(pixel.sent).toEqual([URL_UNDER_TEST]);
+
+        pixel.restore();
+        beacon.restore();
+    });
+});
+
+describe('the delivery signal drives session persistence', () => {
+
+    test('a queued beacon commits deferred state immediately', () => {
+        const beacon = installBeacon(() => true);
+        const commit = jest.spyOn(OWA, 'commitDeferredStatePersistence');
+
+        newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        expect(commit).toHaveBeenCalled();
+
+        beacon.restore();
+    });
+
+    test('the pixel path commits only once the image loads', () => {
+        const gone = removeBeacon();
+        const commit = jest.spyOn(OWA, 'commitDeferredStatePersistence');
+
+        // Capture the element so its handlers can be fired deliberately.
+        const created = [];
+        const Orig = global.Image;
+        global.Image = class {
+            constructor() { created.push(this); }
+            set src(v) { this._src = v; }
+            get src() { return this._src; }
+        };
+
+        newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        // Nothing committed yet: assignment only *initiates* the request.
+        expect(commit).not.toHaveBeenCalled();
+
+        created[0].onload();
+        expect(commit).toHaveBeenCalled();
+
+        global.Image = Orig;
+        gone.restore();
+    });
+
+    test('the pixel path abandons deferred state on error', () => {
+        const gone = removeBeacon();
+        const abandon = jest.spyOn(OWA, 'abandonDeferredStatePersistence');
+
+        const created = [];
+        const Orig = global.Image;
+        global.Image = class {
+            constructor() { created.push(this); }
+            set src(v) { this._src = v; }
+            get src() { return this._src; }
+        };
+
+        newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+        created[0].onerror();
+
+        expect(abandon).toHaveBeenCalled();
+
+        global.Image = Orig;
+        gone.restore();
+    });
+
+    test('a torn-down page commits nothing (neither handler fires)', () => {
+        const gone = removeBeacon();
+        const commit = jest.spyOn(OWA, 'commitDeferredStatePersistence');
+        const abandon = jest.spyOn(OWA, 'abandonDeferredStatePersistence');
+
+        const pixel = installImageSpy();
+        newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        // The request left, but nothing acknowledged it. Session identity stays
+        // out of the cookie, so the next page starts a session the server will
+        // actually create -- one lost pageview instead of a stranded session.
+        expect(commit).not.toHaveBeenCalled();
+        expect(abandon).not.toHaveBeenCalled();
+
+        pixel.restore();
+        gone.restore();
+    });
+
+    test('the handler is onload, not onLoad', () => {
+        // The original code assigned `image.onLoad`, which is not a DOM property
+        // and never fires. Harmless while nothing hung off the success path;
+        // load-bearing now that it commits session identity.
+        const gone = removeBeacon();
+        const created = [];
+        const Orig = global.Image;
+        global.Image = class {
+            constructor() { created.push(this); }
+            set src(v) { this._src = v; }
+        };
+
+        newTracker().sendRequest(URL_UNDER_TEST, 'base.page_request');
+
+        expect(typeof created[0].onload).toBe('function');
+        expect(created[0].onLoad).toBeUndefined();
+
+        global.Image = Orig;
+        gone.restore();
+    });
+});

--- a/tests/js/StatePersistenceFilter.test.js
+++ b/tests/js/StatePersistenceFilter.test.js
@@ -1,0 +1,192 @@
+import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
+import { Util } from '../../modules/Base/src/common/Util.js';
+
+/**
+ * Deferred persistence of session identity.
+ *
+ * The tracker used to write s.sid and s.last_req to the cookie the moment they
+ * were derived -- before the request carrying them was transmitted. When that
+ * first beacon died (typically cancelled by the browser when the visitor clicked
+ * through while the 1x1 pixel was still in flight), the cookie asserted a session
+ * the server had never been told about. Every later page then read that sid, sent
+ * is_new_session UNSET, and the server took sessionHandlers::logSessionUpdate(),
+ * which correctly aborts -- on a multi-server setup an update can legitimately
+ * arrive before its create -- and requeued the event. Nothing ever reconciled it,
+ * so one lost first beacon stranded every subsequent hit in that session.
+ *
+ * The fix withholds ONLY those two keys from the cookie until a send is accepted:
+ *
+ *   - memory (this.stores) always holds them, so every event on the page reads
+ *     the same session and cross-domain state sharing still carries the sid;
+ *   - the filter lives in persist(), not set(), because the cookie is per-STORE.
+ *     Writing any other key in 's' (referer, campaign keys, dsps) re-serializes
+ *     the whole store, and would otherwise smuggle an undelivered sid to disk;
+ *   - everything else persists immediately. referer and campaign keys are facts
+ *     observable ONLY on the landing hit and are unrecoverable if dropped, and
+ *     custom vars are publisher intent that must not hinge on transport.
+ *
+ * These assert against the value handed to Util.setCookie rather than
+ * document.cookie: jsdom refuses cookies whose domain does not match the test
+ * document URL, so reading the jar back would make every "is withheld" assertion
+ * pass trivially against an empty string.
+ */
+
+let writes;
+
+/** The value most recently serialized to a store's cookie, or null. */
+function lastWrite(store) {
+    const calls = writes.mock.calls.filter((c) => c[0] === 'owa_' + store);
+    return calls.length ? String(calls[calls.length - 1][1]) : null;
+}
+
+const NOW = 1700000000;
+
+beforeEach(() => {
+    OWA.setSetting('ns', 'owa_');
+    OWA.setSetting('cookie_domain', 'persist.example');
+    OWA.setSetting('hashCookiesToDomain', false);
+    ['v', 's', 'c', 'b'].forEach((store) => OWA.clearState(store));
+    OWA.abandonDeferredStatePersistence();
+    writes = jest.spyOn(Util, 'setCookie');
+    writes.mockClear();
+});
+
+afterEach(() => {
+    writes.mockRestore();
+    OWA.abandonDeferredStatePersistence();
+    ['v', 's', 'c', 'b'].forEach((store) => OWA.clearState(store));
+});
+
+describe('deferred keys are withheld from the cookie but live in memory', () => {
+
+    test('sid and last_req are not serialized while deferring', () => {
+        OWA.beginDeferredStatePersistence();
+
+        OWA.setState('s', 'sid', 'session-abc', true);
+        OWA.setState('s', 'last_req', NOW, true);
+
+        // The store IS written (it exists) -- it just must not carry these keys.
+        expect(lastWrite('s')).not.toBeNull();
+        expect(lastWrite('s')).not.toContain('session-abc');
+        expect(lastWrite('s')).not.toContain('last_req');
+    });
+
+    test('...but ARE readable from memory, so same-page events share the session', () => {
+        OWA.beginDeferredStatePersistence();
+
+        OWA.setState('s', 'sid', 'session-abc', true);
+
+        expect(OWA.getState('s', 'sid')).toBe('session-abc');
+    });
+
+    test('a whole-store read still sees them (cross-domain state sharing)', () => {
+        OWA.beginDeferredStatePersistence();
+
+        OWA.setState('s', 'sid', 'session-abc', true);
+
+        expect(OWA.getState('s')).toHaveProperty('sid', 'session-abc');
+    });
+});
+
+describe('non-deferred keys in the same store still persist immediately', () => {
+
+    test('referer is serialized even while deferring', () => {
+        OWA.beginDeferredStatePersistence();
+
+        OWA.setState('s', 'referer', 'https://newsletter.example/issue-7');
+
+        expect(lastWrite('s')).toContain('newsletter.example');
+    });
+
+    test('a referer write does not leak the withheld sid to disk', () => {
+        OWA.beginDeferredStatePersistence();
+
+        OWA.setState('s', 'sid', 'session-abc', true);
+        // Writing ANY key re-serializes the whole store. Without the filter in
+        // persist(), this write alone would commit the sid.
+        OWA.setState('s', 'referer', 'https://newsletter.example/issue-7');
+
+        expect(lastWrite('s')).toContain('newsletter.example');
+        expect(lastWrite('s')).not.toContain('session-abc');
+    });
+
+    test('campaign keys are serialized even while deferring', () => {
+        OWA.beginDeferredStatePersistence();
+
+        OWA.setState('s', 'sid', 'session-abc', true);
+        OWA.setState('s', 'campaign', 'spring');
+
+        expect(lastWrite('s')).toContain('spring');
+        expect(lastWrite('s')).not.toContain('session-abc');
+    });
+
+    test('other stores are unaffected by the s-store filter', () => {
+        OWA.beginDeferredStatePersistence();
+
+        OWA.setState('v', 'vid', 'visitor-xyz', true);
+        OWA.setState('b', 'cv1', 'plan=pro');
+
+        expect(lastWrite('v')).toContain('visitor-xyz');
+        expect(lastWrite('b')).toContain('plan=pro');
+    });
+});
+
+describe('commit and abandon', () => {
+
+    test('commit serializes the withheld keys', () => {
+        OWA.beginDeferredStatePersistence();
+        OWA.setState('s', 'sid', 'session-abc', true);
+        expect(lastWrite('s')).not.toContain('session-abc');
+
+        OWA.commitDeferredStatePersistence();
+
+        expect(lastWrite('s')).toContain('session-abc');
+    });
+
+    test('abandon leaves them unwritten', () => {
+        OWA.beginDeferredStatePersistence();
+        OWA.setState('s', 'sid', 'session-abc', true);
+
+        OWA.abandonDeferredStatePersistence();
+
+        expect(lastWrite('s')).not.toContain('session-abc');
+    });
+
+    test('commit is a no-op once deferral has already been resolved', () => {
+        // A second event on the same page must not commit a session whose own
+        // send failed: abandon clears the flag, so the click's later successful
+        // beacon finds nothing to commit.
+        OWA.beginDeferredStatePersistence();
+        OWA.setState('s', 'sid', 'session-abc', true);
+        OWA.abandonDeferredStatePersistence();
+        writes.mockClear();
+
+        OWA.commitDeferredStatePersistence();
+
+        expect(lastWrite('s')).toBeNull();
+    });
+
+    test('once resolved, later writes persist normally', () => {
+        OWA.beginDeferredStatePersistence();
+        OWA.commitDeferredStatePersistence();
+
+        OWA.setState('s', 'sid', 'session-later', true);
+
+        expect(lastWrite('s')).toContain('session-later');
+    });
+});
+
+describe('clearing a single key honours the filter', () => {
+
+    test('clear(s, dsps) does not write the withheld sid to disk', () => {
+        OWA.beginDeferredStatePersistence();
+        OWA.setState('s', 'sid', 'session-abc', true);
+        OWA.setState('s', 'dsps', 3);
+
+        // clear(store, key) rebuilds the store minus one key via replaceStore(),
+        // a second path to the cookie that needs the same filter.
+        OWA.clearState('s', 'dsps');
+
+        expect(lastWrite('s')).not.toContain('session-abc');
+    });
+});


### PR DESCRIPTION
## The problem

A visitor's **first** page view is the one most likely to be lost — the browser cancels an in-flight 1x1 pixel when they click through, including on an in-page anchor. Two coupled defects turned that single lost hit into a stranded session.

**1. The transport could never survive unload.** Every event went out as `new Image(1,1); image.src = url` — fire and forget, no delivery signal of any kind. The `block` flag threaded from `trackCustomEvent` → `trackEvent` → `logEvent` existed to guard exactly this, but its body had been commented out for years, so it did nothing.

**2. Session identity was persisted before it was transmitted.** `setSessionId()` and `setLastRequestTime()` wrote `s.sid` / `s.last_req` to the cookie the moment they were derived. When the beacon then died, the cookie asserted a session the server had never been told about. Every later page read that sid, sent `is_new_session` **unset**, and the server took `sessionHandlers::logSessionUpdate()` — which correctly aborts, because on a multi-server setup an update can legitimately arrive before its create — and requeued the event. Nothing ever reconciled it.

## The change

`navigator.sendBeacon` is now preferred; the browser completes it across unload. Called with no body it POSTs with the query string intact, so `log.php` keeps reading `$_GET` unchanged. Falls back to the pixel when sendBeacon is absent, refuses the payload, or throws.

`s.sid` / `s.last_req` are withheld from the **cookie** until a send is accepted. Memory is written immediately, so every event on the page still reads the same session and cross-domain state sharing still carries the sid.

The filter lives in `StateManager.persist()` rather than `set()` because the cookie is per-**store**: writing any other key in `s` re-serialises the whole store and would otherwise smuggle an undelivered sid to disk. `replaceStore()` routes through `persist()` for the same reason, since `clear(store, key)` is a second path to the cookie.

Everything else keeps persisting immediately, deliberately:

- **`s.referer` and campaign keys** are observable only on the landing hit and are unrecoverable if dropped
- **custom vars** are publisher intent and must not hinge on transport

The deferral is one-shot per page, so a later event whose own send succeeds cannot commit a session the server never heard about.

Also fixes `image.onLoad` → `onload`. Not a DOM property, so it never fired — harmless while nothing hung off the success path, load-bearing now.

## Known limits, asserted in tests rather than papered over

- `sendBeacon` returning `true` means the browser accepted the payload, **not** that it arrived. A beacon queued then dropped in transit still strands a session.
- A click fired after a lost page view still writes a fact row referencing a session that does not exist, and nothing is queued to flag it — `dom.click` reaches `clickHandlers` and the dimension handlers, never `sessionHandlers`. Closing that needs the server to establish a session thinly from any event type, which is a separate change.
- The oversized-URL `cdPost` path commits optimistically. It has no delivery signal, and withholding there would mean sites whose payloads always exceed `getRequestCharacterLimit` could never persist a session at all.

## Tests

| File | Covers |
|---|---|
| `tests/js/StatePersistenceFilter.test.js` | withhold / commit / abandon, incl. that a `referer` write cannot leak the sid |
| `tests/js/BeaconDelivery.test.js` | transport selection and the delivery signal, incl. a torn-down page committing nothing |
| `tests/e2e/session-lifecycle.spec.js` + `session_e2e_helper.php` | one page view → one session; a second extends it; a lost first view no longer strands the session and keeps page A's campaign attribution; the dangling-click case pinned as accepted |

The unit tests were checked against a **disabled** filter — 6 of 12 fail without it, so they are not vacuous. The e2e helper hard-refuses unless booted against the scratch DB, mirroring `queue_e2e_helper.php`.

**Results:** jest 24 suites / 220 tests green; e2e selfhost 4/4 across three consecutive runs.

Two things the e2e surfaced that are worth knowing for future tests:

- `route.abort()` does **not** simulate a lost beacon under sendBeacon — the API returns `true` before the network abort. Scenario 3 forces the pixel transport to exercise the abandon path.
- `logSessionUpdate` applies an update only when the event timestamp is strictly greater than stored `last_req` (the out-of-order idempotency guard), so two page views inside one second are correctly suppressed. The test spaces them.