### PR TITLE
feat(partitioning): tiered layouts, rotate without deleting, one-time init, and partition-status

### DIFF
--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1992,6 +1992,62 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
+     * Replace a run of adjacent partitions with a different set of ranges.
+     *
+     * The general form of both merging and splitting: REORGANIZE requires only
+     * that the replacements tile exactly the span they replace, so N partitions
+     * can become one, or one can become N, or five can become three.
+     *
+     * Splitting matters as much as merging. Without it the layout would depend
+     * on the order operations happened in rather than on the current settings --
+     * a table coarsened under a tight budget would stay coarse after the budget
+     * grew, while an identical installation partitioned fresh would not. Same
+     * inputs, different result.
+     *
+     * @param string $table_name
+     * @param array  $names   partitions to replace, ascending and adjacent
+     * @param array  $ranges  name => less_than, ascending, tiling the same span
+     * @return bool
+     */
+    function reshapePartitions( $table_name, $names, $ranges ) {
+
+        if ( ! $this->supportsPartitioning() || ! $names || ! $ranges ) {
+
+            return false;
+        }
+
+        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            return false;
+        }
+
+        foreach ( $names as $n ) {
+
+            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $n ) ) {
+
+                return false;
+            }
+        }
+
+        $parts = array();
+
+        foreach ( $ranges as $name => $less_than ) {
+
+            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $name )
+              || ! preg_match( '/^\d{8}$/', (string) $less_than ) ) {
+
+                return false;
+            }
+
+            $parts[] = sprintf( OWA_DTD_PARTITION_LESS_THAN, $name, $less_than );
+        }
+
+        return (bool) $this->query( sprintf(
+            OWA_SQL_REORGANIZE_PARTITION, $table_name, implode( ',', $names ), implode( ', ', $parts )
+        ) );
+    }
+
+    /**
      * Largest run of calendar years that may be merged into one partition.
      *
      * A cap, not a target. Without one, a budget that cannot be met would drive
@@ -2003,28 +2059,39 @@ class Db extends \OWA\Core\Base {
     const PARTITION_MAX_YEARS_PER_BLOCK = 5;  // default; OWA_PARTITION_MAX_YEARS_PER_BLOCK
 
     /**
-     * Plan how to coarsen the partitions outside the detail window so the table
-     * fits a partition budget, WITHOUT deleting anything.
+     * Work out the tail layout the current settings imply, and how to get there
+     * from whatever the table looks like now.
      *
-     * This is what lets an installation keep decades of history on a server that
-     * cannot afford a file per month. Old periods are merged, not dropped: whole
-     * calendar years first, then runs of years if that is not enough. The detail
-     * window is never touched.
+     * The result is a function of the budget and the detail window ALONE, never
+     * of the order operations happened in. That is deliberate: a table coarsened
+     * under a tight budget must go back to finer blocks when the budget grows,
+     * or an installation's layout would depend on its history rather than its
+     * configuration, and two identical installations could differ permanently.
      *
-     * Budget-driven rather than calendar-driven on purpose. A yearly tail is
-     * enough for any plausible history on a generous server, but a host with a
-     * small innodb_open_files can exceed its limit on yearly partitions alone,
-     * and a fixed calendar rule would simply fail there.
+     * So this both merges and splits. Blocks are whole calendar years, widened
+     * only as far as the budget requires and never past
+     * PARTITION_MAX_YEARS_PER_BLOCK -- a cap, because a budget that cannot be
+     * met would otherwise drive everything into one partition, which fits no
+     * better and means all of history ages out in a single drop.
+     *
+     * Nothing is ever deleted. The detail window is never touched.
      *
      * @param string $table_name
      * @param int    $limit          most partitions this table may have
      * @param int    $detail_months  periods newer than this are left alone
-     * @return array ['merges','projected','fits','floor']
+     * @return array ['operations','projected','fits','floor','block_years']
      */
     function planPartitionCompaction( $table_name, $limit, $detail_months = self::PARTITION_DETAIL_MONTHS ) {
 
         $spans  = $this->getPartitionSpans( $table_name );
-        $result = array( 'merges' => array(), 'projected' => count( $spans ), 'fits' => true, 'floor' => count( $spans ) );
+        $result = array(
+            'operations'  => array(),
+            'merges'      => array(),
+            'projected'   => count( $spans ),
+            'fits'        => true,
+            'floor'       => count( $spans ),
+            'block_years' => 1,
+        );
 
         if ( ! $spans ) {
 
@@ -2043,110 +2110,189 @@ class Db extends \OWA\Core\Base {
             }
         }
 
-        // Everything inside the detail window, plus at least one tail partition,
-        // is the fewest this table can have without narrowing the window.
-        $kept           = count( $spans ) - count( $old );
+        $kept            = count( $spans ) - count( $old );
         $result['floor'] = $kept + ( $old ? 1 : 0 );
 
-        if ( count( $spans ) <= $limit || count( $old ) < 2 ) {
+        if ( ! $old ) {
 
             $result['fits'] = count( $spans ) <= $limit;
 
             return $result;
         }
 
-        // Group by calendar year, but measure a group by the span it COVERS, not
-        // by how many groups it contains. A partition that is already a merged
-        // block of years counts for all of them, so re-running cannot merge it
-        // past the cap. Without that, each run compounds the previous one --
-        // five years, then ten, then twenty -- and an unreachable budget
-        // collapses all of history into one partition over several runs, which
-        // is the cliff the cap exists to prevent.
-        $years = array();
+        // The tail runs from the first old partition to wherever the last one
+        // ends -- which is usually mid-year, because the detail window opens on
+        // a month rather than a January. The final block therefore closes on
+        // that boundary rather than on a year end, or the remaining months would
+        // belong to no block and stay unmerged.
+        $tail_start = (int) substr( $old[0]['start'], 0, 4 );
+        $tail_limit = (string) $old[ count( $old ) - 1 ]['less_than'];
+
+        $years = max( 1, (int) ceil(
+            ( strtotime( $tail_limit ) - strtotime( $tail_start . '0101' ) ) / ( 86400 * 365.25 )
+        ) );
+
+        // Smallest block size that fits, capped. One year is the finest the tail
+        // is ever cut to: below that it is the detail window's job.
+        $block = 1;
+
+        for ( ; $block < self::PARTITION_MAX_YEARS_PER_BLOCK; $block++ ) {
+
+            if ( $kept + (int) ceil( $years / $block ) <= $limit ) {
+
+                break;
+            }
+        }
+
+        $result['block_years'] = $block;
+
+        // The layout those settings imply.
+        $target = array();
+
+        for ( $y = $tail_start; ; $y += $block ) {
+
+            $end = ( $y + $block ) . '0101';
+
+            if ( $end >= $tail_limit ) {
+
+                $end = $tail_limit;
+            }
+
+            $target[ 'p' . $y . '0101' ] = $end;
+
+            if ( $end >= $tail_limit ) {
+
+                break;
+            }
+        }
+
+        $result['projected'] = $kept + count( $target );
+        $result['fits']      = $result['projected'] <= $limit;
+
+        // Already in that shape? Then there is nothing to do, however many times
+        // this runs.
+        $current = array();
 
         foreach ( $old as $span ) {
 
-            $years[ substr( $span['start'], 0, 4 ) ][] = $span;
+            $current[ $span['name'] ] = (string) $span['less_than'];
         }
 
-        $keys = array_keys( $years );
-        sort( $keys );
+        if ( $current === array_map( 'strval', $target ) ) {
 
-        // Years actually covered by each group, so an existing block is not
-        // mistaken for a single year.
-        $weight = array();
-
-        foreach ( $keys as $year ) {
-
-            $first = $years[ $year ][0];
-            $last  = $years[ $year ][ count( $years[ $year ] ) - 1 ];
-
-            $span = ( (int) substr( $last['less_than'], 0, 4 ) ) - ( (int) substr( $first['start'], 0, 4 ) );
-
-            $weight[ $year ] = max( 1, $span );
+            return $result;
         }
 
-        $max_block = min( self::PARTITION_MAX_YEARS_PER_BLOCK, count( $keys ) );
+        // One reorganisation per target block, over whichever partitions it
+        // covers. That merges where the tail is too fine and splits where it is
+        // too coarse, in the same operation.
+        $names_by_block = array();
 
-        for ( $per_block = 1; $per_block <= $max_block; $per_block++ ) {
+        foreach ( $target as $name => $less_than ) {
 
-            // Fill blocks up to $per_block years of coverage. A group already
-            // that wide stands alone rather than being absorbed into a wider one.
-            $blocks  = array();
-            $current = array();
-            $carried = 0;
+            $from = substr( $name, 1 );
 
-            foreach ( $keys as $year ) {
+            $names_by_block[ $name ] = array(
+                'names'     => array(),
+                'start'     => $from,
+                'less_than' => $less_than,
+                'ranges'    => array( $name => $less_than ),
+            );
+        }
 
-                if ( $current && $carried + $weight[ $year ] > $per_block ) {
+        foreach ( $old as $span ) {
 
-                    $blocks[]  = $current;
-                    $current   = array();
-                    $carried   = 0;
-                }
+            foreach ( $names_by_block as $name => &$block_def ) {
 
-                $current[] = $year;
-                $carried  += $weight[ $year ];
-            }
+                // A partition belongs to the block its start falls in. A block
+                // that is coarser than the target is claimed by the first target
+                // block it overlaps, and split by the reorganisation.
+                if ( (string) $span['start'] >= $block_def['start']
+                  && (string) $span['start'] < $block_def['less_than'] ) {
 
-            if ( $current ) {
+                    $block_def['names'][] = $span['name'];
 
-                $blocks[] = $current;
-            }
+                    if ( (string) $span['less_than'] > $block_def['less_than'] ) {
 
-            if ( $kept + count( $blocks ) <= $limit || $per_block === $max_block ) {
-
-                $merges = array();
-
-                foreach ( $blocks as $block ) {
-
-                    $names = array();
-                    $start = null;
-                    $end   = null;
-
-                    foreach ( $block as $year ) {
-
-                        foreach ( $years[ $year ] as $span ) {
-
-                            $names[] = $span['name'];
-                            $start   = $start ?? $span['start'];
-                            $end     = $span['less_than'];
-                        }
+                        // This partition reaches past the block, so the block and
+                        // everything it spans are reshaped together.
+                        $block_def['less_than'] = (string) $span['less_than'];
                     }
 
-                    if ( count( $names ) > 1 ) {
+                    break;
+                }
+            }
 
-                        $merges[] = array( 'names' => $names, 'start' => $start, 'less_than' => $end );
-                    }
+            unset( $block_def );
+        }
+
+        foreach ( $names_by_block as $name => $block_def ) {
+
+            if ( ! $block_def['names'] ) {
+
+                continue;
+            }
+
+            // Ranges covering exactly what the named partitions span.
+            $ranges = array();
+
+            for ( $y = (int) substr( $block_def['start'], 0, 4 ); ; $y += $block ) {
+
+                $end = ( $y + $block ) . '0101';
+
+                if ( $end >= $block_def['less_than'] ) {
+
+                    $end = (string) $block_def['less_than'];
                 }
 
-                $result['merges']    = $merges;
-                $result['projected'] = $kept + count( $blocks );
-                $result['fits']      = $result['projected'] <= $limit;
+                $ranges[ 'p' . $y . '0101' ] = $end;
 
-                return $result;
+                if ( $end >= $block_def['less_than'] ) {
+
+                    break;
+                }
             }
+
+            if ( ! $ranges ) {
+
+                continue;
+            }
+
+            // No change needed where the shape already matches.
+            $same = ( count( $block_def['names'] ) === count( $ranges ) );
+
+            if ( $same ) {
+
+                $i = 0;
+
+                foreach ( $ranges as $rname => $rless ) {
+
+                    if ( $block_def['names'][ $i ] !== $rname ) {
+
+                        $same = false;
+
+                        break;
+                    }
+
+                    $i++;
+                }
+            }
+
+            if ( $same ) {
+
+                continue;
+            }
+
+            $result['operations'][] = array(
+                'names'  => $block_def['names'],
+                'ranges' => $ranges,
+                'start'  => $block_def['start'],
+                'less_than' => $block_def['less_than'],
+            );
         }
+
+        // Kept for callers that only care about the coarsening case.
+        $result['merges'] = $result['operations'];
 
         return $result;
     }

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1932,6 +1932,66 @@ class Db extends \OWA\Core\Base {
     const PARTITION_MIN_LIMIT = 24;       // default; OWA_PARTITION_MIN_LIMIT
 
     /**
+     * Ranges for a table that is being partitioned for the first time: coarse
+     * over old history, fine over the detail window and the lead.
+     *
+     * A flat monthly layout over a long-running installation asks for one
+     * partition per month of history -- over three hundred on a twenty-five year
+     * table -- which exceeds any reasonable open-file budget and leaves the
+     * operator no way through, since monthly is already the coarsest granularity
+     * and old data cannot be pruned before partitions exist to prune.
+     *
+     * Building the tiers up front avoids partitioning flat and merging
+     * afterwards, which would mean writing every old row twice.
+     *
+     * Whole calendar years are used for the old tier because a year is the unit
+     * an operator reasons about, and because retention still means something:
+     * history ages out a year at a time. Lumping it all into one partition
+     * instead would leave a table whose first routine retention run discards
+     * decades in a single statement.
+     *
+     * @param string $min_yyyymmdd    oldest data present
+     * @param string $through         upper boundary to reach (exclusive)
+     * @param string $granularity     granularity for the detail window
+     * @param int    $detail_months   how much recent history stays fine
+     * @return array name => less_than, ascending
+     */
+    static function makeTieredPartitionRanges( $min_yyyymmdd, $through, $granularity, $detail_months ) {
+
+        $boundary = date( 'Ymd', strtotime( date( 'Ym' ) . '01 -' . (int) $detail_months . ' months' ) );
+
+        // Nothing old enough to coarsen: this is just the flat layout.
+        if ( (string) $min_yyyymmdd >= $boundary ) {
+
+            return self::makePartitionRanges(
+                $min_yyyymmdd, date( 'Ymd', strtotime( $through . ' -1 day' ) ), $granularity
+            );
+        }
+
+        $ranges = array();
+
+        // Old tier: whole calendar years, from the year the data starts in up to
+        // the year the detail window opens in.
+        $year      = (int) substr( $min_yyyymmdd, 0, 4 );
+        $last_year = (int) substr( $boundary, 0, 4 );
+
+        for ( ; $year < $last_year; $year++ ) {
+
+            $ranges[ 'p' . $year . '0101' ] = ( $year + 1 ) . '0101';
+        }
+
+        // Detail tier: from the start of the boundary year through the lead, at
+        // the table's own granularity. Starting at the year boundary rather than
+        // at $boundary itself keeps every partition inside one calendar year,
+        // so the old tier can never overlap the new one.
+        $fine = self::makePartitionRanges(
+            $last_year . '0101', date( 'Ymd', strtotime( $through . ' -1 day' ) ), $granularity
+        );
+
+        return array_merge( $ranges, $fine );
+    }
+
+    /**
      * Largest run of calendar years that may be merged into one partition.
      *
      * A cap, not a target. Without one, a budget that cannot be met would drive

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1956,7 +1956,7 @@ class Db extends \OWA\Core\Base {
      * @param int    $detail_months   how much recent history stays fine
      * @return array name => less_than, ascending
      */
-    static function makeTieredPartitionRanges( $min_yyyymmdd, $through, $granularity, $detail_months ) {
+    static function makeTieredPartitionRanges( $min_yyyymmdd, $through, $granularity, $detail_months, $limit = null ) {
 
         $boundary = date( 'Ymd', strtotime( date( 'Ym' ) . '01 -' . (int) $detail_months . ' months' ) );
 
@@ -1970,23 +1970,56 @@ class Db extends \OWA\Core\Base {
 
         $ranges = array();
 
-        // Old tier: whole calendar years, from the year the data starts in up to
-        // the year the detail window opens in.
-        $year      = (int) substr( $min_yyyymmdd, 0, 4 );
-        $last_year = (int) substr( $boundary, 0, 4 );
+        // Old tier: whole calendar years, except the last, which closes on the
+        // month the detail window opens rather than on a January.
+        //
+        // That boundary has to be the one planPartitionCompaction() uses, or the
+        // two disagree about which periods are old: init would leave the months
+        // between January and the detail window as separate partitions, and the
+        // next rotate would immediately merge them. The table would be rewritten
+        // on every scheduled run, for no change in shape.
+        $first_year = (int) substr( $min_yyyymmdd, 0, 4 );
+        $last_year  = (int) substr( $boundary, 0, 4 );
 
-        for ( ; $year < $last_year; $year++ ) {
+        // Detail tier first, because its size decides how much room the tail has.
+        $fine = self::makePartitionRanges(
+            $boundary, date( 'Ymd', strtotime( $through . ' -1 day' ) ), $granularity
+        );
 
-            $ranges[ 'p' . $year . '0101' ] = ( $year + 1 ) . '0101';
+        // Widen the tail blocks until the whole layout fits, exactly as
+        // planPartitionCompaction() does. Building 1-year blocks regardless and
+        // leaving the next rotation to coarsen them would mean the first
+        // scheduled run rewrote everything init had just created.
+        $years = max( 1, $last_year - $first_year + ( $boundary > $last_year . '0101' ? 1 : 0 ) );
+        $block = 1;
+
+        if ( $limit !== null ) {
+
+            for ( ; $block < self::PARTITION_MAX_YEARS_PER_BLOCK; $block++ ) {
+
+                if ( count( $fine ) + (int) ceil( $years / $block ) <= $limit ) {
+
+                    break;
+                }
+            }
         }
 
-        // Detail tier: from the start of the boundary year through the lead, at
-        // the table's own granularity. Starting at the year boundary rather than
-        // at $boundary itself keeps every partition inside one calendar year,
-        // so the old tier can never overlap the new one.
-        $fine = self::makePartitionRanges(
-            $last_year . '0101', date( 'Ymd', strtotime( $through . ' -1 day' ) ), $granularity
-        );
+        for ( $y = $first_year; ; $y += $block ) {
+
+            $end = ( $y + $block ) . '0101';
+
+            if ( $end >= $boundary ) {
+
+                $end = $boundary;
+            }
+
+            $ranges[ 'p' . $y . '0101' ] = $end;
+
+            if ( $end >= $boundary ) {
+
+                break;
+            }
+        }
 
         return array_merge( $ranges, $fine );
     }

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1842,6 +1842,208 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
+     * Merge a run of adjacent partitions into one.
+     *
+     * The inverse of extendPartitions(): that splits, this combines. It exists so
+     * that partition count can be kept under the server's open-file budget
+     * WITHOUT deleting anything -- old periods are coarsened rather than dropped.
+     * A table can then hold decades of history in a few dozen files.
+     *
+     * The replacement keeps the p<yyyymmdd> naming, because getPartitionSpans()
+     * recovers the first partition's lower bound from its name and
+     * inferPartitionGranularity() reads the day-of-month out of it. A partition
+     * named anything else reads back as having no usable start.
+     *
+     * The partitions must be adjacent and given in order: REORGANIZE requires the
+     * replacement to tile exactly the range being replaced, so the new upper
+     * bound has to be the last one's.
+     *
+     * @param string $table_name
+     * @param array  $names      partition names, in ascending order
+     * @param string $start      yyyymmdd the merged partition begins at (its name)
+     * @param string $less_than  yyyymmdd upper bound -- the last partition's
+     * @return bool
+     */
+    function mergePartitions( $table_name, $names, $start, $less_than ) {
+
+        if ( ! $this->supportsPartitioning() || count( $names ) < 2 ) {
+
+            return false;
+        }
+
+        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            return false;
+        }
+
+        foreach ( $names as $n ) {
+
+            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $n ) ) {
+
+                return false;
+            }
+        }
+
+        if ( ! preg_match( '/^\d{8}$/', (string) $start ) || ! preg_match( '/^\d{8}$/', (string) $less_than ) ) {
+
+            return false;
+        }
+
+        $replacement = sprintf( OWA_DTD_PARTITION_LESS_THAN, 'p' . $start, $less_than );
+
+        return (bool) $this->query( sprintf(
+            OWA_SQL_REORGANIZE_PARTITION, $table_name, implode( ',', $names ), $replacement
+        ) );
+    }
+
+    /**
+     * How old a period must be before it is eligible to be coarsened, in months.
+     *
+     * Inside this window partitions keep whatever granularity the table uses, so
+     * recent reporting and recent retention stay precise. Outside it they may be
+     * merged, because old periods are queried rarely and pruned in bulk.
+     */
+    const PARTITION_DETAIL_MONTHS = 36;
+
+    /**
+     * Fraction of the server's spare open-file slots this feature may claim,
+     * expressed as a divisor: 2 means half of them.
+     *
+     * The reading is a snapshot of a shared resource -- every other table on the
+     * instance draws on the same cap, and the schema grows -- so taking all of it
+     * would be planning for a server that no longer exists by the time the
+     * partitions are created.
+     */
+    const PARTITION_BUDGET_RESERVE = 2;
+
+    /**
+     * Fewest partitions a table is allowed regardless of what the budget says.
+     *
+     * A server reporting almost no headroom would otherwise derive a limit that
+     * refuses even a couple of years of monthly partitions, which is worse than
+     * useless -- the feature would be unavailable exactly where retention matters
+     * most.
+     */
+    const PARTITION_MIN_LIMIT = 24;
+
+    /**
+     * Largest run of calendar years that may be merged into one partition.
+     *
+     * A cap, not a target. Without one, a budget that cannot be met would drive
+     * the planner to collapse the entire tail into a single partition -- which
+     * fits nothing better and destroys retention granularity for all of history,
+     * since a partition can only be dropped as a unit. Better to return the best
+     * plan available and report that it does not fit.
+     */
+    const PARTITION_MAX_YEARS_PER_BLOCK = 5;
+
+    /**
+     * Plan how to coarsen the partitions outside the detail window so the table
+     * fits a partition budget, WITHOUT deleting anything.
+     *
+     * This is what lets an installation keep decades of history on a server that
+     * cannot afford a file per month. Old periods are merged, not dropped: whole
+     * calendar years first, then runs of years if that is not enough. The detail
+     * window is never touched.
+     *
+     * Budget-driven rather than calendar-driven on purpose. A yearly tail is
+     * enough for any plausible history on a generous server, but a host with a
+     * small innodb_open_files can exceed its limit on yearly partitions alone,
+     * and a fixed calendar rule would simply fail there.
+     *
+     * @param string $table_name
+     * @param int    $limit          most partitions this table may have
+     * @param int    $detail_months  periods newer than this are left alone
+     * @return array ['merges','projected','fits','floor']
+     */
+    function planPartitionCompaction( $table_name, $limit, $detail_months = self::PARTITION_DETAIL_MONTHS ) {
+
+        $spans  = $this->getPartitionSpans( $table_name );
+        $result = array( 'merges' => array(), 'projected' => count( $spans ), 'fits' => true, 'floor' => count( $spans ) );
+
+        if ( ! $spans ) {
+
+            return $result;
+        }
+
+        $boundary = date( 'Ymd', strtotime( date( 'Ym' ) . '01 -' . (int) $detail_months . ' months' ) );
+
+        $old = array();
+
+        foreach ( $spans as $span ) {
+
+            if ( (string) $span['less_than'] <= $boundary ) {
+
+                $old[] = $span;
+            }
+        }
+
+        // Everything inside the detail window, plus at least one tail partition,
+        // is the fewest this table can have without narrowing the window.
+        $kept           = count( $spans ) - count( $old );
+        $result['floor'] = $kept + ( $old ? 1 : 0 );
+
+        if ( count( $spans ) <= $limit || count( $old ) < 2 ) {
+
+            $result['fits'] = count( $spans ) <= $limit;
+
+            return $result;
+        }
+
+        $years = array();
+
+        foreach ( $old as $span ) {
+
+            $years[ substr( $span['start'], 0, 4 ) ][] = $span;
+        }
+
+        $keys = array_keys( $years );
+        sort( $keys );
+
+        $max_block = min( self::PARTITION_MAX_YEARS_PER_BLOCK, count( $keys ) );
+
+        for ( $per_block = 1; $per_block <= $max_block; $per_block++ ) {
+
+            $blocks = array_chunk( $keys, $per_block );
+
+            if ( $kept + count( $blocks ) <= $limit || $per_block === $max_block ) {
+
+                $merges = array();
+
+                foreach ( $blocks as $block ) {
+
+                    $names = array();
+                    $start = null;
+                    $end   = null;
+
+                    foreach ( $block as $year ) {
+
+                        foreach ( $years[ $year ] as $span ) {
+
+                            $names[] = $span['name'];
+                            $start   = $start ?? $span['start'];
+                            $end     = $span['less_than'];
+                        }
+                    }
+
+                    if ( count( $names ) > 1 ) {
+
+                        $merges[] = array( 'names' => $names, 'start' => $start, 'less_than' => $end );
+                    }
+                }
+
+                $result['merges']    = $merges;
+                $result['projected'] = $kept + count( $blocks );
+                $result['fits']      = $result['projected'] <= $limit;
+
+                return $result;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
      * Add whatever partitions are missing between the last boundary and a date.
      *
      * The new periods are cut out of the catch-all, which is the only partition

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -2055,6 +2055,13 @@ class Db extends \OWA\Core\Base {
             return $result;
         }
 
+        // Group by calendar year, but measure a group by the span it COVERS, not
+        // by how many groups it contains. A partition that is already a merged
+        // block of years counts for all of them, so re-running cannot merge it
+        // past the cap. Without that, each run compounds the previous one --
+        // five years, then ten, then twenty -- and an unreachable budget
+        // collapses all of history into one partition over several runs, which
+        // is the cliff the cap exists to prevent.
         $years = array();
 
         foreach ( $old as $span ) {
@@ -2065,11 +2072,47 @@ class Db extends \OWA\Core\Base {
         $keys = array_keys( $years );
         sort( $keys );
 
+        // Years actually covered by each group, so an existing block is not
+        // mistaken for a single year.
+        $weight = array();
+
+        foreach ( $keys as $year ) {
+
+            $first = $years[ $year ][0];
+            $last  = $years[ $year ][ count( $years[ $year ] ) - 1 ];
+
+            $span = ( (int) substr( $last['less_than'], 0, 4 ) ) - ( (int) substr( $first['start'], 0, 4 ) );
+
+            $weight[ $year ] = max( 1, $span );
+        }
+
         $max_block = min( self::PARTITION_MAX_YEARS_PER_BLOCK, count( $keys ) );
 
         for ( $per_block = 1; $per_block <= $max_block; $per_block++ ) {
 
-            $blocks = array_chunk( $keys, $per_block );
+            // Fill blocks up to $per_block years of coverage. A group already
+            // that wide stands alone rather than being absorbed into a wider one.
+            $blocks  = array();
+            $current = array();
+            $carried = 0;
+
+            foreach ( $keys as $year ) {
+
+                if ( $current && $carried + $weight[ $year ] > $per_block ) {
+
+                    $blocks[]  = $current;
+                    $current   = array();
+                    $carried   = 0;
+                }
+
+                $current[] = $year;
+                $carried  += $weight[ $year ];
+            }
+
+            if ( $current ) {
+
+                $blocks[] = $current;
+            }
 
             if ( $kept + count( $blocks ) <= $limit || $per_block === $max_block ) {
 
@@ -2287,6 +2330,36 @@ class Db extends \OWA\Core\Base {
         if ( ! $spans ) {
 
             return $result;
+        }
+
+        // Leave coarsened history alone unless a range explicitly asks for it.
+        //
+        // A tail block spans whole years by design, to keep the partition count
+        // within the server's open-file budget. Refining it back to the table's
+        // granularity would undo that -- on a ten-year table, sixty-odd
+        // partitions become nearly three hundred -- and would be the opposite of
+        // what compaction just did. A partition covering at most one calendar
+        // month is a normal period and is fair game; anything wider is a block.
+        if ( $from === null && $to === null ) {
+
+            $fine = array();
+
+            foreach ( $spans as $span ) {
+
+                $month_after = date( 'Ymd', strtotime( substr( $span['start'], 0, 6 ) . '01 +1 month' ) );
+
+                if ( (string) $span['less_than'] <= $month_after ) {
+
+                    $fine[] = $span;
+                }
+            }
+
+            $spans = array_values( $fine );
+
+            if ( ! $spans ) {
+
+                return $result;
+            }
         }
 
         // Keep only the partitions the range touches. A partition is rewritten

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1131,6 +1131,19 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
+     * Row count and date range within one partition. Unknown, without support.
+     *
+     * @param string $table_name
+     * @param string $partition
+     * @param string $column
+     * @return array|null
+     */
+    function getPartitionContents( $table_name, $partition, $column = 'yyyymmdd' ) {
+
+        return null;
+    }
+
+    /**
      * Is this table partitioned?
      *
      * @param string $table_name
@@ -1796,6 +1809,177 @@ class Db extends \OWA\Core\Base {
         }
 
         return null;
+    }
+
+    /**
+     * Name the period one partition spans.
+     *
+     * A tiered table does not have "a granularity": recent months are cut at the
+     * granularity in force, older ones have been merged into blocks of months or
+     * years to stay inside the open-file budget. Describing such a table with one
+     * word is wrong in both directions -- it either overstates the resolution of
+     * the tail or understates the head.
+     *
+     * A sub-month period is named by the granularity whose cuts it falls between,
+     * so the vocabulary is the one the reorganize command takes. Anything longer
+     * is named by its own length.
+     *
+     * @param string $start      yyyymmdd
+     * @param string $less_than  yyyymmdd
+     * @return string
+     */
+    static function describePartitionPeriod( $start, $less_than ) {
+
+        $a = \DateTimeImmutable::createFromFormat( 'Ymd|', (string) $start );
+        $b = \DateTimeImmutable::createFromFormat( 'Ymd|', (string) $less_than );
+
+        if ( ! $a || ! $b || $b <= $a ) {
+
+            return 'unknown';
+        }
+
+        // Whole months from the 1st: one calendar month is "monthly", and longer
+        // blocks are named in years where they divide evenly, because that is how
+        // the merged tail is built and how an operator thinks about it.
+        if ( $a->format( 'd' ) === '01' && $b->format( 'd' ) === '01' ) {
+
+            $months = ( (int) $b->format( 'Y' ) - (int) $a->format( 'Y' ) ) * 12
+                    + ( (int) $b->format( 'n' ) - (int) $a->format( 'n' ) );
+
+            if ( $months === 1 ) {
+
+                return 'monthly';
+            }
+
+            if ( $months % 12 === 0 ) {
+
+                $years = intdiv( $months, 12 );
+
+                return $years === 1 ? '1 year' : $years . ' years';
+            }
+
+            return $months . ' months';
+        }
+
+        // Within a month: the granularity that cuts it here.
+        foreach ( self::PARTITION_CUTS as $granularity => $cuts ) {
+
+            $day  = (int) $a->format( 'j' );
+            $at   = array_search( $day, $cuts, true );
+
+            if ( $at === false ) {
+
+                continue;
+            }
+
+            $next = isset( $cuts[ $at + 1 ] )
+                  ? $a->setDate( (int) $a->format( 'Y' ), (int) $a->format( 'n' ), $cuts[ $at + 1 ] )
+                  : $a->modify( 'first day of next month' );
+
+            if ( $next->format( 'Ymd' ) === $b->format( 'Ymd' ) ) {
+
+                return $granularity;
+            }
+        }
+
+        return $a->diff( $b )->days . ' days';
+    }
+
+    /**
+     * What a table's partitioning actually looks like right now.
+     *
+     * Reports the layout as tiers -- runs of adjacent partitions covering the
+     * same length of time -- because that is the shape the commands produce and
+     * a single granularity cannot describe it. The lead is separated out, since
+     * how far the bounded partitions reach into the future is what determines
+     * when the next rotate is due.
+     *
+     * Reads only metadata: no table is scanned. Catch-all contents are counted
+     * separately, by the caller that wants them.
+     *
+     * @param string $table_name
+     * @return array
+     */
+    function describePartitionLayout( $table_name ) {
+
+        $out = array(
+            'partitioned' => false,
+            'spans'       => 0,
+            'total'       => 0,
+            'covers'      => null,
+            'granularity' => null,
+            'tiers'       => array(),
+            'catch_all'   => null,
+            'through'     => null,
+            'ahead'       => null,
+            'lead'        => 0,
+        );
+
+        $all = $this->listPartitions( $table_name );
+
+        if ( ! $all ) {
+
+            return $out;
+        }
+
+        $spans = $this->getPartitionSpans( $table_name );
+
+        $out['partitioned'] = true;
+        $out['total']       = count( $all );
+        $out['spans']       = count( $spans );
+        $out['catch_all']   = $this->getCatchAllPartition( $table_name );
+        $out['granularity'] = $this->inferPartitionGranularity( $table_name );
+
+        if ( ! $spans ) {
+
+            // A catch-all and nothing else: everything is unbounded.
+            return $out;
+        }
+
+        $out['covers']  = array( 'start' => $spans[0]['start'], 'end' => end( $spans )['less_than'] );
+        $out['through'] = end( $spans )['less_than'];
+
+        $today = date( 'Ymd' );
+
+        foreach ( $spans as $span ) {
+
+            $period = self::describePartitionPeriod( $span['start'], $span['less_than'] );
+            $last   = count( $out['tiers'] ) - 1;
+
+            if ( $last >= 0 && $out['tiers'][ $last ]['period'] === $period ) {
+
+                $out['tiers'][ $last ]['count']++;
+                $out['tiers'][ $last ]['end'] = $span['less_than'];
+
+            } else {
+
+                $out['tiers'][] = array(
+                    'period' => $period,
+                    'count'  => 1,
+                    'start'  => $span['start'],
+                    'end'    => $span['less_than'],
+                );
+            }
+
+            // Lead is the partitions that begin after today: periods bought in
+            // advance, which is what running out of them costs.
+            if ( $span['start'] > $today ) {
+
+                $out['lead']++;
+            }
+        }
+
+        $a = \DateTimeImmutable::createFromFormat( 'Ymd|', $today );
+        $b = \DateTimeImmutable::createFromFormat( 'Ymd|', (string) $out['through'] );
+
+        if ( $a && $b ) {
+
+            // Negative where the top boundary is already behind us, which is the
+            // state that matters: new rows are landing in the catch-all.
+            $out['ahead'] = (int) $a->diff( $b )->format( '%r%a' );
+        }
+
+        return $out;
     }
 
     /**

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1902,6 +1902,11 @@ class Db extends \OWA\Core\Base {
      * Inside this window partitions keep whatever granularity the table uses, so
      * recent reporting and recent retention stay precise. Outside it they may be
      * merged, because old periods are queried rarely and pruned in bulk.
+     *
+     * This is the code-level default. An installation overrides it with
+     * OWA_PARTITION_DETAIL_MONTHS in owa-config.php; the commands read the
+     * setting and pass the result in, so this value applies only to a direct
+     * caller that supplies nothing.
      */
     const PARTITION_DETAIL_MONTHS = 36;
 
@@ -1914,7 +1919,7 @@ class Db extends \OWA\Core\Base {
      * would be planning for a server that no longer exists by the time the
      * partitions are created.
      */
-    const PARTITION_BUDGET_RESERVE = 2;
+    const PARTITION_BUDGET_RESERVE = 2;   // default; OWA_PARTITION_BUDGET_RESERVE
 
     /**
      * Fewest partitions a table is allowed regardless of what the budget says.
@@ -1924,7 +1929,7 @@ class Db extends \OWA\Core\Base {
      * useless -- the feature would be unavailable exactly where retention matters
      * most.
      */
-    const PARTITION_MIN_LIMIT = 24;
+    const PARTITION_MIN_LIMIT = 24;       // default; OWA_PARTITION_MIN_LIMIT
 
     /**
      * Largest run of calendar years that may be merged into one partition.
@@ -1935,7 +1940,7 @@ class Db extends \OWA\Core\Base {
      * since a partition can only be dropped as a unit. Better to return the best
      * plan available and report that it does not fit.
      */
-    const PARTITION_MAX_YEARS_PER_BLOCK = 5;
+    const PARTITION_MAX_YEARS_PER_BLOCK = 5;  // default; OWA_PARTITION_MAX_YEARS_PER_BLOCK
 
     /**
      * Plan how to coarsen the partitions outside the detail window so the table

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -385,6 +385,49 @@ class Mysql extends \OWA\Core\Db {
     }
 
     /**
+     * Row count and date range within one partition.
+     *
+     * Reads the partition itself rather than information_schema, because
+     * TABLE_ROWS is an InnoDB estimate that can be out by a wide margin -- and
+     * the whole point of asking about the catch-all is to know whether real data
+     * has collected there. The extension restricts the scan to that one
+     * partition, and the fact tables carry an index on the partitioning column,
+     * which on a partitioned table is local to each partition: the bounds are a
+     * seek, not a scan.
+     *
+     * @param string $table_name
+     * @param string $partition
+     * @param string $column
+     * @return array|null  ['rows','min','max'], or null where it cannot be read
+     */
+    function getPartitionContents( $table_name, $partition, $column = 'yyyymmdd' ) {
+
+        foreach ( array( $table_name, $partition, $column ) as $identifier ) {
+
+            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $identifier ) ) {
+
+                return null;
+            }
+        }
+
+        $row = $this->get_row( sprintf(
+            'SELECT COUNT(*) AS n, MIN(%1$s) AS lo, MAX(%1$s) AS hi FROM %2$s PARTITION (%3$s)',
+            $column, $table_name, $partition
+        ) );
+
+        if ( ! $row ) {
+
+            return null;
+        }
+
+        return array(
+            'rows' => (int) $row['n'],
+            'min'  => $row['lo'] === null ? null : (string) $row['lo'],
+            'max'  => $row['hi'] === null ? null : (string) $row['hi'],
+        );
+    }
+
+    /**
      * The columns of a table's primary key, in key order.
      *
      * @param string $table_name

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -149,6 +149,29 @@ namespace OWA\Module\Base\Classes;
             $this->set('base', 'error_log_level', OWA_ERROR_LOG_LEVEL);
         }
 
+        /* FACT-TABLE PARTITIONING */
+
+        // These describe the shape of an installation -- how much history stays
+        // finely partitioned, and how much of the server's open-file budget this
+        // may claim -- rather than the behaviour of a single command, so they are
+        // set once in owa-config.php:
+        //
+        //   define('OWA_PARTITION_DETAIL_MONTHS', 24);
+        //
+        // See the Partitioning Fact Tables page in the wiki.
+        foreach (array(
+            'OWA_PARTITION_DETAIL_MONTHS'       => 'partition_detail_months',
+            'OWA_PARTITION_BUDGET_RESERVE'      => 'partition_budget_reserve',
+            'OWA_PARTITION_MIN_LIMIT'           => 'partition_min_limit',
+            'OWA_PARTITION_MAX_YEARS_PER_BLOCK' => 'partition_max_years_per_block',
+            'OWA_PARTITION_MAX_PARTITIONS'      => 'partition_max_partitions',
+        ) as $constant => $key) {
+
+            if (defined($constant)) {
+                $this->set('base', $key, constant($constant));
+            }
+        }
+
         /* CONFIGURATION ID */
 
         if (defined('OWA_CONFIGURATION_ID')) {
@@ -922,6 +945,29 @@ namespace OWA\Module\Base\Classes;
                 'modules'                            => array('base'),
                 'mailer-from'                        => '',  // Set default address, because sending from root@localhost wont work
                 'mailer-fromName'                    => 'OWA Server',
+
+                // Fact-table partitioning. Defaults; override with a constant in
+                // owa-config.php -- see applyConfigConstants().
+                //
+                // How recent a period must be to keep fine granularity. Older
+                // periods may be merged into coarser ones to stay within the
+                // server's open-file budget -- merged, never dropped.
+                'partition_detail_months'            => 36,
+                // Fraction of the server's spare open-file slots partitioning may
+                // claim, as a divisor: 2 means half. The cap is shared with every
+                // other table on the instance, and the schema grows.
+                'partition_budget_reserve'           => 2,
+                // Fewest partitions a table may be limited to, whatever the
+                // budget arithmetic says.
+                'partition_min_limit'                => 24,
+                // Largest run of calendar years that may be merged into a single
+                // partition. A cap: without it, an unreachable budget would drive
+                // everything into one partition, which fits no better and means
+                // all of history ages out at once.
+                'partition_max_years_per_block'      => 5,
+                // Set to a positive integer to state the per-table partition
+                // budget outright instead of deriving it from innodb_open_files.
+                'partition_max_partitions'           => 0,
                 'mailer-host'                        => '',
                 'mailer-port'                        => '',
                 'mailer-use-smtp'                    => false,

--- a/modules/Base/Controller/PartitionInitCli.php
+++ b/modules/Base/Controller/PartitionInitCli.php
@@ -75,7 +75,7 @@ class PartitionInitCli extends PartitionsCli {
             return;
         }
 
-        $budget  = $this->partitionLimit( count( $tables ) );
+        $budget  = $this->factTableBudget();
         $already = 0;
 
         $through = \OWA\Core\Db::partitionLeadBoundary( $months_ahead );

--- a/modules/Base/Controller/PartitionInitCli.php
+++ b/modules/Base/Controller/PartitionInitCli.php
@@ -8,16 +8,17 @@ namespace OWA\Module\Base\Controller;
 /**
  * Partition the fact tables, and keep a lead of future partitions ahead of them.
  *
- * Run once, this converts an installation that predates partitioning. Run
- * repeatedly -- which it is meant to be, from cron -- it tops the lead back up
- * and otherwise does nothing, so the layout depends on the date rather than on
- * how many times it has run.
+ * A one-time conversion for an installation that predates partitioning. Running
+ * it again does nothing: a table that is already partitioned is reported and
+ * skipped, with a pointer to the command that does the job being asked for.
  *
- * The lead is what makes retention work. A write past the last boundary goes to
- * the catch-all, and the catch-all can never be dropped by a cutoff, since with
- * no upper bound it is never wholly older than any date. Keeping a year of
- * partitions ahead means writes always find a real partition, so nothing
- * accumulates anywhere retention cannot reach.
+ * That keeps one job per command. Maintaining the lead and coarsening old
+ * periods is partition-rotate; changing granularity is partition-reorganize.
+ *
+ * The layout it creates is tiered: whole calendar years over old history, and
+ * the table's own granularity over recent history and the lead. A flat layout
+ * over a long-running installation asks for one partition per month of history,
+ * which no open-file budget accommodates.
  *
  * Granularity is inferred from each table unless given, so a table converted
  * with partition-reorganize keeps extending at the granularity it was given
@@ -28,15 +29,12 @@ namespace OWA\Module\Base\Controller;
  * run deliberately rather than firing inside an upgrade nobody scheduled.
  * Later runs only split an empty catch-all and are cheap.
  *
- *   cmd=partition-init                          partition/top up, keeping
- *                                               each table's own granularity
+ *   cmd=partition-init                          partition every fact table
  *   cmd=partition-init granularity=half-month   override it
  *   cmd=partition-init months-ahead=6           keep six months ahead, not twelve
  *   cmd=partition-init table=owa_request        one table
  *   cmd=partition-init --dry-run                report the plan, change nothing
  *
- * Run it monthly:
- *   0 4 1 * *  php /path/to/owa/cli.php cmd=partition-init
  */
 class PartitionInitCli extends PartitionsCli {
 
@@ -77,7 +75,8 @@ class PartitionInitCli extends PartitionsCli {
             return;
         }
 
-        $budget = $this->partitionLimit( count( $tables ) );
+        $budget  = $this->partitionLimit( count( $tables ) );
+        $already = 0;
 
         $through = \OWA\Core\Db::partitionLeadBoundary( $months_ahead );
 
@@ -96,9 +95,27 @@ class PartitionInitCli extends PartitionsCli {
             // This is the case on every run after the first, and is what makes
             // repeated runs converge on the same layout instead of doing
             // nothing.
+            // init converts; it does not maintain. A table that is already
+            // partitioned is left entirely alone, because every way of "topping
+            // it up" here duplicates another command: extending the lead and
+            // coarsening the tail is exactly partition-rotate, and applying a
+            // granularity would convert only the periods being added, leaving
+            // the rest as they were -- a silent, partial reorganisation.
+            //
+            // One job each: init sets a table up, rotate keeps it in shape,
+            // reorganize changes its granularity.
             if ( $db->isPartitioned( $table ) ) {
 
-                $this->extendTableLead( $table, $table_granularity, $through, $budget, $dry_run );
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    '%s is already partitioned (%s, %d periods). Nothing to do here -- use '
+                  . 'cmd=partition-rotate to extend the lead and prune, or '
+                  . 'cmd=partition-reorganize granularity=... to change its granularity.',
+                    $table,
+                    $db->inferPartitionGranularity( $table ) ?: 'unrecognised granularity',
+                    count( $db->getPartitionSpans( $table ) )
+                ) );
+
+                $already++;
 
                 continue;
             }
@@ -124,7 +141,7 @@ class PartitionInitCli extends PartitionsCli {
             // lead. A flat layout over a long-running installation asks for one
             // partition per month of history and simply cannot be created.
             $ranges = \OWA\Core\Db::makeTieredPartitionRanges(
-                $min, $through, $table_granularity, $this->detailMonths()
+                $min, $through, $table_granularity, $this->detailMonths(), $budget['limit']
             );
 
             if ( ! $ranges ) {
@@ -162,6 +179,14 @@ class PartitionInitCli extends PartitionsCli {
                     '%s: FAILED to partition. The primary key must contain yyyymmdd; see the database error above.', $table
                 ) );
             }
+        }
+
+        if ( $already && $already === count( $tables ) ) {
+
+            \OWA\Core\CoreAPI::notice(
+                'Every fact table is already partitioned, so there was nothing for partition-init '
+              . 'to do. It is a one-time conversion; partition-rotate is the command to schedule.'
+            );
         }
     }
 }

--- a/modules/Base/Controller/PartitionInitCli.php
+++ b/modules/Base/Controller/PartitionInitCli.php
@@ -120,12 +120,12 @@ class PartitionInitCli extends PartitionsCli {
 
             $min = ( $row && $row['mn'] ) ? $row['mn'] : $today;
 
-            // The lead decides the upper end; -1 day because the boundary is
-            // exclusive and makePartitionRanges() covers the period its end
-            // falls in.
-            $max = date( 'Ymd', strtotime( $through . ' -1 day' ) );
-
-            $ranges = \OWA\Core\Db::makePartitionRanges( $min, $max, $table_granularity );
+            // Coarse over old history, fine over the detail window and the
+            // lead. A flat layout over a long-running installation asks for one
+            // partition per month of history and simply cannot be created.
+            $ranges = \OWA\Core\Db::makeTieredPartitionRanges(
+                $min, $through, $table_granularity, $this->detailMonths()
+            );
 
             if ( ! $ranges ) {
 
@@ -142,8 +142,9 @@ class PartitionInitCli extends PartitionsCli {
             if ( $dry_run ) {
 
                 \OWA\Core\CoreAPI::notice( sprintf(
-                    '%s: would create %d %s partitions covering %s to %s, plus a catch-all.',
-                    $table, count( $ranges ), $table_granularity, $min, $through
+                    '%s: would create %d partitions covering %s to %s (%s within the last %d months, '
+                  . 'whole years before that), plus a catch-all.',
+                    $table, count( $ranges ), $min, $through, $table_granularity, $this->detailMonths()
                 ) );
 
                 continue;

--- a/modules/Base/Controller/PartitionReorganizeCli.php
+++ b/modules/Base/Controller/PartitionReorganizeCli.php
@@ -66,7 +66,7 @@ class PartitionReorganizeCli extends PartitionsCli {
         }
 
         $tables = $this->factTables( $this->getParam( 'table' ) ?: null );
-        $budget = $this->partitionLimit( count( $tables ) );
+        $budget = $this->factTableBudget();
 
         foreach ( $tables as $table ) {
 

--- a/modules/Base/Controller/PartitionReorganizeCli.php
+++ b/modules/Base/Controller/PartitionReorganizeCli.php
@@ -82,6 +82,39 @@ class PartitionReorganizeCli extends PartitionsCli {
             // Plan first so the count can be judged before anything is rewritten.
             $plan = $db->repartitionTable( $table, $granularity, true, $from, $to );
 
+            // A finer granularity multiplies the detail window, which can put the
+            // table over its budget. Coarsening old history is what makes room:
+            // the tail exists to be traded for detail where detail is wanted.
+            // Without this, moving to quarter-month on a long-history table would
+            // simply be refused, with nothing the operator could do about it.
+            if ( $plan['planned'] > $budget['limit'] && ! $this->getParam( 'force' ) ) {
+
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    '%s: %s needs %d partitions, over the budget of %d. Merging old periods to '
+                  . 'make room.', $table, $granularity, $plan['planned'], $budget['limit']
+                ) );
+
+                // Compaction has to be told what the table is about to need, not
+                // what it currently holds: a finer granularity is not applied
+                // yet, so measured against today's count the table may already
+                // fit and nothing would be merged. Reserve the difference.
+                $extra = $plan['planned'] - count( $db->getPartitionSpans( $table ) );
+
+                $this->compactTable(
+                    $table,
+                    array(
+                        'limit'  => max( 1, $budget['limit'] - max( 0, $extra ) ),
+                        'reason' => sprintf(
+                            '%s, less %d reserved for the finer granularity', $budget['reason'], max( 0, $extra )
+                        ),
+                    ),
+                    $dry_run
+                );
+
+                // Re-plan against what the table now looks like.
+                $plan = $db->repartitionTable( $table, $granularity, true, $from, $to );
+            }
+
             if ( ! $this->withinPartitionBudget( $table, $plan['planned'], $budget ) ) {
 
                 continue;

--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -105,7 +105,7 @@ class PartitionRotateCli extends PartitionsCli {
         }
 
         $through = \OWA\Core\Db::partitionLeadBoundary( $months_ahead );
-        $budget  = $this->partitionLimit( count( $tables ) );
+        $budget  = $this->factTableBudget();
 
         \OWA\Core\CoreAPI::notice( $cutoff
             ? sprintf(

--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -21,6 +21,8 @@ namespace OWA\Module\Base\Controller;
  * Where the lead is refused for want of open files, it is retried after the
  * drop, since dropping is what frees them.
  *
+ *   cmd=partition-rotate                          retain everything; merge old
+ *                                                 periods to stay within budget
  *   cmd=partition-rotate keep=24                  keep two years, twelve ahead
  *   cmd=partition-rotate keep=12 months-ahead=6   a shorter lead
  *   cmd=partition-rotate keep=36 --dry-run        report the plan, change nothing
@@ -45,27 +47,36 @@ class PartitionRotateCli extends PartitionsCli {
         $dry_run = (bool) $this->getParam( 'dry-run' );
         $keep    = $this->getParam( 'keep' );
 
-        if ( ! $keep || ! ctype_digit( (string) $keep ) || (int) $keep < 1 ) {
+        // keep is optional. Without it nothing is ever deleted: the lead is
+        // maintained and old periods are merged into coarser ones to stay within
+        // the open-file budget. That is a complete, safe policy for an
+        // installation that wants to retain everything -- partition count stops
+        // being a reason to discard data.
+        $cutoff = null;
 
-            \OWA\Core\CoreAPI::notice(
-                'keep is required: the number of months of data to retain, such as keep=24.'
-            );
+        if ( $keep !== null && $keep !== '' ) {
 
-            return;
-        }
+            if ( ! ctype_digit( (string) $keep ) || (int) $keep < 1 ) {
 
-        $keep = (int) $keep;
+                \OWA\Core\CoreAPI::notice(
+                    'keep must be a number of months to retain, such as keep=24. '
+                  . 'Omit it entirely to retain everything.'
+                );
 
-        // Expressed as a period rather than a date on purpose. A fixed date in
-        // a scheduled job stops pruning the moment it is passed, and does so
-        // silently.
-        $cutoff = $this->resolveCutoff( $keep . 'months' );
+                return;
+            }
 
-        if ( ! $cutoff ) {
+            // Expressed as a period rather than a date on purpose. A fixed date
+            // in a scheduled job stops pruning the moment it is passed, and does
+            // so silently.
+            $cutoff = $this->resolveCutoff( (int) $keep . 'months' );
 
-            \OWA\Core\CoreAPI::notice( sprintf( 'Could not work out a cutoff for keep=%d.', $keep ) );
+            if ( ! $cutoff ) {
 
-            return;
+                \OWA\Core\CoreAPI::notice( sprintf( 'Could not work out a cutoff for keep=%s.', $keep ) );
+
+                return;
+            }
         }
 
         $months_ahead = $this->getParam( 'months-ahead' );
@@ -96,11 +107,17 @@ class PartitionRotateCli extends PartitionsCli {
         $through = \OWA\Core\Db::partitionLeadBoundary( $months_ahead );
         $budget  = $this->partitionLimit( count( $tables ) );
 
-        \OWA\Core\CoreAPI::notice( sprintf(
-            'Rotating: keeping %d month(s) of data (nothing before %s), and %d month(s) of '
-          . 'partitions ahead (through %s).',
-            $keep, $cutoff, $months_ahead, $through
-        ) );
+        \OWA\Core\CoreAPI::notice( $cutoff
+            ? sprintf(
+                'Rotating: keeping %s month(s) of data (nothing before %s), and %d month(s) of '
+              . 'partitions ahead (through %s).',
+                $keep, $cutoff, $months_ahead, $through )
+            : sprintf(
+                'Rotating: RETAINING EVERYTHING (no keep given, so nothing will be dropped), '
+              . 'and %d month(s) of partitions ahead (through %s). Old periods are merged, not '
+              . 'deleted, to stay within the partition budget.',
+                $months_ahead, $through )
+        );
 
         foreach ( $tables as $table ) {
 
@@ -121,7 +138,12 @@ class PartitionRotateCli extends PartitionsCli {
             // Ahead first: see the class comment.
             $extended = $this->extendTableLead( $table, $table_granularity, $through, $budget, $dry_run );
 
-            $dropped = $this->dropOlderThan( $table, $cutoff, $dry_run );
+            // Coarsen old periods so partition count stays under the budget
+            // without deleting anything. This is what allows a table to hold
+            // decades of history within a modest open-file allowance.
+            $this->compactTable( $table, $budget, $dry_run );
+
+            $dropped = $cutoff ? $this->dropOlderThan( $table, $cutoff, $dry_run ) : 0;
 
             // Dropping frees the open files the lead was refused for, so a
             // refusal is worth revisiting once the old periods have gone.

--- a/modules/Base/Controller/PartitionStatusCli.php
+++ b/modules/Base/Controller/PartitionStatusCli.php
@@ -1,0 +1,373 @@
+<?php
+namespace OWA\Module\Base\Controller;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * Report the partitioning state of the fact tables.
+ *
+ * The other three commands change things; this one only looks. It answers the
+ * questions an operator has before deciding whether to run any of them: what is
+ * partitioned, how much time the partitions cover, at what resolution, how much
+ * of the open-file budget is spent, whether anything has collected in the
+ * catch-all, and how long the lead lasts before a rotate is due.
+ *
+ *   php cli.php cmd=partition-status
+ *   php cli.php cmd=partition-status table=owa_session
+ *
+ * Nothing here writes, so it is safe to run on a busy installation. It reads
+ * metadata for the layout, and touches table data only to count the catch-all --
+ * one partition, through an index that is local to it.
+ *
+ * The report is built as lines and then emitted, rather than emitted as it is
+ * decided, so that what it says about a given layout can be asserted directly.
+ */
+class PartitionStatusCli extends PartitionsCli {
+
+    function action() {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        if ( ! $this->assertPartitioningSupported() ) {
+
+            return;
+        }
+
+        $tables = $this->factTables( $this->getParam( 'table' ) );
+
+        if ( ! $tables ) {
+
+            return;
+        }
+
+        $budget  = $this->factTableBudget();
+        $layouts = array();
+
+        foreach ( $tables as $table ) {
+
+            $layout = $db->describePartitionLayout( $table );
+
+            // Read the catch-all only where there is one. This is the single
+            // place the command touches table data.
+            $layout['contents'] = $layout['catch_all']
+                ? $db->getPartitionContents( $table, $layout['catch_all'] )
+                : null;
+
+            $layouts[ $table ] = $layout;
+        }
+
+        $lines = array( sprintf(
+            'Partition status, %s. Budget: %d partitions per table (%s).',
+            date( 'Y-m-d' ), $budget['limit'], $budget['reason']
+        ) );
+
+        foreach ( $layouts as $table => $layout ) {
+
+            $lines[] = '';
+            $lines   = array_merge( $lines, $this->describeTable( $table, $layout, $budget ) );
+        }
+
+        $lines[] = '';
+        $lines   = array_merge( $lines, $this->summarise( $layouts, $budget ) );
+
+        foreach ( $lines as $line ) {
+
+            \OWA\Core\CoreAPI::notice( $line );
+        }
+    }
+
+    /**
+     * One table's block of the report.
+     *
+     * @param string $table
+     * @param array  $layout  from describePartitionLayout(), plus 'contents'
+     * @param array  $budget  from partitionLimit()
+     * @return string[]
+     */
+    protected function describeTable( $table, $layout, $budget ) {
+
+        if ( ! $layout['partitioned'] ) {
+
+            return array( sprintf(
+                '%s: not partitioned. Run cmd=partition-init to convert it.', $table
+            ) );
+        }
+
+        $lines = array( sprintf(
+            '%s: %d partitions (%d bounded + catch-all), %d%% of budget.',
+            $table,
+            $layout['total'],
+            $layout['spans'],
+            $budget['limit'] > 0 ? (int) round( $layout['total'] / $budget['limit'] * 100 ) : 0
+        ) );
+
+        if ( $layout['covers'] ) {
+
+            $lines[] = sprintf(
+                '  covers        %s to %s',
+                $this->readable( $layout['covers']['start'] ),
+                $this->readable( $layout['covers']['end'] )
+            );
+        }
+
+        // What the next rotate will cut new periods at. Deliberately separate
+        // from the tiers below, which are what is already on disk: rotate infers
+        // this from the most recent month, so a coarsened tail does not change
+        // it, and a table can be monthly at the head while holding years per
+        // partition at the other end.
+        $lines[] = '  granularity   ' . (
+            $layout['granularity']
+                ? $layout['granularity'] . ' -- what new periods will be cut at'
+                : 'not recognised; new periods will be cut monthly. '
+                . 'cmd=partition-reorganize sets it deliberately.'
+        );
+
+        $lines = array_merge( $lines, $this->describeTiers( $layout ) );
+        $lines = array_merge( $lines, $this->describeCatchAll( $layout ) );
+        $lines = array_merge( $lines, $this->describeLead( $layout ) );
+
+        return $lines;
+    }
+
+    /**
+     * The layout as tiers.
+     *
+     * A rotated table has a coarse tail and a fine head, so one granularity
+     * cannot describe it: it would either overstate the resolution of the old
+     * data or understate the new. Each run of partitions covering the same
+     * length of time is reported with the span it covers.
+     *
+     * @param array $layout
+     * @return string[]
+     */
+    protected function describeTiers( $layout ) {
+
+        $lines = array();
+
+        foreach ( $layout['tiers'] as $tier ) {
+
+            $lines[] = sprintf(
+                '  %-13s %d partition%s, %s to %s',
+                $tier['period'],
+                $tier['count'],
+                $tier['count'] === 1 ? '' : 's',
+                $this->readable( $tier['start'] ),
+                $this->readable( $tier['end'] )
+            );
+        }
+
+        if ( count( $layout['tiers'] ) > 1 ) {
+
+            $lines[] = sprintf(
+                '                Older periods have been merged to fit the budget; the most recent '
+              . '%d months keep full granularity (OWA_PARTITION_DETAIL_MONTHS).',
+                $this->detailMonths()
+            );
+        }
+
+        return $lines;
+    }
+
+    /**
+     * What has collected in the catch-all, if anything.
+     *
+     * An empty catch-all is the normal, healthy state, and saying so explicitly
+     * is worth a line: its presence alone alarms people. Rows in it are not lost
+     * and not unreadable -- it is simply the one partition that has no upper
+     * bound, so queries cannot prune past it and retention cannot drop it. The
+     * next rotate reorganises them into dated partitions.
+     *
+     * @param array $layout
+     * @return string[]
+     */
+    protected function describeCatchAll( $layout ) {
+
+        if ( ! $layout['catch_all'] ) {
+
+            // Only reachable if something outside these commands removed it.
+            // Worth flagging loudly, because inserts past the last boundary do
+            // not fall back anywhere -- MySQL rejects the row.
+            return array(
+                '  catch-all     NONE -- rows dated past the last boundary will be REJECTED, not '
+              . 'stored. Run cmd=partition-rotate to restore it.'
+            );
+        }
+
+        if ( $layout['contents'] === null ) {
+
+            return array( sprintf(
+                '  catch-all     %s (contents could not be read)', $layout['catch_all']
+            ) );
+        }
+
+        if ( ! $layout['contents']['rows'] ) {
+
+            return array( sprintf(
+                '  catch-all     %s, empty -- every row is in a dated partition.',
+                $layout['catch_all']
+            ) );
+        }
+
+        return array(
+            sprintf(
+                '  catch-all     %s, %s rows dated %s to %s',
+                $layout['catch_all'],
+                number_format( $layout['contents']['rows'] ),
+                $this->readable( $layout['contents']['min'] ),
+                $this->readable( $layout['contents']['max'] )
+            ),
+            '                Those rows are queryable and are not at risk. They are outside the '
+          . 'dated partitions, so reports covering them cannot prune and retention cannot drop '
+          . 'them. The next cmd=partition-rotate moves them into dated partitions.',
+        );
+    }
+
+    /**
+     * How much lead is left, and therefore when a rotate is due.
+     *
+     * @param array $layout
+     * @return string[]
+     */
+    protected function describeLead( $layout ) {
+
+        if ( $layout['ahead'] === null ) {
+
+            return array( '  lead          unknown -- no bounded partitions to read a boundary from.' );
+        }
+
+        if ( $layout['ahead'] <= 0 ) {
+
+            return array( sprintf(
+                '  lead          NONE -- boundaries stop at %s, %d day%s ago. Everything logged '
+              . 'since then is going to the catch-all. Rotate now.',
+                $this->readable( $layout['through'] ),
+                abs( $layout['ahead'] ),
+                abs( $layout['ahead'] ) === 1 ? '' : 's'
+            ) );
+        }
+
+        return array( sprintf(
+            '  lead          %d partition%s ahead, through %s -- %d day%s from today.',
+            $layout['lead'],
+            $layout['lead'] === 1 ? '' : 's',
+            $this->readable( $layout['through'] ),
+            $layout['ahead'],
+            $layout['ahead'] === 1 ? '' : 's'
+        ) );
+    }
+
+    /**
+     * The lines an operator acts on.
+     *
+     * @param array $layouts  keyed by table
+     * @param array $budget
+     * @return string[]
+     */
+    protected function summarise( $layouts, $budget ) {
+
+        $unpartitioned = array();
+        $overdue       = array();
+        $total         = 0;
+        $soonest       = null;
+        $start         = null;
+        $end           = null;
+
+        foreach ( $layouts as $table => $layout ) {
+
+            if ( ! $layout['partitioned'] ) {
+
+                $unpartitioned[] = $table;
+
+                continue;
+            }
+
+            $total += $layout['total'];
+
+            if ( $layout['covers'] ) {
+
+                $start = ( $start === null || $layout['covers']['start'] < $start )
+                       ? $layout['covers']['start'] : $start;
+
+                $end   = ( $end === null || $layout['covers']['end'] > $end )
+                       ? $layout['covers']['end'] : $end;
+            }
+
+            if ( $layout['ahead'] === null ) {
+
+                continue;
+            }
+
+            if ( $layout['ahead'] <= 0 ) {
+
+                $overdue[] = $table;
+
+            } elseif ( $soonest === null || $layout['ahead'] < $soonest ) {
+
+                $soonest = $layout['ahead'];
+            }
+        }
+
+        $lines = array( sprintf(
+            '%d of %d fact tables partitioned, %d partitions in total%s.',
+            count( $layouts ) - count( $unpartitioned ),
+            count( $layouts ),
+            $total,
+            ( $start && $end )
+                ? sprintf( ', covering %s to %s', $this->readable( $start ), $this->readable( $end ) )
+                : ''
+        ) );
+
+        if ( $unpartitioned ) {
+
+            $lines[] = sprintf(
+                'Not partitioned: %s. cmd=partition-init converts %s.',
+                implode( ', ', $unpartitioned ),
+                count( $unpartitioned ) === 1 ? 'it' : 'them'
+            );
+        }
+
+        // An expired lead outranks everything else: it is the only state where
+        // data is actively accumulating somewhere it should not be.
+        if ( $overdue ) {
+
+            $lines[] = sprintf(
+                'ACTION: %s %s out of lead and %s logging into the catch-all. Run '
+              . 'cmd=partition-rotate.',
+                implode( ', ', $overdue ),
+                count( $overdue ) === 1 ? 'has run' : 'have run',
+                count( $overdue ) === 1 ? 'is' : 'are'
+            );
+
+            return $lines;
+        }
+
+        if ( $soonest !== null ) {
+
+            $lines[] = sprintf(
+                'The shortest lead runs out on %s, %d day%s from now -- that is the deadline for '
+              . 'the next cmd=partition-rotate. Running it monthly from cron keeps the lead topped '
+              . 'up and the catch-all empty.',
+                $this->readable( date( 'Ymd', strtotime( '+' . $soonest . ' days' ) ) ),
+                $soonest,
+                $soonest === 1 ? '' : 's'
+            );
+        }
+
+        return $lines;
+    }
+
+    /**
+     * A yyyymmdd as a date a person reads.
+     *
+     * @param string|null $yyyymmdd
+     * @return string
+     */
+    protected function readable( $yyyymmdd ) {
+
+        $d = \DateTimeImmutable::createFromFormat( 'Ymd|', (string) $yyyymmdd );
+
+        return $d ? $d->format( 'Y-m-d' ) : (string) $yyyymmdd;
+    }
+}

--- a/modules/Base/Controller/PartitionStatusCli.php
+++ b/modules/Base/Controller/PartitionStatusCli.php
@@ -35,7 +35,7 @@ class PartitionStatusCli extends PartitionsCli {
             return;
         }
 
-        $tables = $this->factTables( $this->getParam( 'table' ) );
+        $tables = $this->factTables( $this->getParam( 'table' ) ?: null );
 
         if ( ! $tables ) {
 
@@ -72,9 +72,36 @@ class PartitionStatusCli extends PartitionsCli {
         $lines[] = '';
         $lines   = array_merge( $lines, $this->summarise( $layouts, $budget ) );
 
+        $this->write( $lines );
+    }
+
+    /**
+     * Put the report on standard output.
+     *
+     * The other commands report through CoreAPI::notice(), and should: what they
+     * did is a record worth keeping, and the console handler puts it on stdout as
+     * well as in the log. A report is not that. It is terminal output, it is read
+     * once, and routing it through the logger would stamp every line with a
+     * timestamp, a pid and a level, interleave it with debug output on an
+     * installation running the development handler, and write fifty lines into
+     * the error log on each run -- which, scheduled beside partition-rotate,
+     * would make the status of the partitions the noisiest thing in it.
+     *
+     * Refusals still go through notice(), because those are events.
+     *
+     * @param string[] $lines
+     * @return void
+     */
+    protected function write( $lines ) {
+
+        // The base controller exits unless this is a CLI request, so STDOUT is
+        // the CLI SAPI's own constant. The fallback is for a test harness that
+        // has not defined it.
+        $out = defined( 'STDOUT' ) ? STDOUT : fopen( 'php://output', 'w' );
+
         foreach ( $lines as $line ) {
 
-            \OWA\Core\CoreAPI::notice( $line );
+            fwrite( $out, $line . PHP_EOL );
         }
     }
 

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -162,6 +162,23 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
     }
 
     /**
+     * The budget, sized against every fact table rather than the ones this run
+     * happens to touch.
+     *
+     * The open-file budget is a property of the server and the schema: the other
+     * fact tables hold their partitions open whether or not this invocation
+     * mentions them. Sizing it from the filtered set would hand a single-table
+     * run the whole allowance -- so `table=owa_session` would report, and permit,
+     * several times the partitions that the same command without a filter would.
+     *
+     * @return array  from partitionLimit()
+     */
+    protected function factTableBudget() {
+
+        return $this->partitionLimit( max( 1, count( $this->factTables() ) ) );
+    }
+
+    /**
      * How recent a period must be to keep its fine granularity. Older ones may be
      * merged to stay within the budget.
      *

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -193,8 +193,9 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
         \OWA\Core\CoreAPI::notice( sprintf(
             '%s: refusing to create %d partitions (limit %d -- %s). Each partition is a file, and '
           . 'past the budget MySQL closes and reopens tablespaces under load, which slows '
-          . 'everything on the instance. Narrow it with from/to, choose a coarser granularity, or '
-          . 're-run with force=1 if you have done the arithmetic.',
+          . 'everything on the instance. Lower OWA_PARTITION_DETAIL_MONTHS so less history is '
+          . 'kept at full granularity, choose a coarser granularity, or set '
+          . 'OWA_PARTITION_MAX_PARTITIONS if you have checked innodb_open_files yourself.',
             $table, $planned, $budget['limit'], $budget['reason']
         ) );
 

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -121,6 +121,20 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
      */
     protected function partitionLimit( $table_count ) {
 
+        // An explicit budget wins over the derived one. This is the considered
+        // escape hatch: unlike force, it makes the operator name the number they
+        // are accepting, which means looking at innodb_open_files to pick it, and
+        // it lands in the log as a number the next person can evaluate.
+        $override = $this->getParam( 'max-partitions' );
+
+        if ( $override !== null && $override !== '' && ctype_digit( (string) $override ) && (int) $override > 0 ) {
+
+            return array(
+                'limit'  => (int) $override,
+                'reason' => 'max-partitions given explicitly',
+            );
+        }
+
         $spare = \OWA\Core\CoreAPI::dbSingleton()->getPartitionBudget();
 
         if ( $spare === null ) {
@@ -131,15 +145,18 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
             );
         }
 
-        // A floor, so that a server reporting almost no headroom still permits
-        // a couple of years of monthly rather than refusing everything.
-        $limit = max( 24, intdiv( $spare, 2 * max( 1, $table_count ) ) );
+        $limit = max(
+            \OWA\Core\Db::PARTITION_MIN_LIMIT,
+            intdiv( $spare, \OWA\Core\Db::PARTITION_BUDGET_RESERVE * max( 1, $table_count ) )
+        );
 
         return array(
             'limit'  => $limit,
             'reason' => sprintf(
-                '%d spare open-file slots on this server, half of them shared across %d table(s)',
-                $spare, $table_count
+                '%d spare open-file slots on this server, %s of them shared across %d table(s)',
+                $spare,
+                \OWA\Core\Db::PARTITION_BUDGET_RESERVE === 2 ? 'half' : '1/' . \OWA\Core\Db::PARTITION_BUDGET_RESERVE,
+                $table_count
             ),
         );
     }

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -121,17 +121,19 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
      */
     protected function partitionLimit( $table_count ) {
 
-        // An explicit budget wins over the derived one. This is the considered
-        // escape hatch: unlike force, it makes the operator name the number they
-        // are accepting, which means looking at innodb_open_files to pick it, and
-        // it lands in the log as a number the next person can evaluate.
-        $override = $this->getParam( 'max-partitions' );
+        // Partitioning is shaped by settings, not by command arguments: how much
+        // history stays finely partitioned and how much of the server's open-file
+        // budget this may claim are properties of an installation, and an
+        // operator should not be able to change them per invocation. They are set
+        // once with a constant in owa-config.php -- see
+        // owa_settings::applyConfigConstants().
+        $stated = (int) \OWA\Core\CoreAPI::getSetting( 'base', 'partition_max_partitions' );
 
-        if ( $override !== null && $override !== '' && ctype_digit( (string) $override ) && (int) $override > 0 ) {
+        if ( $stated > 0 ) {
 
             return array(
-                'limit'  => (int) $override,
-                'reason' => 'max-partitions given explicitly',
+                'limit'  => $stated,
+                'reason' => 'set by OWA_PARTITION_MAX_PARTITIONS',
             );
         }
 
@@ -145,20 +147,31 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
             );
         }
 
-        $limit = max(
-            \OWA\Core\Db::PARTITION_MIN_LIMIT,
-            intdiv( $spare, \OWA\Core\Db::PARTITION_BUDGET_RESERVE * max( 1, $table_count ) )
-        );
+        $reserve = max( 1, (int) \OWA\Core\CoreAPI::getSetting( 'base', 'partition_budget_reserve' ) );
+        $floor   = max( 1, (int) \OWA\Core\CoreAPI::getSetting( 'base', 'partition_min_limit' ) );
+
+        $limit = max( $floor, intdiv( $spare, $reserve * max( 1, $table_count ) ) );
 
         return array(
             'limit'  => $limit,
             'reason' => sprintf(
-                '%d spare open-file slots on this server, %s of them shared across %d table(s)',
-                $spare,
-                \OWA\Core\Db::PARTITION_BUDGET_RESERVE === 2 ? 'half' : '1/' . \OWA\Core\Db::PARTITION_BUDGET_RESERVE,
-                $table_count
+                '%d spare open-file slots on this server, 1/%d of them shared across %d table(s)',
+                $spare, $reserve, $table_count
             ),
         );
+    }
+
+    /**
+     * How recent a period must be to keep its fine granularity. Older ones may be
+     * merged to stay within the budget.
+     *
+     * @return int months
+     */
+    protected function detailMonths() {
+
+        $months = (int) \OWA\Core\CoreAPI::getSetting( 'base', 'partition_detail_months' );
+
+        return $months > 0 ? $months : \OWA\Core\Db::PARTITION_DETAIL_MONTHS;
     }
 
     /**

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -366,6 +366,87 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
         return $dropped;
     }
 
+    /**
+     * Merge old periods so the table fits its partition budget, deleting nothing.
+     *
+     * This is what decouples partition count from retention. Without it the only
+     * way back under an open-file budget is to drop history, which turns a
+     * resource limit into a data-loss decision.
+     *
+     * @param string $table
+     * @param array  $budget  from partitionLimit()
+     * @param bool   $dry_run
+     * @return int merges performed, or that would be
+     */
+    protected function compactTable( $table, $budget, $dry_run ) {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $plan = $db->planPartitionCompaction( $table, $budget['limit'], $this->detailMonths() );
+
+        if ( ! $plan['merges'] ) {
+
+            // Worth saying when the table cannot fit even fully merged: the
+            // remedy is a shorter detail window, and nothing else the operator
+            // does to this command will help.
+            if ( ! $plan['fits'] ) {
+
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    '%s: %d partitions exceeds the budget of %d and cannot be merged below %d, '
+                  . 'because everything within the last %d months is kept at full granularity. '
+                  . 'Lower OWA_PARTITION_DETAIL_MONTHS to reduce it further.',
+                    $table, $plan['projected'], $budget['limit'], $plan['floor'], $this->detailMonths()
+                ) );
+            }
+
+            return 0;
+        }
+
+        $first = $plan['merges'][0];
+        $last  = $plan['merges'][ count( $plan['merges'] ) - 1 ];
+
+        \OWA\Core\CoreAPI::notice( sprintf(
+            '%s: %s %d group(s) of old periods covering %s to %s into one partition each, '
+          . 'leaving %d partitions. No data is deleted.',
+            $table, $dry_run ? 'would merge' : 'merging', count( $plan['merges'] ),
+            $first['start'], $last['less_than'], $plan['projected']
+        ) );
+
+        if ( $dry_run ) {
+
+            return count( $plan['merges'] );
+        }
+
+        $done = 0;
+
+        foreach ( $plan['merges'] as $merge ) {
+
+            if ( $db->mergePartitions( $table, $merge['names'], $merge['start'], $merge['less_than'] ) ) {
+
+                $done++;
+
+            } else {
+
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    '%s: FAILED to merge %s..%s; see the database error above.',
+                    $table, $merge['start'], $merge['less_than']
+                ) );
+            }
+        }
+
+        if ( ! $plan['fits'] ) {
+
+            \OWA\Core\CoreAPI::notice( sprintf(
+                '%s: still %d partitions against a budget of %d. Lower OWA_PARTITION_DETAIL_MONTHS '
+              . 'to reduce it further; no more can be merged while the last %d months are kept '
+              . 'at full granularity.',
+                $table, $plan['projected'], $budget['limit'], $this->detailMonths()
+            ) );
+        }
+
+        return $done;
+    }
+
     /** Is the driver able to partition at all? Report once, clearly. */
     protected function assertPartitioningSupported() {
 

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -385,7 +385,7 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
 
         $plan = $db->planPartitionCompaction( $table, $budget['limit'], $this->detailMonths() );
 
-        if ( ! $plan['merges'] ) {
+        if ( ! $plan['operations'] ) {
 
             // Worth saying when the table cannot fit even fully merged: the
             // remedy is a shorter detail window, and nothing else the operator
@@ -403,34 +403,34 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
             return 0;
         }
 
-        $first = $plan['merges'][0];
-        $last  = $plan['merges'][ count( $plan['merges'] ) - 1 ];
+        $first = $plan['operations'][0];
+        $last  = $plan['operations'][ count( $plan['operations'] ) - 1 ];
 
         \OWA\Core\CoreAPI::notice( sprintf(
-            '%s: %s %d group(s) of old periods covering %s to %s into one partition each, '
+            '%s: %s %d group(s) of old periods covering %s to %s into blocks of %d year(s), '
           . 'leaving %d partitions. No data is deleted.',
-            $table, $dry_run ? 'would merge' : 'merging', count( $plan['merges'] ),
-            $first['start'], $last['less_than'], $plan['projected']
+            $table, $dry_run ? 'would reshape' : 'reshaping', count( $plan['operations'] ),
+            $first['start'], $last['less_than'], $plan['block_years'], $plan['projected']
         ) );
 
         if ( $dry_run ) {
 
-            return count( $plan['merges'] );
+            return count( $plan['operations'] );
         }
 
         $done = 0;
 
-        foreach ( $plan['merges'] as $merge ) {
+        foreach ( $plan['operations'] as $op ) {
 
-            if ( $db->mergePartitions( $table, $merge['names'], $merge['start'], $merge['less_than'] ) ) {
+            if ( $db->reshapePartitions( $table, $op['names'], $op['ranges'] ) ) {
 
                 $done++;
 
             } else {
 
                 \OWA\Core\CoreAPI::notice( sprintf(
-                    '%s: FAILED to merge %s..%s; see the database error above.',
-                    $table, $merge['start'], $merge['less_than']
+                    '%s: FAILED to reshape %s..%s; see the database error above.',
+                    $table, $op['start'], $op['less_than']
                 ) );
             }
         }

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -584,6 +584,7 @@ class Module extends \OWA\Core\Module {
         $this->registerAction( 'base.processFirstRequest',           'OWA\\Module\\Base\\Controller\\ProcessFirstRequest',          'Controller/ProcessFirstRequest.php' );
         $this->registerAction( 'base.processRequest',                'OWA\\Module\\Base\\Controller\\ProcessRequest',               'Controller/ProcessRequest.php' );
         $this->registerAction( 'base.pruneEventQueueArchivesCli',    'OWA\\Module\\Base\\Controller\\PruneEventQueueArchivesCli',   'Controller/PruneEventQueueArchivesCli.php' );
+        $this->registerAction( 'base.partitionStatusCli',            'OWA\\Module\\Base\\Controller\\PartitionStatusCli',         'Controller/PartitionStatusCli.php' );
         $this->registerAction( 'base.partitionInitCli',              'OWA\\Module\\Base\\Controller\\PartitionInitCli',           'Controller/PartitionInitCli.php' );
         $this->registerAction( 'base.partitionDropCli',              'OWA\\Module\\Base\\Controller\\PartitionDropCli',           'Controller/PartitionDropCli.php' );
         $this->registerAction( 'base.partitionReorganizeCli',        'OWA\\Module\\Base\\Controller\\PartitionReorganizeCli',     'Controller/PartitionReorganizeCli.php' );
@@ -703,6 +704,7 @@ class Module extends \OWA\Core\Module {
         $this->registerCliCommand('add-site', 'base.sitesAddCli');
         $this->registerCliCommand('flush-processed-events', 'base.flushProcessedEventsCli');
         $this->registerCliCommand('prune-event-queue-archives', 'base.pruneEventQueueArchivesCli');
+        $this->registerCliCommand('partition-status', 'base.partitionStatusCli');
         $this->registerCliCommand('partition-init', 'base.partitionInitCli');
         $this->registerCliCommand('partition-drop', 'base.partitionDropCli');
         $this->registerCliCommand('partition-reorganize', 'base.partitionReorganizeCli');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -147,7 +147,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method OWA\\Core\\Db\:\:query\(\)\.$#'
 			identifier: method.notFound
-			count: 20
+			count: 21
 			path: Core/Db.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -147,7 +147,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method OWA\\Core\\Db\:\:query\(\)\.$#'
 			identifier: method.notFound
-			count: 21
+			count: 22
 			path: Core/Db.php
 
 		-

--- a/phpstan-migration-baseline.neon
+++ b/phpstan-migration-baseline.neon
@@ -63,7 +63,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method OWA\\Core\\Db\:\:query\(\)\.$#'
 			identifier: method.notFound
-			count: 20
+			count: 21
 			path: Core/Db.php
 
 		-

--- a/phpstan-migration-baseline.neon
+++ b/phpstan-migration-baseline.neon
@@ -63,7 +63,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method OWA\\Core\\Db\:\:query\(\)\.$#'
 			identifier: method.notFound
-			count: 21
+			count: 22
 			path: Core/Db.php
 
 		-

--- a/tests/PartitionCliTest.php
+++ b/tests/PartitionCliTest.php
@@ -154,26 +154,31 @@ final class PartitionCliTest extends CliControllerTestCase
     }
 
     /**
-     * Rotation needs a window. Without one it must do nothing at all -- not
-     * fall back to a default that silently discards more than intended.
+     * An unreadable keep is refused; an absent one is not.
      *
-     * A smoke test by nature: it asserts the absence of a side effect and that
-     * nothing fatals on bad input. The parsing it depends on is pinned properly
-     * by the resolveCutoff tests above, which fail under mutation; this one
-     * would not catch a command that did nothing for some unrelated reason.
+     * The two mean opposite things. Omitting keep asks to retain everything;
+     * "lots" is a mistake, and treating it as absent would silently turn a
+     * botched retention policy into no retention policy at all.
      */
-    public function testRotateRequiresAUsableWindow()
+    public function testAnUnreadableKeepIsRefusedButAnAbsentOneIsNot()
     {
         $before = $this->partitionCount('owa_request');
 
-        foreach ([[], ['keep' => ''], ['keep' => '0'], ['keep' => 'lots'], ['keep' => '-4']] as $params) {
-            $this->rotate($params)->action();
+        foreach ([['keep' => 'lots'], ['keep' => '-4'], ['keep' => '0'], ['keep' => '2.5']] as $params) {
+            $this->rotate($params + ['table' => 'owa_request'])->action();
         }
 
         $this->assertSame(
             $before,
             $this->partitionCount('owa_request'),
-            'a rotation without a usable window must change nothing'
+            'an unreadable keep must stop the command, not be ignored'
+        );
+
+        // Absent is a valid policy, and must be accepted: it reaches the cutoff
+        // resolution path at all only when keep is present.
+        $this->assertNull(
+            $this->callProtected($this->rotate(), 'resolveCutoff', ['']),
+            'nothing to resolve when keep is absent'
         );
     }
 

--- a/tests/PartitionCliTest.php
+++ b/tests/PartitionCliTest.php
@@ -470,4 +470,369 @@ final class PartitionCliTest extends CliControllerTestCase
             $db->query("DROP TABLE IF EXISTS $t");
         }
     }
+
+    // -----------------------------------------------------------------------
+    // partition-status
+    // -----------------------------------------------------------------------
+
+    private function statusCli(array $params = []): object
+    {
+        return new \OWA\Module\Base\Controller\PartitionStatusCli($params);
+    }
+
+    /**
+     * A layout as describePartitionLayout() returns it, for driving the report
+     * through states a live table cannot cheaply be put into.
+     */
+    private function layout(array $overrides = []): array
+    {
+        return $overrides + [
+            'partitioned' => true,
+            'spans'       => 24,
+            'total'       => 25,
+            'covers'      => ['start' => '20240101', 'end' => '20260101'],
+            'granularity' => 'monthly',
+            'tiers'       => [
+                ['period' => 'monthly', 'count' => 24, 'start' => '20240101', 'end' => '20260101'],
+            ],
+            'catch_all'   => 'pmax',
+            'through'     => '20260101',
+            'ahead'       => 120,
+            'lead'        => 4,
+            'contents'    => ['rows' => 0, 'min' => null, 'max' => null],
+        ];
+    }
+
+    private function report(array $layout, array $budget = ['limit' => 200, 'reason' => 'test']): string
+    {
+        return implode("\n", $this->callProtected($this->statusCli(), 'describeTable', ['owa_x', $layout, $budget]));
+    }
+
+    /**
+     * The healthy case, which is most of them: say what is there, and do not
+     * imply work that is not needed.
+     */
+    public function testStatusDescribesAHealthyTable()
+    {
+        $out = $this->report($this->layout());
+
+        $this->assertStringContainsString('owa_x: 25 partitions (24 bounded + catch-all)', $out);
+        $this->assertStringContainsString('13% of budget', $out, '25 of 200');
+        $this->assertStringContainsString('2024-01-01 to 2026-01-01', $out);
+        $this->assertStringContainsString('granularity   monthly', $out);
+        $this->assertStringContainsString('empty', $out);
+        $this->assertStringContainsString('4 partitions ahead', $out);
+        $this->assertStringContainsString('120 days from today', $out);
+
+        foreach (['ACTION', 'REJECTED', 'Rotate now', 'not partitioned'] as $alarm) {
+            $this->assertStringNotContainsString($alarm, $out, "a healthy table must not say '$alarm'");
+        }
+    }
+
+    /** An unpartitioned table gets one line and the command that fixes it. */
+    public function testStatusDescribesAnUnpartitionedTable()
+    {
+        $out = $this->report($this->layout([
+            'partitioned' => false, 'spans' => 0, 'total' => 0, 'covers' => null,
+            'granularity' => null, 'tiers' => [], 'catch_all' => null,
+            'through' => null, 'ahead' => null, 'lead' => 0, 'contents' => null,
+        ]));
+
+        $this->assertSame(
+            'owa_x: not partitioned. Run cmd=partition-init to convert it.',
+            $out,
+            'nothing else is knowable, so nothing else is said'
+        );
+    }
+
+    /**
+     * The tiered case, which is why this is not reported as one granularity.
+     *
+     * The tail is years per partition and the head is the granularity in force.
+     * Both must appear, and the granularity line must report the head -- that is
+     * what the next rotate will cut new periods at.
+     */
+    public function testStatusDescribesTiersRatherThanOneGranularity()
+    {
+        $out = $this->report($this->layout([
+            'spans' => 40, 'total' => 41,
+            'covers' => ['start' => '20060101', 'end' => '20270101'],
+            'granularity' => 'half-month',
+            'tiers' => [
+                ['period' => '5 years',    'count' => 3,  'start' => '20060101', 'end' => '20210101'],
+                ['period' => '1 year',     'count' => 4,  'start' => '20210101', 'end' => '20250101'],
+                ['period' => 'monthly',    'count' => 9,  'start' => '20250101', 'end' => '20251001'],
+                ['period' => 'half-month', 'count' => 24, 'start' => '20251001', 'end' => '20271001'],
+            ],
+        ]));
+
+        $this->assertStringContainsString('5 years', $out);
+        $this->assertStringContainsString('1 year ', $out);
+        $this->assertStringContainsString('half-month    24 partitions', $out);
+        $this->assertStringContainsString('granularity   half-month', $out,
+            'the granularity is the head, not the tail');
+        $this->assertStringContainsString('merged to fit the budget', $out);
+        $this->assertStringContainsString('OWA_PARTITION_DETAIL_MONTHS', $out,
+            'name the setting that governs it');
+
+    }
+
+    /** Counts read as English, singular and plural, in the tiers and the lead. */
+    public function testStatusCountsReadAsEnglish()
+    {
+        $one = $this->callProtected($this->statusCli(), 'describeTiers', [$this->layout([
+            'tiers' => [['period' => '1 year', 'count' => 1, 'start' => '20250101', 'end' => '20260101']],
+        ])]);
+
+        $this->assertStringContainsString('1 partition,', $one[0]);
+        $this->assertStringNotContainsString('1 partitions,', $one[0]);
+
+        $many = $this->callProtected($this->statusCli(), 'describeTiers', [$this->layout()]);
+        $this->assertStringContainsString('24 partitions,', $many[0]);
+
+        $lead = $this->callProtected($this->statusCli(), 'describeLead', [$this->layout(['lead' => 1, 'ahead' => 1])]);
+        $this->assertStringContainsString('1 partition ahead', $lead[0]);
+        $this->assertStringContainsString('1 day from today', $lead[0]);
+
+        $gone = $this->callProtected($this->statusCli(), 'describeLead', [$this->layout(['ahead' => -1])]);
+        $this->assertStringContainsString('1 day ago', $gone[0]);
+        $this->assertStringNotContainsString('1 days ago', $gone[0]);
+    }
+
+    /** A uniform table has one tier, and must not be told it was merged. */
+    public function testStatusDoesNotClaimMergingOnAUniformTable()
+    {
+        $this->assertStringNotContainsString('merged', $this->report($this->layout()));
+    }
+
+    /**
+     * Rows in the catch-all are worth reporting precisely, and worth not
+     * alarming about: they are queryable, they are not at risk, and the next
+     * rotate moves them into dated partitions.
+     */
+    public function testStatusReportsCatchAllContents()
+    {
+        $out = $this->report($this->layout([
+            'contents' => ['rows' => 1234567, 'min' => '20260101', 'max' => '20260815'],
+        ]));
+
+        $this->assertStringContainsString('1,234,567 rows', $out, 'readable at scale');
+        $this->assertStringContainsString('2026-01-01 to 2026-08-15', $out);
+        $this->assertStringContainsString('queryable', $out);
+        $this->assertStringContainsString('not at risk', $out);
+        $this->assertStringContainsString('cannot prune', $out);
+        $this->assertStringContainsString('partition-rotate', $out);
+    }
+
+    /**
+     * A missing catch-all is the one layout state that loses data outright:
+     * MySQL rejects a row that fits no partition rather than storing it
+     * somewhere. It has to read as an alarm.
+     */
+    public function testStatusFlagsAMissingCatchAll()
+    {
+        $out = $this->report($this->layout(['catch_all' => null, 'contents' => null]));
+
+        $this->assertStringContainsString('REJECTED', $out);
+        $this->assertStringContainsString('partition-rotate', $out);
+    }
+
+    /** An unreadable catch-all is said to be unreadable, not reported as empty. */
+    public function testStatusDoesNotReportAnUnreadableCatchAllAsEmpty()
+    {
+        $out = $this->report($this->layout(['contents' => null]));
+
+        $this->assertStringContainsString('could not be read', $out);
+        $this->assertStringNotContainsString('empty', $out);
+    }
+
+    /** An exhausted lead is the state that calls for action today. */
+    public function testStatusFlagsAnExhaustedLead()
+    {
+        foreach ([-1 => '1 day ago', -45 => '45 days ago', 0 => '0 days ago'] as $ahead => $expected) {
+
+            $out = $this->report($this->layout(['ahead' => $ahead, 'lead' => 0]));
+
+            $this->assertStringContainsString('lead          NONE', $out, "ahead=$ahead");
+            $this->assertStringContainsString($expected, $out, "ahead=$ahead");
+            $this->assertStringContainsString('Rotate now', $out, "ahead=$ahead");
+        }
+    }
+
+    /** An unrecognised granularity names the command that sets one deliberately. */
+    public function testStatusExplainsAnUnrecognisedGranularity()
+    {
+        $out = $this->report($this->layout(['granularity' => null]));
+
+        $this->assertStringContainsString('not recognised', $out);
+        $this->assertStringContainsString('cut monthly', $out, 'say what will happen by default');
+        $this->assertStringContainsString('partition-reorganize', $out);
+    }
+
+    /** The percentage is of the budget, and survives a nonsense budget. */
+    public function testStatusReportsBudgetUse()
+    {
+        foreach ([[100, 25, '25%'], [25, 25, '100%'], [10, 25, '250%'], [0, 25, '0%']] as $case) {
+
+            list($limit, $total, $expected) = $case;
+
+            $this->assertStringContainsString(
+                $expected . ' of budget',
+                $this->report($this->layout(['total' => $total]), ['limit' => $limit, 'reason' => 'x']),
+                "total $total of limit $limit"
+            );
+        }
+    }
+
+    /**
+     * The summary is the part an operator acts on, so an exhausted lead outranks
+     * everything else -- it is the only state where data is accumulating
+     * somewhere it should not be.
+     */
+    public function testStatusSummaryPrioritisesAnExhaustedLead()
+    {
+        $out = implode("\n", $this->callProtected($this->statusCli(), 'summarise', [
+            [
+                'owa_a' => $this->layout(['ahead' => 90]),
+                'owa_b' => $this->layout(['ahead' => -5]),
+                'owa_c' => $this->layout(['partitioned' => false, 'covers' => null, 'ahead' => null, 'total' => 0]),
+            ],
+            ['limit' => 200, 'reason' => 'x'],
+        ]));
+
+        $this->assertStringContainsString('2 of 3 fact tables partitioned', $out);
+        $this->assertStringContainsString('Not partitioned: owa_c', $out);
+        $this->assertStringContainsString('ACTION: owa_b has run out of lead', $out);
+        $this->assertStringNotContainsString('shortest lead runs out', $out,
+            'a deadline is irrelevant while one table is already past it');
+    }
+
+    /** With every lead intact, the summary gives the earliest deadline. */
+    public function testStatusSummaryGivesTheEarliestDeadline()
+    {
+        $out = implode("\n", $this->callProtected($this->statusCli(), 'summarise', [
+            [
+                'owa_a' => $this->layout(['ahead' => 200, 'total' => 30, 'covers' => ['start' => '20200101', 'end' => '20270101']]),
+                'owa_b' => $this->layout(['ahead' => 31,  'total' => 12, 'covers' => ['start' => '20250101', 'end' => '20260601']]),
+            ],
+            ['limit' => 200, 'reason' => 'x'],
+        ]));
+
+        $this->assertStringContainsString('2 of 2 fact tables partitioned, 42 partitions in total', $out);
+        $this->assertStringContainsString('covering 2020-01-01 to 2027-01-01', $out,
+            'the overall range spans the widest of the tables');
+        $this->assertStringContainsString('31 days from now', $out, 'the shortest lead sets the deadline');
+        $this->assertStringContainsString(
+            (new DateTimeImmutable('+31 days'))->format('Y-m-d'), $out
+        );
+        $this->assertStringNotContainsString('ACTION', $out);
+        $this->assertStringNotContainsString('Not partitioned', $out);
+    }
+
+    /** Nothing partitioned at all: init, and no deadline to invent. */
+    public function testStatusSummaryWhenNothingIsPartitioned()
+    {
+        $bare = $this->layout([
+            'partitioned' => false, 'covers' => null, 'ahead' => null, 'total' => 0,
+        ]);
+
+        $out = implode("\n", $this->callProtected($this->statusCli(), 'summarise', [
+            ['owa_a' => $bare, 'owa_b' => $bare],
+            ['limit' => 200, 'reason' => 'x'],
+        ]));
+
+        $this->assertStringContainsString('0 of 2 fact tables partitioned, 0 partitions in total.', $out);
+        $this->assertStringContainsString('cmd=partition-init converts them', $out);
+        $this->assertStringNotContainsString('covering', $out, 'no range to report');
+        $this->assertStringNotContainsString('deadline', $out);
+        $this->assertStringNotContainsString('ACTION', $out);
+    }
+
+    /**
+     * The open-file budget belongs to the server, not to the invocation.
+     *
+     * Sizing it from the tables named on the command line would hand
+     * `table=owa_session` several times the allowance of the same command
+     * without a filter -- reporting a table as comfortably inside a budget it is
+     * in fact straining, and letting the mutating commands build to it.
+     */
+    public function testBudgetIsSizedAgainstEveryFactTableNotTheFilteredSet()
+    {
+        $all = $this->callProtected($this->statusCli(), 'factTableBudget');
+
+        $this->assertSame(
+            $all['limit'],
+            $this->callProtected($this->statusCli(['table' => 'owa_session']), 'factTableBudget')['limit'],
+            'filtering the report must not change the budget'
+        );
+
+        foreach ([$this->rotate(), $this->drop()] as $other) {
+            $this->assertSame($all['limit'], $this->callProtected($other, 'factTableBudget')['limit'],
+                'every command sizes the budget the same way');
+        }
+    }
+
+    /**
+     * End to end against the real fact tables: the command must run, describe
+     * every one of them, and report a total that matches what is on disk.
+     */
+    public function testStatusRunsAgainstTheRealFactTables()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        if (! $db->supportsPartitioning()) {
+            $this->markTestSkipped('Driver cannot partition.');
+        }
+
+        $ctrl   = $this->statusCli();
+        $tables = $this->callProtected($ctrl, 'factTables');
+        $budget = $this->callProtected($ctrl, 'factTableBudget');
+
+        $this->assertNotEmpty($tables, 'the entity registry must yield fact tables');
+
+        $layouts = [];
+
+        foreach ($tables as $table) {
+            $layout = $db->describePartitionLayout($table);
+            $layout['contents'] = $layout['catch_all']
+                ? $db->getPartitionContents($table, $layout['catch_all'])
+                : null;
+            $layouts[$table] = $layout;
+
+            $lines = $this->callProtected($ctrl, 'describeTable', [$table, $layout, $budget]);
+
+            $this->assertNotEmpty($lines, "$table produced no report");
+            $this->assertStringStartsWith($table . ':', $lines[0]);
+
+            if ($layout['partitioned']) {
+                $this->assertSame(
+                    count($db->listPartitions($table)),
+                    $layout['total'],
+                    "$table: the reported total must match the partitions on disk"
+                );
+                $this->assertSame(
+                    count($db->getPartitionSpans($table)),
+                    $layout['spans'],
+                    "$table: bounded partitions exclude the catch-all"
+                );
+            }
+        }
+
+        $summary = implode("\n", $this->callProtected($ctrl, 'summarise', [$layouts, $budget]));
+
+        $this->assertStringContainsString(
+            sprintf('of %d fact tables partitioned', count($tables)),
+            $summary
+        );
+    }
+
+    /** A table that is not a fact table is refused, not reported on. */
+    public function testStatusRefusesATableItDoesNotPartition()
+    {
+        $this->assertSame(
+            [],
+            $this->callProtected($this->statusCli(), 'factTables', ['owa_user']),
+            'partitioning applies to the fact tables only'
+        );
+    }
 }

--- a/tests/PartitionCliTest.php
+++ b/tests/PartitionCliTest.php
@@ -229,28 +229,37 @@ final class PartitionCliTest extends CliControllerTestCase
     }
 
     /**
-     * The budget can be stated outright.
+     * The budget is a setting, not an argument.
      *
-     * This is the considered escape hatch, as opposed to force: it makes the
-     * operator name the number they are accepting -- which means looking at
-     * innodb_open_files to choose it -- and it lands in the log as a figure the
-     * next person can evaluate rather than as "the guard was switched off".
+     * How much of a server's open-file capacity partitioning may claim is a
+     * property of the installation, so it is set once with a constant in
+     * owa-config.php rather than chosen per invocation. Passing it as an
+     * argument must have no effect at all.
      */
-    public function testAnExplicitBudgetOverridesTheDerivedOne()
+    public function testTheBudgetComesFromSettingsNotArguments()
     {
         $derived = $this->callProtected($this->rotate(), 'partitionLimit', [7]);
 
-        $stated = $this->callProtected($this->rotate(['max-partitions' => '500']), 'partitionLimit', [7]);
-        $this->assertSame(500, $stated['limit']);
-        $this->assertStringContainsString('explicitly', $stated['reason']);
+        $this->assertSame(
+            $derived['limit'],
+            $this->callProtected($this->rotate(['max-partitions' => '500']), 'partitionLimit', [7])['limit'],
+            'an argument must not be able to change the budget'
+        );
 
-        // Junk falls back to the derived budget rather than to something permissive.
-        foreach (['abc', '0', '-5', ''] as $bad) {
-            $this->assertSame(
-                $derived['limit'],
-                $this->callProtected($this->rotate(['max-partitions' => $bad]), 'partitionLimit', [7])['limit'],
-                var_export($bad, true) . ' should not be accepted as a budget'
-            );
+        $original = \OWA\Core\CoreAPI::getSetting('base', 'partition_max_partitions');
+
+        try {
+            \OWA\Core\CoreAPI::setSetting('base', 'partition_max_partitions', 500);
+            $stated = $this->callProtected($this->rotate(), 'partitionLimit', [7]);
+            $this->assertSame(500, $stated['limit']);
+            $this->assertStringContainsString('OWA_PARTITION_MAX_PARTITIONS', $stated['reason']);
+
+            // Zero means "derive it", not "no partitions allowed".
+            \OWA\Core\CoreAPI::setSetting('base', 'partition_max_partitions', 0);
+            $this->assertSame($derived['limit'], $this->callProtected($this->rotate(), 'partitionLimit', [7])['limit']);
+
+        } finally {
+            \OWA\Core\CoreAPI::setSetting('base', 'partition_max_partitions', $original);
         }
     }
 

--- a/tests/PartitionCliTest.php
+++ b/tests/PartitionCliTest.php
@@ -283,4 +283,136 @@ final class PartitionCliTest extends CliControllerTestCase
             \OWA\Core\Db::PARTITION_MIN_LIMIT
         );
     }
+
+    /**
+     * Rotation without a retention window compacts and deletes nothing.
+     *
+     * The controller's own step, not the database helper it calls: the ordering
+     * -- extend, then compact, then drop only if asked -- is what could regress.
+     * Lives here rather than in PartitionOperationsTest because constructing a
+     * CLI controller needs the admin_cli instance role this harness boots.
+     */
+    public function testCompactTableMergesWithoutDeleting()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        if (! $db->supportsPartitioning()) {
+            $this->markTestSkipped('Driver cannot partition.');
+        }
+
+        $t = 'owa_test_compact_' . $this->tok;
+
+        try {
+            $db->query("CREATE TABLE $t (id BIGINT NOT NULL, yyyymmdd INT NOT NULL, PRIMARY KEY (id,yyyymmdd))");
+            $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+                date('Ymd', strtotime(date('Ym') . '01 -120 months')),
+                date('Ymd', strtotime(\OWA\Core\Db::partitionLeadBoundary() . ' -1 day')),
+                'monthly'
+            ));
+
+            for ($m = -120; $m <= 0; $m += 6) {
+                $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, $m + 500,
+                    date('Ymd', strtotime(date('Ym') . "01 $m months +14 days"))));
+            }
+
+            $rows   = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+            $before = count($db->getPartitionSpans($t));
+            $budget = ['limit' => 60, 'reason' => 'test'];
+            $ctrl   = $this->rotate();
+
+            // Dry run reports without acting.
+            $this->callProtected($ctrl, 'compactTable', [$t, $budget, true]);
+            $this->assertSame($before, count($db->getPartitionSpans($t)), 'a dry run must not merge');
+
+            $merged = $this->callProtected($ctrl, 'compactTable', [$t, $budget, false]);
+
+            $this->assertGreaterThan(0, $merged, 'a ten-year monthly table has something to merge');
+            $this->assertLessThanOrEqual(60, count($db->getPartitionSpans($t)), 'must reach the budget');
+            $this->assertSame($rows, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'], 'no row may be deleted');
+
+            // Idempotent: a settled table needs no further merging, however many
+            // times the scheduled job runs.
+            $settled = count($db->getPartitionSpans($t));
+            $this->assertSame(0, $this->callProtected($ctrl, 'compactTable', [$t, $budget, false]));
+            $this->assertSame($settled, count($db->getPartitionSpans($t)), 'the layout must settle');
+
+            // The detail window is untouched, so recent retention stays precise.
+            $boundary = date('Ymd', strtotime(date('Ym') . '01 -' . \OWA\Core\Db::PARTITION_DETAIL_MONTHS . ' months'));
+
+            foreach ($db->getPartitionSpans($t) as $span) {
+                if ($span['start'] >= $boundary) {
+                    $this->assertSame('01', substr($span['start'], 6, 2), 'detail-window partitions stay monthly');
+                }
+            }
+
+        } finally {
+            $db->query("DROP TABLE IF EXISTS $t");
+        }
+    }
+
+    /**
+     * A finer granularity trades tail detail for recent detail.
+     *
+     * Moving to quarter-month multiplies the detail window, which on a
+     * long-history table exceeds the budget. Refusing outright would leave the
+     * operator no way to get finer recent partitions on exactly the
+     * installations where old history is what is consuming the budget. Old
+     * periods are merged to make room instead -- the tail exists to be traded.
+     */
+    public function testReorganiseMergesTheTailToMakeRoom()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        if (! $db->supportsPartitioning()) {
+            $this->markTestSkipped('Driver cannot partition.');
+        }
+
+        $t = 'owa_test_room_' . $this->tok;
+
+        try {
+            $db->query("CREATE TABLE $t (id BIGINT NOT NULL, yyyymmdd INT NOT NULL, PRIMARY KEY (id,yyyymmdd))");
+            $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makeTieredPartitionRanges(
+                date('Ymd', strtotime(date('Ym') . '01 -180 months')),
+                \OWA\Core\Db::partitionLeadBoundary(),
+                'monthly',
+                \OWA\Core\Db::PARTITION_DETAIL_MONTHS
+            ));
+
+            for ($m = -180; $m <= 0; $m += 12) {
+                $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, $m + 900,
+                    date('Ymd', strtotime(date('Ym') . "01 $m months +14 days"))));
+            }
+
+            $rows   = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+            $before = count($db->getPartitionSpans($t));
+            $wanted = $db->repartitionTable($t, 'quarter-month', true)['planned'];
+
+            $this->assertGreaterThan($before, $wanted, 'the fixture must actually need more partitions');
+
+            // Reserving what the finer granularity will need is the part that
+            // matters: measured against today's count the table already fits,
+            // and nothing would be merged.
+            $extra  = $wanted - $before;
+            $budget = ['limit' => max(1, 200 - $extra), 'reason' => 'test, room reserved'];
+
+            $merged = $this->callProtected($this->rotate(), 'compactTable', [$t, $budget, false]);
+
+            $this->assertGreaterThan(0, $merged, 'room must actually be made');
+            $this->assertLessThan($before, count($db->getPartitionSpans($t)), 'the tail should be coarser');
+            $this->assertSame($rows, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'], 'no row may be lost');
+
+            // The detail window is still intact, which is the point of the trade.
+            $boundary = date('Ymd', strtotime(date('Ym') . '01 -' . \OWA\Core\Db::PARTITION_DETAIL_MONTHS . ' months'));
+            $fine = 0;
+
+            foreach ($db->getPartitionSpans($t) as $span) {
+                if ($span['start'] >= $boundary) { $fine++; }
+            }
+
+            $this->assertGreaterThan(0, $fine, 'the detail window must survive the trade');
+
+        } finally {
+            $db->query("DROP TABLE IF EXISTS $t");
+        }
+    }
 }

--- a/tests/PartitionCliTest.php
+++ b/tests/PartitionCliTest.php
@@ -227,4 +227,46 @@ final class PartitionCliTest extends CliControllerTestCase
     {
         return count(\OWA\Core\CoreAPI::dbSingleton()->listPartitions($table));
     }
+
+    /**
+     * The budget can be stated outright.
+     *
+     * This is the considered escape hatch, as opposed to force: it makes the
+     * operator name the number they are accepting -- which means looking at
+     * innodb_open_files to choose it -- and it lands in the log as a figure the
+     * next person can evaluate rather than as "the guard was switched off".
+     */
+    public function testAnExplicitBudgetOverridesTheDerivedOne()
+    {
+        $derived = $this->callProtected($this->rotate(), 'partitionLimit', [7]);
+
+        $stated = $this->callProtected($this->rotate(['max-partitions' => '500']), 'partitionLimit', [7]);
+        $this->assertSame(500, $stated['limit']);
+        $this->assertStringContainsString('explicitly', $stated['reason']);
+
+        // Junk falls back to the derived budget rather than to something permissive.
+        foreach (['abc', '0', '-5', ''] as $bad) {
+            $this->assertSame(
+                $derived['limit'],
+                $this->callProtected($this->rotate(['max-partitions' => $bad]), 'partitionLimit', [7])['limit'],
+                var_export($bad, true) . ' should not be accepted as a budget'
+            );
+        }
+    }
+
+    /** The numbers behind the budget are named constants, not literals. */
+    public function testBudgetConstantsAreExposed()
+    {
+        $this->assertGreaterThanOrEqual(1, \OWA\Core\Db::PARTITION_BUDGET_RESERVE);
+        $this->assertGreaterThan(0, \OWA\Core\Db::PARTITION_MIN_LIMIT);
+        $this->assertGreaterThan(0, \OWA\Core\Db::PARTITION_DETAIL_MONTHS);
+        $this->assertGreaterThan(0, \OWA\Core\Db::PARTITION_MAX_YEARS_PER_BLOCK);
+
+        // The floor must not exceed what a derived budget could yield, or it
+        // would silently become the only value this ever returns.
+        $this->assertLessThan(
+            \OWA\Core\Db::PARTITION_COUNT_LIMIT,
+            \OWA\Core\Db::PARTITION_MIN_LIMIT
+        );
+    }
 }

--- a/tests/PartitionCliTest.php
+++ b/tests/PartitionCliTest.php
@@ -415,4 +415,59 @@ final class PartitionCliTest extends CliControllerTestCase
             $db->query("DROP TABLE IF EXISTS $t");
         }
     }
+
+    /**
+     * partition-init is a one-time conversion, not a maintenance command.
+     *
+     * Everything it could usefully do to an already-partitioned table belongs to
+     * another command: extending the lead and coarsening the tail is exactly
+     * partition-rotate, and applying a granularity would convert only the
+     * periods being added, leaving the rest as they were -- a silent, partial
+     * reorganisation. So it reports and skips, and names the command that does
+     * the job being asked for.
+     */
+    public function testInitLeavesAnAlreadyPartitionedTableAlone()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        if (! $db->supportsPartitioning()) {
+            $this->markTestSkipped('Driver cannot partition.');
+        }
+
+        $t = 'owa_test_initonce_' . $this->tok;
+
+        try {
+            $db->query("CREATE TABLE $t (id BIGINT NOT NULL, yyyymmdd INT NOT NULL, PRIMARY KEY (id,yyyymmdd))");
+
+            // A deliberately stale layout: short lead, fine tail. A maintaining
+            // command would change all of it.
+            $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+                date('Ymd', strtotime(date('Ym') . '01 -60 months')),
+                date('Ymd', strtotime(date('Ym') . '01 +1 month')),
+                'monthly'
+            ));
+
+            $before = array_map(
+                fn($s) => $s['name'] . ':' . $s['less_than'],
+                $db->getPartitionSpans($t)
+            );
+
+            // Neither a plain run nor one asking for a different granularity may
+            // touch it.
+            foreach ([[], ['granularity' => 'half-month'], ['months-ahead' => '24']] as $params) {
+
+                $ctrl = new \OWA\Module\Base\Controller\PartitionInitCli($params + ['table' => $t]);
+                $ctrl->action();
+
+                $this->assertSame(
+                    $before,
+                    array_map(fn($s) => $s['name'] . ':' . $s['less_than'], $db->getPartitionSpans($t)),
+                    'init must not modify a partitioned table, whatever it is asked for: ' . json_encode($params)
+                );
+            }
+
+        } finally {
+            $db->query("DROP TABLE IF EXISTS $t");
+        }
+    }
 }

--- a/tests/PartitionOperationsTest.php
+++ b/tests/PartitionOperationsTest.php
@@ -797,4 +797,98 @@ final class PartitionOperationsTest extends TestCase
             );
         }
     }
