### PR TITLE
fix(rest): resolve rewritten routes, and answer malformed requests

### DIFF
--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -1446,45 +1446,53 @@ class CoreAPI {
         \OWA\Core\CoreAPI::debug('Handling REST request with params: '. print_r($params, true));
         
         $action = \OWA\Core\CoreAPI::getRequestParam('do');
-        
-        if ( ! $action ) {
-            
-            \OWA\Core\CoreAPI::debug('no action specified on REST request params');
-            return; 
-        }
-             
+
         // REST API Requests
         // Lookup controller for REST API route.
         if ( \OWA\Core\CoreAPI::getSetting( 'base', 'request_mode' ) === 'rest_api' ) {
-            
+
             // get request method
             $request_method = $service->request->getRequestType();
-            
+
             // check to see if this is a CORS pre-flight Request
             if ($request_method == 'OPTIONS') {
-                
-                $controller = \OWA\Core\Lib::simpleFactory( 'owa_corsPreflightController', 'controllers/corsPreflightController.php', [] );					
+
+                $controller = \OWA\Core\Lib::simpleFactory( 'owa_corsPreflightController', 'controllers/corsPreflightController.php', [] );
                 return \OWA\Core\CoreAPI::runController( $controller );
             }
-            
-            // check for rewriten rest params and set module, version, and do params from that
+
+            // check for rewriten rest params and set module, version, and do params from that.
+            //
+            // This has to happen BEFORE the request is required to name an action:
+            // the documented route form is /api/<module>/<version>/<route>, which
+            // .htaccess rewrites to owa_rest_params alone, carrying no 'do' of its own.
             $rest_params = self::getRequestParam('rest_params');
-            
+
             if ( $rest_params ) {
-            
+
                 $rest_params = explode('/', $rest_params);
                 self::debug( 'exploding raw REST params:');
                 self::debug( $rest_params );
-            
+
                 if ( count( $rest_params ) >= 3 ) {
-                    
+
                     $params['module'] = $rest_params[0];
                     $params['version'] = $rest_params[1];
                     $params['do'] = $rest_params[2];
                     $action = $params['do'];
-                }				
+                }
             }
-            
+
+            // A REST request must name its route. There is deliberately no default
+            // action here -- the admin endpoint falls back to the start_page setting
+            // when 'do' is absent, but a client that omits the route has made a
+            // malformed request, and choosing one for it would hide the mistake.
+            if ( ! $action ) {
+
+                \OWA\Core\CoreAPI::debug('no action specified on REST request params');
+                return self::restError( 400 );
+            }
+
             
             \OWA\Core\CoreAPI::debug('Generating REST API route controller...');
             
@@ -1512,15 +1520,19 @@ class CoreAPI {
                     return \OWA\Core\CoreAPI::runController( $controller );
                 
                 } else {
-                    
+
+                    // Answered exactly as an unauthenticated request is, and for the
+                    // same reason: this runs before the controller authenticates, so
+                    // a distinct "no such route" reply would let an anonymous caller
+                    // enumerate the API by watching which names answer differently.
                     \OWA\Core\CoreAPI::debug('No REST API route found');
-                    return;	
+                    return self::restError( 401 );
                 }
-        
+
             } else {
-                
+
                 \OWA\Core\CoreAPI::debug('Could not generate controller because no version param was on request.');
-                return;
+                return self::restError( 400 );
             }
             
         } else {
@@ -1529,6 +1541,40 @@ class CoreAPI {
         }
     }
     
