### PR TITLE
fix: fix incorrect wiki URL

### DIFF
--- a/modules/Base/templates/options.php
+++ b/modules/Base/templates/options.php
@@ -10,7 +10,7 @@
     <TR>
         <TD colspan="2" class="introtext">
             <P>You are using <strong>Open Web Analytics <?php $view->out(OWA_VERSION);?></strong></P>
-            <P>Open Web Analytics has several configuration options that can be set using the controls below. Once changes are made click the "save" button to save the configuration to the database. To learn more about configuring OWA, visit the <a href="http://wiki.openwebanalytics.com">OWA Wiki</a></P>
+            <P>Open Web Analytics has several configuration options that can be set using the controls below. Once changes are made click the "save" button to save the configuration to the database. To learn more about configuring OWA, visit the <a href="https://github.com/Open-Web-Analytics/Open-Web-Analytics/wiki">OWA Wiki</a></P>
         </TD>
     </TR>
     <TR>


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [x] Build (`npm run build`) was run locally and any changes were pushed

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## What is the current behavior?
Currently, the wiki link in the settings is a broken link to wiki.openwebanalytics.com

Issue Number: #900


## What is the new behavior?
Replaced the link with a link to the documentation on github, the same as the larger "Documentation" button in the main menu.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Docs need to be updated?

- [ ] Yes
- [x] No

## Other information