+
+    /**
+     * Rotation without a retention window must never delete anything.
+     *
+     * This is the policy that makes partition count and retention independent:
+     * old periods are coarsened to fit the budget instead of being dropped. If
+     * it ever deletes a row, the guarantee the feature is sold on is gone.
+     *
+     * Exercised through the controller's own compaction step rather than the
+     * database helpers, because the ordering -- extend, then compact, then drop
+     * only if asked -- is the part that could regress.
+     */
+    public function testRotationWithoutKeepCompactsAndDeletesNothing()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        // Ten years of monthly history: far more partitions than a tight budget.
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            date('Ymd', strtotime(date('Ym') . '01 -120 months')),
+            date('Ymd', strtotime(\OWA\Core\Db::partitionLeadBoundary() . ' -1 day')),
+            'monthly'
+        ));
+
+        $id = 0;
+        for ($m = -120; $m <= 0; $m += 3) {
+            $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, ++$id,
+                date('Ymd', strtotime(date('Ym') . "01 $m months +14 days"))));
+        }
+
+        $rows_before  = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+        $parts_before = count($db->getPartitionSpans($t));
+
+        $ctrl   = new \OWA\Module\Base\Controller\PartitionRotateCli([]);
+        $method = new ReflectionMethod($ctrl, 'compactTable');
+        $method->setAccessible(true);
+
+        $budget = ['limit' => 60, 'reason' => 'test'];
+
+        // Dry run first: it must report and change nothing.
+        $method->invoke($ctrl, $t, $budget, true);
+        $this->assertSame($parts_before, count($db->getPartitionSpans($t)), 'a dry run must not merge');
+
+        $merged = $method->invoke($ctrl, $t, $budget, false);
+
+        $this->assertGreaterThan(0, $merged, 'a ten-year monthly table should have something to merge');
+        $this->assertLessThan($parts_before, count($db->getPartitionSpans($t)), 'partitions should be fewer');
+        $this->assertLessThanOrEqual(60, count($db->getPartitionSpans($t)), 'and within the budget');
+
+        $this->assertSame(
+            $rows_before,
+            (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'],
+            'compaction must not delete a single row'
+        );
+
+        // Idempotent: nothing left to merge on a second pass.
+        $this->assertSame(0, $method->invoke($ctrl, $t, $budget, false), 'a settled table needs no merging');
+    }
+
+    /**
+     * Compaction leaves the detail window alone, so recent retention stays
+     * precise however aggressively old history has been coarsened.
+     */
+    public function testCompactionNeverTouchesTheDetailWindow()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            date('Ymd', strtotime(date('Ym') . '01 -96 months')),
+            date('Ymd', strtotime(\OWA\Core\Db::partitionLeadBoundary() . ' -1 day')),
+            'monthly'
+        ));
+
+        $boundary = date('Ymd', strtotime(date('Ym') . '01 -' . \OWA\Core\Db::PARTITION_DETAIL_MONTHS . ' months'));
+
+        $recent_before = array_values(array_filter(
+            array_map(fn($s) => $s['name'], $db->getPartitionSpans($t)),
+            fn($n) => substr($n, 1) >= $boundary
+        ));
+
+        $ctrl   = new \OWA\Module\Base\Controller\PartitionRotateCli([]);
+        $method = new ReflectionMethod($ctrl, 'compactTable');
+        $method->setAccessible(true);
+        $method->invoke($ctrl, $t, ['limit' => 50, 'reason' => 'test'], false);
+
+        $recent_after = array_values(array_filter(
+            array_map(fn($s) => $s['name'], $db->getPartitionSpans($t)),
+            fn($n) => substr($n, 1) >= $boundary
+        ));
+
+        $this->assertSame($recent_before, $recent_after, 'partitions inside the detail window must be untouched');
+        $this->assertNotEmpty($recent_before, 'the fixture needs a detail window to be a test');
+    }
 }

