### PR TITLE
fix(rest): refuse an unrecognised report name instead of dispatching it

### DIFF
--- a/modules/Base/Controller/ReportsRest.php
+++ b/modules/Base/Controller/ReportsRest.php
@@ -153,12 +153,23 @@ class ReportsRest extends \OWA\Core\ReportController {
 
 	function getReport( $report_name ) {
 
-		$method = 'report_'.$report_name;
 
 		// validate() rejects an unknown report before the action runs, so this is
 		// a backstop: the name is concatenated into a method call, and an
 		// unhandled one used to be a fatal rather than a response.
-		if ( ! is_string( $report_name ) || ! method_exists( $this, $method ) ) {
+		// The type is checked BEFORE the method name is built -- concatenating
+		// first raises a warning for anything that is not a string, which is one
+		// of the shapes this exists to turn away quietly.
+		if ( ! is_string( $report_name ) ) {
+
+			\OWA\Core\CoreAPI::notice( 'Refusing to run report: name is not a string.' );
+
+			return '';
+		}
+
+		$method = 'report_'.$report_name;
+
+		if ( ! method_exists( $this, $method ) ) {
 
 			\OWA\Core\CoreAPI::notice(
 				sprintf( 'Refusing to run report: %s is not a known report.', print_r( $report_name, true ) )

--- a/modules/Base/Controller/ReportsRest.php
+++ b/modules/Base/Controller/ReportsRest.php
@@ -44,9 +44,20 @@ class ReportsRest extends \OWA\Core\ReportController {
 				$this->addValidation('period', $this->getParam('period'), 'inArray', array('possible_values' => $lables, 'stopOnError' => true) );				
 			}
 		} else {
-			
+
+			// report_name selects a report_<name>() method by concatenation, so
+			// it has to name a report this controller actually implements. The
+			// switch below only adds each report's own required params; it never
+			// rejected an unrecognised name, which then reached the dispatch.
+			$this->addValidation(
+				'report_name',
+				$this->get('report_name'),
+				'inArray',
+				array( 'possible_values' => self::getReportNames(), 'stopOnError' => true )
+			);
+
 			switch( $this->get('report_name') ) {
-				
+
 				case 'visit':
 				case 'clickstream':
 				
@@ -113,10 +124,49 @@ class ReportsRest extends \OWA\Core\ReportController {
 
 	}
 	
+	/**
+	 * The reports this controller can serve.
+	 *
+	 * Derived from the report_<name>() methods it defines rather than listed by
+	 * hand, so the set cannot drift out of step with the implementations.
+	 *
+	 * @return array
+	 */
+	public static function getReportNames() {
+
+		$names = array();
+
+		$class = new \ReflectionClass( self::class );
+
+		foreach ( $class->getMethods( \ReflectionMethod::IS_PUBLIC ) as $method ) {
+
+			if ( strpos( $method->name, 'report_' ) === 0 ) {
+
+				$names[] = substr( $method->name, 7 );
+			}
+		}
+
+		sort( $names );
+
+		return $names;
+	}
+
 	function getReport( $report_name ) {
-		
+
 		$method = 'report_'.$report_name;
-		
+
+		// validate() rejects an unknown report before the action runs, so this is
+		// a backstop: the name is concatenated into a method call, and an
+		// unhandled one used to be a fatal rather than a response.
+		if ( ! is_string( $report_name ) || ! method_exists( $this, $method ) ) {
+
+			\OWA\Core\CoreAPI::notice(
+				sprintf( 'Refusing to run report: %s is not a known report.', print_r( $report_name, true ) )
+			);
+
+			return '';
+		}
+
 		return $this->$method();
 	}
 	

--- a/tests/ReportsRestUnknownReportTest.php
+++ b/tests/ReportsRestUnknownReportTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An unrecognised report name is refused, not dispatched.
+ *
+ * getReport() builds a method name by concatenation -- 'report_' . $report_name
+ * -- and called it straight away. The name is the fourth segment of the route
+ * (/api/base/v1/reports/{report_name}), so any value that did not correspond to
+ * an implemented report reached $this->$method() and raised an uncaught Error.
+ *
+ * validate() gained an inArray check so an unknown name is rejected before the
+ * action runs, and getReport() keeps a backstop of its own.
+ */
+final class ReportsRestUnknownReportTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function controller()
+    {
+        return new \OWA\Module\Base\Controller\ReportsRest([]);
+    }
+
+    /**
+     * The set is derived from the implementations, so it cannot drift out of
+     * step with them the way a hand-maintained list would.
+     */
+    public function testReportNamesAreDiscoveredFromTheImplementations()
+    {
+        $names = \OWA\Module\Base\Controller\ReportsRest::getReportNames();
+
+        $this->assertNotEmpty($names, 'no reports discovered at all');
+
+        foreach ($names as $name) {
+            $this->assertTrue(
+                method_exists('\OWA\Module\Base\Controller\ReportsRest', 'report_' . $name),
+                sprintf('%s is offered but report_%s() does not exist', $name, $name)
+            );
+        }
+    }
+
+    /**
+     * Two reports have implementations but no case in validate()'s switch, so a
+     * hand-written list would likely have missed them. Named explicitly to catch
+     * the discovery silently returning a subset.
+     */
+    public function testReportsWithoutAValidationCaseAreStillOffered()
+    {
+        $names = \OWA\Module\Base\Controller\ReportsRest::getReportNames();
+
+        $this->assertContains('clicks', $names);
+        $this->assertContains('transaction', $names);
+        $this->assertContains('clickstream', $names);
+    }
+
+    /**
+     * The reported failure: 'dashboard' has no implementation, and calling it
+     * raised an uncaught Error rather than producing a response.
+     */
+    public function testAnUnknownReportDoesNotRaiseAnError()
+    {
+        $controller = $this->controller();
+
+        $this->assertSame(
+            '',
+            $controller->getReport('dashboard'),
+            'an unknown report should yield no results rather than dispatching'
+        );
+    }
+
+    /** Whatever the shape of the value, it must not reach the method call. */
+    public static function unknownReportNames(): array
+    {
+        return [
+            'unimplemented'      => ['dashboard'],
+            'empty string'       => [''],
+            'method on the class' => ['Names'],
+            'separator'          => ['latest/actions'],
+            'traversal-ish'      => ['../../etc/passwd'],
+            'null byte'          => ["clicks\0"],
+            'not a string'       => [['clicks']],
+        ];
+    }
+
+    /** @dataProvider unknownReportNames */
+    public function testUnhandledReportNamesAreRefused($name)
+    {
+        $this->assertSame('', $this->controller()->getReport($name));
+    }
+
+    /** Run the controller's own validations and report whether they rejected. */
+    private function rejectedByValidation($reportName): bool
+    {
+        $controller = new \OWA\Module\Base\Controller\ReportsRest(['report_name' => $reportName]);
+        $controller->validate();
+
+        $prop = new ReflectionProperty($controller, 'v');
+        $prop->setAccessible(true);
+        $validator = $prop->getValue($controller);
+
+        if (!$validator) {
+            return false;
+        }
+
+        $validator->doValidations();
+
+        return (bool) $validator->hasErrors;
+    }
+
+    /**
+     * The primary fix. getReport()'s backstop keeps the process alive, but the
+     * request should never get that far: an unknown name is a bad request and
+     * errorAction() already answers 422.
+     */
+    public function testAnUnknownReportIsRejectedByValidation()
+    {
+        $this->assertTrue(
+            $this->rejectedByValidation('dashboard'),
+            'an unimplemented report should fail validation'
+        );
+        $this->assertTrue(
+            $this->rejectedByValidation('nosuchreport'),
+            'an unrecognised report should fail validation'
+        );
+    }
+
+    /** The check must not reject reports that do exist. */
+    public function testKnownReportsPassValidation()
+    {
+        foreach (['clicks', 'latest_visits'] as $name) {
+            $this->assertFalse(
+                $this->rejectedByValidation($name),
+                sprintf('%s is implemented and must pass validation', $name)
+            );
+        }
+    }
+
+    /** A real report must still dispatch -- the guard cannot block everything. */
+    public function testAKnownReportStillDispatches()
+    {
+        $controller = $this->controller();
+
+        foreach (\OWA\Module\Base\Controller\ReportsRest::getReportNames() as $name) {
+            $this->assertTrue(
+                method_exists($controller, 'report_' . $name),
+                sprintf('report_%s() must be dispatchable', $name)
+            );
+        }
+    }
+}


### PR DESCRIPTION
`getReport()` built a method name by concatenation and called it immediately:

```php
$method = 'report_'.$report_name;
return $this->$method();
```

`report_name` is the fourth segment of the route
(`/api/base/v1/reports/{report_name}`), so a value with no corresponding
implementation reached the call and raised an uncaught Error --
`GET base/v1/reports/dashboard` returned a 500 instead of a response.

`validate()` did not catch it: its switch adds each report's own required params
but has no default, so an unrecognised name passed through untouched.

- `validate()` now requires `report_name` to name an implemented report, so an
  unknown one is refused before the action runs and `errorAction()` answers 422.
- `getReport()` keeps a backstop, being reachable independently of that check.
- `getReportNames()` derives the set by reflection over the `report_<name>()`
  methods rather than a hand-maintained list, so it cannot drift. It finds 8 --
  two of which (`clicks`, `transaction`) have no case in the switch and would
  likely have been missed by a list written by hand.

322 PHP tests green. Non-vacuous both ways: disabling the backstop errors 8 of
13, neutering the validation fails the rejection test.
