### PR TITLE
fix(auth): answer a nonce failure on its own terms

### DIFF
--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -753,7 +753,24 @@ class Controller extends \OWA\Core\Base {
 
 			// generic_error.php echoes error_msg directly, so it has to be a
 			// string -- handing it the getMsg() array renders as "Array".
-			$this->set('error_msg', $this->getMsgAsString(2005));
+			$msg = $this->getMsgAsString(2005);
+
+			// Telling someone to go back to where they started is only useful if
+			// they are given the way back. The screen that rendered the expired
+			// form is the referring page, and it will mint a fresh nonce.
+			$back = $this->getReferringPage();
+
+			if ( $back ) {
+
+				// $back is client-supplied and lands in an href, so it is escaped
+				// as an attribute rather than trusted the way a built URL is.
+				$msg .= sprintf(
+					' <a href="%s">Return to the previous screen</a>',
+					htmlspecialchars( $back, ENT_QUOTES, 'UTF-8' )
+				);
+			}
+
+			$this->set('error_msg', $msg);
 		}
     }
 

--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -235,7 +235,7 @@ class Controller extends \OWA\Core\Base {
 	
 	            if (!$nonce || !$this->verifyNonce($nonce)) {
 	                $this->e->debug('Nonce is not valid.');
-	                return $this->finishActionCall($this->notAuthenticatedAction());
+	                return $this->finishActionCall($this->nonceFailedAction());
 	            }
 	        }
 		}
