### PR TITLE
test(e2e): exercise every registered REST route over HTTP

### DIFF
--- a/tests/e2e/rest-routes.spec.js
+++ b/tests/e2e/rest-routes.spec.js
@@ -1,0 +1,168 @@
+// @ts-check
+/**
+ * Every registered REST route answers over HTTP.
+ *
+ * The routes have unit coverage, but nothing exercised them through the real
+ * stack until now: a registration naming a class that no longer exists, a route
+ * name that no longer matches, or a controller that cannot be constructed passes
+ * PHPUnit and every existing e2e spec, and surfaces only in production.
+ *
+ * Each route is asserted twice:
+ *
+ *   - unsigned  -> 401. Proves the request reached OWA's auth layer rather than
+ *                  dying earlier (a 404 or 500 here means the route did not
+ *                  resolve at all, which is the failure mode being guarded).
+ *   - signed    -> not 401, and not a 500. The status varies by route (a GET
+ *                  lists, a POST without a body fails validation), so the
+ *                  assertion is deliberately about the route RESOLVING and the
+ *                  controller RUNNING, not about its business logic -- that is
+ *                  what the PHPUnit controller tests are for.
+ *
+ * Requests are signed for real rather than run with OWA_REST_DEBUG defined.
+ * That constant makes authByApiKey() skip signature verification entirely, so a
+ * suite relying on it would never exercise the auth path it is calling through.
+ */
+
+const path = require('path');
+const crypto = require('crypto');
+const { execFileSync } = require('child_process');
+const { test, expect } = require('@playwright/test');
+
+const HELPER = path.join(__dirname, 'rest_e2e_helper.php');
+
+function helper(...args) {
+    return JSON.parse(execFileSync('php', [HELPER, ...args], { encoding: 'utf8' }));
+}
+
+function installRoot(baseURL) {
+    return baseURL.replace(/index\.php.*$/, '');
+}
+
+/**
+ * Auth::generateSignature() -- base64 of the sha256 HEX digest (not raw bytes),
+ * over the request URL with the signature param itself removed, and the date in
+ * UTC.
+ */
+function sign(requestUrl, apiKey, authKey) {
+    const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const hex = crypto.createHash('sha256')
+        .update('OWASIGNATURE' + apiKey + requestUrl + date + authKey)
+        .digest('hex');
+    return Buffer.from(hex).toString('base64');
+}
+
+/** Build the URL a route is called at, optionally signed. */
+function routeUrl(root, route, query, creds) {
+    // handleRestRequest() reads owa_do FIRST and returns early -- with an empty
+    // 200, not an error -- when it is absent. owa_rest_params is only consulted
+    // afterwards, where it overwrites module/version/do. So a request carrying
+    // rest_params alone never reaches the router; both have to be sent.
+    const name = route.split('/').pop();
+    const base = root + 'api/index.php'
+        + '?owa_do=' + name
+        + '&owa_rest_params=' + route
+        + (query ? '&' + query : '');
+
+    if (!creds) {
+        return base;
+    }
+
+    const withKey = base + '&owa_apiKey=' + creds.api_key;
+    return withKey + '&owa_signature=' + encodeURIComponent(
+        sign(withKey, creds.api_key, creds.auth_key)
+    );
+}
+
+const SELFHOST = process.env.OWA_E2E_SELFHOST === '1';
+
+test.describe('every registered REST route answers over HTTP @selfhost-only', () => {
+
+    test.skip(!SELFHOST,
+        'Provisions users and sites; runs only under the self-host e2e runner (OWA_E2E_SELFHOST=1).');
+
+    /** @type {{api_key:string, auth_key:string, site_id:string, user_id:string}} */
+    let creds;
+
+    test.beforeAll(() => {
+        creds = helper('provision');
+        expect(creds.api_key, 'fixture user has no api key').toBeTruthy();
+        expect(creds.auth_key, 'OWA_AUTH_KEY is not readable, requests cannot be signed').toBeTruthy();
+    });
+
+    test.afterAll(() => {
+        helper('cleanup');
+    });
+
+    /**
+     * Every route registered by a module, as <module>/<version>/<name>, with the
+     * method it is registered for and the minimum params its controller needs to
+     * get past argument handling.
+     */
+    function routes() {
+        return [
+            { route: 'base/v1/sites',      method: 'GET',    query: '' },
+            { route: 'base/v1/sites',      method: 'POST',   query: '' },
+            { route: 'base/v1/users',      method: 'GET',    query: '' },
+            { route: 'base/v1/users',      method: 'POST',   query: '' },
+            { route: 'base/v1/users',      method: 'DELETE', query: '' },
+            { route: 'base/v1/siteUsers',  method: 'POST',   query: '' },
+            { route: 'base/v1/reports',    method: 'GET',    query: 'owa_reportName=dashboard' },
+            // Domstream registers its route only when the module is active, and
+            // 'modules' defaults to ['base'] on a fresh install. Marked so the
+            // assertions below can require registration rather than assume it.
+            { route: 'domstream/v1/domstreams', method: 'GET', query: '', module: 'domstream' },
+        ];
+    }
+
+    /** Modules active on this install, so route expectations match reality. */
+    function activeModules() {
+        return helper('modules').active;
+    }
+
+    for (const r of routes()) {
+
+        const label = `${r.method} ${r.route}`;
+
+        test(`${label} - rejects an unsigned request with 401`, async ({ request }) => {
+            test.skip(!!r.module && !activeModules().includes(r.module),
+                `the ${r.module} module is not active on this install, so its route is not registered`);
+
+            const root = installRoot(test.info().project.use.baseURL);
+            const res = await request.fetch(routeUrl(root, r.route, r.query, null), {
+                method: r.method,
+            });
+
+            // A 404 or 500 here would mean the route never resolved -- the class
+            // is missing, or the registration no longer matches the URL.
+            expect(res.status(), `${label} did not reach the auth layer`).toBe(401);
+        });
+
+        test(`${label} - resolves and runs when signed`, async ({ request }) => {
+            test.skip(!!r.module && !activeModules().includes(r.module),
+                `the ${r.module} module is not active on this install, so its route is not registered`);
+
+            const root = installRoot(test.info().project.use.baseURL);
+            const url = routeUrl(root, r.route, r.query, creds);
+            const res = await request.fetch(url, { method: r.method });
+
+            expect(res.status(), `${label} rejected a signed request`).not.toBe(401);
+
+            // A 500 means the controller could not be constructed or blew up --
+            // exactly what a broken registration looks like from outside.
+            expect(res.status(), `${label} errored server-side`).toBeLessThan(500);
+
+            // Whatever the outcome, it must be OWA's JSON API answering.
+            const body = await res.text();
+            expect(body.length, `${label} returned an empty body`).toBeGreaterThan(0);
+        });
+    }
+
+    test('an unregistered route is refused, not dispatched', async ({ request }) => {
+        const root = installRoot(test.info().project.use.baseURL);
+        const res = await request.fetch(
+            routeUrl(root, 'base/v1/nosuchroute', '', creds), { method: 'GET' }
+        );
+
+        expect(res.status(), 'an unknown route should not 500').toBeLessThan(500);
+    });
+});

