### PR TITLE
fix(reports): visitors roster shows the requested day; access-hardening asserts what it means

### DIFF
--- a/modules/Base/Controller/ReportVisitorsRoster.php
+++ b/modules/Base/Controller/ReportVisitorsRoster.php
@@ -52,8 +52,19 @@ class ReportVisitorsRoster extends \OWA\Core\ReportController {
 
         $db->where('site_id', $this->getParam('site_id'));
 
-        // make new timeperiod of a day
-        $period = \OWA\Core\CoreAPI::makeTimePeriod('day', array('startDate' => $this->getParam('first_session')));
+        // A single day, expressed as a date range whose ends are equal.
+        //
+        // NOT makeTimePeriod('day', ...): there is no period named 'day' --
+        // the set is in TimePeriod::getPeriodLabels() -- so isValid() rejected
+        // it, TimePeriod fell back to the default reporting period, and the
+        // requested date was dropped on the floor. This report titled itself
+        // "New Visitors from <day>" while listing the default window instead.
+        $first_session = $this->getParam('first_session');
+
+        $period = \OWA\Core\CoreAPI::makeTimePeriod('date_range', array(
+            'startDate' => $first_session,
+            'endDate'   => $first_session,
+        ));
         $start = $period->getStartDate();
         $end = $period->getEndDate();
         //print_r($period);

--- a/tests/TimePeriodTest.php
+++ b/tests/TimePeriodTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The period contract, and the way it fails.
+ *
+ * TimePeriod::isValid() rejects an unknown period name by falling back to the
+ * default reporting period and logging a debug line. Nothing throws, nothing
+ * warns, and any startDate that came with it is dropped -- so a caller asking
+ * for a period that does not exist gets a plausible window over the wrong
+ * dates. ReportVisitorsRoster did exactly that for as long as it has existed,
+ * asking for 'day' and titling itself "New Visitors from <date>" while
+ * listing the default window.
+ *
+ * These pin both halves: which names are real, and how a single day is
+ * actually expressed.
+ */
+final class TimePeriodTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function period(string $name, array $map = []): object
+    {
+        return \OWA\Core\CoreAPI::makeTimePeriod($name, $map);
+    }
+
+    private function span(object $p): array
+    {
+        return [
+            date('Y-m-d', $p->getStartDate()->getTimestamp()),
+            date('Y-m-d', $p->getEndDate()->getTimestamp()),
+        ];
+    }
+
+    /**
+     * A single day is a date range whose ends are equal. There is no period
+     * named 'day', and asking for one silently yields the default window.
+     */
+    public function testASingleDayIsADateRangeWithEqualEnds()
+    {
+        $day = date('Ymd', strtotime('-5 days'));
+
+        $this->assertSame(
+            [date('Y-m-d', strtotime($day)), date('Y-m-d', strtotime($day))],
+            $this->span($this->period('date_range', ['startDate' => $day, 'endDate' => $day])),
+            'a date_range with equal ends must cover exactly that day'
+        );
+    }
+
+    /**
+     * The failure mode that hid the bug: an unknown name is not refused, it is
+     * replaced -- and the requested date goes with it.
+     */
+    public function testAnUnknownPeriodNameSilentlyDiscardsTheRequestedDate()
+    {
+        $day = date('Ymd', strtotime('-5 days'));
+
+        $asked  = $this->span($this->period('day', ['startDate' => $day]));
+        $wanted = date('Y-m-d', strtotime($day));
+
+        $this->assertNotSame(
+            [$wanted, $wanted],
+            $asked,
+            "'day' is not a period name; if this ever starts working, the fallback in "
+            . 'TimePeriod::setFromMap() has changed and callers should be revisited'
+        );
+    }
+
+    /** The names that actually exist, so a typo in a caller is catchable. */
+    public function testTheValidPeriodNames()
+    {
+        $tp = \OWA\Core\CoreAPI::supportClassFactory('base', 'timePeriod');
+
+        foreach ([
+            'today', 'yesterday', 'this_week', 'this_month', 'this_year',
+            'last_week', 'last_month', 'last_year', 'last_seven_days',
+            'last_thirty_days', 'same_day_last_week', 'same_week_last_year',
+            'same_month_last_year', 'date_range',
+        ] as $name) {
+            $this->assertTrue($tp->isValid($name), "$name should be a valid period");
+        }
+
+        foreach (['day', 'week', 'month', 'year', 'hour', 'last_24_hours', ''] as $name) {
+            $this->assertFalse($tp->isValid($name), "$name should not be a valid period");
+        }
+    }
+
+    /** A range with no dates falls back to today rather than to nothing. */
+    public function testAnEmptyDateRangeCoversToday()
+    {
+        $this->assertSame(
+            [date('Y-m-d'), date('Y-m-d')],
+            $this->span($this->period('date_range', ['startDate' => '', 'endDate' => ''])),
+            'an empty range should still be a usable single day'
+        );
+    }
+}