@@ -667,6 +667,94 @@ class Controller extends \OWA\Core\Base {
         $msg['message'] .= $additionalMessage;
         $this->setView('base.error');
         $this->set('error_msg', $msg);
+    }
+
+    /**
+     * The page the browser came from, when it belongs to this installation.
+     *
+     * Used to resume someone at the screen that offered a blocked action rather
+     * than dumping them on start_page. Browsers send the full URL on a
+     * same-origin request, which is what an admin form post is, so this is
+     * normally the page that rendered the form.
+     *
+     * The value is client-supplied, so it is resolved against the installation
+     * exactly like any other redirect target, and discarded if it does not
+     * belong to it. A referrer pointing back at the current request is discarded
+     * too -- resuming that would fail the same check all over again.
+     *
+     * @return string The referring page, or '' when there is nothing usable.
+     */
+    protected function getReferringPage() {
+
+        $referer = isset( $_SERVER['HTTP_REFERER'] ) ? trim( (string) $_SERVER['HTTP_REFERER'] ) : '';
+
+        if ( ! $referer ) {
+
+            return '';
+        }
+
+        // resolveRedirectUrl() substitutes the base URL for anything outside the
+        // installation, so a value it did not return unchanged was not ours.
+        if ( \OWA\Core\Lib::resolveRedirectUrl( $referer ) !== $referer ) {
+
+            return '';
+        }
+
+        if ( $referer === \OWA\Core\Lib::get_current_url() ) {
+
+            return '';
+        }
+
+        // Coming from the login screen itself means the previous request was
+        // already turned away. Resuming it would land the user back on the form
+        // they just completed.
+        if ( strpos( $referer, 'base.login' ) !== false ) {
+
+            return '';
+        }
+
+        return $referer;
+    }
+
+    /**
+     * Answers a request whose nonce was missing or did not verify.
+     *
+     * A nonce failure and a missing session are different conditions and were
+     * answered the same way -- with the login form. For someone who is already
+     * signed in that is untrue and unactionable: they re-enter credentials that
+     * were never the problem, which is what made the report on #979 read as an
+     * authentication failure rather than an expired token.
+     *
+     * A nonce carries a time window and the user_id it was minted for, so it can
+     * lapse for a perfectly valid session: a form left open too long, or one
+     * rendered before signing in as someone else.
+     *
+     * The action is deliberately not retried once a fresh nonce could be minted.
+     * The nonce exists so that a state-changing request is one the user just
+     * confirmed, and completing it on their behalf would defeat that.
+     */
+    function nonceFailedAction() {
+
+		// Not signed in: the nonce is beside the point, credentials come first.
+		if ( ! \OWA\Core\CoreAPI::getCurrentUser()->isAuthenticated() ) {
+
+			return $this->notAuthenticatedAction();
+		}
+
+		if (\OWA\Core\CoreAPI::getSetting('base', 'request_mode') === 'rest_api') {
+
+			$this->setView('base.restApi');
+			$this->set('error_msg', $this->getMsg(2005));
+			http_response_code(403);
+
+		} else {
+
+			$this->setView('base.error');
+
+			// generic_error.php echoes error_msg directly, so it has to be a
+			// string -- handing it the getMsg() array renders as "Array".
+			$this->set('error_msg', $this->getMsgAsString(2005));
+		}
     }
 
     function notAuthenticatedAction() {

--- a/conf/messages.php
+++ b/conf/messages.php
@@ -35,6 +35,7 @@ $_owa_messages = [
     2002 => ['headline' => 'Login Failed', 'message' => 'Your user name or password did not match.'],
     2003 => ['headline' => 'Error', 'message' => 'Your Account lacks the necessary privileges to access the requested resource.'],
     2004 => ['headline' => 'Error', 'message' => 'You must login to access the requested resource.'],
+    2005 => ['headline' => 'This form is no longer valid', 'message' => 'You are still signed in -- the form simply expired, or was opened under a different account. Go back to the screen you started from and try the action again.'],
     2010 => ['headline' => 'Success', 'message' => 'Logout Complete.'],
     2011 => ['headline' => 'Error', 'message' => 'Can\'t find your temporary passkey in the db.'],
 

--- a/conf/messages.php
+++ b/conf/messages.php
@@ -35,7 +35,7 @@ $_owa_messages = [
     2002 => ['headline' => 'Login Failed', 'message' => 'Your user name or password did not match.'],
     2003 => ['headline' => 'Error', 'message' => 'Your Account lacks the necessary privileges to access the requested resource.'],
     2004 => ['headline' => 'Error', 'message' => 'You must login to access the requested resource.'],
-    2005 => ['headline' => 'This form is no longer valid', 'message' => 'You are still signed in -- the form simply expired, or was opened under a different account. Go back to the screen you started from and try the action again.'],
+    2005 => ['headline' => 'This form is no longer valid', 'message' => 'It expired, or was opened under a different account. Start the action again from the screen you began on.'],
     2010 => ['headline' => 'Success', 'message' => 'Logout Complete.'],
     2011 => ['headline' => 'Error', 'message' => 'Can\'t find your temporary passkey in the db.'],
 

--- a/modules/Base/View/Error.php
+++ b/modules/Base/View/Error.php
@@ -51,6 +51,22 @@ class Error extends \OWA\Core\View {
         endif;
 
         // load body template
+        // generic_error.php reads error_msg from the body's own scope, so the
+        // controller's message has to be handed across or the template falls back
+        // to its placeholder and the reason for the error is lost.
+        if ( isset( $data['error_msg'] ) ) {
+
+            $msg = $data['error_msg'];
+
+            // Controllers set this from getMsg(), which returns headline/message.
+            if ( is_array( $msg ) ) {
+
+                $msg = implode( ' ', array_values( $msg ) );
+            }
+
+            $this->body->set( 'error_msg', $msg );
+        }
+
         $this->body->set_template('generic_error.php');
 
         return;

--- a/tests/LoginRedirectNonceTest.php
+++ b/tests/LoginRedirectNonceTest.php
@@ -114,6 +114,55 @@ final class LoginRedirectNonceTest extends TestCase
         }
     }
 
+    /**
+     * A nonce-guarded controller declares a capability, so the authentication
+     * gate turns an anonymous request away before the nonce is ever examined.
+     *
+     * The gate only authenticates when a capability is set and not granted to
+     * everyone, so a controller that requires a nonce but declares no capability
+     * is reachable unauthenticated, with the nonce as the only thing in front of
+     * it. That is intended for exactly two: the installer runs before any user
+     * exists, and requiring authentication there would deadlock the bootstrap.
+     * Anything else acquiring that shape is a mistake, not a decision.
+     */
+    public function testNonceGuardedControllersDeclareACapability()
+    {
+        $bootstrapExempt = ['InstallBase', 'InstallConfig'];
+
+        foreach (glob(__DIR__ . '/../modules/*/Controller/*.php') as $file) {
+            $source = (string) file_get_contents($file);
+
+            if (strpos($source, 'setNonceRequired') === false) {
+                continue;
+            }
+
+            $name = basename($file, '.php');
+
+            if (in_array($name, $bootstrapExempt, true)) {
+                $this->assertStringNotContainsString(
+                    'setRequiredCapability',
+                    $source,
+                    sprintf(
+                        '%s is exempt because it runs before any user exists. Now that it '
+                        . 'declares a capability, drop the exemption.',
+                        $name
+                    )
+                );
+                continue;
+            }
+
+            $this->assertStringContainsString(
+                'setRequiredCapability',
+                $source,
+                sprintf(
+                    '%s requires a nonce but declares no capability, so the authentication '
+                    . 'gate is skipped and it can be reached without signing in.',
+                    $name
+                )
+            );
+        }
+    }
+
     /** No report/view controller may require a nonce, or it loses 'go' silently. */
     public function testNoReportControllerRequiresANonce()
     {

--- a/tests/NonceFailureResponseTest.php
+++ b/tests/NonceFailureResponseTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A nonce failure is answered on its own terms, not as a missing session.
+ *
+ * Both conditions used to reach notAuthenticatedAction(), so someone already
+ * signed in was shown the login form. That is untrue and unactionable -- they
+ * re-enter credentials that were never the problem -- and it is why the report
+ * on #979 read as an authentication failure rather than an expired token.
+ *
+ * A nonce carries a time window and the user_id it was minted for, so it lapses
+ * for perfectly valid sessions: a form left open too long, or one rendered
+ * before signing in as somebody else.
+ */
+final class NonceFailureResponseTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        $_SERVER['HTTP_HOST']   = 'owa.example.test';
+        $_SERVER['REQUEST_URI'] = '/owa/index.php?owa_do=base.sitesDelete';
+
+        // request_mode is global and decides which branch answers, so a REST
+        // test running earlier would otherwise steer these.
+        \OWA\Core\CoreAPI::setSetting('base', 'request_mode', 'admin_web');
+    }
+
+    private function respondTo(bool $authenticated): array
+    {
+        // setAuthStatus() assigns true regardless of its argument, so the flag
+        // has to be set directly to express "not signed in" -- the same
+        // workaround RestControllerTestCase uses. Setting it through the public
+        // method would make both cases authenticated and the assertions below
+        // would compare two identical responses.
+        $currentUser = \OWA\Core\CoreAPI::getCurrentUser();
+        $flag = new ReflectionProperty($currentUser, 'is_authenticated');
+        $flag->setAccessible(true);
+        $flag->setValue($currentUser, $authenticated);
+
+        $controller = new \OWA\Module\Base\Controller\Sites([]);
+        $controller->setNonceRequired();
+        $controller->nonceFailedAction();
+
+        $prop = new ReflectionProperty($controller, 'data');
+        $prop->setAccessible(true);
+
+        return (array) $prop->getValue($controller);
+    }
+
+    /** Signed in: the response must not be a request for credentials. */
+    public function testAnAuthenticatedUserIsNotAskedToLogInAgain()
+    {
+        $data = $this->respondTo(true);
+
+        $this->assertSame(
+            'base.error',
+            $data['view'] ?? null,
+            'a signed-in user with a bad nonce should not be sent to the login form'
+        );
+
+        $this->assertArrayNotHasKey(
+            'go',
+            $data,
+            'nothing should be queued for replay after a nonce failure'
+        );
+    }
+
+    /** And the message has to say what actually happened. */
+    public function testTheMessageDescribesAnExpiredForm()
+    {
+        $data = $this->respondTo(true);
+        $msg  = strtolower(json_encode($data['error_msg'] ?? []));
+
+        $this->assertStringNotContainsString(
+            'password',
+            $msg,
+            'the message must not suggest the credentials were wrong'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/(expired|no longer valid|signed in)/',
+            $msg,
+            'the message should explain that the form lapsed'
+        );
+    }
+
+    /** Not signed in: the login form is still the right answer. */
+    public function testAnUnauthenticatedUserIsStillSentToLogin()
+    {
+        $data = $this->respondTo(false);
+
+        $this->assertNotSame(
+            'base.error',
+            $data['view'] ?? null,
+            'someone with no session should still be asked to authenticate'
+        );
+    }
+
+    /** The two conditions must not share a response. */
+    public function testTheTwoConditionsAnswerDifferently()
+    {
+        $this->assertNotEquals(
+            $this->respondTo(true),
+            $this->respondTo(false),
+            'a bad nonce and a missing session are different conditions'
+        );
+    }
+}

--- a/tests/NonceFailureResponseTest.php
+++ b/tests/NonceFailureResponseTest.php
@@ -29,6 +29,14 @@ final class NonceFailureResponseTest extends TestCase
         // request_mode is global and decides which branch answers, so a REST
         // test running earlier would otherwise steer these.
         \OWA\Core\CoreAPI::setSetting('base', 'request_mode', 'admin_web');
+
+        // The referring page decides whether a way back is offered, so each test
+        // states its own rather than inheriting a previous one's.
+        unset($_SERVER['HTTP_REFERER']);
+
+        // getReferringPage() resolves against this; without a matching host every
+        // referrer below would read as foreign and the link would never appear.
+        \OWA\Core\CoreAPI::setSetting('base', 'public_url', 'https://owa.example.test/owa/');
     }
 
     private function respondTo(bool $authenticated): array
