### PR TITLE
fix(base): password reset 500s on PHP 8, and never mails when a From is configured

### DIFF
--- a/Core/Base.php
+++ b/Core/Base.php
@@ -101,15 +101,18 @@ class Base {
 
             $msg = $_owa_messages[$code];
 			
-			if ( $substitutions ) {
-	            if (isset($msg['headline'])) {
-	                $msg['headline'] = vsprintf($msg['headline'], $substitutions['headline']);
-	            }
-	
-	            if (isset($msg['message'])) {
-	                $msg['message'] = vsprintf($msg['message'], $substitutions['message']);
-	            }
-	        }
+			// Substitutions are keyed by the message part they fill in, and each
+			// value is that part's vsprintf() argument list. A caller that fills
+			// in only one part must leave the other one untouched, and a caller
+			// passing a bare scalar means a single argument -- handing either of
+			// those straight to vsprintf() is a TypeError on PHP 8.
+			foreach ( ['headline', 'message'] as $part ) {
+
+				if ( isset( $msg[ $part ] ) && isset( $substitutions[ $part ] ) ) {
+
+					$msg[ $part ] = vsprintf( $msg[ $part ], (array) $substitutions[ $part ] );
+				}
+			}
         }
 
         return $msg;

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -782,6 +782,18 @@ namespace OWA\Module\Base\Classes;
      
      function setMailerDomain() {
 
+	     // Only a fallback. This runs from the constructor, BEFORE load() merges
+	     // the stored settings in, so overwriting unconditionally would clobber
+	     // an address set by the config file or by an operator editing the
+	     // defaults -- and the auto-computed value is 'owa@' . SERVER_NAME,
+	     // which an authenticating relay rejects as an envelope sender the
+	     // account does not own ("553 Sender address rejected"). A stored value
+	     // still wins either way; this is about the two earlier layers.
+	     if ( $this->get( 'base', 'mailer-from' ) ) {
+
+		     return;
+	     }
+
 	     // Fall back to a valid domain: neither SERVER_NAME (CLI/cron have no
 	     // web server context) nor a usable PUBLIC_URL host is guaranteed, and
 	     // mailer-from below reads this unconditionally.

--- a/modules/Base/Controller/PasswordResetRequest.php
+++ b/modules/Base/Controller/PasswordResetRequest.php
@@ -58,7 +58,7 @@ class PasswordResetRequest extends \OWA\Core\Controller {
         // return view
         $this->setView('base.passwordResetForm');
         $email_address = trim((string) $this->getParam('email_address'));
-        $msg = $this->getMsg(2000, ['message' => $email_address]);
+        $msg = $this->getMsg(2000, ['message' => [$email_address]]);
         $this->set('status_msg', $msg);
     }
 
@@ -66,7 +66,7 @@ class PasswordResetRequest extends \OWA\Core\Controller {
 
         $this->setView('base.passwordResetForm');
         $email_address = trim((string) $this->getParam('email_address'));
-        $this->set('error_msg', $this->getMsg(2001, ['message' => $email_address]));
+        $this->set('error_msg', $this->getMsg(2001, ['message' => [$email_address]]));
     }
 }
 

