### PR TITLE
chore(psr-4): finish the relocation for REST routes and the Domstream view

### DIFF
--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -560,13 +560,13 @@ class Module extends \OWA\Core\Module {
      */
     function registerApiMethods() {
 
-    	$this->registerRestApiRoute( 'v1', 'sites', 'GET', 'owa_sitesRestController', 'controllers/sitesRestController.php' );
-        $this->registerRestApiRoute( 'v1', 'sites', 'POST', 'owa_addSiteRestController', 'controllers/addSiteRestController.php' );
-        $this->registerRestApiRoute( 'v1', 'users', 'GET', 'owa_usersRestController', 'controllers/usersRestController.php' );
-        $this->registerRestApiRoute( 'v1', 'users', 'POST', 'owa_addUserRestController', 'controllers/addUserRestController.php' );
-		$this->registerRestApiRoute( 'v1', 'users', 'DELETE', 'owa_deleteUserRestController', 'controllers/deleteUserRestController.php', [ 'params_order' => ['user_id'] ] );
-		$this->registerRestApiRoute( 'v1', 'siteUsers', 'POST', 'owa_siteAddAllowedUserRestController', 'controllers/siteAddAllowedUserRestController.php' );
-		$this->registerRestApiRoute( 'v1', 'reports', 'GET', 'owa_reportsRestController', 'controllers/reportsRestController.php', [ 'params_order' => ['report_name'] ] );
+    	$this->registerRestApiRoute( 'v1', 'sites', 'GET', 'OWA\\Module\\Base\\Controller\\SitesRest', 'Controller/SitesRest.php' );
+        $this->registerRestApiRoute( 'v1', 'sites', 'POST', 'OWA\\Module\\Base\\Controller\\AddSiteRest', 'Controller/AddSiteRest.php' );
+        $this->registerRestApiRoute( 'v1', 'users', 'GET', 'OWA\\Module\\Base\\Controller\\UsersRest', 'Controller/UsersRest.php' );
+        $this->registerRestApiRoute( 'v1', 'users', 'POST', 'OWA\\Module\\Base\\Controller\\AddUserRest', 'Controller/AddUserRest.php' );
+		$this->registerRestApiRoute( 'v1', 'users', 'DELETE', 'OWA\\Module\\Base\\Controller\\DeleteUserRest', 'Controller/DeleteUserRest.php', [ 'params_order' => ['user_id'] ] );
+		$this->registerRestApiRoute( 'v1', 'siteUsers', 'POST', 'OWA\\Module\\Base\\Controller\\SiteAddAllowedUserRest', 'Controller/SiteAddAllowedUserRest.php' );
+		$this->registerRestApiRoute( 'v1', 'reports', 'GET', 'OWA\\Module\\Base\\Controller\\ReportsRest', 'Controller/ReportsRest.php', [ 'params_order' => ['report_name'] ] );
     }
 
     /**

--- a/modules/Domstream/Module.php
+++ b/modules/Domstream/Module.php
@@ -93,6 +93,6 @@ class Module extends \OWA\Core\Module {
      */
     function registerApiMethods() {
 		
-		$this->registerRestApiRoute( 'v1', 'domstreams', 'GET', 'owa_domstreamsRestController', 'controllers/domstreamsRestController.php' );
+		$this->registerRestApiRoute( 'v1', 'domstreams', 'GET', 'OWA\\Module\\Domstream\\Controller\\DomstreamsRestController', 'Controller/DomstreamsRestController.php' );
     }
 }

--- a/modules/Domstream/View/DomstreamsRest.php
+++ b/modules/Domstream/View/DomstreamsRest.php
@@ -1,5 +1,5 @@
 <?php
-namespace OWA\Module\Domstream\Controller;
+namespace OWA\Module\Domstream\View;
 
 
 /**
@@ -12,7 +12,7 @@ namespace OWA\Module\Domstream\Controller;
  * View
  *
  */