@@ -88,6 +96,46 @@ final class NonceFailureResponseTest extends TestCase
             $msg,
             'the message should explain that the form lapsed'
         );
+    }
+
+    /**
+     * "Start the action again" is only actionable if the way back is offered.
+     * The referring page is the screen that rendered the expired form.
+     */
+    public function testTheWayBackIsOffered()
+    {
+        $_SERVER['HTTP_REFERER'] = 'https://owa.example.test/owa/index.php?owa_do=base.optionsGeneral';
+
+        $data = $this->respondTo(true);
+
+        $this->assertStringContainsString(
+            'owa_do=base.optionsGeneral',
+            (string) ($data['error_msg'] ?? ''),
+            'the screen the form came from should be linked'
+        );
+    }
+
+    /** The referrer reaches an href, so it cannot be trusted as markup. */
+    public function testTheWayBackIsEscaped()
+    {
+        $_SERVER['HTTP_REFERER'] =
+            'https://owa.example.test/owa/index.php?owa_do=base.sites&x="><script>alert(1)</script>';
+
+        $msg = (string) ($this->respondTo(true)['error_msg'] ?? '');
+
+        $this->assertStringNotContainsString('<script>', $msg, 'markup must not survive into the page');
+        $this->assertStringNotContainsString('"><', $msg, 'the attribute must not be breakable');
+    }
+
+    /** Nothing to link to when the referrer is unusable; the message still stands. */
+    public function testTheMessageStandsAloneWithoutAReferrer()
+    {
+        unset($_SERVER['HTTP_REFERER']);
+
+        $msg = (string) ($this->respondTo(true)['error_msg'] ?? '');
+
+        $this->assertNotSame('', $msg, 'the explanation is still required');
+        $this->assertStringNotContainsString('<a href', $msg, 'no link when there is nowhere to send them');
     }
 
     /** Not signed in: the login form is still the right answer. */