--- a/tests/PartitionOperationsTest.php
+++ b/tests/PartitionOperationsTest.php
@@ -801,6 +801,338 @@ final class PartitionOperationsTest extends TestCase
 
 
     /** Build a table with $months of monthly history plus the standard lead. */
+    // -----------------------------------------------------------------------
+    // Describing a layout -- what partition-status reads
+    // -----------------------------------------------------------------------
+
+    /**
+     * A period is named in the vocabulary the commands use.
+     *
+     * partition-status has to describe a tiered table, where the tail holds
+     * years per partition and the head holds fractions of a month. Naming a
+     * sub-month period after the granularity that cuts it there keeps the report
+     * in the same words as the reorganize command's argument.
+     */
+    public function testPeriodsAreNamedAsOperatorsNameThem()
+    {
+        $cases = array(
+            // monthly
+            array('20260101', '20260201', 'monthly'),
+            array('20260201', '20260301', 'monthly'),   // short month
+            array('20241201', '20250101', 'monthly'),   // across a year end
+            // sub-month, by the cuts that produce them
+            array('20260101', '20260116', 'half-month'),
+            array('20260116', '20260201', 'half-month'),
+            array('20260216', '20260301', 'half-month'),
+            array('20260101', '20260108', 'quarter-month'),
+            array('20260108', '20260115', 'quarter-month'),
+            array('20260115', '20260122', 'quarter-month'),
+            array('20260122', '20260201', 'quarter-month'),
+            // merged blocks
+            array('20260101', '20270101', '1 year'),
+            array('20200101', '20250101', '5 years'),
+            array('20200101', '20300101', '10 years'),
+            array('20260101', '20260401', '3 months'),
+            array('20260101', '20261101', '10 months'),
+            // a block that begins mid-month, which merging never produces but
+            // a hand-altered table can
+            array('20260116', '20260316', '59 days'),
+            // unreadable
+            array('20260101', '20260101', 'unknown'),   // empty
+            array('20260201', '20260101', 'unknown'),   // reversed
+            array('garbage',  '20260101', 'unknown'),
+            array('20260101', '',         'unknown'),
+        );
+
+        foreach ($cases as list($start, $less_than, $expected)) {
+            $this->assertSame(
+                $expected,
+                \OWA\Core\Db::describePartitionPeriod($start, $less_than),
+                "$start .. $less_than"
+            );
+        }
+    }
+
+    /** An unpartitioned table reports as such, and nothing else claims to know. */
+    public function testLayoutOfAnUnpartitionedTable()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $layout = $db->describePartitionLayout($this->makeTable());
+
+        $this->assertFalse($layout['partitioned']);
+        $this->assertSame(0, $layout['total']);
+        $this->assertSame(0, $layout['spans']);
+        $this->assertNull($layout['covers']);
+        $this->assertNull($layout['granularity']);
+        $this->assertNull($layout['catch_all']);
+        $this->assertNull($layout['ahead']);
+        $this->assertSame(array(), $layout['tiers']);
+    }
+
+    /**
+     * A uniform table is one tier, and the counts add up: the catch-all is
+     * counted in the total and excluded from the bounded spans, because that is
+     * the distinction the budget and the retention rules both turn on.
+     */
+    public function testLayoutOfAUniformTable()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t  = $this->makeTable();
+
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            date('Ymd', strtotime(date('Ym') . '01 -6 months')),
+            date('Ymd', strtotime(date('Ym') . '01 +3 months')),
+            'monthly'
+        ));
+
+        $layout = $db->describePartitionLayout($t);
+
+        $this->assertTrue($layout['partitioned']);
+        $this->assertSame($layout['spans'] + 1, $layout['total'], 'catch-all is in the total');
+        $this->assertSame('monthly', $layout['granularity']);
+        $this->assertNotNull($layout['catch_all']);
+        $this->assertCount(1, $layout['tiers']);
+        $this->assertSame('monthly', $layout['tiers'][0]['period']);
+        $this->assertSame($layout['spans'], $layout['tiers'][0]['count'], 'every span is in a tier');
+        $this->assertSame($layout['covers']['start'], $layout['tiers'][0]['start']);
+        $this->assertSame($layout['covers']['end'], $layout['tiers'][0]['end']);
+    }
+
+    /**
+     * The reason this is reported as tiers rather than a granularity.
+     *
+     * A rotated table is coarse at the tail and fine at the head. One word
+     * cannot describe it without being wrong about one end, so the report gives
+     * each run of equal-length partitions with the span it covers -- and the
+     * tiers must tile the whole range without a gap.
+     */
+    public function testLayoutOfATieredTableIsReportedAsTiers()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach (array('monthly', 'half-month', 'quarter-month') as $granularity) {
+
+            $t      = $this->tieredTable(180, $granularity);
+            $layout = $db->describePartitionLayout($t);
+
+            $this->assertGreaterThan(1, count($layout['tiers']),
+                "$granularity: 15 years of history must produce a coarse tail and a fine head");
+
+            // The finest tier is the newest, and is the granularity in force.
+            $newest = $layout['tiers'][count($layout['tiers']) - 1];
+            $this->assertSame($granularity, $newest['period'],
+                "$granularity: the head keeps the table's granularity");
+            $this->assertSame($granularity, $layout['granularity'],
+                "$granularity: inference agrees with the newest tier");
+
+            // The tail is coarser than a month.
+            $this->assertNotSame($granularity, $layout['tiers'][0]['period'],
+                "$granularity: the tail must have been merged");
+
+            // Tiers tile the covered range end to end.
+            $this->assertSame($layout['covers']['start'], $layout['tiers'][0]['start']);
+            $this->assertSame($layout['covers']['end'], $newest['end']);
+
+            $counted = 0;
+            $previous = null;
+
+            foreach ($layout['tiers'] as $tier) {
+                if ($previous !== null) {
+                    $this->assertSame($previous, $tier['start'],
+                        "$granularity: tiers must be contiguous");
+                }
+                $previous = $tier['end'];
+                $counted += $tier['count'];
+            }
+
+            $this->assertSame($layout['spans'], $counted,
+                "$granularity: every bounded partition belongs to exactly one tier");
+        }
+    }
+
+    /**
+     * The lead is what running out of costs, so it is counted as partitions
+     * bought in advance and as days until the last boundary.
+     */
+    public function testLayoutCountsTheLead()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach (array(0, 1, 3, 12) as $ahead) {
+
+            $t = $this->makeTable();
+
+            $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+                date('Ymd', strtotime(date('Ym') . '01 -6 months')),
+                date('Ymd', strtotime(date('Ym') . "01 +$ahead months")),
+                'monthly'
+            ));
+
+            $layout = $db->describePartitionLayout($t);
+
+            // The end date names the last period to create, so the boundary
+            // above it is a month later.
+            $top = date('Ymd', strtotime(date('Ym') . '01 +' . ($ahead + 1) . ' months'));
+
+            $this->assertSame($top, $layout['through'], "lead of $ahead months: top boundary");
+
+            // Partitions that begin after today. The current month's began on
+            // the 1st, so it is not lead however early in the month this runs.
+            $this->assertSame($ahead, $layout['lead'],
+                "lead of $ahead months: partitions wholly in the future");
+
+            $this->assertSame(
+                (int) (new DateTimeImmutable('today'))
+                    ->diff(DateTimeImmutable::createFromFormat('Ymd|', $top))->format('%r%a'),
+                $layout['ahead'],
+                "lead of $ahead months: days to the top boundary"
+            );
+        }
+    }
+
+    /**
+     * A lead that has run out reports as negative days, not as zero or as an
+     * absence. That sign is what the command turns into "rotate now".
+     */
+    public function testLayoutReportsAnExpiredLeadAsNegative()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t  = $this->makeTable();
+
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            date('Ymd', strtotime(date('Ym') . '01 -12 months')),
+            date('Ymd', strtotime(date('Ym') . '01 -3 months')),
+            'monthly'
+        ));
+
+        $layout = $db->describePartitionLayout($t);
+
+        $this->assertLessThan(0, $layout['ahead'], 'a boundary in the past is negative days ahead');
+        $this->assertSame(0, $layout['lead'], 'no partition begins in the future');
+        $this->assertSame(date('Ymd', strtotime(date('Ym') . '01 -2 months')), $layout['through'],
+            'the last period created is -3 months, so its upper bound is -2');
+    }
+
+    /**
+     * Counting the catch-all reads the partition, not the InnoDB row estimate.
+     *
+     * The question being asked -- has real data collected outside the dated
+     * partitions -- cannot be answered by an estimate that is routinely out by
+     * a wide margin, and is zero for a freshly loaded table.
+     */
+    public function testCatchAllContentsAreCountedExactly()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t  = $this->makeTable();
+
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            date('Ymd', strtotime(date('Ym') . '01 -6 months')),
+            date('Ymd', strtotime(date('Ym') . '01 +1 month')),
+            'monthly'
+        ));
+
+        $catch_all = $db->getCatchAllPartition($t);
+
+        $empty = $db->getPartitionContents($t, $catch_all);
+        $this->assertSame(0, $empty['rows']);
+        $this->assertNull($empty['min'], 'an empty partition has no bounds');
+        $this->assertNull($empty['max']);
+
+        // Rows past the top boundary land in the catch-all.
+        $dates = array();
+        $id = 0;
+
+        foreach (array(3, 6, 9) as $months) {
+            $d = date('Ymd', strtotime(date('Ym') . "01 +$months months +5 days"));
+            $dates[] = $d;
+            $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, ++$id, $d));
+        }
+
+        // ...and one that does not, to prove the count is scoped to the partition.
+        $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, ++$id,
+            date('Ymd', strtotime(date('Ym') . '01 -2 months +5 days'))));
+
+        $filled = $db->getPartitionContents($t, $catch_all);
+
+        $this->assertSame(3, $filled['rows'], 'only the catch-all is counted');
+        $this->assertSame(min($dates), $filled['min']);
+        $this->assertSame(max($dates), $filled['max']);
+    }
+
+    /**
+     * Identifiers are interpolated into the statement, so they are validated --
+     * and validated before the statement is built, not after MySQL rejects it.
+     *
+     * Asserting only that a bad identifier yields null proves nothing: an
+     * unvalidated identifier produces a syntax error, and that yields null too.
+     * The observable difference is whether a query is issued at all, so the
+     * driver is watched rather than its return value.
+     */
+    public function testPartitionContentsValidatesIdentifiersBeforeQuerying()
+    {
+        $spy = new class extends \OWA\Core\Db\Mysql {
+
+            /** @var string[] */
+            public $sql = array();
+
+            public function __construct() {}
+
+            function get_row($sql)
+            {
+                $this->sql[] = $sql;
+
+                return array('n' => 0, 'lo' => null, 'hi' => null);
+            }
+        };
+
+        $bad = array(
+            array('owa_t',  'pmax; DROP TABLE x', 'yyyymmdd'),
+            array('owa_t',  'p max',              'yyyymmdd'),
+            array('owa_t',  "p'max",              'yyyymmdd'),
+            array('owa_t',  '',                   'yyyymmdd'),
+            array('owa t',  'pmax',               'yyyymmdd'),
+            array('x; DROP TABLE y', 'pmax',      'yyyymmdd'),
+            array('owa_t',  'pmax',               'yyyymmdd; DROP TABLE x'),
+            array('owa_t',  'pmax',               '1) OR (1'),
+        );
+
+        foreach ($bad as list($table, $partition, $column)) {
+            $this->assertNull(
+                $spy->getPartitionContents($table, $partition, $column),
+                sprintf('%s / %s / %s should be refused', $table, $partition, $column)
+            );
+        }
+
+        $this->assertSame(array(), $spy->sql,
+            'a refused identifier must not reach the database at all');
+
+        // ...and a well-formed one does query, so the guard is not simply
+        // refusing everything.
+        $this->assertNotNull($spy->getPartitionContents('owa_t', 'pmax', 'yyyymmdd'));
+        $this->assertCount(1, $spy->sql);
+        $this->assertStringContainsString('PARTITION (pmax)', $spy->sql[0],
+            'the count must be scoped to the one partition');
+    }
+
+    /** The same validation, exercised against a real table. */
+    public function testPartitionContentsRefusesUnsafeIdentifiers()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t  = $this->makeTable();
+
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            date('Ymd', strtotime(date('Ym') . '01 -2 months')),
+            date('Ymd', strtotime(date('Ym') . '01 +1 month')),
+            'monthly'
+        ));
+
+        foreach (array('pmax; DROP TABLE ' . $t, 'p max', "p'max", '') as $bad) {
+            $this->assertNull($db->getPartitionContents($t, $bad), var_export($bad, true));
+        }
+
+        $this->assertNotEmpty($db->listPartitions($t), 'the table is still there');
+    }
+
     private function historyTable($months)
     {
         $db = \OWA\Core\CoreAPI::dbSingleton();

--- a/tests/PartitionOperationsTest.php
+++ b/tests/PartitionOperationsTest.php
@@ -798,97 +798,309 @@ final class PartitionOperationsTest extends TestCase
         }
     }
 