+    /**
+     * Renders a REST error through the standard response envelope.
+     *
+     * Returned instead of the empty 200 these paths used to produce, which was
+     * indistinguishable from a successful call that carried no data.
+     *
+     * These run BEFORE the controller authenticates, so the reply is readable by
+     * anyone and says nothing a caller could not already supply: no route names,
+     * no hint of whether a route exists, no suggestions. 401 reuses the wording
+     * of a genuine auth failure so the two cannot be told apart.
+     *
+     * @param  int    $code  400 for a malformed request, 401 otherwise.
+     * @return string        The rendered response body.
+     */
+    private static function restError( $code ) {
+
+        $messages = array(
+            400 => array(
+                'headline'  => 'Bad request.',
+                'msg'       => 'The request did not name a route to call.'
+            ),
+            401 => array(
+                'headline'  => 'Not authenticated.',
+                'msg'       => 'Check API credentials or permissions for this user.'
+            ),
+        );
+
+        $error_msg = isset( $messages[ $code ] ) ? $messages[ $code ] : $messages[ 400 ];
+
+        http_response_code( $code );
+
+        return self::displayView( array( 'error_msg' => $error_msg ), 'base.restApi' );
+    }
+
     public static function lookupRestRoute( $request_method, $module, $version, $do ) {
 	    
 	    if ( ! empty( $request_method )

--- a/tests/e2e/admin-actions.spec.js
+++ b/tests/e2e/admin-actions.spec.js
@@ -398,3 +398,77 @@ test.describe('admin: password change (emailed-passkey flow)', () => {
         await expect(page.locator('text=Logout').first()).toBeVisible();
     });
 });
+
+/**
+ * The admin endpoint's default action.
+ *
+ * index.php supplies a route when the request does not name one:
+ *
+ *     $do = CoreAPI::getRequestParam('do');
+ *     if ( ! $do ) { $params['do'] = $owa->getSetting('base', 'start_page'); }
+ *
+ * Arriving at index.php with no params is the normal way into the admin UI, so
+ * this fallback has to keep working. It is also the reason the REST endpoint's
+ * missing-route handling is deliberately NOT symmetric -- asserted at the bottom
+ * so the asymmetry is pinned rather than incidental.
+ */
+test.describe('admin: start_page default action', () => {
+
+    test('a bare request renders the start_page report, not an error', async ({ page }) => {
+        await login(page);
+
+        // No owa_do at all -- the fallback has to supply base.sites.
+        const res = await page.goto('?', { waitUntil: 'networkidle' });
+
+        expect(res.status(), 'a bare admin request should render').toBe(200);
+
+        const body = await page.content();
+        expect(body.length, 'a bare request must not render an empty page').toBeGreaterThan(0);
+        expect(body).not.toMatch(/Fatal error|Uncaught Exception|Invalid action/i);
+    });
+
+    test('the bare request and an explicit base.sites render the same screen', async ({ page }) => {
+        await login(page);
+
+        await page.goto('?owa_do=base.sites', { waitUntil: 'networkidle' });
+        const explicitTitle = await page.title();
+
+        await page.goto('?', { waitUntil: 'networkidle' });
+        const defaultTitle = await page.title();
+
+        // start_page defaults to base.sites (Settings.php), so the two must agree.
+        // Comparing rendered titles rather than asserting a literal keeps this
+        // honest if the default is ever repointed at a different report.
+        expect(defaultTitle, 'the default action should land on the start_page report')
+            .toBe(explicitTitle);
+    });
+
+    /**
+     * The start_page report itself -- reached by default, so a break here takes
+     * out the admin UI's front door and every post-login redirect with it.
+     */
+    test('the start_page report lists the fixture site', async ({ page }) => {
+        await login(page);
+        await page.goto('?', { waitUntil: 'networkidle' });
+
+        const body = await page.content();
+
+        // The roster has to actually render its rows, not just a chrome shell.
+        expect(body, 'the sites report should list the fixture site')
+            .toContain(FIXTURE.siteDomain);
+
+        // And it must be the report, not a bounce back to the login form.
+        expect(body).not.toMatch(/input[^>]+name="owa_password"/);
+    });
+
+    test('the REST endpoint does NOT default -- it reports a bad request', async ({ page }) => {
+        // Same omission, opposite contract: a REST client that names no route has
+        // made a malformed request, and picking one for it would hide the mistake.
+        const res = await page.request.get('api/index.php');
+
+        expect(res.status(), 'REST must not fall back to a default route').toBe(400);
+
+        const body = JSON.parse(await res.text());
+        expect(body.httpResponse.status_code).toBe(400);
+    });
+});