--- a/tests/NonceFailureResponseTest.php
+++ b/tests/NonceFailureResponseTest.php
@@ -92,7 +92,7 @@ final class NonceFailureResponseTest extends TestCase
         );
 
         $this->assertMatchesRegularExpression(
-            '/(expired|no longer valid|signed in)/',
+            '/(expired|no longer valid)/',
             $msg,
             'the message should explain that the form lapsed'
         );

--- a/tests/e2e/nonce-expiry.spec.js
+++ b/tests/e2e/nonce-expiry.spec.js
@@ -1,0 +1,81 @@
+// @ts-check
+/**
+ * A signed-in user with a stale nonce is told the form expired, not to log in.
+ *
+ * A nonce carries a time window and the user_id it was minted for, so it lapses
+ * for perfectly valid sessions -- a form left open too long, or one rendered
+ * before signing in as somebody else. Both conditions used to reach the
+ * not-authenticated handler, so the user was shown the login form despite having
+ * a working session, re-entered credentials that were never the problem, and had
+ * no way to tell what had actually happened.
+ *
+ * Driven through the real form rather than a hand-built URL. The capability
+ * check runs BEFORE the nonce check, so a direct GET is refused for lacking
+ * privileges and never reaches the code under test -- assertions written that
+ * way pass against the capability error page and prove nothing.
+ */
+
+const { test, expect } = require('@playwright/test');
+const { adminLogin } = require('./fixtures');
+
+const onLoginForm = (page) => page.locator('input[name="owa_password"]').count();
+
+/** Load a real admin form, invalidate its nonce, and submit it. */
+async function submitWithStaleNonce(page) {
+    await adminLogin(page);
+    await page.goto('?owa_do=base.optionsGeneral', { waitUntil: 'networkidle' });
+
+    // createNonceFormField() emits <input type="hidden" name="<ns>nonce">, and
+    // ns defaults to 'owa_'.
+    const nonce = page.locator('input[name="owa_nonce"]');
+    await expect(nonce, 'the options form should carry a nonce').toHaveCount(1);
+
+    // Exactly what an expired or wrong-user nonce looks like to the server.
+    await nonce.evaluate((el) => { el.value = 'staleaaaaa'; });
+
+    // The submit control is a button carrying name=owa_action value=<action>;
+    // the nonce is a separate hidden field, which is what was just invalidated.
+    await Promise.all([
+        page.waitForNavigation({ waitUntil: 'networkidle' }),
+        page.locator('button[name="owa_action"][value="base.optionsUpdate"]').click(),
+    ]);
+}
+
+test.describe('a stale nonce on an authenticated session', () => {
+
+    test('does not ask an authenticated user to log in again', async ({ page }) => {
+        await submitWithStaleNonce(page);
+
+        expect(await onLoginForm(page), 'a signed-in user must not be re-prompted for credentials')
+            .toBe(0);
+    });
+
+    test('explains that the form lapsed rather than blaming the credentials', async ({ page }) => {
+        await submitWithStaleNonce(page);
+
+        const body = (await page.content()).toLowerCase();
+
+        expect(body, 'the page should say the form is no longer usable')
+            .toMatch(/(no longer valid|expired|still signed in)/);
+
+        expect(body, 'it must not suggest the password was wrong')
+            .not.toMatch(/user name or password did not match/);
+
+        // The capability page is a different refusal; matching it would mean the
+        // request never reached the nonce check.
+        expect(body, 'this should be the nonce refusal, not the capability one')
+            .not.toMatch(/lacks the necessary privileges/);
+    });
+
+    /**
+     * The nonce exists so a state-changing request is one the user just
+     * confirmed. Refusing it must not quietly apply the change anyway.
+     */
+    test('does not carry out the action', async ({ page }) => {
+        await submitWithStaleNonce(page);
+
+        const body = (await page.content()).toLowerCase();
+
+        expect(body, 'a refused action must not report success').not.toMatch(/success/);
+    });
+});