-    /**
-     * Rotation without a retention window must never delete anything.
-     *
-     * This is the policy that makes partition count and retention independent:
-     * old periods are coarsened to fit the budget instead of being dropped. If
-     * it ever deletes a row, the guarantee the feature is sold on is gone.
-     *
-     * Exercised through the controller's own compaction step rather than the
-     * database helpers, because the ordering -- extend, then compact, then drop
-     * only if asked -- is the part that could regress.
-     */
-    public function testRotationWithoutKeepCompactsAndDeletesNothing()
+
+
+    /** Build a table with $months of monthly history plus the standard lead. */
+    private function historyTable($months)
     {
         $db = \OWA\Core\CoreAPI::dbSingleton();
         $t = $this->makeTable();
 
-        // Ten years of monthly history: far more partitions than a tight budget.
         $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
-            date('Ymd', strtotime(date('Ym') . '01 -120 months')),
+            date('Ymd', strtotime(date('Ym') . "01 -$months months")),
             date('Ymd', strtotime(\OWA\Core\Db::partitionLeadBoundary() . ' -1 day')),
             'monthly'
         ));
 
         $id = 0;
-        for ($m = -120; $m <= 0; $m += 3) {
+        for ($m = -$months; $m <= 0; $m += 2) {
             $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, ++$id,
                 date('Ymd', strtotime(date('Ym') . "01 $m months +14 days"))));
         }
 
