### PR TITLE
fix(db): drop indexes that duplicate another exactly (Update013)

### DIFF
--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1076,6 +1076,65 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
+     * Every non-primary index on the OWA tables.
+     *
+     * Schema introspection is driver-specific. A driver that cannot introspect
+     * reports nothing, so callers see no indexes rather than a wrong answer.
+     *
+     * @return array
+     */
+    function listIndexes() {
+
+        return array();
+    }
+
+    /**
+     * Indexes that duplicate another index on the same table, exactly.
+     *
+     * Same columns in the same order, same uniqueness, same type. The first by
+     * name is kept and the rest are returned as removable, so the result is
+     * stable and one index always survives for each column list.
+     *
+     * Reporting is separated from removing so the decision can be inspected --
+     * and tested -- without touching the schema.
+     *
+     * @return array of ['t' => table, 'i' => index, 'cols' => column list, 'keeping' => index kept]
+     */
+    function getDuplicateIndexes( $only_table = null ) {
+
+        $seen = array();
+        $dupes = array();
+
+        foreach ( $this->listIndexes() as $row ) {
+
+            if ( $only_table !== null && $row['t'] !== $only_table ) {
+
+                continue;
+            }
+
+            // Uniqueness and type are part of the identity: a unique index and a
+            // non-unique one over the same columns are not copies of each other.
+            $key = $row['t'] . "\0" . $row['cols'] . "\0" . $row['nu'] . "\0" . $row['ty'];
+
+            if ( isset( $seen[ $key ] ) ) {
+
+                $dupes[] = array(
+                    't'       => $row['t'],
+                    'i'       => $row['i'],
+                    'cols'    => $row['cols'],
+                    'keeping' => $seen[ $key ],
+                );
+
+            } else {
+
+                $seen[ $key ] = $row['i'];
+            }
+        }
+
+        return $dupes;
+    }
+
+    /**
      * Adds index to a column
      *
      * Does nothing when an index over the same columns is already present.

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -74,6 +74,18 @@ define('OWA_SQL_ADD_INDEX', 'ALTER TABLE %s ADD INDEX (%s) %s');
 define('OWA_SQL_ADD_NAMED_INDEX', 'ALTER TABLE %s ADD INDEX %s (%s) %s');
 // Does an index covering exactly this column list already exist? Matched on the
 // columns, not the name, so indexes MySQL auto-named are recognised too.
+// Every non-primary index on the OWA tables, with the column list that
+// identifies it. Grouped in PHP rather than SQL so the "keep one" decision is
+// visible and testable. Uniqueness and type are reported so indexes that merely
+// share columns are not mistaken for copies of each other.
+define('OWA_SQL_LIST_INDEXES',
+    "SELECT TABLE_NAME AS t, INDEX_NAME AS i, NON_UNIQUE AS nu, INDEX_TYPE AS ty, "
+  . "GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS cols "
+  . "FROM information_schema.STATISTICS "
+  . "WHERE TABLE_SCHEMA = DATABASE() AND INDEX_NAME <> 'PRIMARY' "
+  . "AND TABLE_NAME LIKE 'owa\\\\_%%' "
+  . "GROUP BY TABLE_NAME, INDEX_NAME, NON_UNIQUE, INDEX_TYPE "
+  . "ORDER BY TABLE_NAME, INDEX_NAME");
 define('OWA_SQL_INDEX_EXISTS',
     "SELECT COUNT(*) AS n FROM ( "
   . "SELECT INDEX_NAME FROM information_schema.STATISTICS "
@@ -324,6 +336,23 @@ class Mysql extends \OWA\Core\Db {
         );
 
         return ( is_array( $row ) && isset( $row['n'] ) && (int) $row['n'] > 0 );
+    }
+
+    /**
+     * Every non-primary index on the OWA tables.
+     *
+     * Scoped to the 'owa_' prefix because an installation may share its
+     * database with another application -- WordPress, typically -- and nothing
+     * here should look at, let alone touch, tables OWA does not own.
+     *
+     * @return array of ['t' => table, 'i' => index, 'nu' => non_unique,
+     *                   'ty' => type, 'cols' => comma-separated column list]
+     */
+    function listIndexes() {
+
+        $rows = $this->get_results( OWA_SQL_LIST_INDEXES );
+
+        return is_array( $rows ) ? $rows : array();
     }
 
     /**

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -46,7 +46,7 @@ class Module extends \OWA\Core\Module {
         $this->version = 11;
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
-        $this->required_schema_version = 12;
+        $this->required_schema_version = 13;
         return parent::__construct();
     }
 

--- a/modules/Base/Update/Update013.php
+++ b/modules/Base/Update/Update013.php
@@ -1,0 +1,102 @@
+<?php
+namespace OWA\Module\Base\Update;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * Remove indexes that duplicate another index on the same table, exactly.
+ *
+ * addIndex() issued an unnamed statement -- 'ALTER TABLE x ADD INDEX (col)' --
+ * so MySQL assigned the name and a repeated call produced site_id, site_id_2,
+ * site_id_3 rather than failing as a duplicate. It was reachable on an ordinary
+ * upgrade, not only by re-running: Update005 indexes yyyymmdd on four tables and
+ * Update007 indexes site_id/session_id on the same set plus more yyyymmdd.
+ *
+ * The copies are exact, so they can never be chosen over the original -- they
+ * only take space and are written on every INSERT, which on a tracker is the
+ * hot path. One observed installation carried 33 redundant copies totalling
+ * ~196MB, on tables whose indexes are hit by every logged event.
+ *
+ * addIndex() no longer creates them, so this is a one-off repair of the installs
+ * that already have them.
+ *
+ * What it will not do:
+ *  - touch PRIMARY, or any table outside the 'owa_' prefix, since an install may
+ *    share its database with another application
+ *  - remove the last index over a given column list; one always survives
+ *  - treat a unique and a non-unique index over the same columns as copies
+ *  - rename what survives. Renaming means rebuilding the index, which on a large
+ *    fact table is expensive and buys nothing.
+ */
+class Update013 extends \OWA\Core\Update {
+
+    var $schema_version = 13;
+
+    function up($force = true) {
+
+        $result = self::repair( \OWA\Core\CoreAPI::dbSingleton() );
+
+        if ( ! $result['dropped'] && ! $result['failed'] ) {
+
+            \OWA\Core\CoreAPI::notice( 'No duplicate indexes found.' );
+
+            return true;
+        }
+
+        foreach ( $result['dropped'] as $line ) {
+
+            \OWA\Core\CoreAPI::notice( $line );
+        }
+
+        \OWA\Core\CoreAPI::notice( sprintf( 'Dropped %d duplicate index(es).', count( $result['dropped'] ) ) );
+
+        if ( $result['failed'] ) {
+
+            // Report and carry on. A duplicate left in place costs space, which
+            // is not a reason to fail the upgrade and strand the schema version.
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Could not drop %d index(es): %s. They are duplicates and can be removed by hand.',
+                count( $result['failed'] ), implode( ', ', $result['failed'] )
+            ) );
+        }
+
+        return true;
+    }
+
+    /**
+     * Drop every duplicate, keeping one index per column list.
+     *
+     * Separated from up() so it can be exercised against a single table. The
+     * update itself passes no filter and therefore covers the whole schema.
+     *
+     * @param object $db
+     * @param string|null $only_table  restrict to one table; null means all
+     * @return array ['dropped' => string[], 'failed' => string[]]
+     */
+    public static function repair( $db, $only_table = null ) {
+
+        $dropped = array();
+        $failed  = array();
+
+        foreach ( $db->getDuplicateIndexes( $only_table ) as $dupe ) {
+
+            // dropIndex() takes the index name, which came from
+            // information_schema rather than from user input.
+            if ( $db->dropIndex( $dupe['t'], $dupe['i'] ) ) {
+
+                $dropped[] = sprintf(
+                    'Dropped duplicate index %s on %s (%s); %s covers the same columns.',
+                    $dupe['i'], $dupe['t'], $dupe['cols'], $dupe['keeping']
+                );
+
+            } else {
+
+                $failed[] = $dupe['t'] . '.' . $dupe['i'];
+            }
+        }
+
+        return array( 'dropped' => $dropped, 'failed' => $failed );
+    }
+}