--- a/tests/e2e/access-hardening.spec.js
+++ b/tests/e2e/access-hardening.spec.js
@@ -117,8 +117,17 @@ test.describe('web-access hardening policy @server-config', () => {
     for (const p of PUBLIC_PATHS) {
         test(`public: ${p} is served`, async ({ request }) => {
             const code = await statusOf(request, ROOT + p);
-            // Served = 2xx or a redirect (login flow / legacy-tracker 301). NOT 403/404.
-            expect(code, `${p} should be publicly reachable`).toBeLessThan(400);
+
+            // This suite is about the web server's deny rules, so "served"
+            // means the request reached PHP -- 2xx, a redirect (login flow /
+            // legacy-tracker 301), or an application-level rejection. It does
+            // NOT mean 2xx: api/index.php answers a request that names no
+            // route with a well-formed 400, which is the endpoint working, and
+            // asserting `< 400` failed it for doing so.
+            expect([403, 404], `${p} should be publicly reachable, not blocked`).not.toContain(code);
+
+            // Reachable but broken is a different failure, and still one.
+            expect(code, `${p} should not be a server error`).toBeLessThan(500);
         });
     }
 


### PR DESCRIPTION
Two unrelated bugs found while working on #989, neither caused by it.

## The visitors roster showed a different day than it claimed

`ReportVisitorsRoster` asked for a period named `day`. There is no such period — the set lives in `TimePeriod::getPeriodLabels()` — so `isValid()` rejected it, `setFromMap()` substituted the default reporting period, and the `startDate` that came with it was discarded.

```
asked for 20260810 -> 2026-08-08 .. 2026-08-15   (before: the default window)
asked for 20260810 -> 2026-08-10 .. 2026-08-10   (after)
```

The report titled itself *"New Visitors from &lt;date&gt;"* while listing the last seven days. Clicking a different day changed the title and nothing else. A single day is a `date_range` whose ends are equal, which is what it now asks for; an absent parameter still resolves to today.

**The failure mode is what makes this worth a test.** An unknown period name is not refused — it is replaced, silently, taking the caller's date with it. `TimePeriodTest` pins that behaviour, pins the valid names so a future typo is catchable, and asserts `day` stays invalid: if that ever starts working, the fallback has changed and every caller wants revisiting.

Other callers were swept first — the only other `makeTimePeriod()` calls pass a variable from request input, where falling back to a default is intended.

## The access-hardening suite failed an endpoint for working correctly

The public-path assertion required a status below 400. But the suite tests the **web server's deny rules**, and its own comment says as much: *served* means the request reached PHP, not that PHP liked it.

`api/index.php` answers a request that names no route with a well-formed 400 and a JSON body explaining itself. That is the endpoint working, and the assertion failed it for that. It now asserts what it means — not 403, not 404 — and separately that the response is not a server error, so reachable-but-broken is still caught rather than folded into the relaxation.

Verified in both directions against a live Apache: `owa-config.php` and `composer.json` still answer 403 and would still fail if listed as public, while `api/index.php` passes. The suite goes from 28 passing with one failure to **29 passing**.

Note this suite is `@server-config` and does not run in CI — it needs a real web server, so `php -S` skips it. It was run locally against Apache.

## Verified

413 tests, 3079 assertions. All three phpstan configurations clean.