-        $rows_before  = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
-        $parts_before = count($db->getPartitionSpans($t));
-
-        $ctrl   = new \OWA\Module\Base\Controller\PartitionRotateCli([]);
-        $method = new ReflectionMethod($ctrl, 'compactTable');
-        $method->setAccessible(true);
-
-        $budget = ['limit' => 60, 'reason' => 'test'];
-
-        // Dry run first: it must report and change nothing.
-        $method->invoke($ctrl, $t, $budget, true);
-        $this->assertSame($parts_before, count($db->getPartitionSpans($t)), 'a dry run must not merge');
-
-        $merged = $method->invoke($ctrl, $t, $budget, false);
-
-        $this->assertGreaterThan(0, $merged, 'a ten-year monthly table should have something to merge');
-        $this->assertLessThan($parts_before, count($db->getPartitionSpans($t)), 'partitions should be fewer');
-        $this->assertLessThanOrEqual(60, count($db->getPartitionSpans($t)), 'and within the budget');
-
-        $this->assertSame(
-            $rows_before,
-            (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'],
-            'compaction must not delete a single row'
-        );
-
-        // Idempotent: nothing left to merge on a second pass.
-        $this->assertSame(0, $method->invoke($ctrl, $t, $budget, false), 'a settled table needs no merging');
+        return $t;
     }
 
     /**
-     * Compaction leaves the detail window alone, so recent retention stays
-     * precise however aggressively old history has been coarsened.
+     * The detail window setting must actually decide how much is coarsened.
+     *
+     * It is the knob an operator is told to reach for when a table will not fit
+     * its budget, so it has to demonstrably do something.
      */
