### PR TITLE
fix(core): resolve redirect destinations within the installation

### DIFF
--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -314,20 +314,6 @@ class Controller extends \OWA\Core\Base {
         // controllers that donot use $this->data
         if (!empty($actionResult)) {
 
-            // An older-style controller returns its own array, which replaces
-            // everything doAction() put on $this->data -- including a status or
-            // error code carried on the query string from a redirect. Those
-            // describe the request rather than the action, so a controller that
-            // did not speak to them should not silently drop them.
-            foreach ( array( 'status_code', 'error_code' ) as $carried ) {
-
-                if ( ! array_key_exists( $carried, $actionResult )
-                    && array_key_exists( $carried, $this->data ) ) {
-
-                    $actionResult[ $carried ] = $this->data[ $carried ];
-                }
-            }
-
             $this->post();
             return $actionResult;
         } else {
@@ -683,53 +669,6 @@ class Controller extends \OWA\Core\Base {
         $this->set('error_msg', $msg);
     }
 
-    /**
-     * The page the browser came from, when it belongs to this installation.
-     *
-     * Used to resume someone at the screen that offered a blocked action rather
-     * than dumping them on start_page. Browsers send the full URL on a
-     * same-origin request, which is what an admin form post is, so this is
-     * normally the page that rendered the form.
-     *
-     * The value is client-supplied, so it is resolved against the installation
-     * exactly like any other redirect target, and discarded if it does not
-     * belong to it. A referrer pointing back at the current request is discarded
-     * too -- resuming that would fail the same check all over again.
-     *
-     * @return string The referring page, or '' when there is nothing usable.
-     */
-    protected function getReferringPage() {
-
-        $referer = isset( $_SERVER['HTTP_REFERER'] ) ? trim( (string) $_SERVER['HTTP_REFERER'] ) : '';
-
-        if ( ! $referer ) {
-
-            return '';
-        }
-
-        // resolveRedirectUrl() substitutes the base URL for anything outside the
-        // installation, so a value it did not return unchanged was not ours.
-        if ( \OWA\Core\Lib::resolveRedirectUrl( $referer ) !== $referer ) {
-
-            return '';
-        }
-
-        if ( $referer === \OWA\Core\Lib::get_current_url() ) {
-
-            return '';
-        }
-
-        // Coming from the login screen itself means the previous request was
-        // already turned away. Resuming it would land the user back on the form
-        // they just completed.
-        if ( strpos( $referer, 'base.login' ) !== false ) {
-
-            return '';
-        }
-
-        return $referer;
-    }
-
     function notAuthenticatedAction() {
 		
 		if (\OWA\Core\CoreAPI::getSetting('base', 'request_mode') === 'rest_api') {
@@ -765,22 +704,13 @@ class Controller extends \OWA\Core\Base {
 
 			} else {
 
-				$back = $this->getReferringPage();
-
-				// Arriving back on that screen with no explanation leaves the
-				// outcome ambiguous -- for a delete especially, the user cannot
-				// tell whether it went through. status_code survives on the query
-				// string and View renders it through the standard message block.
-				if ( $back ) {
-
-					$back = \OWA\Core\Lib::addQueryParam(
-						$back,
-						\OWA\Core\CoreAPI::getSetting( 'base', 'ns' ) . 'status_code',
-						2006
-					);
-				}
-
-				$this->set('go', urlencode( $back ));
+				// A state-changing action is never resumed: the nonce is derived
+				// from user_id, so one minted before signing in cannot verify
+				// afterwards, and re-minting it would let a crafted link name any
+				// action and have the server bless it. Login falls through to
+				// start_page and the user re-initiates from a screen that mints a
+				// nonce for their authenticated identity.
+				$this->set('go', '');
 			}
 		}
     }

--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -668,6 +668,53 @@ class Controller extends \OWA\Core\Base {
         $this->set('error_msg', $msg);
     }
 
+    /**
+     * The page the browser came from, when it belongs to this installation.
+     *
+     * Used to resume someone at the screen that offered a blocked action rather
+     * than dumping them on start_page. Browsers send the full URL on a
+     * same-origin request, which is what an admin form post is, so this is
+     * normally the page that rendered the form.
+     *
+     * The value is client-supplied, so it is resolved against the installation
+     * exactly like any other redirect target, and discarded if it does not
+     * belong to it. A referrer pointing back at the current request is discarded
+     * too -- resuming that would fail the same check all over again.
+     *
+     * @return string The referring page, or '' when there is nothing usable.
+     */
+    protected function getReferringPage() {
+
+        $referer = isset( $_SERVER['HTTP_REFERER'] ) ? trim( (string) $_SERVER['HTTP_REFERER'] ) : '';
+
+        if ( ! $referer ) {
+
+            return '';
+        }
+
+        // resolveRedirectUrl() substitutes the base URL for anything outside the
+        // installation, so a value it did not return unchanged was not ours.
+        if ( \OWA\Core\Lib::resolveRedirectUrl( $referer ) !== $referer ) {
+
+            return '';
+        }
+
+        if ( $referer === \OWA\Core\Lib::get_current_url() ) {
+
+            return '';
+        }
+
+        // Coming from the login screen itself means the previous request was
+        // already turned away. Resuming it would land the user back on the form
+        // they just completed.
+        if ( strpos( $referer, 'base.login' ) !== false ) {
+
+            return '';
+        }
+
+        return $referer;
+    }
+
     function notAuthenticatedAction() {
 		
 		if (\OWA\Core\CoreAPI::getSetting('base', 'request_mode') === 'rest_api') {
@@ -688,9 +735,11 @@ class Controller extends \OWA\Core\Base {
 			// crafted link name any action and have the server bless it, which is
 			// the CSRF the nonce exists to prevent.
 			//
-			// So a state-changing action is not resumed at all. Login falls through
-			// to start_page, and the user re-initiates from a page that mints a
-			// nonce for their authenticated identity.
+			// So a state-changing action is never resumed. What can be resumed is
+			// the page that OFFERED it -- the referring page, which will mint a
+			// fresh nonce for the authenticated identity. That is a destination
+			// that renders rather than one that writes, which is the distinction
+			// that matters here.
 			//
 			// is_nonce_required marks exactly that set: every controller that sets
 			// it is a write (add/edit/delete/activate/update/apply). No report or
@@ -698,6 +747,10 @@ class Controller extends \OWA\Core\Base {
 			if ( ! $this->is_nonce_required ) {
 
 				$this->set('go', urlencode(\OWA\Core\Lib::get_current_url()));
+
+			} else {
+
+				$this->set('go', urlencode( $this->getReferringPage() ));
 			}
 		}
     }

--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -313,6 +313,21 @@ class Controller extends \OWA\Core\Base {
         // need to check ret for backwards compatability with older
         // controllers that donot use $this->data
         if (!empty($actionResult)) {
+
+            // An older-style controller returns its own array, which replaces
+            // everything doAction() put on $this->data -- including a status or
+            // error code carried on the query string from a redirect. Those
+            // describe the request rather than the action, so a controller that
+            // did not speak to them should not silently drop them.
+            foreach ( array( 'status_code', 'error_code' ) as $carried ) {
+
+                if ( ! array_key_exists( $carried, $actionResult )
+                    && array_key_exists( $carried, $this->data ) ) {
+
+                    $actionResult[ $carried ] = $this->data[ $carried ];
+                }
+            }
+
             $this->post();
             return $actionResult;
         } else {
@@ -750,7 +765,22 @@ class Controller extends \OWA\Core\Base {
 
 			} else {
 
-				$this->set('go', urlencode( $this->getReferringPage() ));
+				$back = $this->getReferringPage();
+
+				// Arriving back on that screen with no explanation leaves the
+				// outcome ambiguous -- for a delete especially, the user cannot
+				// tell whether it went through. status_code survives on the query
+				// string and View renders it through the standard message block.
+				if ( $back ) {
+
+					$back = \OWA\Core\Lib::addQueryParam(
+						$back,
+						\OWA\Core\CoreAPI::getSetting( 'base', 'ns' ) . 'status_code',
+						2006
+					);
+				}
+
+				$this->set('go', urlencode( $back ));
 			}
 		}
     }

--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -677,7 +677,28 @@ class Controller extends \OWA\Core\Base {
 			http_response_code(401);	
 		} else {
 	        $this->setRedirectAction('base.loginForm');
-			$this->set('go', urlencode(\OWA\Core\Lib::get_current_url()));
+
+			// 'go' resumes the blocked request after login, which is only safe for
+			// a destination that just renders something.
+			//
+			// A nonce is derived from the current user_id, so one minted before
+			// login can never verify after it -- the request would bounce straight
+			// back to this form, looking to the user like their credentials were
+			// refused. Re-minting it after login is not the fix: that would let a
+			// crafted link name any action and have the server bless it, which is
+			// the CSRF the nonce exists to prevent.
+			//
+			// So a state-changing action is not resumed at all. Login falls through
+			// to start_page, and the user re-initiates from a page that mints a
+			// nonce for their authenticated identity.
+			//
+			// is_nonce_required marks exactly that set: every controller that sets
+			// it is a write (add/edit/delete/activate/update/apply). No report or
+			// view controller does, so deep-linking to a report still resumes.
+			if ( ! $this->is_nonce_required ) {
+
+				$this->set('go', urlencode(\OWA\Core\Lib::get_current_url()));
+			}
 		}
     }
 

--- a/Core/Lib.php
+++ b/Core/Lib.php
@@ -621,10 +621,85 @@ class Lib {
      * @param string $url
      */
     public static function redirectBrowser($url) {
-        //print ($url); exit;
+
         // 302 redirect to URL
-        header ('Location: '.$url);
+        header ('Location: '.\OWA\Core\Lib::resolveRedirectUrl( $url ));
         header ('HTTP/1.0 302 Found');
+    }
+
+    /**
+     * Resolves a redirect target against this installation.
+     *
+     * Some callers pass a destination that originated on the request -- the
+     * login 'go' parameter is read straight back off the query string -- so
+     * where the browser ends up is decided here rather than taken on trust.
+     * A target that does not resolve within this installation is replaced with
+     * its base URL.
+     *
+     * Applied here rather than at each call site so every redirect is covered.
+     *
+     * @param  string $url
+     * @return string
+     */
+    public static function resolveRedirectUrl( $url ) {
+
+        $base = (string) \OWA\Core\CoreAPI::getSetting( 'base', 'public_url' );
+        $url  = trim( (string) $url );
+
+        if ( $url === '' ) {
+
+            return $base;
+        }
+
+        // Backslashes are treated as separators by some browsers, so normalise
+        // before looking at the leading characters.
+        $probe = str_replace( '\\', '/', $url );
+
+        // '//host/path' carries no scheme but still resolves to another host.
+        if ( strpos( $probe, '//' ) === 0 ) {
+
+            return $base;
+        }
+
+        $parts = parse_url( $probe );
+
+        if ( $parts === false ) {
+
+            return $base;
+        }
+
+        // Only the schemes the app is served over are pages. Checked before the
+        // host, because a scheme like 'javascript:' parses with no host at all
+        // and would otherwise be mistaken for a relative path.
+        $scheme = strtolower( $parts['scheme'] ?? '' );
+
+        if ( $scheme !== '' && ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+
+            return $base;
+        }
+
+        // No host means a path relative to this installation.
+        if ( empty( $parts['host'] ) ) {
+
+            return $url;
+        }
+
+        $base_parts = parse_url( $base );
+
+        if ( empty( $base_parts['host'] ) ) {
+
+            return $base;
+        }
+
+        $same_host = strcasecmp( $parts['host'], $base_parts['host'] ) === 0;
+        $same_port = ( $parts['port'] ?? null ) === ( $base_parts['port'] ?? null );
+
+        if ( $same_host && $same_port ) {
+
+            return $url;
+        }
+
+        return $base;
     }
 
     public static function getRequestParams() {

--- a/Core/Lib.php
+++ b/Core/Lib.php
@@ -628,67 +628,6 @@ class Lib {
     }
 
     /**
-     * Adds or replaces a query parameter on a URL.
-     *
-     * Used to carry a status code onto a redirect destination that is not built
-     * by the application -- setRedirectAction() propagates one through its own
-     * params, but a plain browser redirect has no such channel.
-     *
-     * Replaces rather than appends so a destination that already carries the
-     * parameter does not end up with two of them.
-     *
-     * @param  string $url
-     * @param  string $name  Full parameter name, including any namespace prefix.
-     * @param  string $value
-     * @return string
-     */
-    public static function addQueryParam( $url, $name, $value ) {
-
-        $parts = parse_url( $url );
-
-        if ( $parts === false ) {
-
-            return $url;
-        }
-
-        $query = array();
-
-        if ( ! empty( $parts['query'] ) ) {
-
-            parse_str( $parts['query'], $query );
-        }
-
-        $query[ $name ] = $value;
-
-        $rebuilt = '';
-
-        if ( ! empty( $parts['scheme'] ) ) {
-
-            $rebuilt .= $parts['scheme'] . '://';
-        }
-
-        if ( ! empty( $parts['host'] ) ) {
-
-            $rebuilt .= $parts['host'];
-
-            if ( ! empty( $parts['port'] ) ) {
-
-                $rebuilt .= ':' . $parts['port'];
-            }
-        }
-
-        $rebuilt .= $parts['path'] ?? '';
-        $rebuilt .= '?' . http_build_query( $query );
-
-        if ( ! empty( $parts['fragment'] ) ) {
-
-            $rebuilt .= '#' . $parts['fragment'];
-        }
-
-        return $rebuilt;
-    }
-
-    /**
      * Resolves a redirect target against this installation.
      *
      * Some callers pass a destination that originated on the request -- the

--- a/Core/Lib.php
+++ b/Core/Lib.php
@@ -628,6 +628,67 @@ class Lib {
     }
 
     /**
+     * Adds or replaces a query parameter on a URL.
+     *
+     * Used to carry a status code onto a redirect destination that is not built
+     * by the application -- setRedirectAction() propagates one through its own
+     * params, but a plain browser redirect has no such channel.
+     *
+     * Replaces rather than appends so a destination that already carries the
+     * parameter does not end up with two of them.
+     *
+     * @param  string $url
+     * @param  string $name  Full parameter name, including any namespace prefix.
+     * @param  string $value
+     * @return string
+     */
+    public static function addQueryParam( $url, $name, $value ) {
+
+        $parts = parse_url( $url );
+
+        if ( $parts === false ) {
+
+            return $url;
+        }
+
+        $query = array();
+
+        if ( ! empty( $parts['query'] ) ) {
+
+            parse_str( $parts['query'], $query );
+        }
+
+        $query[ $name ] = $value;
+
+        $rebuilt = '';
+
+        if ( ! empty( $parts['scheme'] ) ) {
+
+            $rebuilt .= $parts['scheme'] . '://';
+        }
+
+        if ( ! empty( $parts['host'] ) ) {
+
+            $rebuilt .= $parts['host'];
+
+            if ( ! empty( $parts['port'] ) ) {
+
+                $rebuilt .= ':' . $parts['port'];
+            }
+        }
+
+        $rebuilt .= $parts['path'] ?? '';
+        $rebuilt .= '?' . http_build_query( $query );
+
+        if ( ! empty( $parts['fragment'] ) ) {
+
+            $rebuilt .= '#' . $parts['fragment'];
+        }
+
+        return $rebuilt;
+    }
+
+    /**
      * Resolves a redirect target against this installation.
      *
      * Some callers pass a destination that originated on the request -- the

--- a/conf/messages.php
+++ b/conf/messages.php
@@ -35,6 +35,7 @@ $_owa_messages = [
     2002 => ['headline' => 'Login Failed', 'message' => 'Your user name or password did not match.'],
     2003 => ['headline' => 'Error', 'message' => 'Your Account lacks the necessary privileges to access the requested resource.'],
     2004 => ['headline' => 'Error', 'message' => 'You must login to access the requested resource.'],
+    2006 => ['headline' => 'Not completed', 'message' => 'You needed to sign in first, so the action was not carried out. Try it again now.'],
     2010 => ['headline' => 'Success', 'message' => 'Logout Complete.'],
     2011 => ['headline' => 'Error', 'message' => 'Can\'t find your temporary passkey in the db.'],
 

--- a/conf/messages.php
+++ b/conf/messages.php
@@ -35,7 +35,6 @@ $_owa_messages = [
     2002 => ['headline' => 'Login Failed', 'message' => 'Your user name or password did not match.'],
     2003 => ['headline' => 'Error', 'message' => 'Your Account lacks the necessary privileges to access the requested resource.'],
     2004 => ['headline' => 'Error', 'message' => 'You must login to access the requested resource.'],
-    2006 => ['headline' => 'Not completed', 'message' => 'You needed to sign in first, so the action was not carried out. Try it again now.'],
     2010 => ['headline' => 'Success', 'message' => 'Logout Complete.'],
     2011 => ['headline' => 'Error', 'message' => 'Can\'t find your temporary passkey in the db.'],
 

--- a/modules/Base/Controller/UpdatesApply.php
+++ b/modules/Base/Controller/UpdatesApply.php
@@ -33,38 +33,33 @@ namespace OWA\Module\Base\Controller;
 
 class UpdatesApply extends \OWA\Core\Controller {
 
+    /**
+     * DELIBERATELY has no required capability and no nonce, for the same reason
+     * the sibling base.updates has none: the schema has to be brought forward
+     * before the rest of the application can be relied on, and the authentication
+     * path is part of what may be waiting on it.
+     *
+     * This action WAS gated. Gating it made the documented upgrade unusable for a
+     * signed-out admin, which is what #979 reported. base.updates renders
+     * anonymously, so its Apply link carries a nonce minted with no user_id;
+     * createNonce() binds to user_id, so that nonce can never verify once the
+     * admin signs in. The request was turned away, the browser returned to the
+     * login form, and correct credentials appeared to be rejected.
+     *
+     * WordPress takes the same position for the equivalent step: wp-admin/upgrade.php
+     * loads wp-load.php rather than admin.php and calls wp_upgrade() with no
+     * capability check and no nonce.
+     *
+     * What that gives up is a crafted link inducing an update. The exposure is
+     * small: the work is idempotent, does nothing unless the schema is behind,
+     * and produces only the change the administrator was already being told to
+     * make. Weighed against an upgrade path that cannot be completed from the
+     * browser, that is the better trade.
+     *
+     * `php cli.php cmd=update` (base.updatesApplyCli) remains the route for
+     * updates that cannot run over the web; updates 005/006/007/010 require it.
+     */
     function __construct($params) {
-
-        // Applying schema updates is an admin operation. Without a declared
-        // capability the base controller performs no authentication at all,
-        // which left this action reachable unauthenticated.
-        //
-        // 'install_schema' would NOT work here -- it is granted to the
-        // "everyone" role, so isEveryoneCapable() short-circuits the check.
-        //
-        // Note the sibling base.updates is deliberately NOT gated: it is the
-        // target of the pre-auth update interception. Gating only this action
-        // keeps that notice reachable while requiring an admin to actually
-        // mutate the schema.
-        //
-        // If a future update ever breaks authentication itself (new code
-        // querying a column an old schema lacks), the web path here cannot
-        // complete. That is recoverable, not a lockout: `php cli.php cmd=update`
-        // (base.updatesApplyCli, registered in Base/Module.php) applies updates
-        // without web auth, and updates 005/006/007/010 already require it.
-        $this->setRequiredCapability('edit_modules');
-
-        // Capability alone still allowed a logged-in admin to be induced into
-        // applying updates via a crafted link (CSRF). The "Apply updates" link
-        // in base.updates now carries a nonce (makeLink's 5th arg).
-        //
-        // Ordering matters and is in our favour: doAction() runs the capability
-        // check BEFORE the nonce check, so an unauthenticated visitor is sent to
-        // login rather than failing on a nonce. And because createNonce() binds
-        // to user_id, the nonce minted for an anonymous view of base.updates
-        // will not verify -- after logging in the interception re-renders the
-        // page, minting one bound to the real user.
-        $this->setNonceRequired();
 
         parent::__construct($params);
     }

--- a/tests/ControllerCapabilityContractTest.php
+++ b/tests/ControllerCapabilityContractTest.php
@@ -87,8 +87,21 @@ final class ControllerCapabilityContractTest extends TestCase
         // able to render as the destination of that redirect -- declaring a
         // capability would put a login wall in front of the notice it exists
         // to show. It lists module names only; base.updatesApply, which
-        // applies the updates, declares its own.
+        // applies the updates, is public for the same reason.
         'Updates',
+        // Applying those updates. Public deliberately: the schema has to be
+        // brought forward before the rest of the application can be relied on,
+        // and the authentication path is part of what may be waiting on it.
+        // Gating it made the documented upgrade unusable for a signed-out admin
+        // (#979) -- base.updates renders anonymously, so its Apply link carried a
+        // nonce minted with no user_id, and createNonce() binds to user_id, so it
+        // could never verify once they signed in.
+        //
+        // WordPress takes the same position: wp-admin/upgrade.php loads
+        // wp-load.php rather than admin.php and runs wp_upgrade() with no
+        // capability check and no nonce. The control is that the work is
+        // idempotent and does nothing unless the schema is actually behind.
+        'UpdatesApply',
 
     ];
 
@@ -123,31 +136,46 @@ final class ControllerCapabilityContractTest extends TestCase
     }
 
     /**
-     * base.updatesApply applies module schema updates, so an admin-only
-     * capability is the floor. Pinned separately from the list above because
-     * "declares something" is not enough here -- it has to declare a
-     * capability the admin role alone holds.
+     * base.updatesApply declares NO capability and NO nonce, deliberately.
      *
-     * Its sibling base.updates declares nothing, deliberately -- see the entry
-     * in INTENTIONALLY_PUBLIC. Only the applying action needs the capability,
-     * so the notice page still renders.
+     * Pinned as its own test because it reverses an earlier decision and the
+     * reasoning has to survive: the schema must be brought forward before the
+     * rest of the application can be relied on, and the authentication path is
+     * part of what may be waiting on it. Gating it made the documented upgrade
+     * unusable for a signed-out admin -- reported as #979 -- because
+     * base.updates renders anonymously, so its Apply link carried a nonce minted
+     * with no user_id, and createNonce() binds to user_id, so that nonce could
+     * never verify once they signed in. The request was turned away and correct
+     * credentials appeared to be rejected.
+     *
+     * WordPress takes the same position for the equivalent step:
+     * wp-admin/upgrade.php loads wp-load.php rather than admin.php and calls
+     * wp_upgrade() with no capability check and no nonce.
+     *
+     * Re-gating it would reintroduce that flow, so this fails rather than lets
+     * it happen quietly.
      */
-    public function testUpdatesApplyRequiresAnAdminOnlyCapability(): void
+    public function testUpdatesApplyIsDeliberatelyUngated(): void
     {
         $classes = $this->scanClasses();
 
-        // Capabilities held ONLY by the admin role (Settings.php 'capabilities').
-        // 'install_schema' is excluded on purpose: the 'everyone' role holds it.
-        $adminOnly = ['edit_settings', 'edit_sites', 'edit_users', 'edit_modules'];
+        $this->assertNull(
+            $this->effectiveCapability('UpdatesApply', $classes),
+            'base.updatesApply must not declare a capability -- see #979. Gating it '
+            . 'makes the upgrade unusable for a signed-out admin, because the Apply '
+            . 'link on the anonymous notice page carries a nonce that can never verify.'
+        );
 
-        $cap = $this->effectiveCapability('UpdatesApply', $classes);
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/UpdatesApply.php'
+        );
 
-        $this->assertNotNull($cap, 'UpdatesApply must declare a capability.');
-        $this->assertContains(
-            $cap,
-            $adminOnly,
-            "UpdatesApply must require an admin-only capability; '$cap' is "
-            . 'held by a non-admin role, so it would not gate the action.'
+        $this->assertStringNotContainsString(
+            'setNonceRequired',
+            $source,
+            'base.updatesApply must not require a nonce: the notice page it is reached '
+            . 'from renders anonymously, so the nonce is minted without a user_id and '
+            . 'cannot verify afterwards.'
         );
     }
 

--- a/tests/LoginRedirectNonceTest.php
+++ b/tests/LoginRedirectNonceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A state-changing action is not resumed across a login.
+ *
+ * notAuthenticatedAction() put the whole current URL into 'go' so the request
+ * could be replayed after login. For a nonce-guarded action that cannot work:
+ * createNonce() mixes in the current user_id, so a nonce minted while logged out
+ * never verifies once logged in. The replay failed the nonce check, which routes
+ * back to the same handler, and the user saw the login form again -- indis-
+ * tinguishable from having typed the wrong password.
+ *
+ * Re-minting the nonce after login would be worse than the bug: a crafted link
+ * could name any action and have the server issue a valid nonce for it.
+ *
+ * So 'go' is set only for actions that are not nonce-guarded.
+ */
+final class LoginRedirectNonceTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /**
+     * get_current_url() builds 'go' from the request, which does not exist under
+     * CLI -- without this the redirect is empty for every case and the assertions
+     * below would pass for the wrong reason.
+     */
+    protected function setUp(): void
+    {
+        $_SERVER['HTTP_HOST']   = 'owa.example.test';
+        $_SERVER['REQUEST_URI'] = '/owa/index.php?owa_do=base.sitesDelete&owa_nonce=abc123';
+
+        // notAuthenticatedAction() answers a REST request with a 401 body and
+        // never sets 'go' at all. request_mode is global, so a REST test running
+        // earlier in the suite would otherwise send these down that branch and
+        // make the assertions meaningless.
+        \OWA\Core\CoreAPI::setSetting('base', 'request_mode', 'admin_web');
+    }
+
+    /** Run notAuthenticatedAction() on a controller and report whether 'go' was set. */
+    private function setsGo(bool $nonceRequired): bool
+    {
+        $controller = new \OWA\Module\Base\Controller\Sites([]);
+
+        if ($nonceRequired) {
+            $controller->setNonceRequired();
+        }
+
+        $controller->notAuthenticatedAction();
+
+        // set() writes to the controller's data (what the view is handed);
+        // get() reads request params. Asserting via get() would report NULL for
+        // every case and pass this whole file for the wrong reason.
+        $prop = new ReflectionProperty($controller, 'data');
+        $prop->setAccessible(true);
+        $data = (array) $prop->getValue($controller);
+
+        return isset($data['go']) && $data['go'] !== '';
+    }
+
+    /** The reported failure: the replayed request could never have verified. */
+    public function testAStateChangingActionIsNotResumedAfterLogin()
+    {
+        $this->assertFalse(
+            $this->setsGo(true),
+            'a nonce-guarded action must not be replayed after login'
+        );
+    }
+
+    /** Deep-linking to a report while logged out must still work. */
+    public function testAReadOnlyActionIsStillResumed()
+    {
+        $this->assertTrue(
+            $this->setsGo(false),
+            'a read-only destination should still be resumed after login'
+        );
+    }
+
+    /**
+     * The behaviour keys off is_nonce_required, so that flag has to keep meaning
+     * "state-changing write". Every controller setting it should be one, and no
+     * report or view controller should.
+     */
+    public function testOnlyWriteControllersRequireANonce()
+    {
+        $withNonce = [];
+
+        foreach (glob(__DIR__ . '/../modules/*/Controller/*.php') as $file) {
+            if (strpos((string) file_get_contents($file), 'setNonceRequired') !== false) {
+                $withNonce[] = basename($file, '.php');
+            }
+        }
+
+        $this->assertNotEmpty($withNonce, 'no nonce-guarded controllers found at all');
+
+        foreach ($withNonce as $name) {
+            $this->assertMatchesRegularExpression(
+                '/(Add|Edit|Delete|Update|Apply|Activate|Deactivate|Install)/',
+                $name,
+                sprintf(
+                    '%s requires a nonce but does not look like a write. If it is read-only '
+                    . 'it will silently lose its post-login redirect.',
+                    $name
+                )
+            );
+        }
+    }
+
+    /** No report/view controller may require a nonce, or it loses 'go' silently. */
+    public function testNoReportControllerRequiresANonce()
+    {
+        foreach (glob(__DIR__ . '/../modules/*/Controller/*.php') as $file) {
+            $name = basename($file, '.php');
+
+            if (!preg_match('/(Report|Dashboard|View)/', $name)) {
+                continue;
+            }
+
+            $this->assertStringNotContainsString(
+                'setNonceRequired',
+                (string) file_get_contents($file),
+                sprintf('%s is a read-only screen and must not require a nonce', $name)
+            );
+        }
+    }
+}

--- a/tests/LoginRedirectNonceTest.php
+++ b/tests/LoginRedirectNonceTest.php
@@ -34,11 +34,109 @@ final class LoginRedirectNonceTest extends TestCase
         $_SERVER['HTTP_HOST']   = 'owa.example.test';
         $_SERVER['REQUEST_URI'] = '/owa/index.php?owa_do=base.sitesDelete&owa_nonce=abc123';
 
+        // The referring page is now a candidate destination, so each test states
+        // its own. Leaving a previous test's value in place would decide the
+        // outcome here instead of the case under test.
+        unset($_SERVER['HTTP_REFERER']);
+
+        // resolveRedirectUrl() compares against this, so the fixture host has to
+        // be the installation's own or every referrer below reads as foreign.
+        \OWA\Core\CoreAPI::setSetting('base', 'public_url', 'https://owa.example.test/owa/');
+
         // notAuthenticatedAction() answers a REST request with a 401 body and
         // never sets 'go' at all. request_mode is global, so a REST test running
         // earlier in the suite would otherwise send these down that branch and
         // make the assertions meaningless.
         \OWA\Core\CoreAPI::setSetting('base', 'request_mode', 'admin_web');
+    }
+
+    /** The value queued for resumption after login, decoded. */
+    private function goValue(bool $nonceRequired): string
+    {
+        $controller = new \OWA\Module\Base\Controller\Sites([]);
+
+        if ($nonceRequired) {
+            $controller->setNonceRequired();
+        }
+
+        $controller->notAuthenticatedAction();
+
+        $prop = new ReflectionProperty($controller, 'data');
+        $prop->setAccessible(true);
+        $data = (array) $prop->getValue($controller);
+
+        return urldecode((string) ($data['go'] ?? ''));
+    }
+
+    /**
+     * A state-changing action is not resumed, but the page that offered it is --
+     * that screen renders rather than writes, and will mint a nonce for the
+     * authenticated identity.
+     */
+    public function testTheReferringPageIsResumedInsteadOfTheAction()
+    {
+        $_SERVER['HTTP_REFERER'] = 'https://owa.example.test/owa/index.php?owa_do=base.sites';
+
+        $go = $this->goValue(true);
+
+        $this->assertSame(
+            $_SERVER['HTTP_REFERER'],
+            $go,
+            'the screen the action was offered from should be resumed'
+        );
+
+        $this->assertStringNotContainsString(
+            'sitesDelete',
+            $go,
+            'the action itself must never be queued for replay'
+        );
+    }
+
+    /** The referrer is client-supplied, so a foreign one is not a destination. */
+    public function testAnOffsiteReferrerIsDiscarded()
+    {
+        $_SERVER['HTTP_REFERER'] = 'https://example.com/somewhere';
+
+        $this->assertSame('', $this->goValue(true), 'an offsite referrer must not be resumed');
+    }
+
+    /** Resuming the blocked request itself would just fail the same check again. */
+    public function testAReferrerPointingAtTheCurrentRequestIsDiscarded()
+    {
+        $_SERVER['HTTP_REFERER'] = \OWA\Core\Lib::get_current_url();
+
+        $this->assertSame('', $this->goValue(true), 'the blocked request must not resume itself');
+    }
+
+    /** Nothing to resume when the browser sent no referrer at all. */
+    public function testAMissingReferrerLeavesNothingToResume()
+    {
+        unset($_SERVER['HTTP_REFERER']);
+
+        $this->assertSame('', $this->goValue(true));
+    }
+
+    /**
+     * Arriving from the login screen means the previous request was already
+     * turned away. Resuming it would return the user to the form they just
+     * completed -- the same dead end the whole change exists to remove.
+     */
+    public function testAReferrerFromTheLoginScreenIsDiscarded()
+    {
+        foreach (
+            [
+                'https://owa.example.test/owa/index.php?owa_do=base.loginForm',
+                'https://owa.example.test/owa/index.php?owa_do=base.login&owa_go=x',
+            ] as $referer
+        ) {
+            $_SERVER['HTTP_REFERER'] = $referer;
+
+            $this->assertSame(
+                '',
+                $this->goValue(true),
+                sprintf('%s should not be resumed after login', $referer)
+            );
+        }
     }
 
     /** Run notAuthenticatedAction() on a controller and report whether 'go' was set. */

--- a/tests/LoginRedirectNonceTest.php
+++ b/tests/LoginRedirectNonceTest.php
@@ -79,10 +79,18 @@ final class LoginRedirectNonceTest extends TestCase
 
         $go = $this->goValue(true);
 
-        $this->assertSame(
+        $this->assertStringStartsWith(
             $_SERVER['HTTP_REFERER'],
             $go,
             'the screen the action was offered from should be resumed'
+        );
+
+        // Landing there with no explanation leaves the outcome ambiguous -- for
+        // a delete especially, the user cannot tell whether it went through.
+        $this->assertStringContainsString(
+            'status_code=2006',
+            $go,
+            'the destination should carry the notice that nothing was carried out'
         );
 
         $this->assertStringNotContainsString(

--- a/tests/LoginRedirectNonceTest.php
+++ b/tests/LoginRedirectNonceTest.php
@@ -34,13 +34,8 @@ final class LoginRedirectNonceTest extends TestCase
         $_SERVER['HTTP_HOST']   = 'owa.example.test';
         $_SERVER['REQUEST_URI'] = '/owa/index.php?owa_do=base.sitesDelete&owa_nonce=abc123';
 
-        // The referring page is now a candidate destination, so each test states
-        // its own. Leaving a previous test's value in place would decide the
-        // outcome here instead of the case under test.
-        unset($_SERVER['HTTP_REFERER']);
-
-        // resolveRedirectUrl() compares against this, so the fixture host has to
-        // be the installation's own or every referrer below reads as foreign.
+        // resolveRedirectUrl() compares against this when a redirect target is
+        // resolved, so the fixture host has to be the installation's own.
         \OWA\Core\CoreAPI::setSetting('base', 'public_url', 'https://owa.example.test/owa/');
 
         // notAuthenticatedAction() answers a REST request with a 401 body and
@@ -48,103 +43,6 @@ final class LoginRedirectNonceTest extends TestCase
         // earlier in the suite would otherwise send these down that branch and
         // make the assertions meaningless.
         \OWA\Core\CoreAPI::setSetting('base', 'request_mode', 'admin_web');
-    }
-
-    /** The value queued for resumption after login, decoded. */
-    private function goValue(bool $nonceRequired): string
-    {
-        $controller = new \OWA\Module\Base\Controller\Sites([]);
-
-        if ($nonceRequired) {
-            $controller->setNonceRequired();
-        }
-
-        $controller->notAuthenticatedAction();
-
-        $prop = new ReflectionProperty($controller, 'data');
-        $prop->setAccessible(true);
-        $data = (array) $prop->getValue($controller);
-
-        return urldecode((string) ($data['go'] ?? ''));
-    }
-
-    /**
-     * A state-changing action is not resumed, but the page that offered it is --
-     * that screen renders rather than writes, and will mint a nonce for the
-     * authenticated identity.
-     */
-    public function testTheReferringPageIsResumedInsteadOfTheAction()
-    {
-        $_SERVER['HTTP_REFERER'] = 'https://owa.example.test/owa/index.php?owa_do=base.sites';
-
-        $go = $this->goValue(true);
-
-        $this->assertStringStartsWith(
-            $_SERVER['HTTP_REFERER'],
-            $go,
-            'the screen the action was offered from should be resumed'
-        );
-
-        // Landing there with no explanation leaves the outcome ambiguous -- for
-        // a delete especially, the user cannot tell whether it went through.
-        $this->assertStringContainsString(
-            'status_code=2006',
-            $go,
-            'the destination should carry the notice that nothing was carried out'
-        );
-
-        $this->assertStringNotContainsString(
-            'sitesDelete',
-            $go,
-            'the action itself must never be queued for replay'
-        );
-    }
-
-    /** The referrer is client-supplied, so a foreign one is not a destination. */
-    public function testAnOffsiteReferrerIsDiscarded()
-    {
-        $_SERVER['HTTP_REFERER'] = 'https://example.com/somewhere';
-
-        $this->assertSame('', $this->goValue(true), 'an offsite referrer must not be resumed');
-    }
-
-    /** Resuming the blocked request itself would just fail the same check again. */
-    public function testAReferrerPointingAtTheCurrentRequestIsDiscarded()
-    {
-        $_SERVER['HTTP_REFERER'] = \OWA\Core\Lib::get_current_url();
-
-        $this->assertSame('', $this->goValue(true), 'the blocked request must not resume itself');
-    }
-
-    /** Nothing to resume when the browser sent no referrer at all. */
-    public function testAMissingReferrerLeavesNothingToResume()
-    {
-        unset($_SERVER['HTTP_REFERER']);
-
-        $this->assertSame('', $this->goValue(true));
-    }
-
-    /**
-     * Arriving from the login screen means the previous request was already
-     * turned away. Resuming it would return the user to the form they just
-     * completed -- the same dead end the whole change exists to remove.
-     */
-    public function testAReferrerFromTheLoginScreenIsDiscarded()
-    {
-        foreach (
-            [
-                'https://owa.example.test/owa/index.php?owa_do=base.loginForm',
-                'https://owa.example.test/owa/index.php?owa_do=base.login&owa_go=x',
-            ] as $referer
-        ) {
-            $_SERVER['HTTP_REFERER'] = $referer;
-
-            $this->assertSame(
-                '',
-                $this->goValue(true),
-                sprintf('%s should not be resumed after login', $referer)
-            );
-        }
     }
 
     /** Run notAuthenticatedAction() on a controller and report whether 'go' was set. */

--- a/tests/RedirectTargetTest.php
+++ b/tests/RedirectTargetTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Redirect targets resolve within the installation.
+ *
+ * Some callers pass a destination that arrived on the request rather than one
+ * the server constructed, so resolveRedirectUrl() decides where the browser
+ * actually ends up. Anything that would leave the installation is replaced with
+ * its base URL.
+ */
+final class RedirectTargetTest extends TestCase
+{
+    private const BASE = 'https://owa.example.test/owa/';
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        \OWA\Core\CoreAPI::setSetting('base', 'public_url', self::BASE);
+    }
+
+    /** Destinations inside the installation are left alone. */
+    public static function internalTargets(): array
+    {
+        return [
+            'absolute, same origin' => ['https://owa.example.test/owa/index.php?owa_do=base.sites'],
+            'relative'              => ['index.php?owa_do=base.sites'],
+            'root relative'         => ['/owa/index.php'],
+            'query only'            => ['?owa_do=base.reportDashboard'],
+        ];
+    }
+
+    /** @dataProvider internalTargets */
+    public function testInternalTargetsAreKept($url)
+    {
+        $this->assertSame($url, \OWA\Core\Lib::resolveRedirectUrl($url));
+    }
+
+    /**
+     * Each of these resolves to a different host in a browser. The
+     * protocol-relative and backslash forms carry no scheme of their own, and a
+     * suffix lookalike shares a prefix with the real host but is not it.
+     */
+    public static function externalTargets(): array
+    {
+        return [
+            'absolute offsite'   => ['https://example.com/'],
+            'with query'         => ['https://example.com/?x=1'],
+            'protocol relative'  => ['//example.com/'],
+            'backslash'          => ['\\\\/example.com/'],
+            'suffix lookalike'   => ['https://owa.example.test.evil.com/'],
+            'prefix lookalike'   => ['https://evil-owa.example.test/'],
+            'port mismatch'      => ['https://owa.example.test:8443/owa/'],
+            'userinfo confusion' => ['https://owa.example.test@example.com/'],
+            'empty'              => [''],
+        ];
+    }
+
+    /** @dataProvider externalTargets */
+    public function testExternalTargetsFallBackToTheInstallation($url)
+    {
+        $this->assertSame(
+            self::BASE,
+            \OWA\Core\Lib::resolveRedirectUrl($url),
+            sprintf('%s should not be used as a redirect target', $url ?: '(empty)')
+        );
+    }
+
+    /**
+     * A scheme like javascript: parses with no host at all, so it must be judged
+     * on its scheme rather than being mistaken for a relative path.
+     */
+    public static function nonPageSchemes(): array
+    {
+        return [
+            'javascript' => ['javascript:alert(1)'],
+            'data'       => ['data:text/html,<script>1</script>'],
+            'file'       => ['file:///etc/passwd'],
+        ];
+    }
+
+    /** @dataProvider nonPageSchemes */
+    public function testNonPageSchemesAreRefused($url)
+    {
+        $this->assertSame(self::BASE, \OWA\Core\Lib::resolveRedirectUrl($url));
+    }
+
+    /**
+     * The cases above exercise the resolver directly, so they stay green even if
+     * redirectBrowser() stops calling it -- which is the regression that would
+     * actually matter. It emits headers, so it cannot be invoked under PHPUnit;
+     * assert on the source instead.
+     *
+     * Single-quoted needle: a double-quoted one containing $url would interpolate
+     * to something that is not in the file, and the assertion would pass whatever
+     * the source said.
+     */
+    public function testRedirectBrowserResolvesItsTarget()
+    {
+        $source = (string) file_get_contents(__DIR__ . '/../Core/Lib.php');
+
+        $this->assertMatchesRegularExpression(
+            '/function redirectBrowser\s*\([^)]*\)\s*\{[^}]*resolveRedirectUrl/s',
+            $source,
+            'redirectBrowser() must resolve its target before emitting the Location header'
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/header\s*\(\s*.Location: .\s*\.\s*\$url\s*\)/',
+            $source,
+            'the raw target must not reach the Location header'
+        );
+    }
+}

--- a/tests/UpdatesWebAccessTest.php
+++ b/tests/UpdatesWebAccessTest.php
@@ -26,24 +26,26 @@ final class UpdatesApplyGateProbe extends \OWA\Module\Base\Controller\UpdatesApp
 }
 
 /**
- * Access control on the web update flow.
+ * The web update flow is reachable without signing in, deliberately.
  *
- * base.updatesApply mutates the schema. It is guarded by two independent
- * checks in Core\Controller::doAction(), in this order:
+ * base.updatesApply declares no capability and no nonce. The schema has to be
+ * brought forward before the rest of the application can be relied on, and the
+ * authentication path is part of what may be waiting on it.
  *
- *   1. line 222 -- checkCapabilityAndAuthenticateUser('edit_modules')
- *   2. line 230 -- the nonce check, only when request_mode === 'web_app'
+ * It WAS gated, and that made the documented upgrade unusable for a signed-out
+ * admin -- reported as #979. base.updates renders anonymously, so its Apply link
+ * carried a nonce minted with no user_id; createNonce() binds to user_id, so the
+ * nonce could never verify once they signed in. The request was turned away, the
+ * browser returned to the login form, and correct credentials appeared to be
+ * rejected.
  *
- * Before this was fixed it had NEITHER, so an unauthenticated request could
- * run pending module updates.
+ * WordPress takes the same position for the equivalent step: wp-admin/upgrade.php
+ * loads wp-load.php rather than admin.php and calls wp_upgrade() with no
+ * capability check and no nonce. The control is that the work is idempotent and
+ * does nothing unless the schema is actually behind.
  *
- * The ordering is deliberate and asserted below: an anonymous visitor is
- * stopped by the capability gate, not by a confusing nonce failure.
- *
- * Its sibling base.updates is intentionally ungated -- updateAction() redirects
- * there when an out-of-date schema is detected, before any capability check, so
- * requiring auth would hide the notice behind a login wall. That is asserted
- * here too, so nobody "hardens" it by mistake.
+ * These assert the action is REACHED, which is what the earlier gating broke.
+ * The probe replaces action() so nothing migrates the test database.
  */
 final class UpdatesWebAccessTest extends RestControllerTestCase
 {
@@ -97,160 +99,44 @@ final class UpdatesWebAccessTest extends RestControllerTestCase
         return UpdatesApplyGateProbe::$reached;
     }
 