--- a/tests/DuplicateIndexRepairTest.php
+++ b/tests/DuplicateIndexRepairTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Update013 removes indexes that duplicate another exactly, and nothing else.
+ *
+ * The duplicates exist because addIndex() ran unnamed, so MySQL assigned the
+ * name and repeated calls produced site_id, site_id_2, site_id_3 instead of
+ * failing. The copies can never be chosen over the original; they only cost
+ * space and are written on every INSERT.
+ *
+ * The risk in a repair like this is removing one too many, so the assertions
+ * below are mostly about what must survive: one index per column list, PRIMARY
+ * untouched, a unique index not mistaken for a copy of a non-unique one, and
+ * nothing outside the 'owa_' prefix considered at all.
+ */
+final class DuplicateIndexRepairTest extends TestCase
+{
+    /** @var string[] scratch tables, dropped in tearDown */
+    private $tables = array();
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable; skipping index repair test.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach ($this->tables as $t) {
+            $db->query(sprintf('DROP TABLE IF EXISTS %s', $t));
+        }
+
+        $this->tables = array();
+    }
+
+    /** A scratch table carrying the given prefix. */
+    private function makeTable($prefix = 'owa_test_dup_')
+    {
+        $name = $prefix . bin2hex(random_bytes(4));
+        $this->tables[] = $name;
+
+        \OWA\Core\CoreAPI::dbSingleton()->query(sprintf(
+            'CREATE TABLE %s (id BIGINT NOT NULL, site_id INT, yyyymmdd INT, guid BIGINT, PRIMARY KEY (id))',
+            $name
+        ));
+
+        return $name;
+    }
+
+    /** Index names present on a table, excluding PRIMARY. */
+    private function indexNames($table)
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $rows = $db->get_results(sprintf(
+            "SELECT DISTINCT INDEX_NAME AS i FROM information_schema.STATISTICS "
+          . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND INDEX_NAME <> 'PRIMARY' "
+          . "ORDER BY INDEX_NAME",
+            $table
+        ));
+
+        $names = array();
+
+        foreach ((array) $rows as $r) {
+            $names[] = $r['i'];
+        }
+
+        return $names;
+    }
+
+    /** Reproduce the historic state, then repair it. */
+    public function testDuplicatesAreRemovedAndOneSurvives()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        // Exactly what the old unnamed statement produced three times over.
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (yyyymmdd)', $t));
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (yyyymmdd)', $t));
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (yyyymmdd)', $t));
+
+        $this->assertCount(3, $this->indexNames($t), 'setup should have produced three copies');
+
+        $dupes = $db->getDuplicateIndexes();
+
+        $mine = array_values(array_filter($dupes, function ($d) use ($t) {
+            return $d['t'] === $t;
+        }));
+
+        $this->assertCount(2, $mine, 'two of the three copies are removable');
+
+        \OWA\Module\Base\Update\Update013::repair(\OWA\Core\CoreAPI::dbSingleton(), $t);
+
+        $this->assertCount(1, $this->indexNames($t), 'exactly one index must survive');
+    }
+
+    /** A clean table must be left completely alone. */
+    public function testNoDuplicatesIsANoOp()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (yyyymmdd)', $t));
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (site_id)', $t));
+
+        $before = $this->indexNames($t);
+
+        \OWA\Module\Base\Update\Update013::repair(\OWA\Core\CoreAPI::dbSingleton(), $t);
+
+        $this->assertSame($before, $this->indexNames($t), 'distinct indexes must be untouched');
+    }
+
+    /** PRIMARY is never a candidate, however the table is indexed. */
+    public function testPrimaryKeySurvives()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (id)', $t));
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (id)', $t));
+
+        \OWA\Module\Base\Update\Update013::repair(\OWA\Core\CoreAPI::dbSingleton(), $t);
+
+        $row = $db->get_row(sprintf(
+            "SELECT COUNT(*) AS n FROM information_schema.STATISTICS "
+          . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND INDEX_NAME = 'PRIMARY'",
+            $t
+        ));
+
+        $this->assertSame(1, (int) $row['n'], 'PRIMARY must still be there');
+    }
+
+    /** A unique index is not a copy of a non-unique one over the same column. */
+    public function testUniqueIndexIsNotTreatedAsADuplicate()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (guid)', $t));
+        $db->query(sprintf('ALTER TABLE %s ADD UNIQUE INDEX uniq_guid (guid)', $t));
+
+        \OWA\Module\Base\Update\Update013::repair(\OWA\Core\CoreAPI::dbSingleton(), $t);
+
+        $this->assertContains('uniq_guid', $this->indexNames($t), 'the unique index must survive');
+        $this->assertCount(2, $this->indexNames($t), 'neither should be removed');
+    }
+
+    /** Tables outside the owa_ prefix are not OWA's to touch. */
+    public function testTablesOutsideThePrefixAreIgnored()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable('wp_notowa_');
+
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (yyyymmdd)', $t));
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (yyyymmdd)', $t));
+
+        \OWA\Module\Base\Update\Update013::repair(\OWA\Core\CoreAPI::dbSingleton(), $t);
+
+        $this->assertCount(2, $this->indexNames($t), 'a foreign table must be left alone');
+    }
+}