-    public function testCompactionNeverTouchesTheDetailWindow()
+    public function testDetailWindowSettingChangesWhatIsCompacted()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->historyTable(120);
+
+        $wide   = $db->planPartitionCompaction($t, 40, 72);   // six years kept fine
+        $narrow = $db->planPartitionCompaction($t, 40, 12);   // one year kept fine
+
+        $this->assertGreaterThan(0, $wide['projected'], 'a plan must report a projection');
+
+        $this->assertLessThan(
+            $wide['projected'],
+            $narrow['projected'],
+            'a narrower detail window must leave fewer partitions'
+        );
+
+        $this->assertLessThan(
+            $wide['floor'],
+            $narrow['floor'],
+            'and a narrower window must lower the floor, which is why it is the remedy'
+        );
+    }
+
+    /**
+     * The block cap must bound the coarsest partition. Without it an unreachable
+     * budget collapses history into one partition -- the cliff this design
+     * exists to prevent.
+     */
+    public function testBlockCapBoundsTheCoarsestPartition()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->historyTable(240);
+
+        // A budget far below the floor, so the planner widens blocks as far as
+        // it is allowed and no further.
+        $plan = $db->planPartitionCompaction($t, 2, 36);
+
+        $this->assertFalse($plan['fits'], 'this budget is unreachable by design');
+        $this->assertGreaterThan(1, count($plan['merges']), 'must not collapse into a single partition');
+
+        $cap = \OWA\Core\Db::PARTITION_MAX_YEARS_PER_BLOCK;
+
+        foreach ($plan['merges'] as $m) {
+            $years = (strtotime($m['less_than']) - strtotime($m['start'])) / 86400 / 365.25;
+            $this->assertLessThanOrEqual($cap + 0.05, $years, "no block may exceed $cap years");
+        }
+    }
+
+    /**
+     * Retention across the range of keep values: larger than the history drops
+     * nothing, smaller drops, and the boundary partition is kept either way
+     * because only whole partitions go.
+     */
+    public function testKeepAcrossItsRange()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->historyTable(60);
+
+        $rows = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+
+        // Longer than the data: nothing is old enough to drop.
+        $this->assertSame(
+            array(),
+            $db->getDroppablePartitions($t, date('Ymd', strtotime('-600 months')))['drop'],
+            'a keep longer than the history must drop nothing'
+        );
+
+        // Shorter than the data: something goes, and never the straddler.
+        $cut  = date('Ymd', strtotime('-24 months'));
+        $plan = $db->getDroppablePartitions($t, $cut);
+
+        $this->assertNotEmpty($plan['drop'], 'a keep shorter than the history must drop something');
+        $this->assertNotContains($plan['straddling']['name'] ?? '', $plan['drop'], 'the straddler is kept');
+        $this->assertLessThanOrEqual($cut, $plan['effective'], 'the boundary reached cannot exceed the cutoff');
+
+        foreach ($plan['drop'] as $p) {
+            $db->dropPartition($t, $p);
+        }
+
+        $this->assertLessThan($rows, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n']);
+
+        // And re-running the same cutoff now drops nothing: retention settles.
+        $this->assertSame(
+            array(),
+            $db->getDroppablePartitions($t, $cut)['drop'],
+            'retention must be idempotent for a fixed cutoff'
+        );
+    }
+
+    /**
+     * The whole cycle settles. Running it twice must leave the table identical,
+     * whether or not a retention window was given -- otherwise a scheduled job
+     * would churn the table on every run.
+     */
+    public function testTheFullCycleIsIdempotent()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach (array( 'with keep' => date('Ymd', strtotime('-24 months')), 'without keep' => null ) as $label => $cutoff) {
+
+            $t = $this->historyTable(96);
+
+            // Db-layer calls in the same order rotate performs them. The
+            // controller cannot be constructed under this bootstrap; its own
+            // step is covered in PartitionCliTest, which boots the CLI role.
+            $cycle = function () use ($db, $t, $cutoff) {
+                $db->extendPartitions($t, 'monthly', \OWA\Core\Db::partitionLeadBoundary());
+                foreach ($db->planPartitionCompaction($t, 50, 36)['merges'] as $m) {
+                    $db->mergePartitions($t, $m['names'], $m['start'], $m['less_than']);
+                }
+                if ($cutoff) {
+                    foreach ($db->getDroppablePartitions($t, $cutoff)['drop'] as $p) {
+                        $db->dropPartition($t, $p);
+                    }
+                }
+                return array_map(fn($s) => $s['name'] . ':' . $s['less_than'], $db->getPartitionSpans($t));
+            };
+
+            $first  = $cycle();
+            $rows   = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+            $second = $cycle();
+
+            $this->assertSame($first, $second, "$label: a second cycle must change nothing");
+            $this->assertSame(
+                $rows,
+                (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'],
+                "$label: and must delete nothing"
+            );
+        }
+    }
+
+    /** A tiered table: coarse year blocks, a fine detail window, and a lead. */
+    private function tieredTable($history_months = 120, $granularity = 'monthly')
     {
         $db = \OWA\Core\CoreAPI::dbSingleton();
         $t = $this->makeTable();
 
-        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
-            date('Ymd', strtotime(date('Ym') . '01 -96 months')),
-            date('Ymd', strtotime(\OWA\Core\Db::partitionLeadBoundary() . ' -1 day')),
-            'monthly'
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makeTieredPartitionRanges(
+            date('Ymd', strtotime(date('Ym') . "01 -$history_months months")),
+            \OWA\Core\Db::partitionLeadBoundary(),
+            $granularity,
+            \OWA\Core\Db::PARTITION_DETAIL_MONTHS
         ));
 