--- a/tests/MailerFromFallbackTest.php
+++ b/tests/MailerFromFallbackTest.php
@@ -1,0 +1,106 @@
+<?php
+
+require_once( __DIR__ . '/SettingsSingletonSnapshot.php' );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * setMailerDomain() computes a DEFAULT From address, not an override.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * It runs from Settings::__construct(), i.e. before load() merges the stored
+ * settings in. A stored address therefore always wins, but the two earlier
+ * layers -- the shipped defaults array and anything the config file sets --
+ * used to be overwritten unconditionally with 'owa@' . SERVER_NAME.
+ *
+ * That is not a cosmetic default. An authenticating SMTP relay rejects an
+ * envelope sender the account does not own, so an install whose operator had
+ * configured a real From still handed the relay 'owa@<servername>' and every
+ * mail died at RCPT TO with "553 5.7.1 Sender address rejected". The
+ * password-reset flow reports success regardless -- the mail failure is only a
+ * debug-level log line -- so the symptom was a reset mail that silently never
+ * arrived.
+ *
+ * The auto-computed value must still appear when nothing is configured: an
+ * empty From builds a malformed header that the local MTA drops (see the note
+ * in owa_mailer::__construct), which is the failure this fallback exists to
+ * prevent in the first place.
+ */
+final class MailerFromFallbackTest extends TestCase
+{
+    use SettingsSingletonSnapshot;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        $this->snapshotSettings();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreSettings();
+    }
+
+    /** The regression: a configured address survives the constructor's default. */
+    public function testAConfiguredFromAddressIsNotOverwritten(): void
+    {
+        $c = $this->settings();
+        $c->set('base', 'mailer-from', 'no-reply@example.com');
+
+        $c->setMailerDomain();
+
+        $this->assertSame('no-reply@example.com', $c->get('base', 'mailer-from'));
+    }
+
+    /** With nothing configured the auto-computed default still fills in. */
+    public function testAnUnsetFromAddressGetsTheServerNameDefault(): void
+    {
+        $c = $this->settings();
+        $c->set('base', 'mailer-from', '');
+
+        $server_name = $_SERVER['SERVER_NAME'] ?? null;
+        $_SERVER['SERVER_NAME'] = 'owa.example.com';
+
+        try {
+            $c->setMailerDomain();
+        } finally {
+            if ($server_name === null) {
+                unset($_SERVER['SERVER_NAME']);
+            } else {
+                $_SERVER['SERVER_NAME'] = $server_name;
+            }
+        }
+
+        $this->assertSame('owa@owa.example.com', $c->get('base', 'mailer-from'));
+    }
+
+    /**
+     * A dotless host still gets the '.localdomain' suffix -- PHPMailer rejects
+     * 'owa@localhost' as invalid.
+     */
+    public function testADotlessServerNameStillGetsAValidDomain(): void
+    {
+        $c = $this->settings();
+        $c->set('base', 'mailer-from', '');
+
+        $server_name = $_SERVER['SERVER_NAME'] ?? null;
+        $_SERVER['SERVER_NAME'] = 'localhost';
+
+        try {
+            $c->setMailerDomain();
+        } finally {
+            if ($server_name === null) {
+                unset($_SERVER['SERVER_NAME']);
+            } else {
+                $_SERVER['SERVER_NAME'] = $server_name;
+            }
+        }
+
+        $this->assertSame('owa@localhost.localdomain', $c->get('base', 'mailer-from'));
+    }
+}