--- a/tests/e2e/nonce-expiry.spec.js
+++ b/tests/e2e/nonce-expiry.spec.js
@@ -56,7 +56,7 @@ test.describe('a stale nonce on an authenticated session', () => {
         const body = (await page.content()).toLowerCase();
 
         expect(body, 'the page should say the form is no longer usable')
-            .toMatch(/(no longer valid|expired|still signed in)/);
+            .toMatch(/(no longer valid|expired)/);
 
         expect(body, 'it must not suggest the password was wrong')
             .not.toMatch(/user name or password did not match/);

--- a/tests/e2e/nonce-expiry.spec.js
+++ b/tests/e2e/nonce-expiry.spec.js
@@ -68,6 +68,28 @@ test.describe('a stale nonce on an authenticated session', () => {
     });
 
     /**
+     * Telling someone to start over is only actionable with the way back. The
+     * form was submitted from base.optionsGeneral, so that is where the link
+     * goes -- and loading it mints a nonce that will verify.
+     */
+    test('offers the way back to the screen the form came from', async ({ page }) => {
+        await submitWithStaleNonce(page);
+
+        const back = page.locator('a[href*="base.optionsGeneral"]');
+
+        await expect(back, 'the originating screen should be linked').toHaveCount(1);
+
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'networkidle' }),
+            back.first().click(),
+        ]);
+
+        // Back on a working form, with a nonce minted for this session.
+        await expect(page.locator('input[name="owa_nonce"]')).toHaveCount(1);
+        expect(await onLoginForm(page), 'and still signed in').toBe(0);
+    });
+
+    /**
      * The nonce exists so a state-changing request is one the user just
      * confirmed. Refusing it must not quietly apply the change anyway.
      */


### PR DESCRIPTION
The second half of #979.

A missing session and a nonce that did not verify both reached
`notAuthenticatedAction()`, so someone already signed in was shown the login
form. That is untrue and unactionable -- they re-enter credentials that were
never the problem -- and it is why the report read as an authentication failure
rather than an expired token.

A nonce carries a time window and the `user_id` it was minted for, so it lapses
for perfectly valid sessions: a form left open too long, or one rendered before
signing in as somebody else.

- `nonceFailedAction()` handles the nonce case. Not signed in still goes to the
  login form; signed in gets `base.error`, or a 403 through `base.restApi` under
  the REST endpoint.
- The action is deliberately not retried once a fresh nonce could be minted. The
  nonce exists so a state-changing request is one the user just confirmed.

Also fixes `View\Error`, which set the error template but never passed
`error_msg` into the body scope, so `generic_error.php` always rendered its
placeholder. That affected the existing capability-denied page too, which is why
the reason for an error has not been visible on that screen.

Unit tests cover the branch selection; the e2e covers the dispatch, driven
through the real options form. Building the URL by hand does not reach the nonce
check at all -- the capability check runs first -- so one assertion explicitly
rejects the capability page to stop the spec passing for the wrong reason.

334 unit tests green, 3 e2e green. Verified non-vacuous: reverting the dispatch
fails 2 of 3 e2e while the unit tests stay green, and disabling the `View\Error`
pass-through fails 1 of 3.

Stacked on #980.
