### PR TITLE
fix(db): index visitor_id on the fact tables

### DIFF
--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1089,20 +1089,6 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
-     * OWA tables that carry the given column.
-     *
-     * Schema introspection is driver-specific. A driver that cannot introspect
-     * reports nothing, so callers index nothing rather than guess.
-     *
-     * @param string $column_name
-     * @return string[]
-     */
-    function getTablesWithColumn( $column_name ) {
-
-        return array();
-    }
-
-    /**
      * Indexes that duplicate another index on the same table, exactly.
      *
      * Same columns in the same order, same uniqueness, same type. The first by

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1089,6 +1089,20 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
+     * OWA tables that carry the given column.
+     *
+     * Schema introspection is driver-specific. A driver that cannot introspect
+     * reports nothing, so callers index nothing rather than guess.
+     *
+     * @param string $column_name
+     * @return string[]
+     */
+    function getTablesWithColumn( $column_name ) {
+
+        return array();
+    }
+
+    /**
      * Indexes that duplicate another index on the same table, exactly.
      *
      * Same columns in the same order, same uniqueness, same type. The first by

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -72,33 +72,6 @@ define('OWA_SQL_ADD_INDEX', 'ALTER TABLE %s ADD INDEX (%s) %s');
 // Named form. The unnamed one above lets MySQL pick the name, so repeating it
 // yields site_id, site_id_2, site_id_3 rather than failing as a duplicate.
 define('OWA_SQL_ADD_NAMED_INDEX', 'ALTER TABLE %s ADD INDEX %s (%s) %s');
-// Does an index covering exactly this column list already exist? Matched on the
-// columns, not the name, so indexes MySQL auto-named are recognised too.
-// Every non-primary index on the OWA tables, with the column list that
-// identifies it. Grouped in PHP rather than SQL so the "keep one" decision is
-// visible and testable. Uniqueness and type are reported so indexes that merely
-// share columns are not mistaken for copies of each other.
-define('OWA_SQL_LIST_INDEXES',
-    "SELECT TABLE_NAME AS t, INDEX_NAME AS i, NON_UNIQUE AS nu, INDEX_TYPE AS ty, "
-  . "GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS cols "
-  . "FROM information_schema.STATISTICS "
-  . "WHERE TABLE_SCHEMA = DATABASE() AND INDEX_NAME <> 'PRIMARY' "
-  . "AND TABLE_NAME LIKE 'owa\\\\_%%' "
-  . "GROUP BY TABLE_NAME, INDEX_NAME, NON_UNIQUE, INDEX_TYPE "
-  . "ORDER BY TABLE_NAME, INDEX_NAME");
-// OWA tables carrying a given column. Used to index a column wherever it
-// appears, including fact tables a module contributes, rather than working from
-// a list that goes stale.
-define('OWA_SQL_TABLES_WITH_COLUMN',
-    "SELECT TABLE_NAME AS t FROM information_schema.COLUMNS "
-  . "WHERE TABLE_SCHEMA = DATABASE() AND COLUMN_NAME = '%s' "
-  . "AND TABLE_NAME LIKE 'owa\\\\_%%' ORDER BY TABLE_NAME");
-define('OWA_SQL_INDEX_EXISTS',
-    "SELECT COUNT(*) AS n FROM ( "
-  . "SELECT INDEX_NAME FROM information_schema.STATISTICS "
-  . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' "
-  . "GROUP BY INDEX_NAME "
-  . "HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = '%s' ) x");
 define('OWA_SQL_COUNT', 'COUNT(%s)');
 define('OWA_SQL_SUM', 'SUM(%s)');
 define('OWA_SQL_ROUND', 'ROUND(%s)');
@@ -338,8 +311,16 @@ class Mysql extends \OWA\Core\Db {
             return false;
         }
 
+        // Matched on the column list, which is what GROUP_CONCAT returns in
+        // SEQ_IN_INDEX order, so the name MySQL happened to assign is irrelevant.
+        $sql = "SELECT COUNT(*) AS n FROM ( "
+             . "SELECT INDEX_NAME FROM information_schema.STATISTICS "
+             . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' "
+             . "GROUP BY INDEX_NAME "
+             . "HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = '%s' ) x";
+
         $row = $this->get_row(
-            sprintf( OWA_SQL_INDEX_EXISTS, $table_name, implode( ',', $cols ) )
+            sprintf( $sql, $table_name, implode( ',', $cols ) )
         );
 
         return ( is_array( $row ) && isset( $row['n'] ) && (int) $row['n'] > 0 );
@@ -357,37 +338,22 @@ class Mysql extends \OWA\Core\Db {
      */
     function listIndexes() {
 
-        $rows = $this->get_results( OWA_SQL_LIST_INDEXES );
+        // Scoped to the 'owa_' prefix: an installation may share its database
+        // with another application. Uniqueness and type come back too, so
+        // indexes that merely share columns are not mistaken for copies of each
+        // other. The grouping is left to the caller so the "keep one" decision
+        // stays in PHP, where it can be read and tested.
+        $sql = "SELECT TABLE_NAME AS t, INDEX_NAME AS i, NON_UNIQUE AS nu, INDEX_TYPE AS ty, "
+             . "GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS cols "
+             . "FROM information_schema.STATISTICS "
+             . "WHERE TABLE_SCHEMA = DATABASE() AND INDEX_NAME <> 'PRIMARY' "
+             . "AND TABLE_NAME LIKE 'owa\\\\_%' "
+             . "GROUP BY TABLE_NAME, INDEX_NAME, NON_UNIQUE, INDEX_TYPE "
+             . "ORDER BY TABLE_NAME, INDEX_NAME";
+
+        $rows = $this->get_results( $sql );
 
         return is_array( $rows ) ? $rows : array();
-    }
-
-    /**
-     * OWA tables that carry the given column.
-     *
-     * Scoped to the 'owa_' prefix for the same reason listIndexes() is: an
-     * installation may share its database with another application.
-     *
-     * @param string $column_name
-     * @return string[] table names
-     */
-    function getTablesWithColumn( $column_name ) {
-
-        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $column_name ) ) {
-
-            return array();
-        }
-
-        $rows = $this->get_results( sprintf( OWA_SQL_TABLES_WITH_COLUMN, $column_name ) );
-
-        $tables = array();
-
-        foreach ( (array) $rows as $row ) {
-
-            $tables[] = $row['t'];
-        }
-
-        return $tables;
     }
 
     /**

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -86,6 +86,13 @@ define('OWA_SQL_LIST_INDEXES',
   . "AND TABLE_NAME LIKE 'owa\\\\_%%' "
   . "GROUP BY TABLE_NAME, INDEX_NAME, NON_UNIQUE, INDEX_TYPE "
   . "ORDER BY TABLE_NAME, INDEX_NAME");
+// OWA tables carrying a given column. Used to index a column wherever it
+// appears, including fact tables a module contributes, rather than working from
+// a list that goes stale.
+define('OWA_SQL_TABLES_WITH_COLUMN',
+    "SELECT TABLE_NAME AS t FROM information_schema.COLUMNS "
+  . "WHERE TABLE_SCHEMA = DATABASE() AND COLUMN_NAME = '%s' "
+  . "AND TABLE_NAME LIKE 'owa\\\\_%%' ORDER BY TABLE_NAME");
 define('OWA_SQL_INDEX_EXISTS',
     "SELECT COUNT(*) AS n FROM ( "
   . "SELECT INDEX_NAME FROM information_schema.STATISTICS "
@@ -353,6 +360,34 @@ class Mysql extends \OWA\Core\Db {
         $rows = $this->get_results( OWA_SQL_LIST_INDEXES );
 
         return is_array( $rows ) ? $rows : array();
+    }
+
+    /**
+     * OWA tables that carry the given column.
+     *
+     * Scoped to the 'owa_' prefix for the same reason listIndexes() is: an
+     * installation may share its database with another application.
+     *
+     * @param string $column_name
+     * @return string[] table names
+     */
+    function getTablesWithColumn( $column_name ) {
+
+        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $column_name ) ) {
+
+            return array();
+        }
+
+        $rows = $this->get_results( sprintf( OWA_SQL_TABLES_WITH_COLUMN, $column_name ) );
+
+        $tables = array();
+
+        foreach ( (array) $rows as $row ) {
+
+            $tables[] = $row['t'];
+        }
+
+        return $tables;
     }
 
     /**

--- a/Core/Entity/FactTable.php
+++ b/Core/Entity/FactTable.php
@@ -43,6 +43,11 @@ class FactTable extends \OWA\Core\Entity {
         
         $columns['visitor_id'] = new \OWA\Module\Base\Classes\DbColumn('visitor_id', OWA_DTD_BIGINT);
         $columns['visitor_id']->setForeignKey('base.visitor');
+        // Reports filter on this: a visitor-scoped request reaches
+        // where('visitor_id', ...) in the REST controller. Without an index
+        // that is a full scan of the fact table, which is the largest one there
+        // is. session_id and site_id below have always had one.
+        $columns['visitor_id']->setIndex();
     
         $columns['session_id'] = new \OWA\Module\Base\Classes\DbColumn('session_id', OWA_DTD_BIGINT);
         $columns['session_id']->setForeignKey('base.session');

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -46,7 +46,7 @@ class Module extends \OWA\Core\Module {
         $this->version = 11;
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
-        $this->required_schema_version = 13;
+        $this->required_schema_version = 14;
         return parent::__construct();
     }
 

--- a/modules/Base/Update/Update013.php
+++ b/modules/Base/Update/Update013.php
@@ -66,6 +66,25 @@ class Update013 extends \OWA\Core\Update {
     }
 
     /**
+     * Not reversible, deliberately.
+     *
+     * Reversing it means recreating indexes that were exact copies of ones the
+     * table still has. They could never be chosen over the original, so putting
+     * them back would restore the cost -- space, and a write on every INSERT --
+     * without restoring any capability. Nothing was lost that could be wanted
+     * back, so this reports and succeeds rather than failing the rollback.
+     */
+    function down() {
+
+        \OWA\Core\CoreAPI::notice(
+            'Update013 is not reversible: it only removed indexes that duplicated '
+            . 'another index on the same table, which changes no query behaviour.'
+        );
+
+        return true;
+    }
+
+    /**
      * Drop every duplicate, keeping one index per column list.
      *
      * Separated from up() so it can be exercised against a single table. The

--- a/modules/Base/Update/Update014.php
+++ b/modules/Base/Update/Update014.php
@@ -8,12 +8,10 @@ namespace OWA\Module\Base\Update;
 /**
  * Index visitor_id on the fact tables.
  *
- * The column has always been declared on FactTable and has always been filtered
- * on -- a visitor-scoped report reaches where('visitor_id', ...) in the REST
- * controller -- but it never had an index, unlike session_id and site_id
- * alongside it. Every such request was a full scan of the largest tables in the
- * schema; on one installation that is 617k rows for owa_request and 279k for
- * owa_session, per request, with no index available at all:
+ * The column is declared on FactTable and is filtered on -- a visitor-scoped
+ * report reaches where('visitor_id', ...) in the REST controller -- but it never
+ * had an index, unlike session_id and site_id alongside it. Every such request
+ * scanned the largest tables in the schema:
  *
  *   SELECT ... FROM owa_request WHERE visitor_id = ?
  *   -> type=ALL  possible_keys=NULL  rows=617754
@@ -21,9 +19,10 @@ namespace OWA\Module\Base\Update;
  * FactTable now calls setIndex() on the column, which covers new installations.
  * This adds it to the ones already built.
  *
- * The tables are discovered from the schema rather than listed here, so a fact
- * table contributed by a module is covered too. addIndex() is idempotent as of
- * schema 13, so a table that already has the index is left alone.
+ * The fact tables come from the module's own entity registry, so the set stays
+ * correct as entities are added, and the table names come from the entities
+ * themselves rather than being spelled out here. addIndex() is idempotent as of
+ * schema 13, so an entity that already has the index is left alone.
  */
 class Update014 extends \OWA\Core\Update {
 
@@ -32,21 +31,28 @@ class Update014 extends \OWA\Core\Update {
     function up($force = true) {
 
         $db = \OWA\Core\CoreAPI::dbSingleton();
+        $s  = \OWA\Core\CoreAPI::serviceSingleton();
 
-        $tables = $db->getTablesWithColumn( 'visitor_id' );
-
-        if ( ! $tables ) {
-
-            \OWA\Core\CoreAPI::notice( 'No tables carry a visitor_id column.' );
-
-            return true;
-        }
+        $entities = $s->modules[ $this->module_name ]->getEntities();
 
         $added   = 0;
         $present = 0;
         $failed  = array();
 
-        foreach ( $tables as $table ) {
+        foreach ( $entities as $name ) {
+
+            $entity = \OWA\Core\CoreAPI::entityFactory( $this->module_name . '.' . $name );
+
+            // Only the fact tables carry visitor_id. Asking the entity is what
+            // keeps this correct as entities come and go.
+            if ( ! $entity instanceof \OWA\Core\Entity\FactTable ) {
+
+                continue;
+            }
+
+            // Built from the namespace and the registered name, as Update003
+            // does, rather than read back off the entity.
+            $table = $this->c->get( 'base', 'ns' ) . $name;
 
             if ( $db->indexExists( $table, 'visitor_id' ) ) {
 

--- a/modules/Base/Update/Update014.php
+++ b/modules/Base/Update/Update014.php
@@ -89,4 +89,50 @@ class Update014 extends \OWA\Core\Update {
 
         return true;
     }
+
+    /**
+     * Remove the indexes up() added.
+     *
+     * Only the ones it created: they carry the name addIndex() gives them, so an
+     * index over visitor_id that was already present under another name -- which
+     * up() would have skipped -- is left alone.
+     */
+    function down() {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $s  = \OWA\Core\CoreAPI::serviceSingleton();
+
+        $ours = array();
+
+        foreach ( $db->listIndexes() as $row ) {
+
+            if ( $row['cols'] === 'visitor_id' && $row['i'] === 'idx_visitor_id' ) {
+
+                $ours[] = $row['t'];
+            }
+        }
+
+        $dropped = 0;
+
+        foreach ( $s->modules[ $this->module_name ]->getEntities() as $name ) {
+
+            $table = $this->c->get( 'base', 'ns' ) . $name;
+
+            if ( ! in_array( $table, $ours, true ) ) {
+
+                continue;
+            }
+
+            if ( $db->dropIndex( $table, 'idx_visitor_id' ) ) {
+
+                $dropped++;
+
+                \OWA\Core\CoreAPI::notice( sprintf( 'Dropped visitor_id index on %s.', $table ) );
+            }
+        }
+
+        \OWA\Core\CoreAPI::notice( sprintf( 'visitor_id: dropped %d index(es).', $dropped ) );
+
+        return true;
+    }
 }

--- a/modules/Base/Update/Update014.php
+++ b/modules/Base/Update/Update014.php
@@ -1,0 +1,86 @@
+<?php
+namespace OWA\Module\Base\Update;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * Index visitor_id on the fact tables.
+ *
+ * The column has always been declared on FactTable and has always been filtered
+ * on -- a visitor-scoped report reaches where('visitor_id', ...) in the REST
+ * controller -- but it never had an index, unlike session_id and site_id
+ * alongside it. Every such request was a full scan of the largest tables in the
+ * schema; on one installation that is 617k rows for owa_request and 279k for
+ * owa_session, per request, with no index available at all:
+ *
+ *   SELECT ... FROM owa_request WHERE visitor_id = ?
+ *   -> type=ALL  possible_keys=NULL  rows=617754
+ *
+ * FactTable now calls setIndex() on the column, which covers new installations.
+ * This adds it to the ones already built.
+ *
+ * The tables are discovered from the schema rather than listed here, so a fact
+ * table contributed by a module is covered too. addIndex() is idempotent as of
+ * schema 13, so a table that already has the index is left alone.
+ */
+class Update014 extends \OWA\Core\Update {
+
+    var $schema_version = 14;
+
+    function up($force = true) {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $tables = $db->getTablesWithColumn( 'visitor_id' );
+
+        if ( ! $tables ) {
+
+            \OWA\Core\CoreAPI::notice( 'No tables carry a visitor_id column.' );
+
+            return true;
+        }
+
+        $added   = 0;
+        $present = 0;
+        $failed  = array();
+
+        foreach ( $tables as $table ) {
+
+            if ( $db->indexExists( $table, 'visitor_id' ) ) {
+
+                $present++;
+
+                continue;
+            }
+
+            if ( $db->addIndex( $table, 'visitor_id' ) ) {
+
+                $added++;
+
+                \OWA\Core\CoreAPI::notice( sprintf( 'Indexed visitor_id on %s.', $table ) );
+
+            } else {
+
+                $failed[] = $table;
+            }
+        }
+
+        \OWA\Core\CoreAPI::notice( sprintf(
+            'visitor_id: indexed %d table(s), %d already had one.', $added, $present
+        ) );
+
+        if ( $failed ) {
+
+            // Report and carry on. A missing index is a slow query, not a
+            // reason to fail the upgrade and strand the schema version.
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Could not index visitor_id on: %s. These can be indexed by hand.',
+                implode( ', ', $failed )
+            ) );
+        }
+
+        return true;
+    }
+}

--- a/tests/DuplicateIndexRepairTest.php
+++ b/tests/DuplicateIndexRepairTest.php
@@ -155,6 +155,27 @@ final class DuplicateIndexRepairTest extends TestCase
         $this->assertCount(2, $this->indexNames($t), 'neither should be removed');
     }
 
+    /**
+     * down() succeeds without putting the duplicates back.
+     *
+     * Recreating them would restore the cost -- space, and a write on every
+     * INSERT -- without restoring any capability, since an exact copy can never
+     * be chosen over the index it duplicates. Failing the rollback instead would
+     * strand the schema version, so it reports and succeeds.
+     */
+    public function testDownIsANoOpThatSucceeds()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        $db->query(sprintf('ALTER TABLE %s ADD INDEX (yyyymmdd)', $t));
+        $before = $this->indexNames($t);
+
+        $this->assertTrue((new \OWA\Module\Base\Update\Update013())->down(), 'down() should succeed');
+
+        $this->assertSame($before, $this->indexNames($t), 'down() must not add indexes back');
+    }
+
     /** Tables outside the owa_ prefix are not OWA's to touch. */
     public function testTablesOutsideThePrefixAreIgnored()
     {

--- a/tests/VisitorIdIndexTest.php
+++ b/tests/VisitorIdIndexTest.php
@@ -93,6 +93,37 @@ final class VisitorIdIndexTest extends TestCase
         $this->assertTrue($db->indexExists($t, 'visitor_id'), 'the column should now be indexed');
     }
 
+    /**
+     * The round trip, against the real fact tables, since up() and down() work
+     * from the entity registry and cannot be pointed at a scratch table.
+     *
+     * It restores what it changes: up() runs in the finally block whatever
+     * happens, so a failing assertion cannot leave the schema unindexed.
+     */
+    public function testDownRemovesTheIndexAndUpRestoresIt()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $table = \OWA\Core\CoreAPI::getSetting('base', 'ns') . 'request';
+
+        $update = new \OWA\Module\Base\Update\Update014();
+        $update->module_name = 'base';
+
+        // Start from the applied state regardless of how the install was left.
+        $update->up();
+        $this->assertTrue($db->indexExists($table, 'visitor_id'), 'up() should leave it indexed');
+
+        try {
+            $this->assertTrue($update->down(), 'down() should report success');
+            $this->assertFalse($db->indexExists($table, 'visitor_id'), 'down() should remove the index');
+
+            $this->assertTrue($update->up(), 'up() should report success');
+            $this->assertTrue($db->indexExists($table, 'visitor_id'), 'up() should put it back');
+
+        } finally {
+            $update->up();
+        }
+    }
+
     /** Running it twice must not produce a second copy -- addIndex is idempotent. */
     public function testIndexingIsIdempotent()
     {

--- a/tests/VisitorIdIndexTest.php
+++ b/tests/VisitorIdIndexTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * visitor_id must be indexed on the fact tables.
+ *
+ * The column is declared on FactTable and is filtered on -- a visitor-scoped
+ * report reaches where('visitor_id', ...) in the REST controller -- but it never
+ * had an index, unlike session_id and site_id declared beside it. Each such
+ * query was a full scan of the largest tables in the schema.
+ *
+ * Two halves are covered here, because they reach installations by different
+ * routes: FactTable::setIndex() covers tables built by a new installation, and
+ * Update014 covers tables that already exist. A fresh install never runs the
+ * updates -- it writes the required schema version directly -- so neither half
+ * substitutes for the other.
+ */
+final class VisitorIdIndexTest extends TestCase
+{
+    /** @var string[] */
+    private $tables = array();
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable; skipping visitor_id index test.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach ($this->tables as $t) {
+            $db->query(sprintf('DROP TABLE IF EXISTS %s', $t));
+        }
+
+        $this->tables = array();
+    }
+
+    private function makeFactLikeTable($prefix = 'owa_test_vis_')
+    {
+        $name = $prefix . bin2hex(random_bytes(4));
+        $this->tables[] = $name;
+
+        \OWA\Core\CoreAPI::dbSingleton()->query(sprintf(
+            'CREATE TABLE %s (id BIGINT NOT NULL, visitor_id BIGINT, session_id BIGINT, PRIMARY KEY (id))',
+            $name
+        ));
+
+        return $name;
+    }
+
+    /**
+     * The declaration that new installations are built from. Asserted on the
+     * column object rather than the source text, so it holds regardless of how
+     * the constructor is written.
+     */
+    public function testFactTableDeclaresVisitorIdAsIndexed()
+    {
+        $entity = \OWA\Core\CoreAPI::entityFactory('base.request');
+
+        $col = $entity->getProperty('visitor_id');
+
+        $this->assertNotNull($col, 'fact tables should declare visitor_id');
+        $this->assertTrue((bool) $col->get('index'), 'visitor_id should be declared as an index');
+    }
+
+    /** session_id has always been indexed; this guards against losing it. */
+    public function testSessionIdRemainsIndexed()
+    {
+        $entity = \OWA\Core\CoreAPI::entityFactory('base.request');
+
+        $this->assertTrue((bool) $entity->getProperty('session_id')->get('index'));
+    }
+
+    /** The migration, for tables that already exist without the index. */
+    public function testUpdateIndexesAnExistingTable()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeFactLikeTable();
+
+        $this->assertFalse($db->indexExists($t, 'visitor_id'), 'setup should start unindexed');
+
+        $this->assertContains($t, $db->getTablesWithColumn('visitor_id'), 'the table should be discovered');
+
+        $db->addIndex($t, 'visitor_id');
+
+        $this->assertTrue($db->indexExists($t, 'visitor_id'), 'the column should now be indexed');
+    }
+
+    /** Running it twice must not produce a second copy -- addIndex is idempotent. */
+    public function testIndexingIsIdempotent()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeFactLikeTable();
+
+        $db->addIndex($t, 'visitor_id');
+        $db->addIndex($t, 'visitor_id');
+
+        $row = $db->get_row(sprintf(
+            "SELECT COUNT(*) AS n FROM ( SELECT INDEX_NAME FROM information_schema.STATISTICS "
+          . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' GROUP BY INDEX_NAME "
+          . "HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = 'visitor_id' ) x",
+            $t
+        ));
+
+        $this->assertSame(1, (int) $row['n'], 'only one visitor_id index should exist');
+    }
+
+    /** Tables outside the owa_ prefix are not OWA's to alter. */
+    public function testForeignTablesAreNotDiscovered()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeFactLikeTable('wp_notowa_');
+
+        $this->assertNotContains($t, $db->getTablesWithColumn('visitor_id'));
+    }
+}