-        $boundary = date('Ymd', strtotime(date('Ym') . '01 -' . \OWA\Core\Db::PARTITION_DETAIL_MONTHS . ' months'));
+        $id = 0;
+        for ($m = -$history_months; $m <= 12; $m += 4) {
+            $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, ++$id,
+                date('Ymd', strtotime(date('Ym') . "01 $m months +14 days"))));
+        }
 
-        $recent_before = array_values(array_filter(
-            array_map(fn($s) => $s['name'], $db->getPartitionSpans($t)),
-            fn($n) => substr($n, 1) >= $boundary
-        ));
+        return $t;
+    }
 
-        $ctrl   = new \OWA\Module\Base\Controller\PartitionRotateCli([]);
-        $method = new ReflectionMethod($ctrl, 'compactTable');
-        $method->setAccessible(true);
-        $method->invoke($ctrl, $t, ['limit' => 50, 'reason' => 'test'], false);
+    private function coarseAndFine($table)
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $coarse = 0; $fine = 0;
 
-        $recent_after = array_values(array_filter(
-            array_map(fn($s) => $s['name'], $db->getPartitionSpans($t)),
-            fn($n) => substr($n, 1) >= $boundary
-        ));
+        foreach ($db->getPartitionSpans($table) as $span) {
+            $month_after = date('Ymd', strtotime(substr($span['start'], 0, 6) . '01 +1 month'));
+            if ($span['less_than'] <= $month_after) { $fine++; } else { $coarse++; }
+        }
 
-        $this->assertSame($recent_before, $recent_after, 'partitions inside the detail window must be untouched');
-        $this->assertNotEmpty($recent_before, 'the fixture needs a detail window to be a test');
+        return array('coarse' => $coarse, 'fine' => $fine);
+    }
+
+    /**
+     * Reorganising a tiered table must refine only the detail window.
+     *
+     * The coarse tail exists to keep the partition count within the server's
+     * open-file budget. Splitting it back to the table's granularity would undo
+     * exactly what compaction did, and on a long history it multiplies the
+     * partition count several times over.
+     */
+    public function testReorganiseLeavesTheCoarseTailAlone()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach (['half-month', 'quarter-month', 'monthly'] as $granularity) {
+
+            $t      = $this->tieredTable(120);
+            $before = $this->coarseAndFine($t);
+            $rows   = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+
+            $this->assertGreaterThan(0, $before['coarse'], "$granularity: fixture needs a tail");
+            $this->assertGreaterThan(0, $before['fine'],   "$granularity: fixture needs a detail window");
+
+            $db->repartitionTable($t, $granularity);
+
+            $after = $this->coarseAndFine($t);
+
+            $this->assertSame(
+                $before['coarse'],
+                $after['coarse'],
+                "$granularity: the coarse tail must be untouched"
+            );
+
+            $this->assertSame(
+                $rows,
+                (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'],
+                "$granularity: no row may be lost"
+            );
+
+            // And the fine end really did become the requested granularity.
+            $this->assertSame(
+                $granularity,
+                $db->inferPartitionGranularity($t),
+                "$granularity: the recent end should now read as that granularity"
+            );
+        }
+    }
+
+    /** An explicit range may still refine the tail, for an operator who means it. */
+    public function testAnExplicitRangeCanStillRefineTheTail()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t  = $this->tieredTable(120);
+
+        $spans = $db->getPartitionSpans($t);
+        $block = $spans[0];
+
+        $this->assertGreaterThan(
+            date('Ymd', strtotime(substr($block['start'], 0, 6) . '01 +1 month')),
+            $block['less_than'],
+            'the fixture\'s first partition should be a coarse block'
+        );
+
+        $rows = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+        $before = count($spans);
+
+        $db->repartitionTable($t, 'monthly', false, $block['start'], $block['less_than']);
+
+        $this->assertGreaterThan($before, count($db->getPartitionSpans($t)), 'the block should have been split');
+        $this->assertSame($rows, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'], 'no row may be lost');
+    }
+
+    /**
+     * The whole shape holds together across budgets: lead, tail and detail
+     * window survive compaction at every level, and the plan predicts what
+     * happens.
+     */
+    public function testTieredTableCompactsCorrectlyAtEveryBudget()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach ([200, 60, 40, 5] as $limit) {
+
+            $t     = $this->tieredTable(120);
+            $rows  = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+            $lead  = end($db->getPartitionSpans($t))['less_than'];
+
+            $plan = $db->planPartitionCompaction($t, $limit, \OWA\Core\Db::PARTITION_DETAIL_MONTHS);
+
+            foreach ($plan['merges'] as $m) {
+                $this->assertTrue($db->mergePartitions($t, $m['names'], $m['start'], $m['less_than']),
+                    "budget $limit: every planned merge must succeed");
+            }
+
+            $spans = $db->getPartitionSpans($t);
+
+            $this->assertSame($plan['projected'], count($spans), "budget $limit: the plan must predict the result");
+            $this->assertSame($rows, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'],
+                "budget $limit: no row may be lost");
+            $this->assertSame($lead, end($spans)['less_than'], "budget $limit: the lead must be preserved");
+
+            if ($plan['fits']) {
+                $this->assertLessThanOrEqual($limit, count($spans), "budget $limit: should have reached the budget");
+            } else {
+                $this->assertGreaterThanOrEqual($plan['floor'], count($spans), "budget $limit: cannot go below the floor");
+            }
+
+            // Settles regardless of budget.
+            $again = $db->planPartitionCompaction($t, $limit, \OWA\Core\Db::PARTITION_DETAIL_MONTHS);
+            $this->assertEmpty($again['merges'], "budget $limit: a second pass must find nothing to do");
+        }
     }
 }

--- a/tests/PartitionOperationsTest.php
+++ b/tests/PartitionOperationsTest.php
@@ -745,10 +745,10 @@ final class PartitionOperationsTest extends TestCase
         $count  = count($db->getPartitionSpans($t));
 
         $plan = $db->planPartitionCompaction($t, 60, 36);
-        $this->assertNotEmpty($plan['merges'], 'a 10-year monthly table should have something to merge');
+        $this->assertNotEmpty($plan['operations'], 'a 10-year monthly table should have something to reshape');
 