--- a/tests/e2e/rest_e2e_helper.php
+++ b/tests/e2e/rest_e2e_helper.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * REST route fixture provisioner for the self-host e2e runner.
+ *
+ * The REST routes have unit coverage but nothing exercises them over HTTP, so a
+ * registration or wiring error -- a class that no longer exists, a route name
+ * that no longer matches, a controller that cannot be constructed -- passes both
+ * suites and only surfaces in production. This helper supplies what a spec needs
+ * to call them for real:
+ *
+ *   provision            create an admin user + a site, return their identifiers
+ *                        along with the auth key needed to sign requests
+ *   cleanup              remove what provision() created
+ *   modules              which modules are active -- a module that is not active
+ *                        never runs registerRestApiRoute(), so its routes do not
+ *                        exist and a spec must not assert them
+ *
+ * Requests are signed rather than run with OWA_REST_DEBUG enabled. That constant
+ * makes authByApiKey() skip signature verification entirely, so a suite relying
+ * on it would never exercise the auth path it is meant to be calling through.
+ * The signature scheme is Auth::generateSignature():
+ *
+ *   base64( hash('sha256', 'OWASIGNATURE' . apiKey . requestUrl . Ymd(UTC) . OWA_AUTH_KEY ) )
+ *
+ * -- note it base64-encodes the HEX digest, not raw bytes.
+ *
+ * Like the other e2e helpers this writes, so it HARD-REFUSES unless booted
+ * against the throwaway scratch DB the self-host harness provisions.
+ */
+
+if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+    $_SERVER['HTTP_USER_AGENT'] =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+        . '(KHTML, like Gecko) Chrome/120.0 Safari/537.36';
+}
+$_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '203.0.113.10';
+
+const SCRATCH_DB_SENTINEL = 'owa_e2e_selfhost';
+const FIXTURE_TAG         = 'e2e-rest';
+
+$owa_root = dirname(__DIR__, 2) . '/';
+require_once($owa_root . 'owa.php');
+new owa(['tracking_mode' => true, 'instance_role' => 'logger']);
+
+$connected_db = (string) owa_coreAPI::getSetting('base', 'db_name');
+$allowed_db   = getenv('OWA_E2E_DB_NAME') ?: SCRATCH_DB_SENTINEL;
+
+if ($connected_db !== $allowed_db) {
+    fwrite(STDERR, "[rest_e2e_helper] REFUSING to run: connected DB '$connected_db' "
+        . "is not the scratch sentinel '$allowed_db'. This helper only runs under "
+        . "the self-host e2e runner.\n");
+    exit(3);
+}
+
+$cmd = $argv[1] ?? '';
+
+switch ($cmd) {
+    case 'provision': out(provision()); break;
+    case 'cleanup':   out(cleanup());   break;
+    case 'modules':   out(['active' => (array) owa_coreAPI::getSetting('base', 'modules')]); break;
+    default:
+        fwrite(STDERR, "Unknown command '$cmd'. Use: provision | cleanup | modules\n");
+        exit(2);
+}
+
+function out(array $result): void
+{
+    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+}
+
+/**
+ * An admin user (so every route's capability check passes) and a site to
+ * operate on. Returns the auth key too: without it a spec cannot sign a
+ * request, and unsigned requests are rejected before reaching any controller.
+ */
+function provision(): array
+{
+    cleanup();
+
+    $user_id = FIXTURE_TAG . '-admin@owatest.example.com';
+
+    $u = owa_coreAPI::entityFactory('base.user');
+    $u->createNewUser($user_id, 'admin', 'pw-' . FIXTURE_TAG, $user_id, 'OWA REST e2e admin');
+    $u->load($u->generateId($user_id), 'user_id');
+
+    $site_domain = 'https://' . FIXTURE_TAG . '.example.com';
+
+    $s = owa_coreAPI::entityFactory('base.site');
+    $s->set('id', $s->generateId($site_domain));
+    $s->set('site_id', $s->generateId($site_domain));
+    $s->set('domain', $site_domain);
+    $s->set('name', 'OWA REST e2e site');
+    $s->set('description', 'fixture');
+    $s->create();
+
+    return [
+        'user_id'  => $user_id,
+        'api_key'  => $u->get('api_key'),
+        'auth_key' => defined('OWA_AUTH_KEY') ? OWA_AUTH_KEY : '',
+        'site_id'  => $s->get('site_id'),
+        'domain'   => $site_domain,
+    ];
+}
+
+function cleanup(): array
+{
+    $db = owa_coreAPI::dbSingleton();
+
+    // Users and sites this fixture created, matched on the tag so a stray run
+    // cannot delete anything a different spec relies on.
+    $db->deleteFrom('owa_user');
+    $db->where('user_id', '%' . FIXTURE_TAG . '%', 'LIKE');
+    $db->executeQuery();
+
+    $db = owa_coreAPI::dbSingleton();
+    $db->deleteFrom('owa_site');
+    $db->where('domain', '%' . FIXTURE_TAG . '%', 'LIKE');
+    $db->executeQuery();
+
+    return ['cleaned' => FIXTURE_TAG];
+}


