### PR TITLE
chore(deps): pin patched js-yaml and fast-uri through overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4354,9 +4354,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5775,9 +5775,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "webpack-cli": "^4.9.1"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8"
+    "brace-expansion": "^5.0.8",
+    "js-yaml": "^3.15.1",
+    "fast-uri": "^3.1.5"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",


### PR DESCRIPTION
Two open Dependabot alerts, both **transitive devDependencies**:

| package | from | to | advisory |
|---|---|---|---|
| `js-yaml` | 3.15.0 | 3.15.1 | quadratic CPU consumption in `!!omap` resolution |
| `fast-uri` | 3.1.4 | 3.1.5 | host confusion via backslash authority introducer |

Dependency paths:

```
js-yaml   babel-jest -> babel-plugin-istanbul -> @istanbuljs/load-nyc-config
fast-uri  copy-webpack-plugin -> schema-utils -> ajv
```

## Exposure

Neither is a runtime dependency, and neither appears in the shipped tracker bundle — `js-yaml=0 fast-uri=0` in `public/base/dist/owa.tracker.js`. Both roots are `devDependencies`, so no installation is affected: `js-yaml` parses the nyc config at test time, and `fast-uri` validates webpack schema options at build time. Neither reaches untrusted input in this project. GitHub rates the CVEs high in general; the exposure here is build-tooling housekeeping.

## The change

Raised through the **existing** `overrides` block rather than by bumping `babel-jest` or `copy-webpack-plugin`, which keeps the diff to the two packages named in the advisories. `package-lock.json` moves 12 lines; nothing else.

## Verification

- `npm ls` confirms both resolve to the patched versions (`js-yaml@3.15.1 overridden`, `fast-uri@3.1.5 overridden`)
- Jest: **24 suites, 220 tests, all passing** — exercises the `babel-jest` path
- `npm run build`: succeeds, exercising the `copy-webpack-plugin` path; the only warnings are the pre-existing font-awesome asset-size advisories
- The build regenerated its artifacts byte-identically, so the diff is the two dependency files only