### PR DESCRIPTION
Follow-up to #983's sibling #985, which stopped `addIndex()` creating duplicates. This removes the ones existing installations already carry.

They exist because `addIndex()` issued an **unnamed** statement, so MySQL assigned the name and a repeat produced `site_id`, `site_id_2`, `site_id_3` instead of failing. It was reachable on an ordinary upgrade: `Update005` indexes `yyyymmdd` on four tables, `Update007` indexes `site_id`/`session_id` on the same set plus more `yyyymmdd`.

The copies are exact, so they can never be chosen over the original — they only take space and are written on **every INSERT**, which on a tracker is the hot path. One observed installation carried **33 redundant copies totalling ~196 MB**, on the tables every logged event touches:

| table | columns | copies | reclaim |
|---|---|---|---|
| owa_request | site_id | 2× | 31.6 MB |
| owa_request | session_id | 2× | 24.6 MB |
| owa_domstream | domstream_guid | 3× | 21.0 MB |
| owa_click | site_id | 2× | 20.6 MB |

## Design

Discovery is at **runtime from information_schema**, not a hardcoded list — which duplicates an install has depends on how many times its updates ran.

Deliberately conservative about what it will not do:

- **scoped to the `owa_` prefix** — an install may share its database with another application (WordPress, typically), and nothing here should touch tables OWA does not own
- **never removes the last index** over a column list; the first by name is kept so the result is stable
- **PRIMARY is never a candidate**
- **a unique index is not a copy of a non-unique one** over the same columns; uniqueness and index type are part of the identity
- **survivors are not renamed** — renaming means rebuilding the index, expensive on a large fact table and it buys nothing
- a drop that fails is reported and the update continues; a duplicate left in place is not a reason to strand the schema version

`repair()` is separated from `up()` so it can be exercised against a single table, following `Update012`.

## Tests

`tests/DuplicateIndexRepairTest.php` builds scratch tables and asserts mostly about what must **survive**, since the risk in a repair is removing one too many: three copies collapse to one; a clean table is untouched; `PRIMARY` survives; a unique index is not mistaken for a duplicate; a non-`owa_` table is ignored entirely.

Also exercised end to end — applied to a real installation via `php cli.php cmd=update`, which took it from schema 12 to 13 cleanly. Full suite: 363 tests, 2796 assertions, green. phpstan adds no new errors.