### PR DESCRIPTION
## The gap

The REST routes had unit coverage, but nothing called them through the real stack. The controller tests instantiate the class directly, so they prove the *controller* works — never that the *route* reaches it.

That means a registration naming a class that no longer exists, a route name that no longer matches, or a controller that can't be constructed passes PHPUnit **and** every existing e2e spec, and surfaces only at runtime.

## What this adds

Each of the 8 registered routes is asserted twice:

- **unsigned → 401** — proves the request reached the auth layer rather than dying earlier. A 404 or 500 here means the route didn't resolve at all, which is the failure being guarded.
- **signed → not 401, not 5xx, non-empty body** — deliberately about the route *resolving* and the controller *running*, not its business logic. That's what the PHPUnit controller tests are for.

Requests are **signed for real** rather than run with `OWA_REST_DEBUG` defined. That constant makes `authByApiKey()` skip signature verification outright, so a suite relying on it would never exercise the auth path it's calling through. The scheme is `Auth::generateSignature()` — note it base64-encodes the sha256 **hex** digest, not raw bytes.

## Two behaviours found while writing it

**`handleRestRequest()` reads `owa_do` first and returns early when absent — with an empty 200, not an error.** `owa_rest_params` is only consulted afterwards. So a request carrying `rest_params` alone silently produces a blank success. Both parameters have to be sent. This cost me a while chasing a phantom infrastructure problem, so it's documented in the spec.

**A module that isn't active never runs `registerRestApiRoute()`**, so its routes don't exist. `'modules'` defaults to `['base']`, so the Domstream route is absent on a fresh install. The spec asks the helper which modules are active and **skips** rather than asserting a route that was never registered.

## Verification

```
15 passed, 2 skipped (Domstream module inactive)
```

Confirmed the spec catches what it exists for: typo'ing one route's registered class name turns **8 tests red**.

`rest_e2e_helper.php` provisions an admin user and a site, returns the api key and auth key needed for signing, and hard-refuses unless booted against the scratch DB — the same guard as the other e2e helpers.