--- a/tests/MessageSubstitutionTest.php
+++ b/tests/MessageSubstitutionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The getMsg() substitution contract.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * conf/messages.php entries are two independent sprintf templates -- 'headline'
+ * and 'message' -- and a caller normally fills in only one of them. getMsg()
+ * used to decide whether to substitute by looking at which parts the TEMPLATE
+ * has, not which parts the CALLER supplied, so filling in 'message' alone read
+ * $substitutions['headline'] anyway: an undefined-key warning on PHP 8 followed
+ * by vsprintf(null) -- a TypeError, i.e. a 500, on the password-reset flow
+ * (messages 2000/2001, the only substituting call sites in the tree).
+ *
+ * The second half of the contract is the value shape. vsprintf() takes an
+ * ARGUMENT LIST, so a substitution value is an array. Every caller that has
+ * ever passed substitutions passed a bare string instead, which on PHP 5/7
+ * degraded to a warning and a blank message and on PHP 8 is a hard TypeError.
+ * The call sites now pass arrays, and getMsg() casts anyway so that a scalar
+ * from a third-party module cannot 500 an admin screen.
+ *
+ * A message with no substitutions at all must come back verbatim -- that is
+ * how all the other ~20 call sites use it, and running an unsubstituted
+ * template through vsprintf() would fatal on any literal '%' in the text.
+ */
+final class MessageSubstitutionTest extends TestCase
+{
+    private object $base;
+
+    protected function setUp(): void
+    {
+        // getMsg() needs only OWA_DIR (to locate conf/messages.php); the
+        // constructor's error/config singletons are irrelevant to it, so skip
+        // them rather than boot the whole framework.
+        require_once dirname(__DIR__) . '/owa_env.php';
+
+        $this->base = (new ReflectionClass(\OWA\Core\Base::class))
+            ->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * The regression: message 2000 substituted, headline left alone.
+     * failOnWarning="true" in phpunit.xml makes the undefined-key warning a
+     * failure on its own, before the TypeError would have been reached.
+     */
+    public function testSubstitutingOnlyTheMessageLeavesTheHeadlineIntact(): void
+    {
+        $msg = $this->base->getMsg(2000, ['message' => ['user@example.com']]);
+
+        $this->assertSame('Success', $msg['headline']);
+        $this->assertStringContainsString('user@example.com', $msg['message']);
+        $this->assertStringNotContainsString('%s', $msg['message']);
+    }
+
+    /** The error branch of the same flow, message 2001. */
+    public function testTheErrorMessageSubstitutesTheSameWay(): void
+    {
+        $msg = $this->base->getMsg(2001, ['message' => ['nobody@example.com']]);
+
+        $this->assertSame('Error', $msg['headline']);
+        $this->assertStringContainsString('nobody@example.com', $msg['message']);
+    }
+
+    /** A bare scalar is one argument, not a TypeError. */
+    public function testAScalarSubstitutionIsTreatedAsASingleArgument(): void
+    {
+        $msg = $this->base->getMsg(2000, ['message' => 'user@example.com']);
+
+        $this->assertStringContainsString('user@example.com', $msg['message']);
+    }
+
+    /** Substituting only the headline must not touch the message. */
+    public function testSubstitutingOnlyTheHeadlineLeavesTheMessageIntact(): void
+    {
+        $raw = $this->base->getMsg(3010);
+        $msg = $this->base->getMsg(3010, ['headline' => ['ignored']]);
+
+        $this->assertSame($raw['message'], $msg['message']);
+    }
+
+    /** The common case: no substitutions, template returned verbatim. */
+    public function testAMessageWithoutSubstitutionsIsReturnedVerbatim(): void
+    {
+        $msg = $this->base->getMsg(3010);
+
+        $this->assertSame('Error', $msg['headline']);
+        $this->assertSame(
+            'A user with that email address does not exist.',
+            $msg['message']
+        );
+    }
+
+    /** An unknown code is an empty array, not a fatal. */
+    public function testAnUnknownCodeReturnsAnEmptyArray(): void
+    {
+        $this->assertSame([], $this->base->getMsg(99999, ['message' => ['x']]));
+    }
+
+    /**
+     * The call sites the framework actually has: no getMsg() caller may hand a
+     * substitution value that is neither an array nor a scalar (an object or
+     * null would still be a TypeError inside vsprintf()). Cheap source scan --
+     * these two are the only substituting call sites in the tree, and this
+     * keeps a third one from being added in the broken shape.
+     */
+    public function testThePasswordResetCallSitesPassArgumentLists(): void
+    {
+        $source = file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/PasswordResetRequest.php'
+        );
+
+        $this->assertSame(
+            2,
+            preg_match_all("/getMsg\(200[01], \['message' => \[\\\$email_address\]\]\)/", $source),
+            'PasswordResetRequest must pass vsprintf() argument lists, not bare strings.'
+        );
+    }
+}


### PR DESCRIPTION
Fixes #927
Fixes #877

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [ ] Build (`npm run build`) was run locally and any changes were pushed

<!-- PHP-only change; no JS/CSS assets touched, so the bundle is unaffected. -->

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## What is the current behavior?

Two independent bugs sit back to back in the password reset flow, so the
feature is unusable on a current PHP.

**1. Requesting a reset is an HTTP 500 on PHP 8.**

```
Undefined array key "headline"
TypeError: vsprintf(): Argument #2 ($values) must be of type array, null given
owa_base.php:106
```

`getMsg()` decides *whether* to substitute by looking at which parts the
message TEMPLATE has, rather than which parts the CALLER supplied. Messages
2000/2001 have a `headline`, but `PasswordResetRequest` fills in only
`message`, so the headline branch reads `$substitutions['headline']` anyway:
an undefined-key warning followed by `vsprintf(null)`.

