### PR TITLE
fix(db): stop addIndex() adding duplicate copies of an index

### DIFF
--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1037,12 +1037,75 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
+     * Normalizes a column list into its canonical comma-separated form.
+     *
+     * Callers pass either 'yyyymmdd' or 'action_group, action_name'. The
+     * comparison against information_schema needs the form GROUP_CONCAT
+     * produces, so whitespace is removed. Returns an empty array if any part is
+     * not a bare identifier, which is the caller's signal to refuse.
+     */
+    protected function normalizeIndexColumns( $column_name ) {
+
+        $cols = array();
+
+        foreach ( explode( ',', (string) $column_name ) as $col ) {
+
+            $col = trim( $col );
+
+            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $col ) ) {
+
+                return array();
+            }
+
+            $cols[] = $col;
+        }
+
+        return $cols;
+    }
+
+    /**
+     * Is there already an index covering exactly these columns?
+     *
+     * Schema introspection is driver-specific, so the driver answers this. A
+     * driver that cannot introspect reports false, which preserves the old
+     * add-unconditionally behaviour rather than silently skipping the index.
+     */
+    function indexExists( $table_name, $column_name ) {
+
+        return false;
+    }
+
+    /**
      * Adds index to a column
      *
+     * Does nothing when an index over the same columns is already present.
+     * addIndex() ran unnamed, so MySQL assigned a name each time and repeated
+     * calls -- an update re-run, or two updates covering the same table --
+     * silently accumulated duplicate copies rather than failing.
      */
     function addIndex($table_name, $column_name, $index_definition = '') {
 
-        return $this->query(sprintf(OWA_SQL_ADD_INDEX, $table_name, $column_name, $index_definition));
+        $cols = $this->normalizeIndexColumns( $column_name );
+
+        if ( ! $cols || ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            \OWA\Core\CoreAPI::notice( sprintf( 'Refusing to index %s (%s): not a bare identifier.', $table_name, $column_name ) );
+
+            return false;
+        }
+
+        if ( $this->indexExists( $table_name, $column_name ) ) {
+
+            return true;
+        }
+
+        // Name it, so a later run is recognisable and this stays diagnosable.
+        // MySQL caps identifiers at 64 characters.
+        $index_name = substr( 'idx_' . implode( '_', $cols ), 0, 64 );
+
+        return $this->query(
+            sprintf( OWA_SQL_ADD_NAMED_INDEX, $table_name, $index_name, implode( ', ', $cols ), $index_definition )
+        );
     }
 
     /**

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -69,6 +69,17 @@ define('OWA_SQL_REGEXP', 'REGEXP');
 define('OWA_SQL_NOTREGEXP', 'NOT REGEXP');
 define('OWA_SQL_LIKE', 'LIKE');
 define('OWA_SQL_ADD_INDEX', 'ALTER TABLE %s ADD INDEX (%s) %s');
+// Named form. The unnamed one above lets MySQL pick the name, so repeating it
+// yields site_id, site_id_2, site_id_3 rather than failing as a duplicate.
+define('OWA_SQL_ADD_NAMED_INDEX', 'ALTER TABLE %s ADD INDEX %s (%s) %s');
+// Does an index covering exactly this column list already exist? Matched on the
+// columns, not the name, so indexes MySQL auto-named are recognised too.
+define('OWA_SQL_INDEX_EXISTS',
+    "SELECT COUNT(*) AS n FROM ( "
+  . "SELECT INDEX_NAME FROM information_schema.STATISTICS "
+  . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' "
+  . "GROUP BY INDEX_NAME "
+  . "HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = '%s' ) x");
 define('OWA_SQL_COUNT', 'COUNT(%s)');
 define('OWA_SQL_SUM', 'SUM(%s)');
 define('OWA_SQL_ROUND', 'ROUND(%s)');
@@ -287,6 +298,32 @@ class Mysql extends \OWA\Core\Db {
         $row = mysqli_fetch_assoc($this->new_result);
 
         return $row;
+    }
+
+    /**
+     * Is there already an index covering exactly these columns?
+     *
+     * Matched on the column list rather than the index name, so an index MySQL
+     * named itself -- site_id, site_id_2 -- is recognised as covering site_id.
+     *
+     * @param string $table_name
+     * @param string $column_name  one column, or a comma-separated list
+     * @return bool
+     */
+    function indexExists( $table_name, $column_name ) {
+
+        $cols = $this->normalizeIndexColumns( $column_name );
+
+        if ( ! $cols || ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            return false;
+        }
+
+        $row = $this->get_row(
+            sprintf( OWA_SQL_INDEX_EXISTS, $table_name, implode( ',', $cols ) )
+        );
+
+        return ( is_array( $row ) && isset( $row['n'] ) && (int) $row['n'] > 0 );
     }
 
     /**

--- a/tests/AddIndexIdempotentTest.php
+++ b/tests/AddIndexIdempotentTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * addIndex() must not add a second copy of an index it already has.
+ *
+ * The statement behind it was 'ALTER TABLE %s ADD INDEX (%s)' -- unnamed, so
+ * MySQL assigned the name. Repeating the call therefore succeeded and produced
+ * site_id, site_id_2, site_id_3 rather than failing as a duplicate. Two update
+ * scripts index overlapping tables (Update005 adds yyyymmdd, Update007 adds
+ * site_id/session_id to the same set), and a re-run adds another copy again, so
+ * upgraded installations accumulate exact duplicates -- paid for on every
+ * INSERT, which on a tracker is the hot path.
+ *
+ * These run against a scratch table so nothing existing is touched.
+ */
+final class AddIndexIdempotentTest extends TestCase
+{
+    /** @var string scratch table, dropped in tearDown */
+    private $table;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable; skipping index test.');
+        }
+
+        $this->table = 'owa_test_idx_' . bin2hex(random_bytes(4));
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->query(sprintf(
+            'CREATE TABLE %s (id BIGINT NOT NULL, site_id INT, yyyymmdd INT, action_name VARCHAR(32), PRIMARY KEY (id))',
+            $this->table
+        ));
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->table) {
+            \OWA\Core\CoreAPI::dbSingleton()->query(sprintf('DROP TABLE IF EXISTS %s', $this->table));
+        }
+    }
+
+    /** How many indexes currently cover exactly this column list. */
+    private function copies($columns)
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $row = $db->get_row(sprintf(
+            "SELECT COUNT(*) AS n FROM ( SELECT INDEX_NAME FROM information_schema.STATISTICS "
+          . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' GROUP BY INDEX_NAME "
+          . "HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = '%s' ) x",
+            $this->table,
+            $columns
+        ));
+
+        return (int) $row['n'];
+    }
+
+    /** The regression: calling twice used to leave two indexes. */
+    public function testRepeatedCallsLeaveASingleIndex()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->addIndex($this->table, 'yyyymmdd');
+        $this->assertSame(1, $this->copies('yyyymmdd'), 'first call should create the index');
+
+        $db->addIndex($this->table, 'yyyymmdd');
+        $db->addIndex($this->table, 'yyyymmdd');
+
+        $this->assertSame(1, $this->copies('yyyymmdd'), 'repeat calls must not add copies');
+    }
+
+    /** Multi-column lists are matched as a set, whitespace and all. */
+    public function testMultiColumnIndexIsAlsoIdempotent()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->addIndex($this->table, 'site_id, action_name');
+        $db->addIndex($this->table, 'site_id,action_name');
+
+        $this->assertSame(1, $this->copies('site_id,action_name'), 'spacing must not defeat the check');
+    }
+
+    /**
+     * An index MySQL named itself is what existing installations have, so the
+     * check has to recognise it by columns rather than by name.
+     */
+    public function testAnAutoNamedIndexIsRecognised()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        // Exactly what the old unnamed statement produced.
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (site_id)', $this->table));
+        $this->assertSame(1, $this->copies('site_id'));
+
+        $this->assertTrue($db->indexExists($this->table, 'site_id'), 'auto-named index should be seen');
+
+        $db->addIndex($this->table, 'site_id');
+        $this->assertSame(1, $this->copies('site_id'), 'must not add alongside an auto-named index');
+    }
+
+    /** A column list that is not a bare identifier reaches an ALTER, so refuse it. */
+    public function testNonIdentifierColumnIsRefused()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $this->assertFalse($db->addIndex($this->table, 'yyyymmdd); DROP TABLE x; --'));
+        $this->assertSame(0, $this->copies('yyyymmdd'), 'nothing should have been indexed');
+    }
+}