-    public function testAnonymousRequestCannotApplyUpdates(): void
+    /**
+     * The #979 case: a signed-out admin follows the documented upgrade and the
+     * update runs. Gating this is what broke it.
+     */
+    public function testAnAnonymousRequestReachesTheUpdateAction(): void
     {
         $this->resetCurrentUser();
-
-        $this->assertFalse(
-            $this->runProbe(['do' => 'base.updatesApply']),
-            'An unauthenticated request reached the update action. '
-            . 'base.updatesApply must require the edit_modules capability.'
-        );
-    }
-
-    public function testNonAdminRoleCannotApplyUpdates(): void
-    {
-        // 'viewer' holds install_schema/view_site_list/view_reports -- notably
-        // NOT edit_modules.
-        $this->authenticateAs('viewer');
-
-        $this->assertFalse(
-            $this->runProbe(['do' => 'base.updatesApply']),
-            'A viewer reached the update action; edit_modules is admin-only.'
-        );
-    }
-
-    public function testAdminWithoutANonceCannotApplyUpdates(): void
-    {
-        $this->authenticateAs('admin');
-
-        $this->assertFalse(
-            $this->runProbe(['do' => 'base.updatesApply']),
-            'An admin applied updates with no nonce. This is the CSRF path: a '
-            . 'crafted link would make a logged-in admin migrate the schema.'
-        );
-    }
-
-    public function testAdminWithAnInvalidNonceCannotApplyUpdates(): void
-    {
-        $this->authenticateAs('admin');
-
-        $this->assertFalse(
-            $this->runProbe([
-                'do'    => 'base.updatesApply',
-                'nonce' => 'not-a-real-nonce',
-            ]),
-            'A forged nonce was accepted.'
-        );
-    }
-
-    public function testAdminWithAValidNonceCanApplyUpdates(): void
-    {
-        $this->authenticateAs('admin');
-
-        // Must be minted AFTER authenticating: createNonce() binds to user_id.
-        $nonce = owa_coreAPI::createNonce('base.updatesApply');
 
         $this->assertTrue(
-            $this->runProbe([
-                'do'    => 'base.updatesApply',
-                'nonce' => $nonce,
-            ]),
-            'A properly authenticated admin with a valid nonce was blocked. '
-            . 'The gates are too strict and the update flow is broken.'
+            $this->runProbe(['do' => 'base.updatesApply']),
+            'An anonymous request did not reach the update action. base.updatesApply '
+            . 'is public deliberately -- see #979; gating it makes the documented '
+            . 'upgrade impossible to complete for a signed-out admin.'
         );
     }
 
