### PR TITLE
fix(rest): return entity properties, not entity objects

### DIFF
--- a/Core/Entity.php
+++ b/Core/Entity.php
@@ -111,6 +111,29 @@ class Entity {
         return $properties;
     }
     
+    /**
+     * Properties that must never leave the server.
+     *
+     * Declared on the entity rather than at each call site so a field is named
+     * once, next to the column it protects, and every route that serializes the
+     * entity inherits it. Subclasses holding secrets override this.
+     *
+     * @var array
+     */
+    protected $private_properties = [];
+
+    /**
+     * The entity as a plain array, safe to serialize into a response.
+     *
+     * This is what REST responses are built from -- see View\RestApi::setResponseData().
+     *
+     * @return array
+     */
+    public function getPublicProperties() {
+
+	    return $this->getProperties( $this->private_properties );
+    }
+
     function getProperties( $drop_keys = [] ) {
 	    
 	    $properties = $this->_getProperties();

--- a/Core/View/RestApi.php
+++ b/Core/View/RestApi.php
@@ -103,8 +103,55 @@ class RestApi extends \OWA\Core\View {
 	 * Sets the data payload of the response
 	 */
     function setResponseData( $data ) {
-	    
-	    $this->body->set( 'response_data', $data );
+
+	    $this->body->set( 'response_data', self::toResponseData( $data ) );
+    }
+
+    /**
+     * Reduces entities to their public properties before they are serialized.
+     *
+     * Handed an entity, json_encode() would otherwise emit every public member it
+     * happens to have -- the property bag, but also _tableProperties, wasPersisted,
+     * cache and dirty, none of which are API surface. Worse, the payload becomes
+     * whatever the entity currently holds, so a newly added sensitive column ships
+     * the moment it exists unless someone remembers to strip it at the call site.
+     *
+     * Doing it here rather than in each view makes the safe path the default one:
+     * an entity cannot reach a response without passing through this.
+     *
+     * Anything that is not an entity is returned untouched, so views that already
+     * assemble plain arrays are unaffected.
+     *
+     * @param  mixed $data
+     * @param  int   $depth  Guards against a cyclic graph; entity payloads are
+     *                       shallow, so exceeding this means something is wrong.
+     * @return mixed
+     */
+    protected static function toResponseData( $data, $depth = 0 ) {
+
+	    if ( $depth > 10 ) {
+
+		    return null;
+	    }
+
+	    if ( $data instanceof \OWA\Core\Entity ) {
+
+		    return $data->getPublicProperties();
+	    }
+
+	    if ( is_array( $data ) ) {
+
+		    $out = array();
+
+		    foreach ( $data as $k => $v ) {
+
+			    $out[ $k ] = self::toResponseData( $v, $depth + 1 );
+		    }
+
+		    return $out;
+	    }
+
+	    return $data;
     }
     
     function addCorsHeaders() {

--- a/modules/Base/Entity/User.php
+++ b/modules/Base/Entity/User.php
@@ -35,7 +35,12 @@ class User extends \OWA\Core\Entity {
     
     const ADMIN_USER_REAL_NAME = 'default admin';
     const ADMIN_USER_ROLE = 'admin';
-    
+
+    /**
+     * Credential fields. These are never part of a response payload.
+     */
+    protected $private_properties = [ 'password', 'temp_passkey', 'api_key' ];
+
     function __construct() {
     
         $this->setTableName('user');

--- a/modules/Base/View/UsersRest.php
+++ b/modules/Base/View/UsersRest.php
@@ -17,20 +17,10 @@ namespace OWA\Module\Base\View;
 class UsersRest extends \OWA\Core\View\RestApi {
         
     function render() {
-        
-        $users = $this->get('users_objs');
-       
-        $users_sanitized = [];
-        
-        if ( $users ) {
-	        
-	        foreach ( $users as $k => $user ) {
-		        
-		        $users_sanitized[ $k ] = $user->getProperties( ['temp_passkey', 'password', 'api_key'] );
-	        }
-        }
-        
-        $this->setResponseData( $users_sanitized );
+
+        // Private fields are declared on the User entity, so setResponseData()
+        // applies them here and on every other route returning a user.
+        $this->setResponseData( $this->get('users_objs') );
     }
 }
 

--- a/tests/RestResponseDtoTest.php
+++ b/tests/RestResponseDtoTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * REST responses expose entity properties, not entity objects.
+ *
+ * Views used to hand entities straight to setResponseData(), so json_encode()
+ * emitted every public member the object happened to have: the property bag, but
+ * also _tableProperties, wasPersisted, cache and dirty. None of that is API
+ * surface, and it made the payload a function of the entity's current shape --
+ * a newly added sensitive column would ship the moment it existed.
+ *
+ * The reduction now happens inside setResponseData(), so an entity cannot reach
+ * a response without passing through it, and the fields to withhold are declared
+ * on the entity next to the columns they protect.
+ */
+final class RestResponseDtoTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /** Invoke the protected reducer directly. */
+    private function reduce($data)
+    {
+        $m = new ReflectionMethod('\OWA\Core\View\RestApi', 'toResponseData');
+        $m->setAccessible(true);
+
+        return $m->invoke(null, $data, 0);
+    }
+
+    private function makeUser()
+    {
+        $u = \OWA\Core\CoreAPI::entityFactory('base.user');
+        $u->set('user_id', 'dto-test@example.test');
+        $u->set('real_name', 'DTO Test');
+        $u->set('role', 'viewer');
+        $u->set('password', 'a-password-hash');
+        $u->set('temp_passkey', 'a-temp-passkey');
+        $u->set('api_key', 'an-api-key');
+
+        return $u;
+    }
+
+    public function testEntityIsReducedToItsProperties()
+    {
+        $site = \OWA\Core\CoreAPI::entityFactory('base.site');
+        $site->set('domain', 'https://dto.example.test');
+        $site->set('name', 'DTO Test Site');
+
+        $out = $this->reduce($site);
+
+        $this->assertIsArray($out, 'an entity must reduce to an array');
+        $this->assertSame('https://dto.example.test', $out['domain']);
+        $this->assertSame('DTO Test Site', $out['name']);
+    }
+
+    /**
+     * The ORM bookkeeping that used to ride along. These are not fields anyone
+     * asked for and they describe the storage layer, not the resource.
+     */
+    public function testEntityInternalsAreNotExposed()
+    {
+        $site = \OWA\Core\CoreAPI::entityFactory('base.site');
+        $site->set('domain', 'https://dto.example.test');
+
+        $out = $this->reduce($site);
+
+        foreach (['_tableProperties', 'wasPersisted', 'dirty', 'cache', 'properties'] as $internal) {
+            $this->assertArrayNotHasKey(
+                $internal,
+                $out,
+                sprintf('%s is ORM internals and must not be serialized', $internal)
+            );
+        }
+    }
+
+    /** Fields an entity declares private stay out of the payload. */
+    public function testUserCredentialsAreWithheld()
+    {
+        $out = $this->reduce($this->makeUser());
+
+        foreach (['password', 'temp_passkey', 'api_key'] as $secret) {
+            $this->assertArrayNotHasKey(
+                $secret,
+                $out,
+                sprintf('%s must never appear in a response', $secret)
+            );
+        }
+
+        // Still a usable representation of the user.
+        $this->assertSame('dto-test@example.test', $out['user_id']);
+        $this->assertSame('DTO Test', $out['real_name']);
+    }
+
+    /** Collections are the common case -- every element has to be reduced. */
+    public function testArraysOfEntitiesAreReducedElementwise()
+    {
+        $out = $this->reduce(['a' => $this->makeUser(), 'b' => $this->makeUser()]);
+
+        foreach (['a', 'b'] as $k) {
+            $this->assertIsArray($out[$k]);
+            $this->assertArrayNotHasKey('password', $out[$k]);
+            $this->assertSame('dto-test@example.test', $out[$k]['user_id']);
+        }
+    }
+
+    /** Views that already assemble plain data must be unaffected. */
+    public function testNonEntityDataPassesThroughUnchanged()
+    {
+        $payload = ['rows' => [1, 2, 3], 'label' => 'a string', 'n' => 42, 'flag' => true];
+
+        $this->assertSame($payload, $this->reduce($payload));
+        $this->assertSame('scalar', $this->reduce('scalar'));
+        $this->assertNull($this->reduce(null));
+    }
+
+    /** A cyclic graph must terminate rather than exhaust memory. */
+    public function testRecursionIsBounded()
+    {
+        $deep = 'leaf';
+        for ($i = 0; $i < 25; $i++) {
+            $deep = [$deep];
+        }
+
+        $this->assertNotNull($this->reduce($deep), 'a deep structure should still return');
+    }
+}


### PR DESCRIPTION
REST responses now return an entity's properties rather than the entity object.

Serializing the object emitted ORM internals -- `_tableProperties`,
`wasPersisted`, `cache`, `dirty` -- alongside the fields, and made the payload a
function of the entity's current shape rather than a defined contract.

`Entity::getPublicProperties()` reduces an entity to its property bag, minus a
`$private_properties` list declared on the entity itself. `setResponseData()`
applies it recursively, so an entity cannot reach a response without passing
through it. Non-entity data is returned untouched, so views that already
assemble plain arrays are unaffected.

Applied to every registered route.

309 PHP tests green.