### PR DESCRIPTION
`addIndex()` issued an **unnamed** index statement:

```php
define('OWA_SQL_ADD_INDEX', 'ALTER TABLE %s ADD INDEX (%s) %s');
```

MySQL therefore assigned the name, so repeating the call succeeded and produced `site_id`, `site_id_2`, `site_id_3` rather than failing as a duplicate.

It is reachable on a normal upgrade path, not only by re-running: `Update005` indexes `yyyymmdd` on four tables, and `Update007` indexes `site_id`/`session_id` on the same set plus more `yyyymmdd`. Each further run adds another round.

Duplicates cost space and are paid for on **every INSERT** — the tracker's hot path.

## The change

- `addIndex()` returns early when an index over the same columns already exists, and **names** the ones it creates (`idx_<cols>`), so a later run is recognisable.
- Existence is matched on the **column list, not the index name**, so the indexes MySQL auto-named on existing installations are recognised.
- Introspection is driver-specific, so `Mysql` answers `indexExists()`; the base class reports `false`, which keeps the old add-unconditionally behaviour for a driver that cannot introspect rather than silently skipping the index.
- Table names and column lists are validated as bare identifiers first — both reach an `ALTER` by concatenation.

## Tests

`tests/AddIndexIdempotentTest.php` works on a scratch table and covers: repeated calls leaving one index; multi-column lists where spacing differs (`'site_id, action_name'` vs `'site_id,action_name'`); an **auto-named** index being recognised (what existing installs actually have); and a non-identifier column list being refused.

Verified the tests fail without the fix — `Failed asserting that 3 is identical to 1`, reproducing the exact duplication — and pass with it. Full suite: 356 tests, 2784 assertions, green. phpstan on the changed files adds no new errors (the 3 reported in `Db/Mysql.php` are pre-existing on master).

## Scope

This stops new duplicates. It does **not** remove those already present — that is a separate migration, and worth doing: on one real installation the redundant copies total ~196 MB across 33 indexes.