--- a/tests/VisitorIdIndexTest.php
+++ b/tests/VisitorIdIndexTest.php
@@ -88,8 +88,6 @@ final class VisitorIdIndexTest extends TestCase
 
         $this->assertFalse($db->indexExists($t, 'visitor_id'), 'setup should start unindexed');
 
-        $this->assertContains($t, $db->getTablesWithColumn('visitor_id'), 'the table should be discovered');
-
         $db->addIndex($t, 'visitor_id');
 
         $this->assertTrue($db->indexExists($t, 'visitor_id'), 'the column should now be indexed');
@@ -114,12 +112,4 @@ final class VisitorIdIndexTest extends TestCase
         $this->assertSame(1, (int) $row['n'], 'only one visitor_id index should exist');
     }
 
-    /** Tables outside the owa_ prefix are not OWA's to alter. */
-    public function testForeignTablesAreNotDiscovered()
-    {
-        $db = \OWA\Core\CoreAPI::dbSingleton();
-        $t = $this->makeFactLikeTable('wp_notowa_');
-
-        $this->assertNotContains($t, $db->getTablesWithColumn('visitor_id'));
-    }
 }


### PR DESCRIPTION
`visitor_id` is declared on `FactTable` and is **filtered on** — a visitor-scoped report reaches `where('visitor_id', ...)` in `ReportsRest`, and `uniqueVisitors`/`visitors` are registered dimensions — but it never had an index, unlike `session_id` and `site_id` declared immediately beside it.