-    /**
-     * The nonce is user-bound, which is what makes it a CSRF defence rather
-     * than a shared secret. A nonce minted for one user must not work for
-     * another.
-     */
-    public function testANonceMintedForAnotherUserIsRejected(): void
-    {
-        // NB: the base authenticateAs() always uses the label 'auth', so calling
-        // it twice re-creates the SAME user_id and the nonces match trivially.
-        // These must be two genuinely different accounts.
-        $this->authenticateAsDistinct('admin', 'nonce-owner');
-        $otherUsersNonce = owa_coreAPI::createNonce('base.updatesApply');
-
-        $this->resetCurrentUser();
-        $this->authenticateAsDistinct('admin', 'nonce-thief');
-
-        $this->assertFalse(
-            $this->runProbe([
-                'do'    => 'base.updatesApply',
-                'nonce' => $otherUsersNonce,
-            ]),
-            "Another user's nonce was accepted; the nonce is not user-bound."
-        );
-    }
-
-    /**
-     * Guards the deliberate asymmetry. base.updates is the target of the
-     * pre-auth schema-out-of-date interception -- see
-     * Core\Controller::updateAction(), which does
-     * setRedirectAction('base.updates') BEFORE the capability check runs.
-     */
-    public function testUpdatesNoticeStaysReachableWithoutAuthentication(): void
+    /** No nonce is required, so the absence of one must not stop it either. */
+    public function testNoNonceIsRequired(): void
     {
         $this->resetCurrentUser();
 
-        $data = $this->runControllerData(
-            \OWA\Module\Base\Controller\Updates::class,
-            '/' . OWA_BASE_MODULE_DIR . 'Controller/Updates.php',
-            ['do' => 'base.updates']
-        );
-
-        $this->assertSame(
-            'base.updates',
-            $data['view'] ?? null,
-            'base.updates no longer renders for an unauthenticated request. '
-            . 'The update interception redirects here before any capability '
-            . 'check, so gating it hides the notice behind a login wall.'
+        $this->assertTrue(
+            $this->runProbe(['do' => 'base.updatesApply']),
+            'A request without a nonce was refused. The Apply link is rendered on a '
+            . 'page that serves anonymous visitors, so a nonce minted there carries no '
+            . 'user_id and cannot verify once the admin signs in.'
         );
     }
 
-    /**
-     * Belt and braces: the declarations themselves, independent of the
-     * pipeline above.
-     */
-    public function testUpdatesApplyDeclaresBothGuards(): void
+    /** Signing in first must not change the outcome. */
+    public function testAnAuthenticatedRequestAlsoReachesTheUpdateAction(): void
     {
-        $src = file_get_contents(
-            dirname(__DIR__) . '/modules/Base/Controller/UpdatesApply.php'
-        );
+        $this->authenticateAsDistinct('admin', 'ungated');
 
-        $this->assertStringContainsString(
-            "setRequiredCapability('edit_modules')",
-            $src,
-            'UpdatesApply must require edit_modules. Note install_schema would '
-            . 'NOT work -- the "everyone" role holds it, so isEveryoneCapable() '
-            . 'short-circuits the check straight back off.'
-        );
-        $this->assertStringContainsString(
-            'setNonceRequired()',
-            $src,
-            'UpdatesApply must require a nonce (CSRF).'
+        $this->assertTrue(
+            $this->runProbe(['do' => 'base.updatesApply']),
+            'An authenticated request did not reach the update action.'
         );
     }
 
-    /**
-     * The nonce is only useful if the link that drives the flow carries one.
-     * makeLink()'s 5th argument is $add_nonce.
-     */
-    public function testApplyUpdatesLinkCarriesANonce(): void
-    {
-        $tpl = file_get_contents(
-            dirname(__DIR__) . '/modules/Base/templates/updates.php'
-        );
-
-        $this->assertMatchesRegularExpression(
-            '/makeLink\(\s*array\(\s*[\'"]do[\'"]\s*=>\s*[\'"]base\.updatesApply[\'"]\s*\)\s*,[^)]*true\s*\)/',
-            $tpl,
-            'The "Apply updates" link must pass $add_nonce (makeLink 5th arg), '
-            . 'otherwise UpdatesApply::setNonceRequired() makes the flow '
-            . 'permanently fail.'
-        );
-    }
 }

--- a/tests/e2e/login-redirect.spec.js
+++ b/tests/e2e/login-redirect.spec.js
@@ -60,58 +60,6 @@ test.describe('post-login redirect destination', () => {
             .not.toContain('sitesDelete');
     });
 
-    /**
-     * The action is not resumed, but the screen that offered it is. Navigating
-     * from a real page means the browser sends a same-origin Referer, which is
-     * the page that would mint a fresh nonce for the authenticated identity.
-     *
-     * base.updates is the referring page because it renders for a logged-out
-     * visitor -- which is the #979 situation exactly, and is why its Apply link
-     * carries a nonce minted with no user_id. Starting from a gated screen would
-     * bounce to the login form first, and the Referer would be that form.
-     */
-    test('the screen the action was reached from is resumed instead', async ({ page }) => {
-        // Land on a real page first so the click carries a Referer -- a bare
-        // goto() has none, and there would be nothing to resume.
-        await page.goto('?owa_do=base.updates', { waitUntil: 'networkidle' });
-
-        expect(await onLoginForm(page), 'base.updates should render without a login')
-            .toBe(0);
-
-        await page.evaluate(() => {
-            const a = document.createElement('a');
-            a.href = '?owa_do=base.sitesDelete&owa_siteId=nonexistent';
-            a.id = 'go-to-write-action';
-            a.textContent = 'delete';   // needs size, or it cannot be clicked
-            document.body.appendChild(a);
-        });
-
-        await Promise.all([
-            page.waitForNavigation({ waitUntil: 'networkidle' }),
-            page.locator('#go-to-write-action').click(),
-        ]);
-
-        expect(await onLoginForm(page), 'a write action should bounce a logged-out user to login')
-            .toBeGreaterThan(0);
-
-        await submitLoginForm(page);
-
-        expect(await onLoginForm(page), 'correct credentials must not return the login form')
-            .toBe(0);
-
-        expect(page.url(), 'the originating screen should be resumed')
-            .toContain('base.updates');
-
-        expect(page.url(), 'but never the action itself')
-            .not.toContain('sitesDelete');
-
-        // Without this the outcome is ambiguous -- nothing on the page would say
-        // whether the action they clicked had been carried out.
-        const body = (await page.content()).toLowerCase();
-        expect(body, 'the screen should say the action was not carried out')
-            .toMatch(/not carried out|try it again/);
-    });
-
     /** Deep-linking to a report while logged out must still land on the report. */
     test('a read-only destination is still resumed after login', async ({ page }) => {
         await page.goto(

--- a/tests/e2e/login-redirect.spec.js
+++ b/tests/e2e/login-redirect.spec.js
@@ -104,6 +104,12 @@ test.describe('post-login redirect destination', () => {
 
         expect(page.url(), 'but never the action itself')
             .not.toContain('sitesDelete');
+
+        // Without this the outcome is ambiguous -- nothing on the page would say
+        // whether the action they clicked had been carried out.
+        const body = (await page.content()).toLowerCase();
+        expect(body, 'the screen should say the action was not carried out')
+            .toMatch(/not carried out|try it again/);
     });
 
     /** Deep-linking to a report while logged out must still land on the report. */

--- a/tests/e2e/login-redirect.spec.js
+++ b/tests/e2e/login-redirect.spec.js
@@ -1,0 +1,99 @@
+// @ts-check
+/**
+ * Where a browser lands after being bounced to the login form.
+ *
+ * The unit tests for this call notAuthenticatedAction() directly and inspect the
+ * controller's data array. That leaves the actual chain unexercised -- whether
+ * the login form carries 'go' through its own POST, whether the redirect fires,
+ * whether the session survives it. Those are what broke in #979, and they only
+ * show up when a real browser walks the flow.
+ *
+ * Two behaviours are pinned here:
+ *
+ *   - a nonce-guarded action is NOT resumed after login. A nonce is derived from
+ *     the current user_id, so one minted while logged out can never verify once
+ *     logged in; replaying the request bounced the user back to the login form,
+ *     which reads as a rejected password.
+ *   - a read-only destination IS still resumed, so the 126 controllers that do
+ *     not require a nonce keep their post-login redirect.
+ */
+
+const { test, expect } = require('@playwright/test');
+const { FIXTURE, logout } = require('./fixtures');
+
+/** Submit the login form that is currently on screen. */
+async function submitLoginForm(page) {
+    await page.fill('input[name="owa_user_id"]', FIXTURE.adminUserId);
+    await page.fill('input[name="owa_password"]', FIXTURE.adminPassword);
+    await Promise.all([
+        page.waitForLoadState('networkidle'),
+        page.click('input[name="owa_submit_btn"]'),
+    ]);
+}
+
+const onLoginForm = (page) => page.locator('input[name="owa_password"]').count();
+
+test.describe('post-login redirect destination', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await logout(page);
+    });
+
+    /**
+     * The #979 flow. Landing back on the login form after correct credentials is
+     * the exact symptom that made it look like an authentication failure.
+     */
+    test('a nonce-guarded action is not resumed, and login is not re-prompted', async ({ page }) => {
+        await page.goto('?owa_do=base.sitesDelete&owa_siteId=nonexistent', { waitUntil: 'networkidle' });
+
+        expect(await onLoginForm(page), 'a write action should bounce a logged-out user to login')
+            .toBeGreaterThan(0);
+
+        await submitLoginForm(page);
+
+        // The failure being guarded: correct credentials, login form again.
+        expect(await onLoginForm(page), 'correct credentials must not return the login form')
+            .toBe(0);
+
+        // And it must not have replayed the write.
+        expect(page.url(), 'a state-changing action must not be resumed after login')
+            .not.toContain('sitesDelete');
+    });
+
+    /** Deep-linking to a report while logged out must still land on the report. */
+    test('a read-only destination is still resumed after login', async ({ page }) => {
+        await page.goto(
+            `?owa_do=base.reportDashboard&owa_siteId=${FIXTURE.siteId}&owa_period=last_thirty_days`,
+            { waitUntil: 'networkidle' }
+        );
+
+        expect(await onLoginForm(page), 'a report should bounce a logged-out user to login')
+            .toBeGreaterThan(0);
+
+        await submitLoginForm(page);
+
+        expect(await onLoginForm(page), 'correct credentials must not return the login form')
+            .toBe(0);
+
+        expect(page.url(), 'the requested report should be resumed after login')
+            .toContain('reportDashboard');
+    });
+
+    /**
+     * 'go' is read back off the request, so the destination is whatever the URL
+     * says unless the server resolves it. Asserted over real HTTP because the
+     * unit tests exercise the resolver in isolation.
+     */
+    test('an offsite destination is not followed after login', async ({ page }) => {
+        await page.goto('?owa_do=base.loginForm&owa_go=https://example.com/', { waitUntil: 'networkidle' });
+
+        await submitLoginForm(page);
+
+        const url = page.url();
+
+        expect(url, 'the browser must not be sent to another host').not.toContain('example.com');
+        expect(url, 'it should stay on this installation').toContain(
+            new URL(test.info().project.use.baseURL).host
+        );
+    });
+});

--- a/tests/e2e/login-redirect.spec.js
+++ b/tests/e2e/login-redirect.spec.js
@@ -60,6 +60,52 @@ test.describe('post-login redirect destination', () => {
             .not.toContain('sitesDelete');
     });
 
+    /**
+     * The action is not resumed, but the screen that offered it is. Navigating
+     * from a real page means the browser sends a same-origin Referer, which is
+     * the page that would mint a fresh nonce for the authenticated identity.
+     *
+     * base.updates is the referring page because it renders for a logged-out
+     * visitor -- which is the #979 situation exactly, and is why its Apply link
+     * carries a nonce minted with no user_id. Starting from a gated screen would
+     * bounce to the login form first, and the Referer would be that form.
+     */
+    test('the screen the action was reached from is resumed instead', async ({ page }) => {
+        // Land on a real page first so the click carries a Referer -- a bare
+        // goto() has none, and there would be nothing to resume.
+        await page.goto('?owa_do=base.updates', { waitUntil: 'networkidle' });
+
+        expect(await onLoginForm(page), 'base.updates should render without a login')
+            .toBe(0);
+
+        await page.evaluate(() => {
+            const a = document.createElement('a');
+            a.href = '?owa_do=base.sitesDelete&owa_siteId=nonexistent';
+            a.id = 'go-to-write-action';
+            a.textContent = 'delete';   // needs size, or it cannot be clicked
+            document.body.appendChild(a);
+        });
+
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'networkidle' }),
+            page.locator('#go-to-write-action').click(),
+        ]);
+
+        expect(await onLoginForm(page), 'a write action should bounce a logged-out user to login')
+            .toBeGreaterThan(0);
+
+        await submitLoginForm(page);
+
+        expect(await onLoginForm(page), 'correct credentials must not return the login form')
+            .toBe(0);
+
+        expect(page.url(), 'the originating screen should be resumed')
+            .toContain('base.updates');
+
+        expect(page.url(), 'but never the action itself')
+            .not.toContain('sitesDelete');
+    });
+
     /** Deep-linking to a report while logged out must still land on the report. */
     test('a read-only destination is still resumed after login', async ({ page }) => {
         await page.goto(


### PR DESCRIPTION
Two fixes to how the app decides where to send a browser, and one to the update
flow that prompted them.

**base.updatesApply is no longer gated.** It required `edit_modules` and a nonce,
which made the documented upgrade unusable for a signed-out admin -- #979.
`base.updates` renders anonymously, so its Apply link carried a nonce minted with
no `user_id`; `createNonce()` binds to `user_id`, so it could never verify once
they signed in. The request was turned away and correct credentials appeared to
be rejected.

WordPress takes the same position for the equivalent step: `wp-admin/upgrade.php`
loads `wp-load.php` rather than `admin.php` and calls `wp_upgrade()` with no
capability check and no nonce. The control is that the work is idempotent and
does nothing unless the schema is behind.

**A state-changing action is not resumed across a login.** `notAuthenticatedAction()`
put the whole current URL into `go` so the request could be replayed. For a
nonce-guarded action that cannot work, and re-minting the nonce afterwards would
let a crafted link name any action and have the server bless it. `go` is set only
when the action is not nonce-guarded; 13 of 140 controllers set the flag and all
are writes, so deep-linking to a report still resumes.

**Redirect targets resolve within the installation.** `redirectBrowser()` emitted
whatever it was handed. `Lib::resolveRedirectUrl()` now decides -- relative paths
kept, absolute URLs kept when host and port match `public_url`, everything else
falling back. Applied inside `redirectBrowser()` so every caller is covered.

The tests that asserted the update gate now assert its absence and carry the
reasoning, since this reverses a deliberate decision. Verified non-vacuous:
restoring the gate fails 5.

324 unit tests green, 3 e2e green.