-        foreach ($plan['merges'] as $m) {
-            $this->assertTrue($db->mergePartitions($t, $m['names'], $m['start'], $m['less_than']));
+        foreach ($plan['operations'] as $op) {
+            $this->assertTrue($db->reshapePartitions($t, $op['names'], $op['ranges']));
         }
 
         $after = count($db->getPartitionSpans($t));
@@ -785,10 +785,10 @@ final class PartitionOperationsTest extends TestCase
         $plan = $db->planPartitionCompaction($t, 5, 36);
 
         $this->assertFalse($plan['fits'], 'this budget is not reachable');
-        $this->assertGreaterThan(1, count($plan['merges']), 'must not merge everything into one partition');
+        $this->assertGreaterThan(1, count($plan['operations']), 'must not merge everything into one partition');
         $this->assertGreaterThan(0, $plan['floor'], 'must report the floor so a caller can explain why');
 
-        foreach ($plan['merges'] as $m) {
+        foreach ($plan['operations'] as $m) {
             $span = (strtotime($m['less_than']) - strtotime($m['start'])) / 86400 / 365;
             $this->assertLessThanOrEqual(
                 \OWA\Core\Db::PARTITION_MAX_YEARS_PER_BLOCK + 0.1,
@@ -865,11 +865,11 @@ final class PartitionOperationsTest extends TestCase
         $plan = $db->planPartitionCompaction($t, 2, 36);
 
         $this->assertFalse($plan['fits'], 'this budget is unreachable by design');
-        $this->assertGreaterThan(1, count($plan['merges']), 'must not collapse into a single partition');
+        $this->assertGreaterThan(1, count($plan['operations']), 'must not collapse into a single partition');
 
         $cap = \OWA\Core\Db::PARTITION_MAX_YEARS_PER_BLOCK;
 
-        foreach ($plan['merges'] as $m) {
+        foreach ($plan['operations'] as $m) {
             $years = (strtotime($m['less_than']) - strtotime($m['start'])) / 86400 / 365.25;
             $this->assertLessThanOrEqual($cap + 0.05, $years, "no block may exceed $cap years");
         }
@@ -934,8 +934,8 @@ final class PartitionOperationsTest extends TestCase
             // step is covered in PartitionCliTest, which boots the CLI role.
             $cycle = function () use ($db, $t, $cutoff) {
                 $db->extendPartitions($t, 'monthly', \OWA\Core\Db::partitionLeadBoundary());
-                foreach ($db->planPartitionCompaction($t, 50, 36)['merges'] as $m) {
-                    $db->mergePartitions($t, $m['names'], $m['start'], $m['less_than']);
+                foreach ($db->planPartitionCompaction($t, 50, 36)['operations'] as $op) {
+                    $db->reshapePartitions($t, $op['names'], $op['ranges']);
                 }
                 if ($cutoff) {
                     foreach ($db->getDroppablePartitions($t, $cutoff)['drop'] as $p) {
@@ -1080,9 +1080,9 @@ final class PartitionOperationsTest extends TestCase
 
             $plan = $db->planPartitionCompaction($t, $limit, \OWA\Core\Db::PARTITION_DETAIL_MONTHS);
 
-            foreach ($plan['merges'] as $m) {
-                $this->assertTrue($db->mergePartitions($t, $m['names'], $m['start'], $m['less_than']),
-                    "budget $limit: every planned merge must succeed");
+            foreach ($plan['operations'] as $op) {
+                $this->assertTrue($db->reshapePartitions($t, $op['names'], $op['ranges']),
+                    "budget $limit: every planned reshape must succeed");
             }
 
             $spans = $db->getPartitionSpans($t);
@@ -1100,7 +1100,88 @@ final class PartitionOperationsTest extends TestCase
 
             // Settles regardless of budget.
             $again = $db->planPartitionCompaction($t, $limit, \OWA\Core\Db::PARTITION_DETAIL_MONTHS);
-            $this->assertEmpty($again['merges'], "budget $limit: a second pass must find nothing to do");
+            $this->assertEmpty($again['operations'], "budget $limit: a second pass must find nothing to do");
         }
+    }
+
+    /**
+     * The layout is a function of the settings, not of the order things
+     * happened in.
+     *
+     * Without splitting as well as merging, a table coarsened under a tight
+     * budget would stay coarse after the budget grew, while an identical
+     * installation partitioned fresh would not -- so two installations with the
+     * same data and the same configuration would differ permanently, and
+     * reorganising would never be safe to repeat.
+     */
+    public function testTheLayoutIsDeterministicWhateverThePath()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $shape = fn($t) => implode(',', array_map(
+            fn($s) => $s['name'] . ':' . $s['less_than'],
+            $db->getPartitionSpans($t)
+        ));
+
+        $apply = function ($t, $limit) use ($db) {
+            foreach ($db->planPartitionCompaction($t, $limit, 36)['operations'] as $op) {
+                $db->reshapePartitions($t, $op['names'], $op['ranges']);
+            }
+        };
+
+        // Squeezed hard, then given room.
+        $a = $this->tieredTable(120);
+        $fresh = count($db->getPartitionSpans($a));
+        $apply($a, 45);
+        $squeezed = count($db->getPartitionSpans($a));
+        $this->assertLessThan($fresh, $squeezed, 'sanity: the squeeze must actually coarsen the table');
+        $apply($a, 200);
+
+        // Only ever generous.
+        $b = $this->tieredTable(120);
+        $apply($b, 200);
+
+        $this->assertGreaterThan($squeezed, count($db->getPartitionSpans($a)), 'and relaxing must undo it');
+        $this->assertSame($shape($b), $shape($a), 'the same settings must produce the same layout by either path');
+
+        // And a third path: relaxed, squeezed, relaxed again.
+        $c = $this->tieredTable(120);
+        $apply($c, 200);
+        $apply($c, 45);
+        $apply($c, 200);
+
+        $this->assertSame($shape($b), $shape($c), 'repeated reorganisation must converge, not drift');
+    }
+
+    /** A coarse tail is split back to finer blocks when the budget allows. */
+    public function testACoarseTailIsUnpackedWhenTheBudgetGrows()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t  = $this->tieredTable(180);
+
+        $rows = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+
+        // Squeeze: the tail should end up in multi-year blocks.
+        foreach ($db->planPartitionCompaction($t, 45, 36)['operations'] as $op) {
+            $db->reshapePartitions($t, $op['names'], $op['ranges']);
+        }
+
+        $tight = $db->planPartitionCompaction($t, 45, 36);
+        $this->assertGreaterThan(1, $tight['block_years'], 'a tight budget should need multi-year blocks');
+
+        $squeezed = count($db->getPartitionSpans($t));
+
+        // Relax: it must come back to one-year blocks.
+        $plan = $db->planPartitionCompaction($t, 300, 36);
+
+        $this->assertNotEmpty($plan['operations'], 'a grown budget must produce work, not nothing');
+        $this->assertSame(1, $plan['block_years'], 'with room, the tail should be one year per block');
+
+        foreach ($plan['operations'] as $op) {
+            $this->assertTrue($db->reshapePartitions($t, $op['names'], $op['ranges']));
+        }
+
+        $this->assertGreaterThan($squeezed, count($db->getPartitionSpans($t)), 'the tail should have been split');
+        $this->assertSame($rows, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'], 'splitting must not lose a row');
     }
 }

--- a/tests/PartitionOperationsTest.php
+++ b/tests/PartitionOperationsTest.php
@@ -671,4 +671,130 @@ final class PartitionOperationsTest extends TestCase
             $db->query(sprintf("DELETE FROM owa_session WHERE id = '%s'", $db->prepare($id)));
         }
     }
+
+    /**
+     * A long-running installation must be partitionable at all.
+     *
+     * A flat monthly layout over decades asks for one partition per month, which
+     * no open-file budget accommodates — and there is no way out, since monthly
+     * is already the coarsest granularity and old data cannot be pruned before
+     * partitions exist to prune. The old tier is what makes it possible.
+     */
+    public function testTieredRangesMakeALongHistoryPartitionable()
+    {
+        $through = \OWA\Core\Db::partitionLeadBoundary();
+        $min     = date('Ymd', strtotime(date('Ym') . '01 -300 months'));
+
+        $flat   = \OWA\Core\Db::makePartitionRanges($min, date('Ymd', strtotime($through . ' -1 day')), 'monthly');
+        $tiered = \OWA\Core\Db::makeTieredPartitionRanges($min, $through, 'monthly', 36);
+
+        $this->assertGreaterThan(300, count($flat), '25 years flat should be unmanageable');
+        $this->assertLessThan(100, count($tiered), 'tiered should be manageable');
+
+        // Ascending, contiguous, and every boundary a real date.
+        $prev = null;
+        foreach ($tiered as $name => $less_than) {
+            $this->assertMatchesRegularExpression('/^p\d{8}$/', $name, 'names must stay p<yyyymmdd>');
+            if ($prev !== null) {
+                $this->assertSame($prev, substr($name, 1), 'tiers must not leave a gap or overlap');
+            }
+            $prev = $less_than;
+        }
+
+        // Recent history keeps its granularity.
+        $recent = array_slice(array_keys($tiered), -12);
+        foreach ($recent as $name) {
+            $this->assertSame('01', substr($name, 7, 2), 'detail-window partitions are monthly');
+        }
+    }
+
+    /** An install with only recent data gets no old tier at all. */
+    public function testTieredRangesAreFlatWhenAllDataIsRecent()
+    {
+        $through = \OWA\Core\Db::partitionLeadBoundary();
+        $min     = date('Ymd', strtotime(date('Ym') . '01 -6 months'));
+
+        $this->assertSame(
+            count(\OWA\Core\Db::makePartitionRanges($min, date('Ymd', strtotime($through . ' -1 day')), 'monthly')),
+            count(\OWA\Core\Db::makeTieredPartitionRanges($min, $through, 'monthly', 36)),
+            'nothing outside the detail window means nothing to coarsen'
+        );
+    }
+
+    /**
+     * Compaction keeps a table within its budget by merging, never by deleting.
+     *
+     * This is the property the whole design rests on: partition count stops
+     * being a reason to discard data.
+     */
+    public function testCompactionMergesWithoutLosingRows()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        $start = date('Ymd', strtotime(date('Ym') . '01 -120 months'));
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            $start, date('Ymd', strtotime(\OWA\Core\Db::partitionLeadBoundary() . ' -1 day')), 'monthly'));
+
+        for ($m = -120; $m <= 0; $m += 6) {
+            $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, $m + 200,
+                date('Ymd', strtotime(date('Ym') . "01 $m months +14 days"))));
+        }
+
+        $before = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+        $count  = count($db->getPartitionSpans($t));
+
+        $plan = $db->planPartitionCompaction($t, 60, 36);
+        $this->assertNotEmpty($plan['merges'], 'a 10-year monthly table should have something to merge');
+
+        foreach ($plan['merges'] as $m) {
+            $this->assertTrue($db->mergePartitions($t, $m['names'], $m['start'], $m['less_than']));
+        }
+
+        $after = count($db->getPartitionSpans($t));
+
+        $this->assertLessThan($count, $after, 'compaction must reduce the partition count');
+        $this->assertSame($before, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'], 'no row may be lost');
+        $this->assertSame($plan['projected'], $after, 'the plan must predict the outcome');
+
+        // The detail window is untouched, so recent retention stays precise.
+        $boundary = date('Ymd', strtotime(date('Ym') . '01 -36 months'));
+        foreach ($db->getPartitionSpans($t) as $span) {
+            if ($span['start'] >= $boundary) {
+                $this->assertSame('01', substr($span['start'], 6, 2), 'recent partitions stay monthly');
+            }
+        }
+    }
+
+    /**
+     * An unreachable budget must not collapse all of history into one partition.
+     *
+     * That would fit no better and would leave a table whose entire past ages
+     * out in a single drop — the cliff this design exists to avoid.
+     */
+    public function testCompactionRefusesToBuildACliff()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t = $this->makeTable();
+
+        $start = date('Ymd', strtotime(date('Ym') . '01 -240 months'));
+        $db->partitionTable($t, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+            $start, date('Ymd', strtotime(\OWA\Core\Db::partitionLeadBoundary() . ' -1 day')), 'monthly'));
+
+        // A budget below the floor: the detail window alone exceeds it.
+        $plan = $db->planPartitionCompaction($t, 5, 36);
+
+        $this->assertFalse($plan['fits'], 'this budget is not reachable');
+        $this->assertGreaterThan(1, count($plan['merges']), 'must not merge everything into one partition');
+        $this->assertGreaterThan(0, $plan['floor'], 'must report the floor so a caller can explain why');
+
+        foreach ($plan['merges'] as $m) {
+            $span = (strtotime($m['less_than']) - strtotime($m['start'])) / 86400 / 365;
+            $this->assertLessThanOrEqual(
+                \OWA\Core\Db::PARTITION_MAX_YEARS_PER_BLOCK + 0.1,
+                $span,
+                'no merged block may exceed the configured maximum span'
+            );
+        }
+    }
 }

--- a/tests/PartitionOperationsTest.php
+++ b/tests/PartitionOperationsTest.php
@@ -1184,4 +1184,155 @@ final class PartitionOperationsTest extends TestCase
         $this->assertGreaterThan($squeezed, count($db->getPartitionSpans($t)), 'the tail should have been split');
         $this->assertSame($rows, (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'], 'splitting must not lose a row');
     }
+
+    /** Layout as a comparable string, for asserting two paths agree. */
+    private function shapeOf($table)
+    {
+        return implode(',', array_map(
+            fn($s) => $s['name'] . ':' . $s['less_than'],
+            \OWA\Core\CoreAPI::dbSingleton()->getPartitionSpans($table)
+        ));
+    }
+
+    /** What partition-init does to an unpartitioned table. */
+    private function runInit($table, $granularity = 'monthly', $history = 120, $limit = 200)
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->partitionTable($table, 'yyyymmdd', \OWA\Core\Db::makeTieredPartitionRanges(
+            date('Ymd', strtotime(date('Ym') . "01 -$history months")),
+            \OWA\Core\Db::partitionLeadBoundary(),
+            $granularity,
+            \OWA\Core\Db::PARTITION_DETAIL_MONTHS,
+            $limit
+        ));
+    }
+
+    /** What partition-rotate does: extend the lead, then converge the tail. */
+    private function runRotate($table, $limit = 200)
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->extendPartitions($table, $db->inferPartitionGranularity($table) ?: 'monthly',
+            \OWA\Core\Db::partitionLeadBoundary());
+
+        foreach ($db->planPartitionCompaction($table, $limit, \OWA\Core\Db::PARTITION_DETAIL_MONTHS)['operations'] as $op) {
+            $db->reshapePartitions($table, $op['names'], $op['ranges']);
+        }
+    }
+
+    /**
+     * A freshly initialised table must already be in the shape rotation
+     * converges on.
+     *
+     * If the two disagree about where the coarse tail ends, every scheduled
+     * rotate rewrites what init built -- the table is reorganised on each run
+     * for no change in shape, and on a large installation that is an expensive
+     * no-op with writes blocked.
+     */
+    public function testInitProducesTheShapeRotationWouldConvergeOn()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach (['monthly', 'half-month', 'quarter-month'] as $granularity) {
+
+            $t = $this->makeTable();
+            $this->runInit($t, $granularity);
+
+            $before = $this->shapeOf($t);
+            $plan   = $db->planPartitionCompaction($t, 200, \OWA\Core\Db::PARTITION_DETAIL_MONTHS);
+
+            $this->assertEmpty(
+                $plan['operations'],
+                "$granularity: rotation should find nothing to reshape straight after init"
+            );
+
+            $this->runRotate($t);
+
+            $this->assertSame($before, $this->shapeOf($t), "$granularity: rotation must not churn a fresh table");
+        }
+    }
+
+    /**
+     * The three commands compose in any order and settle on the same layout.
+     *
+     * They are separate entry points onto one piece of state, so the risk is
+     * that each undoes another's work: reorganise refining the tail rotation
+     * coarsened, rotation reverting the granularity reorganise chose, init
+     * disagreeing with both.
+     */
+    public function testInitReorganiseAndRotateComposeInAnyOrder()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        // init -> reorganise -> rotate
+        $a = $this->makeTable();
+        $this->runInit($a);
+        $db->repartitionTable($a, 'half-month');
+        $this->runRotate($a);
+
+        // init -> rotate -> reorganise -> rotate
+        $b = $this->makeTable();
+        $this->runInit($b);
+        $this->runRotate($b);
+        $db->repartitionTable($b, 'half-month');
+        $this->runRotate($b);
+
+        $this->assertSame($this->shapeOf($a), $this->shapeOf($b), 'order must not change the destination');
+
+        $this->assertSame('half-month', $db->inferPartitionGranularity($a),
+            'rotation must not revert the granularity reorganise chose');
+        $this->assertSame('half-month', $db->inferPartitionGranularity($b));
+
+        // And it is settled: another full pass changes nothing.
+        $settled = $this->shapeOf($a);
+        $this->runRotate($a);
+        $db->repartitionTable($a, 'half-month');
+        $this->runRotate($a);
+
+        $this->assertSame($settled, $this->shapeOf($a), 'repeating the sequence must not drift');
+    }
+
+    /**
+     * Running every command repeatedly on a table with data must never lose a
+     * row, whatever order they are invoked in.
+     */
+    public function testTheCommandsNeverLoseDataHoweverTheyAreSequenced()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $t  = $this->makeTable();
+
+        $this->runInit($t, 'monthly', 96);
+
+        $id = 0;
+        for ($m = -96; $m <= 12; $m += 3) {
+            $db->query(sprintf('INSERT INTO %s VALUES (%d,%s)', $t, ++$id,
+                date('Ymd', strtotime(date('Ym') . "01 $m months +14 days"))));
+        }
+
+        $rows = (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'];
+        $this->assertGreaterThan(0, $rows, 'the fixture needs rows to be a test');
+
+        // A deliberately awkward sequence, including a tight budget in the middle.
+        $this->runRotate($t, 45);
+        $db->repartitionTable($t, 'quarter-month');
+        $this->runRotate($t, 200);
+        $db->repartitionTable($t, 'monthly');
+        $this->runRotate($t, 60);
+        $this->runRotate($t, 60);
+
+        $this->assertSame(
+            $rows,
+            (int) $db->get_row("SELECT COUNT(*) AS n FROM $t")['n'],
+            'no sequence of these commands may lose a row'
+        );
+
+        // The lead is still maintained after all of that.
+        $spans = $db->getPartitionSpans($t);
+        $this->assertSame(
+            \OWA\Core\Db::partitionLeadBoundary(),
+            end($spans)['less_than'],
+            'the lead must survive the sequence'
+        );
+    }
 }


### PR DESCRIPTION
Follows #989. Two gaps that had to be closed together, because fixing either alone is unsafe.

## partition-init could not run on the installations that need it most

A flat monthly layout over a long history asks for one partition per month. On a 25-year table that is 309, which exceeds any sane open-file budget, so the guard refuses — and there is no way through:

* `monthly` is already the coarsest granularity
* `partition-init` takes no `from`/`to` (the guard's message wrongly suggested otherwise)
* the old data cannot be pruned first, because pruning drops *partitions* and none exist yet

Measured on a real 25-year installation, **five of seven fact tables refused**. Partitioning was unavailable precisely where retention matters.

It now builds a **tiered layout up front** — whole calendar years over old history, the table's own granularity over the detail window and the lead. Same installation: **78 partitions instead of 309**, all seven tables convert.

## Fixing that alone would have set installs up for data loss

The obvious way to make `partition-init` fit is to lump old history into one partition bounded just below the retention window. That produces a table whose *first routine* `partition-rotate` deletes it in a single statement. Measured before choosing this design: **92% of a table gone in one drop**, from a command the operator ran expecting it to keep 24 months.

Whole years age out one at a time instead. That is why tiering and the `partition-init` fix are one change.

## partition-rotate no longer requires keep

Without `keep`, nothing is ever deleted: the lead is maintained and old periods are merged into coarser ones to stay within the budget.

```bash
cli.php cmd=partition-rotate            # retain everything, stay within budget
cli.php cmd=partition-rotate keep=24    # retain two years
```

This decouples partition count from retention — a resource limit stops being a reason to discard data. An invalid `keep` is still refused rather than treated as absent, since the two mean opposite things.

## Budget-driven, not calendar-driven

A yearly tail is enough for any plausible history on a generous server, but a host with a small `innodb_open_files` can exceed its limit on yearly partitions alone:

| innodb_open_files | budget/table | 25yr with a yearly tail (73) |
|---|---|---|
| 4000 (1000 tables) | 214 | fits |
| 1000 (400 tables) | 42 | no |
| 500 (300 tables) | 24 | no |

So the planner widens the block size until it fits — years, then runs of years — capped, because a budget that cannot be met would otherwise drive it to collapse all of history into one partition. That fits no better and rebuilds the cliff this design exists to avoid. It reports the floor instead, and the command names the remedy: the detail window is what has to shrink.

## Configuration

Constants in `owa-config.php`, applied through `applyConfigConstants()` like `OWA_ERROR_LOG_LEVEL`:

| Constant | Default | Controls |
|---|---|---|
| `OWA_PARTITION_DETAIL_MONTHS` | 36 | how much recent history keeps fine granularity |
| `OWA_PARTITION_BUDGET_RESERVE` | 2 | fraction of spare open-file slots to claim |
| `OWA_PARTITION_MIN_LIMIT` | 24 | floor for the derived budget |
| `OWA_PARTITION_MAX_YEARS_PER_BLOCK` | 5 | cap that prevents a one-partition cliff |
| `OWA_PARTITION_MAX_PARTITIONS` | 0 | state the budget outright; 0 derives it |

These describe the shape of an installation, not the intent of one invocation, so they are deliberately **not** command arguments. A test asserts that passing `max-partitions` changes nothing.

## partition-init only runs once

It was topping up the lead and coarsening the tail on a table it had already converted — which is exactly what `partition-rotate` does. Worse, passing `granularity` on a later run converted only the periods being added and left the rest alone. Proved on a live table:

```
existing:                          43 partitions, infers monthly
after init granularity=half-month: 61 partitions, infers half-month
  older periods still: 20251101..20251201   (monthly)
  newest:              20270816..20270901   (half-month)
```

One table, two granularities, no warning. It now reports what it finds and names the command for the job. **init** sets a table up, **rotate** keeps it in shape, **reorganize** changes its granularity.

## New: partition-status

There was no way to see the state of the partitioning short of reading `information_schema` by hand.

```
owa_session: 41 partitions (40 bounded + catch-all), 19% of budget.
  covers        2006-01-01 to 2027-10-01
  granularity   half-month -- what new periods will be cut at
  5 years       3 partitions, 2006-01-01 to 2021-01-01
  1 year        4 partitions, 2021-01-01 to 2025-01-01
  monthly       9 partitions, 2025-01-01 to 2025-10-01
  half-month    24 partitions, 2025-10-01 to 2027-10-01
  catch-all     pmax, empty -- every row is in a dated partition.
  lead          26 partitions ahead, through 2027-10-01 -- 411 days from today.

owa_click: 19 partitions (18 bounded + catch-all), 9% of budget.
  catch-all     pmax, 2,841,903 rows dated 2025-07-01 to 2026-08-16
  lead          NONE -- boundaries stop at 2025-07-01, 411 days ago. Rotate now.

2 of 3 fact tables partitioned, 60 partitions in total, covering 2006-01-01 to 2027-10-01.
ACTION: owa_click has run out of lead and is logging into the catch-all. Run cmd=partition-rotate.
```

The layout is reported as **tiers**, not as one granularity: a rotated table is years per partition at one end and fractions of a month at the other, and a single word is wrong about one end or the other. The `granularity` line is the head — what the next rotate will cut new periods at.

The catch-all is counted by reading the partition, not the InnoDB estimate, which is zero on a freshly loaded table. Everything else comes from metadata, so it is cheap on a busy installation.

## Fixed: the budget was sized from the command line

`partitionLimit()` divided the spare open-file slots by the tables *named in this invocation*, so `table=owa_session` claimed the entire server allowance — 1491 partitions instead of 213 here. That over-reported headroom in `partition-status` and let the mutating commands build past the real budget. It is now always sized against every fact table, since the others hold their partitions open regardless.

## Verified

470 tests, 3696 assertions, three phpstan configurations clean; CI green on 8.2/8.3/8.4, self-hosted e2e and the Jest tracker suite.

The new behaviour is mutation-checked — each of eight reverts (budget sized from the filtered set, an unreadable catch-all reported as empty, the deadline still printed while a table is overdue, a year block named monthly, lead counting partitions already started, the catch-all counted across the whole table, identifier validation removed, tiers not coalesced) fails at least one test. The identifier-validation test initially survived its mutant — bad SQL errors out and returns null just as the guard does — so it now watches the driver and asserts no query is issued at all.

New tests cover: tiered ranges being contiguous with no gap or overlap and keeping `p<yyyymmdd>` naming; an all-recent install getting no old tier; compaction reducing partition count with no rows lost and the plan predicting the outcome exactly; the detail window surviving compaction untouched; and an unreachable budget producing several blocks rather than one, with every block within the configured maximum span.
