### PR TITLE
fix(build): wrap the JS bundles in an IIFE so they stop leaking globals

### DIFF
--- a/modules/Base/src/tracker/OwaEvent.js
+++ b/modules/Base/src/tracker/OwaEvent.js
@@ -7,7 +7,7 @@ import { Util } from '../common/Util.js';
  * @copyright   Copyright &copy; 2006 Peter Adams <peter@openwebanalytics.com>
  * @license     http://www.openwebanalytics.com/licenses/ BSD-3 Clause
  */
-class Event {
+class OwaEvent {
 	
 	constructor() {
 		
@@ -61,4 +61,4 @@ class Event {
     }
 }
 
-export { Event };
+export { OwaEvent };

--- a/modules/Base/src/tracker/Tracker.js
+++ b/modules/Base/src/tracker/Tracker.js
@@ -8,7 +8,7 @@
  
 import { OWA_instance as OWA } from '../common/owa.js';
 import { Util } from '../common/Util.js';
-import { Event } from './Event.js';
+import { OwaEvent } from './OwaEvent.js';
 import { Uri } from './Uri.js';
  
 class OWATracker  {
@@ -551,7 +551,7 @@ class OWATracker  {
      */
     log() {
 
-        var event = new Event
+        var event = new OwaEvent
         event.setEventType("base.page_request");
         return this.logEvent(event);
     }
@@ -1072,7 +1072,7 @@ class OWATracker  {
         // hack for IE
         e = e || window.event;
 
-        var click = new Event();
+        var click = new OwaEvent();
         // set event type
         click.setEventType("dom.click");
 
@@ -1166,7 +1166,7 @@ class OWATracker  {
         var now = this.getTime();
         if (now > this.last_movement + this.getOption('movementInterval')) {
             // set event type
-            this.movement = new Event();
+            this.movement = new OwaEvent();
             this.movement.setEventType("dom.movement");
             var coords = this.getCoords(e);
             this.movement.set('cursor_x', coords.x);
@@ -1190,7 +1190,7 @@ class OWATracker  {
 
         var now = this.getTimestamp();
 
-        var event = new Event();
+        var event = new OwaEvent();
         event.setEventType('dom.scroll');
         var coords = this.getScrollingPosition();
         event.set('x', coords.x);
@@ -1245,7 +1245,7 @@ class OWATracker  {
 
         var key_code = e.keyCode? e.keyCode : e.charCode
         var key_value = String.fromCharCode(key_code);
-        var event = new Event();
+        var event = new OwaEvent();
         event.setEventType('dom.keypress');
         event.set('key_value', key_value);
         event.set('key_code', key_code);
@@ -1330,7 +1330,7 @@ class OWATracker  {
 
     // Event object Factory
     makeEvent() {
-        return new Event();
+        return new OwaEvent();
     }
 
     // adds a new Domstream event binding. takes function name
@@ -1587,7 +1587,7 @@ class OWATracker  {
 
     addTransaction( order_id, order_source, total, tax, shipping, gateway, city, state, country ) {
 	    
-        this.ecommerce_transaction = new Event();
+        this.ecommerce_transaction = new OwaEvent();
         this.ecommerce_transaction.setEventType( 'ecommerce.transaction' );
         this.ecommerce_transaction.set( 'ct_order_id', order_id );
         this.ecommerce_transaction.set( 'ct_order_source', order_source );
@@ -2129,7 +2129,7 @@ class OWATracker  {
      */
     trackPageView( url ) {
 
-        var event = new Event;
+        var event = new OwaEvent;
 
         if (url) {
             event.set('page_url', url);
@@ -2142,7 +2142,7 @@ class OWATracker  {
 
     trackAction(action_group, action_name, action_label, numeric_value) {
 
-        var event = new Event;
+        var event = new OwaEvent;
 
         event.setEventType('track.action');
         event.set('action_group', action_group);
@@ -2162,7 +2162,7 @@ class OWATracker  {
 
     logDomStream() {
 
-        var domstream = new Event;
+        var domstream = new OwaEvent;
 		
         if ( this.event_queue.length > this.options.domstreamEventThreshold ) {
 

--- a/tests/js/BundleGlobalScope.test.js
+++ b/tests/js/BundleGlobalScope.test.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+/**
+ * The built bundles must not declare anything in the page's global scope.
+ *
+ * The tracker ships as a classic <script> into pages OWA does not control. In
+ * production mode webpack concatenates the entry's whole module graph into a
+ * single scope (scope hoisting), so if `output.iife` is off, that scope IS the
+ * host page's global scope: every top-level declaration in every concatenated
+ * source file becomes a global binding.
+ *
+ * That is not a theoretical concern. The tracker's event class, then still named
+ * `Event` (it is OwaEvent now, in tracker/OwaEvent.js), used to land as a global
+ * lexical binding, which shadows the DOM's window.Event for the whole page (lexical
+ * declarations are resolved before the global object), and broke every library doing
+ * `new Event(...)` -- Bootstrap dropdowns, modals and tabs among them, with
+ * "Failed to execute 'dispatchEvent' on 'EventTarget'".
+ *
+ * Two guards, because they fail on different mistakes:
+ *   1. the config guard catches `output.iife: false` coming back;
+ *   2. the artefact guard catches any other way a global escapes the bundle.
+ */
+describe('built bundles keep their declarations out of the global scope', () => {
+
+    const repoRoot = path.resolve(__dirname, '../..');
+    const distDir = path.join(repoRoot, 'public/base/dist');
+    const bundles = ['owa.tracker.js', 'owa.reporting-combined-min.js'];
+
+    // Identifiers that must never resolve after a bundle has been evaluated: the
+    // tracker's own class and module names, plus the DOM globals most likely to be
+    // shadowed by a same-named class.
+    const mustNotResolve = [
+        'Event',
+        'OwaEvent',
+        'OWATracker',
+        'CommandQueue',
+        'StateManager',
+        'Heatmap',
+        'Player',
+        'Uri',
+        'Util',
+        'owa',
+        'CustomEvent',
+        'Request',
+        'Response',
+        'Node',
+        'Element',
+    ];
+
+    test('no JS build product disables the IIFE wrapper', () => {
+        const configs = require(path.join(repoRoot, 'webpack.config.js'));
+        const jsConfigs = configs.filter((c) => c.output && c.output.filename);
+
+        expect(jsConfigs.length).toBeGreaterThan(0);
+        for (const cfg of jsConfigs) {
+            // Undefined is fine: webpack defaults to true for target:web.
+            expect(cfg.output.iife).not.toBe(false);
+        }
+    });
+
+    test.each(bundles)('%s declares no globals', (name) => {
+        const file = path.join(distDir, name);
+        if (!fs.existsSync(file)) {
+            throw new Error(
+                `${file} is missing. The dist tree is gitignored, so run \`npm run build\` before \`npm test\`.`
+            );
+        }
+
+        const code = fs.readFileSync(file, 'utf8');
+
+        // A bare realm: no window, no document, no DOM constructors. Evaluating the
+        // bundle here is expected to throw once it reaches browser APIs, which is
+        // fine -- global declaration instantiation happens before the first
+        // statement runs, so anything the bundle declares is already visible.
+        const context = vm.createContext({});
+        try {
+            vm.runInContext(code, context, { filename: name });
+        } catch (err) {
+            // Expected: the bundle needs a browser.
+        }
+
+        // `var` leaks become properties of the realm's global object.
+        expect(Object.keys(context)).toEqual([]);
+
+        // `let`/`const`/`class` leaks do NOT, so probe them by name from a second
+        // script in the same realm, which shares the global lexical environment.
+        //
+        // A leaked binding shows up one of two ways. If the bundle ran far enough to
+        // evaluate the declaration, `typeof` reports its type. If it threw earlier,
+        // the binding exists but is uninitialized and `typeof` itself throws from
+        // the temporal dead zone -- which still proves the declaration is global.
+        for (const identifier of mustNotResolve) {
+            const resolved = vm.runInContext(
+                `(() => { try { return typeof ${identifier}; } catch (e) { return 'declared (uninitialized)'; } })()`,
+                context
+            );
+            expect({ identifier, resolved }).toEqual({ identifier, resolved: 'undefined' });
+        }
+    });
+});

--- a/tests/js/CustomVarSetter.test.js
+++ b/tests/js/CustomVarSetter.test.js
@@ -1,6 +1,6 @@
 import { OWATracker } from '../../modules/Base/src/tracker/Tracker.js';
 import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
-import { Event } from '../../modules/Base/src/tracker/Event.js';
+import { OwaEvent } from '../../modules/Base/src/tracker/OwaEvent.js';
 
 /**
  * Custom variables, sender side (setCustomVar / getCustomVar / deleteCustomVar).
@@ -202,7 +202,7 @@ describe('addGlobalPropertiesToEvent pulls stored custom vars onto an event', ()
         t.setCustomVar(2, 'Tier', 'Gold', 'session');
         t.setCustomVar(3, 'Cohort', 'Beta', 'visitor');
 
-        const event = new Event();
+        const event = new OwaEvent();
         t.addGlobalPropertiesToEvent(event);
 
         expect(event.get('cv1')).toBe('Plan=Pro');
@@ -214,7 +214,7 @@ describe('addGlobalPropertiesToEvent pulls stored custom vars onto an event', ()
         const t = newTracker();
         t.setCustomVar(1, 'Plan', 'Global', 'session');
 
-        const event = new Event();
+        const event = new OwaEvent();
         event.set('cv1', 'Plan=Local');
         t.addGlobalPropertiesToEvent(event);
 

--- a/tests/js/OwaEvent.test.js
+++ b/tests/js/OwaEvent.test.js
@@ -1,51 +1,51 @@
-import { Event } from '../../modules/Base/src/tracker/Event.js';
+import { OwaEvent } from '../../modules/Base/src/tracker/OwaEvent.js';
 
 /**
  * Unit tests for the tracker Event value object. Event is the payload every
  * track* method assembles before handing it to the beacon transport, so its
  * get/set/merge/type contract underpins every event type.
  */
-describe('Event', () => {
+describe('OwaEvent', () => {
 
     test('new event carries a timestamp by default', () => {
-        const e = new Event();
+        const e = new OwaEvent();
         expect(e.isSet('timestamp')).toBe(true);
         expect(typeof e.get('timestamp')).toBe('number');
     });
 
     test('setEventType stores under event_type', () => {
-        const e = new Event();
+        const e = new OwaEvent();
         e.setEventType('track.action');
         expect(e.get('event_type')).toBe('track.action');
     });
 
     test('set/get round-trips a property', () => {
-        const e = new Event();
+        const e = new OwaEvent();
         e.set('action_group', 'test group');
         expect(e.get('action_group')).toBe('test group');
     });
 
     test('get returns undefined for an unset property', () => {
-        const e = new Event();
+        const e = new OwaEvent();
         expect(e.get('nope')).toBeUndefined();
     });
 
     test('isSet reflects presence', () => {
-        const e = new Event();
+        const e = new OwaEvent();
         expect(e.isSet('action_name')).toBeFalsy();
         e.set('action_name', 'test action');
         expect(e.isSet('action_name')).toBe(true);
     });
 
     test('merge copies own properties onto the event', () => {
-        const e = new Event();
+        const e = new OwaEvent();
         e.merge({ a: 1, b: 'two' });
         expect(e.get('a')).toBe(1);
         expect(e.get('b')).toBe('two');
     });
 
     test('getProperties exposes the backing map', () => {
-        const e = new Event();
+        const e = new OwaEvent();
         e.set('numeric_value', 10);
         expect(e.getProperties().numeric_value).toBe(10);
     });

--- a/tests/js/SessionVisitorState.test.js
+++ b/tests/js/SessionVisitorState.test.js
@@ -1,6 +1,6 @@
 import { OWATracker } from '../../modules/Base/src/tracker/Tracker.js';
 import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
-import { Event } from '../../modules/Base/src/tracker/Event.js';
+import { OwaEvent } from '../../modules/Base/src/tracker/OwaEvent.js';
 
 /**
  * Session / visitor identity state machine.
@@ -60,7 +60,7 @@ function newTracker() {
 }
 
 function eventAt(timestamp) {
-    const e = new Event();
+    const e = new OwaEvent();
     if (timestamp) {
         e.set('timestamp', timestamp);
     }

--- a/tests/js/TrackerMiscMethods.test.js
+++ b/tests/js/TrackerMiscMethods.test.js
@@ -1,6 +1,6 @@
 import { OWATracker } from '../../modules/Base/src/tracker/Tracker.js';
 import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
-import { Event } from '../../modules/Base/src/tracker/Event.js';
+import { OwaEvent } from '../../modules/Base/src/tracker/OwaEvent.js';
 
 /**
  * Assorted tracker helpers: URL/anchor param readers, page-property
@@ -162,7 +162,7 @@ describe('setCampaignRelatedProperties (thirdParty promotion)', () => {
         setUrl('/p?owa_source=news&owa_medium=email');
         const t = newTracker();
 
-        t.setCampaignRelatedProperties(new Event());
+        t.setCampaignRelatedProperties(new OwaEvent());
 
         // Upstream reads the full-name globals; the private-key map resolves
         // owa_source -> source, owa_medium -> medium.
@@ -175,7 +175,7 @@ describe('manageState one-shot guard', () => {
 
     test('runs the identity pipeline once and sets stateInit', () => {
         const t = newTracker();
-        const event = new Event();
+        const event = new OwaEvent();
         event.set('timestamp', 1700000000);
 
         t.manageState(event, null);
@@ -186,7 +186,7 @@ describe('manageState one-shot guard', () => {
 
     test('does not re-run once stateInit is true', () => {
         const t = newTracker();
-        const event = new Event();
+        const event = new OwaEvent();
         event.set('timestamp', 1700000000);
 
         // Simulate a prior run and plant a sentinel the pipeline would overwrite.

--- a/tests/js/TransportAndState.test.js
+++ b/tests/js/TransportAndState.test.js
@@ -1,6 +1,6 @@
 import { OWATracker } from '../../modules/Base/src/tracker/Tracker.js';
 import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
-import { Event } from '../../modules/Base/src/tracker/Event.js';
+import { OwaEvent } from '../../modules/Base/src/tracker/OwaEvent.js';
 
 /**
  * Beacon transport + the trackEvent() state orchestration.
@@ -167,7 +167,7 @@ describe('addDefaultsToEvent', () => {
 
     test('backfills site_id, page_url, page_title and timestamp', () => {
         const t = newTracker();
-        const event = new Event();
+        const event = new OwaEvent();
 
         t.addDefaultsToEvent(event, null);
         const p = event.getProperties();
@@ -180,7 +180,7 @@ describe('addDefaultsToEvent', () => {
 
     test('does not overwrite a value the event already carries', () => {
         const t = newTracker();
-        const event = new Event();
+        const event = new OwaEvent();
         event.set('page_url', 'http://cv.example/explicit');
 
         t.addDefaultsToEvent(event, null);
@@ -194,7 +194,7 @@ describe('addGlobalPropertiesToEvent', () => {
     test('copies a global property onto an event that lacks it', () => {
         const t = newTracker();
         t.setGlobalEventProperty('visitor_id', 'vid-1');
-        const event = new Event();
+        const event = new OwaEvent();
 
         t.addGlobalPropertiesToEvent(event, null);
 
@@ -204,7 +204,7 @@ describe('addGlobalPropertiesToEvent', () => {
     test('never clobbers a value the event set locally', () => {
         const t = newTracker();
         t.setGlobalEventProperty('visitor_id', 'vid-global');
-        const event = new Event();
+        const event = new OwaEvent();
         event.set('visitor_id', 'vid-local-wins');
 
         t.addGlobalPropertiesToEvent(event, null);
@@ -217,7 +217,7 @@ describe('trackEvent: end-to-end orchestration', () => {
 
     test('emits one beacon carrying identity + core params in first-party mode', () => {
         const t = newTracker();
-        const event = new Event();
+        const event = new OwaEvent();
         event.setEventType('base.page_request');
         event.set('page_url', 'http://cv.example/page');
 
@@ -234,7 +234,7 @@ describe('trackEvent: end-to-end orchestration', () => {
 
     test('thirdParty mode flags the event for upstream and skips client state management', () => {
         const t = newTracker({ thirdParty: true });
-        const event = new Event();
+        const event = new OwaEvent();
         event.setEventType('base.page_request');
 
         t.trackEvent(event);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,16 +34,28 @@ const MANIFEST = 'build.manifest.json';
 
 const minimizer = [new TerserPlugin({ extractComments: false })];
 
-// Build the webpack `output` block shared by both JS product types. Kept exactly
-// as the two inline JS configs used it: emit `[name]` verbatim (the package name
-// IS the filename, so no PHP path churn) into the module's output dir, with
-// iife:false so a vendors split emits a sibling entry chunk rather than a runtime
-// import() (see the tracker note below).
+// Build the webpack `output` block shared by both JS product types: emit `[name]`
+// verbatim (the package name IS the filename, so no PHP path churn) into the
+// module's output dir.
+//
+// `output.iife` is deliberately LEFT AT ITS DEFAULT (true for target:web). It used
+// to be forced to false, carried over unexplained from the original webpack
+// migration (0592fcb6). That is not a safe setting for a bundle that ships as a
+// classic <script>: production mode enables scope hoisting, so webpack concatenates
+// the entry's whole module graph into one scope, and without the IIFE that scope IS
+// the page's global scope. Every top-level declaration in every concatenated source
+// file then becomes a global binding -- the tracker's event class, then still
+// named `Event` (it is OwaEvent now, in tracker/OwaEvent.js), shadowed the DOM's
+// window.Event for the entire page, breaking any library that does `new Event(...)`
+// (Bootstrap's dropdowns, modals and tabs, for instance).
+//
+// The flag also does not do what the old comment claimed. `output.iife` controls
+// only the wrapper; whether a vendors split lands in a sibling chunk or an async
+// import() is governed by `optimization.splitChunks` below, which is unchanged.
 function jsOutput(moduleDir, pkg) {
 	return {
 		path: path.resolve(moduleDir, pkg.outputDir),
 		chunkFilename: '[name].js',
-		iife: false,
 		filename: '[name]',
 	};
 }


### PR DESCRIPTION
Fixes #992

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tested the changes
- [x] Build (`npm run build`) was run locally and any changes were pushed

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: #992 

`jsOutput()` in `webpack.config.js` forces `output.iife: false`, carried over
unexplained from the original webpack migration (0592fcb6).

Production mode enables scope hoisting, so webpack concatenates the entry's whole
module graph into a single scope. Without the IIFE wrapper, that scope **is** the
host page's global scope, and every top-level declaration in every concatenated
source file becomes a global binding.

The tracker ships as a classic `<script>` into pages OWA does not control, so this
leaks into other people's sites:

- `class Event` in `tracker/Event.js` lands as a global **lexical** binding. Lexical
  declarations are resolved before the global object, so it shadows the DOM's
  `window.Event` for the entire page. Any library calling `new Event(...)` gets an
  OWA event object back and fails with
  `Failed to execute 'dispatchEvent' on 'EventTarget': parameter 1 is not of type 'Event'`.
  Bootstrap's dropdowns, modals and tabs are among the casualties.
- `__webpack_require__` and `__webpack_modules__` leak onto `window` as well.

## What is the new behavior?

- `output.iife` is dropped from `jsOutput()` and left at webpack's default (`true`
  for `target: web`), restoring the standard wrapper. Both JS products — the tracker
  and the reporting bundle — now keep their declarations to themselves.
- The tracker's `Event` class is renamed to `OwaEvent`, and `tracker/Event.js` to
  `tracker/OwaEvent.js` to match. The wrapper makes the collision impossible today,
  but naming a class after a DOM global should not depend on one build flag staying
  put.
- New `tests/js/BundleGlobalScope.test.js` locks both layers in with two independent
  guards, because they fail on different mistakes:
  1. **Config guard**: no JS build product may set `output.iife` to `false`.
  2. **Artefact guard**: each built bundle, evaluated in a bare realm, must leave no
     properties on the global object and no resolvable bindings for the tracker's
     class names or the DOM globals they could shadow. This catches any *other* way a
     global escapes, not just the flag coming back.

The old comment claimed `iife: false` was needed so a vendors split emits a sibling
chunk rather than a runtime `import()`. That is not what `output.iife` does, it
controls only the wrapper, while sibling-vs-async is governed by
`optimization.splitChunks`, which is unchanged. A rebuild confirms `owa.vendors.js`,
`owa.heatmap.js` and `owa.player.js` are still emitted exactly as before.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

`Event` was never part of any public surface. It is not attached to `window`, is
reachable only through the unchanged `tracker.makeEvent()` factory and the
`owa_cmds` command queue, and has no references anywhere outside the tracker module
graph and its tests. The PHP-side `Event` class (`modules/Base/Classes/Event.php`) is
unrelated and untouched.

The globals the bundles are *supposed* to publish still are, explicitly and by name:
`owa_cmds` from the tracker entry, and `OWA` / `jQuery` / `$` from the reporting
entry. Only the accidental ones are gone.

## Docs need to be updated?

- [ ] Yes
- [x] No

## Other information

**Reproduction.** Verified against the previously deployed bundle in jsdom: bare
`Event !== window.Event` and `dispatchEvent` throws the reported `TypeError`. With
this build, bare `Event === window.Event`, dispatch succeeds, and `window.owa_cmds`
is still a working `CommandQueue`.

**Test suite.** `npx jest` 25 suites, 223 tests passing, including the three new
global-scope assertions run against a freshly built dist.

**Note for reviewers running tests locally.** `BundleGlobalScope.test.js` reads the
built artefacts from `public/base/dist/`, which is gitignored, so `npm test` on a
clean checkout needs `npm run build` first. CI already does this
(`.github/workflows/ci.yml` builds before testing), and the test throws an explicit
"run `npm run build`" message rather than a confusing assertion failure.

**Build.** Both JS configs build clean. The full `npm run build` additionally needs
Node 20 as pinned in CI on Node 18 the CSS config's `copy-webpack-plugin` dies on
`Array.prototype.toSorted`, which is a pre-existing environment issue unrelated to
this change. Nothing to push: the dist tree is gitignored and built at deploy time.