The value shape is wrong on the other side too. `vsprintf()` takes an argument
list, and both call sites pass a bare string. On PHP 5/7 that degraded to a
warning plus a blank message; since PHP 8.0 it is a hard TypeError. These are
the only two call sites in the tree that pass substitutions at all, which is
why this went unnoticed -- the other ~20 pass none.

**2. With that fixed, the page succeeds but no mail arrives.**

`setMailerDomain()` runs from `owa_settings::__construct()` and overwrites
`mailer-from` unconditionally with `'owa@' . SERVER_NAME`. A stored value
still wins (load() merges the DB over the defaults, later), but the defaults
array and anything the config file sets do not -- so an install with a
properly configured From still hands the relay an address the authenticated
account does not own:

```
MAIL FROM:<owa@owa.example.com>
553 5.7.1 <owa@owa.example.com>: Sender address rejected: not owned by user no-reply@example.com
```

Every mail dies at RCPT TO. The reset screen reports success regardless --
the mailer failure is a debug-level log line -- so the symptom is a reset
mail that silently never arrives.

Issue Number: #927, #877

## What is the new behavior?

- `getMsg()` substitutes a message part only when the CALLER supplied a value
  for it, so filling in one part no longer touches the other.
- Substitution values are cast to an array before `vsprintf()`, so a bare
  scalar from a third-party module means "one argument" instead of a fatal.
- `PasswordResetRequest` passes proper vsprintf argument lists, matching the
  documented `@param array $substitutions` contract.
- `setMailerDomain()` returns early when a From address is already configured;
  the auto-computed value is now a fallback rather than an override. It still
  fills in when nothing is set -- an empty From builds a malformed header that
  the local MTA drops.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Both changes only widen what already worked. `getMsg()` callers that pass no
substitutions are untouched (the overwhelming majority), and callers that pass
a string now get the substitution they always intended instead of a TypeError.
An install that never configured `mailer-from` keeps the exact same
auto-computed address, including the `.localdomain` repair for dotless
hostnames.

## Docs need to be updated?

- [ ] Yes
- [x] No

## Other information

The `isset()` guards in `getMsg()` are already upstream (c1bfb81b "fixing
undefined index warning", 24f2791a) -- they were simply on the wrong side of
the comparison, testing the template instead of the substitutions.

Two test files, each of which fails if you revert its source change:

- `tests/MessageSubstitutionTest.php` -- partial substitution in both
  directions, scalar tolerance, verbatim pass-through, unknown code, and the
  two call-site shapes. Reverting the sources gives 4 errors + 1 failure,
  matching the reported stack traces exactly. Note `failOnWarning="true"` in
  phpunit.xml makes the undefined-key warning a failure on its own.
- `tests/MailerFromFallbackTest.php` -- a configured address survives the
  constructor; an unset one still gets `owa@SERVER_NAME`; a dotless hostname
  still gets `.localdomain`.

Verified on PHP 8.3.33: full suite 382 tests / 0 failures (154 skipped -- the
DB-dependent ones, no owa-config.php in the run), PHPStan clean. Manually
confirmed end to end against a real Postfix relay: the 553 is gone and the
reset mail is delivered.

Out of scope, but noticed while tracing the flow and worth separate issues:
the reset token is `md5($seed . time() . rand())` rather than a CSPRNG, and
`owa_userManager::updateUserPassword()` still accepts a `user_id` with no
`temp_passkey`. The latter is not reachable in a default install --
`queue.php` gates on `allowed_queued_event_types` (empty by default) and
`log.php` on `tracking_event_types`, and `base.set_password` is in neither.



### DO NOT FORGET TO SETUP MAILER WITH CORRECT SETTINGS IN CONFIG.PHP

```
$this->set('base', 'mailer-from', 'no-reply@example.com');
$this->set('base', 'mailer-host', 'smtp.example.com');
$this->set('base', 'mailer-port', 587);
$this->set('base', 'mailer-use-smtp', true);
$this->set('base', 'mailer-smtpAuth', true);
$this->set('base', 'mailer-username', 'no-reply@example.com');
$this->set('base', 'mailer-password', 'MY_SUPER_SECRET_PASSWORD');
```