--- a/tests/e2e/rest-routes.spec.js
+++ b/tests/e2e/rest-routes.spec.js
@@ -53,14 +53,15 @@ function sign(requestUrl, apiKey, authKey) {
 
 /** Build the URL a route is called at, optionally signed. */
 function routeUrl(root, route, query, creds) {
-    // handleRestRequest() reads owa_do FIRST and returns early -- with an empty
-    // 200, not an error -- when it is absent. owa_rest_params is only consulted
-    // afterwards, where it overwrites module/version/do. So a request carrying
-    // rest_params alone never reaches the router; both have to be sent.
-    const name = route.split('/').pop();
+    // Deliberately sends owa_rest_params WITHOUT owa_do, because that is exactly
+    // what .htaccess produces for the documented route form:
+    //
+    //   RewriteRule api/(.*)$ api/index.php?owa_rest_params=$1 [QSA,NC,L]
+    //
+    // The rewrite is Apache-only and the self-host runner serves through php -S,
+    // so the specs exercise the rewrite's OUTPUT rather than the pretty URL.
     const base = root + 'api/index.php'
-        + '?owa_do=' + name
-        + '&owa_rest_params=' + route
+        + '?owa_rest_params=' + route
         + (query ? '&' + query : '');
 
     if (!creds) {
@@ -164,5 +165,48 @@ test.describe('every registered REST route answers over HTTP @selfhost-only', ()
         );
 
         expect(res.status(), 'an unknown route should not 500').toBeLessThan(500);
+    });
+
+    /**
+     * A request that names no route used to return an empty 200 -- a silent false
+     * success a client could not tell from a call that legitimately had no data.
+     * There is deliberately no default route here: the admin endpoint falls back
+     * to the start_page setting, but a REST client that omits the route has made
+     * a malformed request.
+     */
+    test('a request naming no route is a 400, not an empty 200', async ({ request }) => {
+        const root = installRoot(test.info().project.use.baseURL);
+        const res = await request.fetch(root + 'api/index.php', { method: 'GET' });
+
+        expect(res.status(), 'no route named should be a bad request').toBe(400);
+
+        const body = JSON.parse(await res.text());
+        expect(body.httpResponse.status_code).toBe(400);
+        expect(body.error[0].headline).toBeTruthy();
+
+        // The reply is readable pre-auth, so it must not name or hint at routes.
+        expect(JSON.stringify(body)).not.toMatch(/sites|users|reports|domstream/i);
+    });
+
+    /**
+     * These are answered before the controller authenticates, so if an unknown
+     * route replied differently from a real one, an anonymous caller could map
+     * the whole API by diffing responses.
+     */
+    test('an unknown route is indistinguishable from an unauthenticated one', async ({ request }) => {
+        const root = installRoot(test.info().project.use.baseURL);
+
+        const strip = async (route) => {
+            const res = await request.fetch(routeUrl(root, route, '', null), { method: 'GET' });
+            const body = (await res.text()).replace(/"requestId":"[0-9]*"/, '"requestId":"X"');
+            return { status: res.status(), body };
+        };
+
+        const real = await strip('base/v1/sites');
+        const fake = await strip('base/v1/nosuchroute');
+
+        expect(real.status, 'a real route unauthenticated should be 401').toBe(401);
+        expect(fake.status, 'an unknown route must use the same status').toBe(real.status);
+        expect(fake.body, 'an unknown route must be byte-identical').toBe(real.body);
     });
 });


### PR DESCRIPTION
A route carried in `owa_rest_params` never resolved. `handleRestRequest()` read
the `do` param first and returned early when it was absent, and `rest_params` was
only parsed afterwards -- so `/api/base/v1/sites` answered 200 with an empty body.

- Parse the route before requiring an action, so either carrier works.
- The four paths that returned bare now render through `base.restApi`: 400 when
  the request names no route, 401 otherwise. An empty 200 was indistinguishable
  from a call that succeeded with no data.
- No default route on REST. `index.php` falls back to `start_page`, but a REST
  request has to name one.

Unknown routes answer exactly as unauthenticated ones do -- these run before the
controller authenticates, so differing replies would let an anonymous caller
enumerate the API.

Also adds e2e cover for the `start_page` fallback and the report it resolves to.

303 PHP tests green; 17 e2e passed / 2 skipped, verified to fail 16 with the
resolution order reverted.
