### PR TITLE
fix(logging): create the error log group-writable

### DIFF
--- a/modules/Base/Classes/Error.php
+++ b/modules/Base/Classes/Error.php
@@ -339,7 +339,15 @@ class Error {
             return;
         }
 
-        $stream = new StreamHandler($path, $level);
+        // Set the mode explicitly. Without it the file inherits the umask of
+        // whichever process happens to create it, and both the web server user
+        // and the account running the CLI write to this same path. A file
+        // created under umask 022 is 0644, so the other one can no longer append
+        // -- and a log write that cannot open its file raises, which turns a
+        // notice into a fatal. The path changes whenever the instance hash does,
+        // so a new file (and a new race over who creates it) appears on every
+        // credential rotation.
+        $stream = new StreamHandler($path, $level, true, 0664);
 
 		$stream->setFormatter($formatter);
 

--- a/tests/ErrorLogFilePermissionTest.php
+++ b/tests/ErrorLogFilePermissionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The error log must be created group-writable.
+ *
+ * Two accounts write to the same file: the web server user, and whoever runs
+ * the CLI. StreamHandler was constructed without a filePermission, so the file
+ * inherited the umask of whichever process created it first -- 0664 from the
+ * web server (umask 002), but 0644 from a shell (umask 022). In the second case
+ * the web server can no longer append, and a log write that cannot open its
+ * file raises, so a notice becomes a fatal.
+ *
+ * That is not a one-off: the path embeds an instance-specific hash derived from
+ * the credentials, so a new file appears -- with a fresh race over who creates
+ * it -- on every rotation.
+ *
+ * This asserts the mode of a file the logger actually creates, rather than
+ * looking for the argument in the source, so it fails if the behaviour
+ * regresses however the code is arranged.
+ */
+final class ErrorLogFilePermissionTest extends TestCase
+{
+    /** @var string */
+    private $path;
+
+    /** @var string|null */
+    private $previous;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable; skipping log permission test.');
+        }
+
+        // isSafeLogPath() constrains where the logger will write, so stay inside
+        // the data directory the real setting uses.
+        $this->path = OWA_DATA_DIR . 'logs/errors_test_' . bin2hex(random_bytes(4)) . '.txt';
+
+        $this->previous = \OWA\Core\CoreAPI::getSetting('base', 'error_log_file');
+        \OWA\Core\CoreAPI::setSetting('base', 'error_log_file', $this->path);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->path && file_exists($this->path)) {
+            unlink($this->path);
+        }
+
+        if ($this->previous !== null) {
+            \OWA\Core\CoreAPI::setSetting('base', 'error_log_file', $this->previous);
+        }
+    }
+
+    /**
+     * A shell umask of 022 is what produced the unusable 0644 file, so set it
+     * explicitly: without an explicit permission the file would come out 0644
+     * and the assertion would fail.
+     */
+    public function testLogFileIsCreatedGroupWritable()
+    {
+        $old_umask = umask(022);
+
+        try {
+            // 'production' reaches make_file_logger() without installing the
+            // global exception handler that 'development' adds.
+            $e = new \OWA\Module\Base\Classes\Error();
+            $e->setHandler('production');
+            $e->notice('permission probe');
+
+            clearstatcache(true, $this->path);
+
+            $this->assertFileExists($this->path, 'the logger should have created its file');
+
+            $mode = fileperms($this->path) & 0777;
+
+            $this->assertSame(
+                0664,
+                $mode,
+                sprintf('expected 0664, got %o -- the group could not append', $mode)
+            );
+
+        } finally {
+            umask($old_umask);
+        }
+    }
+}


### PR DESCRIPTION
`Error::make_file_logger()` built its handler as:

```php
$stream = new StreamHandler($path, $level);
```

Monolog's third argument is `filePermission`; passing nothing leaves the file inheriting the umask of whichever process creates it. **Two accounts write to that same path** — the web server user, and whoever runs the CLI:

| creator | umask | mode | result |
|---|---|---|---|
| web server | 002 | 0664 | both can append |
| a shell | 022 | **0644** | the other cannot append |

A log write that cannot open its file *raises*, so a notice becomes a fatal. Observed in the wild: a CLI run aborting with `could not be opened in append mode` on a file the web server had created, mid-update. The reverse is worse — the web application fataling on a file a CLI run created.

It is not a one-off. The path embeds an instance-specific hash derived from `OWA_SECRET` and the database credentials, so a rotation produces a **new file and a fresh race** over which account creates it.

## The change

Pass `0664` explicitly. Monolog `chmod`s the file after creating it, so the result does not depend on the umask. Only the file handler is touched; the console handler writes to `STDOUT` and takes no permission.

## Tests

`tests/ErrorLogFilePermissionTest.php` sets `error_log_file` to a scratch path inside the data directory (`isSafeLogPath()` constrains where the logger will write), sets **umask 022** — the case that produced the broken file — drives the real logger, and asserts the mode of the file it created.

It asserts observed behaviour rather than scanning the source, so it holds however the code is arranged. Verified it fails without the fix: `expected 0664, got 644 -- the group could not append`. Full suite: 364 tests, 2798 assertions, green.