-class DomstreamsRestView extends \OWA\Core\View\RestApi {
+class DomstreamsRest extends \OWA\Core\View\RestApi {
 
     function render() {
 

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -306,7 +306,7 @@ function owa_compat_class_map(): array
         // module.php files (the module-registry classes themselves) stay global —
         // deferred to the module.php special-case stage.
         'owa_domstreamsRestController' => 'OWA\\Module\\Domstream\\Controller\\DomstreamsRestController',
-        'owa_domstreamsRestView' => 'OWA\\Module\\Domstream\\Controller\\DomstreamsRestView',
+        'owa_domstreamsRestView' => 'OWA\\Module\\Domstream\\View\\DomstreamsRest',
         'owa_domstreamHandlers' => 'OWA\\Module\\Domstream\\Handler\\DomstreamHandlers',
         'owa_fileCache' => 'OWA\\Module\\FileCache\\Classes\\FileCache',
         'owa_exampleSettingsController' => 'OWA\\Module\\Hello\\ExampleSettingsController',

--- a/tests/ControllerCapabilityContractTest.php
+++ b/tests/ControllerCapabilityContractTest.php
@@ -90,10 +90,6 @@ final class ControllerCapabilityContractTest extends TestCase
         // applies the updates, declares its own.
         'Updates',
 
-        // Not a controller at all -- a View (extends Core\View\RestApi)
-        // misfiled into a Controller/ directory. Harmless here; worth
-        // relocating on its own merits.
-        'DomstreamsRestView',
     ];
 
     public function testEveryControllerEitherDeclaresACapabilityOrIsKnownPublic(): void

--- a/tests/DomStreamsRestControllerTest.php
+++ b/tests/DomStreamsRestControllerTest.php
@@ -24,7 +24,7 @@ final class DomStreamsRestControllerTest extends RestControllerTestCase
     /** Absolute path — this controller lives in the domstream module, not base. */
     private function ctrlFile(): string
     {
-        return OWA_MODULES_DIR . 'domstream/controllers/domstreamsRestController.php';
+        return OWA_MODULES_DIR . 'Domstream/Controller/DomstreamsRestController.php';
     }
 
     protected function setUp(): void
@@ -121,6 +121,17 @@ final class DomStreamsRestControllerTest extends RestControllerTestCase
         $this->assertSame(201, $resp['status'],
             'A valid domstreams list query should return 201.');
         $this->assertSame('domstream.domstreamsRest', $resp['view']);
+
+        // Asserting the name alone would pass with the view deleted: the
+        // controller only records a string. Resolve it the way displayView()
+        // does -- owa_<name>View through the class map -- so a move that breaks
+        // the mapping fails here rather than at runtime.
+        $viewClass = \OWA\Core\Lib::resolveNamespacedClass('owa_domstreamsRestView');
+
+        $this->assertNotNull($viewClass,
+            'The view named by the controller does not resolve to a class.');
+        $this->assertTrue(class_exists($viewClass),
+            "Resolved view class {$viewClass} cannot be loaded.");
         $this->assertIsArray($resp['data'],
             'The list payload should be the serialized result set (an array).');
 
@@ -172,6 +183,17 @@ final class DomStreamsRestControllerTest extends RestControllerTestCase
         $this->assertSame(201, $resp['status'],
             'A valid single-domstream query should return 201.');
         $this->assertSame('domstream.domstreamsRest', $resp['view']);
+
+        // Asserting the name alone would pass with the view deleted: the
+        // controller only records a string. Resolve it the way displayView()
+        // does -- owa_<name>View through the class map -- so a move that breaks
+        // the mapping fails here rather than at runtime.
+        $viewClass = \OWA\Core\Lib::resolveNamespacedClass('owa_domstreamsRestView');
+
+        $this->assertNotNull($viewClass,
+            'The view named by the controller does not resolve to a class.');
+        $this->assertTrue(class_exists($viewClass),
+            "Resolved view class {$viewClass} cannot be loaded.");
 
         // getDomstream() decodes + merges the stored events blob into the payload;
         // the captured event types must round-trip to the client.


### PR DESCRIPTION
Two leftovers from the PSR-4 move. Both were invisible because the compat bridge was quietly absorbing them.

## 1. REST route registrations pointed at a directory that no longer exists

All 8 `registerRestApiRoute()` calls named a legacy class and a file under `modules/<mod>/controllers/` — removed during the relocation:

```php
$this->registerRestApiRoute( 'v1', 'sites', 'GET',
    'owa_sitesRestController',
    'controllers/sitesRestController.php' );   // ← this path is dead
```

Every one of those paths was dead. They worked only because `simpleFactory()` resolves the legacy name through the compat map and returns *before* it ever consults the path:

```php
$nsClass = self::resolveNamespacedClass($class_name);
if ($nsClass !== null) { return new $nsClass($args); }   // exits here
```

Now registered with the PSR-4 class name and a real path. Unlike `registerAction()` — which prefixes with a hardcoded `OWA_BASE_MODULE_DIR` and therefore *cannot* express a correct path for a non-Base module — this API prefixes with `$this->path`, so the path can be right.

This also removes core's last reliance on the compat bridge for REST routing. `Lib::factory()` already documents that the bridge "stays only for third-party callers of the old names"; core resolving through it meant core couldn't be exercised bridge-free.

## 2. A View was living in a Controller directory

`modules/Domstream/Controller/DomstreamsRestView.php` extends `Core\View\RestApi` but sat in the `Controller` namespace — and it was the module's only view, so Domstream had no `View/` directory at all.

```
modules/Domstream/Controller/DomstreamsRestView.php
  -> modules/Domstream/View/DomstreamsRest.php
     namespace OWA\Module\Domstream\View
     class DomstreamsRest
```

Suffix dropped to match how Base's 68 views were relocated. The compat map entry for `owa_domstreamsRestView` is retargeted, so `setView('domstream.domstreamsRest')` resolves exactly as before.

`ControllerCapabilityContractTest` carried an exemption for it, whose own comment read *"a View misfiled into a Controller/ directory … worth relocating on its own merits."* The exemption goes with the misfiling.

## Verification

No behaviour change. 286 tests green, plus a runtime check that:

- all 8 REST route classes load, and all 8 declared files now exist (previously 0 of 8 did)
- the relocated view still resolves through its legacy name via the compat map

## Note

`DomstreamsRestController` keeps its redundant `Controller` suffix — Base dropped that during the relocation but this one didn't. Left alone here: renaming it touches the compat map and the route registration together, and is worth its own change.