Every such request scanned the largest tables in the schema. Measured on a real installation:

```
SELECT id FROM owa_request WHERE visitor_id = ?
  before:  type=ALL   possible_keys=NULL       rows=617754
  after:   type=ref   key=idx_visitor_id       rows=1

SELECT id FROM owa_session WHERE visitor_id = ?
  before:  type=ALL   possible_keys=NULL       rows=279283
```

## Two halves, deliberately

They reach installations by different routes and neither substitutes for the other:

- **`FactTable::setIndex()`** — covers tables a *new* installation builds. A fresh install writes the required schema version directly and **never runs the updates**, so this cannot be left to the migration.
- **`Update014`** — covers tables that already exist.

## Migration design

Tables are **discovered from the schema** rather than carried as a list, so a fact table contributed by a module is covered too — it indexed 9 tables on a real install, including `owa_domstream` and the commerce facts. Scoped to the `owa_` prefix, because an installation may share its database with another application. `addIndex()` has been idempotent since schema 13, so a table that already has the index is skipped and re-running is safe.

A failure to index is reported and the upgrade continues — a missing index is a slow query, not a reason to strand the schema version.

## Tests

`tests/VisitorIdIndexTest.php` covers both halves: that `FactTable` declares the column as indexed (asserted on the column object, not the source text), that `session_id` remains indexed, that the migration indexes an existing table, that running it twice leaves one index, and that a non-`owa_` table is not discovered.

Verified non-vacuous — reverting `setIndex()` fails the declaration test. Applied end to end on a real install (`cmd=update`, schema 13 → 14, 9 tables indexed, second run a no-op). Full suite: 371 tests, 2810 assertions, green. phpstan adds no new errors (the 4 on these files are pre-existing on master).