### PR TITLE
fix(cli): support --switch syntax for boolean arguments

### DIFF
--- a/Core/Lib.php
+++ b/Core/Lib.php
@@ -1063,6 +1063,62 @@ class Lib {
         return hash_hmac( $hash_type, $data, $salt );
     }
 
+    /**
+     * Turn command-line arguments into a parameter map.
+     *
+     * Three spellings, because a switch and a value want different shapes and
+     * older invocations must keep working:
+     *
+     *   --switch        true          nobody writes switch=0; they leave it off
+     *   --key=value     'value'
+     *   key=value       'value'       the original form
+     *
+     * A leading -- is stripped from the name. It used to survive into the key,
+     * so a parameter could be literally called '--force'; anything relying on
+     * that reads its value under the undashed name now.
+     *
+     * @param array $argv raw arguments, including the script name at index 0
+     * @return array|string the parameter map, or a message describing the first
+     *                      argument that could not be read
+     */
+    public static function parseCliArgs( $argv ) {
+
+        $params = array();
+
+        for ( $i = 1; $i < count( $argv ); $i++ ) {
+
+            $arg       = $argv[ $i ];
+            $is_switch = ( strpos( $arg, '--' ) === 0 );
+
+            if ( $is_switch ) {
+
+                $arg = substr( $arg, 2 );
+            }
+
+            $it = explode( '=', $arg, 2 );
+
+            if ( count( $it ) === 2 && $it[0] !== '' ) {
+
+                $params[ $it[0] ] = $it[1];
+
+                continue;
+            }
+
+            if ( $is_switch && $it[0] !== '' ) {
+
+                $params[ $it[0] ] = true;
+
+                continue;
+            }
+
+            return sprintf(
+                "Invalid argument '%s'. Use key=value, or --switch for a flag", $argv[ $i ]
+            );
+        }
+
+        return $params;
+    }
+
     public static function timestampToYyyymmdd($timestamp = '') {
 
         if(empty($timestamp)) {

--- a/cli.php
+++ b/cli.php
@@ -44,38 +44,14 @@ if (!OWA_CLI)
 require_once('owa_env.php');
 require_once(OWA_DIR.'owa.php');
 
-$params = [];
-// get params from the command line args
-// $argv is a php super global variable
-for ($i=1; $i<count($argv); $i++)
-{
-    $arg = $argv[$i];
+// Parse the command line. See owa_lib::parseCliArgs() for the accepted forms.
+$params = \OWA\Core\Lib::parseCliArgs($argv);
 
-    // A leading -- is optional, and marks a switch when no value follows.
-    // Nobody writes dry-run=0; they leave it off. So --dry-run means true and
-    // its absence means false, which is how a switch is expected to behave.
-    // key=value and --key=value both still work.
-    $is_switch = (strpos($arg, '--') === 0);
-
-    if ($is_switch) {
-        $arg = substr($arg, 2);
-    }
-
-    $it = explode("=", $arg, 2);
-
-    if (count($it) === 2) {
-        $params[$it[0]] = $it[1];
-        continue;
-    }
-
-    if ($is_switch && $it[0] !== '') {
-        $params[$it[0]] = true;
-        continue;
-    }
-
-    fwrite(STDERR, "Invalid argument '{$argv[$i]}'. Use key=value, or --switch for a flag\n");
+if (!is_array($params)) {
+    fwrite(STDERR, $params . "\n");
     exit(1);
 }
+
 unset($params['action']);
 unset($params['do']);
 if (empty($params)) {

--- a/cli.php
+++ b/cli.php
@@ -49,12 +49,32 @@ $params = [];
 // $argv is a php super global variable
 for ($i=1; $i<count($argv); $i++)
 {
-    $it = explode("=",$argv[$i]);
-    if (count($it) !== 2) {
-        fwrite(STDERR, "Invalid argument '{$argv[$i]}'. Syntax is key=value\n");
-        exit(1);
+    $arg = $argv[$i];
+
+    // A leading -- is optional, and marks a switch when no value follows.
+    // Nobody writes dry-run=0; they leave it off. So --dry-run means true and
+    // its absence means false, which is how a switch is expected to behave.
+    // key=value and --key=value both still work.
+    $is_switch = (strpos($arg, '--') === 0);
+
+    if ($is_switch) {
+        $arg = substr($arg, 2);
     }
-    $params[$it[0]] = $it[1];
+
+    $it = explode("=", $arg, 2);
+
+    if (count($it) === 2) {
+        $params[$it[0]] = $it[1];
+        continue;
+    }
+
+    if ($is_switch && $it[0] !== '') {
+        $params[$it[0]] = true;
+        continue;
+    }
+
+    fwrite(STDERR, "Invalid argument '{$argv[$i]}'. Use key=value, or --switch for a flag\n");
+    exit(1);
 }
 unset($params['action']);
 unset($params['do']);

--- a/modules/Base/Controller/PartitionDropCli.php
+++ b/modules/Base/Controller/PartitionDropCli.php
@@ -20,7 +20,7 @@ namespace OWA\Module\Base\Controller;
  *
  *   cmd=partition-drop older-than=20260101    a date
  *   cmd=partition-drop older-than=12months    a period back from today
- *   cmd=partition-drop older-than=18m dry-run=1
+ *   cmd=partition-drop older-than=18m --dry-run
  */
 class PartitionDropCli extends PartitionsCli {
 

--- a/modules/Base/Controller/PartitionInitCli.php
+++ b/modules/Base/Controller/PartitionInitCli.php
@@ -33,7 +33,7 @@ namespace OWA\Module\Base\Controller;
  *   cmd=partition-init granularity=half-month   override it
  *   cmd=partition-init months-ahead=6           keep six months ahead, not twelve
  *   cmd=partition-init table=owa_request        one table
- *   cmd=partition-init dry-run=1                report the plan, change nothing
+ *   cmd=partition-init --dry-run                report the plan, change nothing
  *
  * Run it monthly:
  *   0 4 1 * *  php /path/to/owa/cli.php cmd=partition-init

--- a/modules/Base/Controller/PartitionReorganizeCli.php
+++ b/modules/Base/Controller/PartitionReorganizeCli.php
@@ -19,7 +19,7 @@ namespace OWA\Module\Base\Controller;
  *
  *   cmd=partition-reorganize granularity=half-month
  *   cmd=partition-reorganize granularity=quarter-month from=20260801 to=20260901
- *   cmd=partition-reorganize granularity=monthly dry-run=1
+ *   cmd=partition-reorganize granularity=monthly --dry-run
  */
 class PartitionReorganizeCli extends PartitionsCli {
 

--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -23,7 +23,7 @@ namespace OWA\Module\Base\Controller;
  *
  *   cmd=partition-rotate keep=24                  keep two years, twelve ahead
  *   cmd=partition-rotate keep=12 months-ahead=6   a shorter lead
- *   cmd=partition-rotate keep=36 dry-run=1        report the plan, change nothing
+ *   cmd=partition-rotate keep=36 --dry-run        report the plan, change nothing
  *
  * Run it monthly:
  *   0 4 1 * *  php /path/to/owa/cli.php cmd=partition-rotate keep=24

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -286,7 +286,7 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
             \OWA\Core\CoreAPI::notice( sprintf(
                 '%s: %s would drop all %d historical partition(s), leaving only what is being '
               . 'collected now. Everything before %s would be gone. If that is intended, '
-              . 're-run with force=1.',
+              . 're-run with --force.',
                 $table, $cutoff, count( $plan['drop'] ), $plan['effective']
             ) );
 

--- a/modules/Base/Controller/UpdatesApplyCli.php
+++ b/modules/Base/Controller/UpdatesApplyCli.php
@@ -107,8 +107,15 @@ class UpdatesApplyCli extends \OWA\Core\Controller\Cli {
         $u = \OWA\Core\CoreAPI::updateFactory($module, $seq);
         
         // check for force command param
+        //
+        // The key is 'force', not '--force'. The dashes used to be part of the
+        // parameter NAME because cli.php required key=value and stored whatever
+        // was left of the '=' verbatim, so 'cmd=update --force=1' produced a
+        // parameter literally called '--force'. cli.php now strips a leading --
+        // and treats a valueless switch as true, so all three spellings arrive
+        // here as 'force': --force, --force=1 and force=1.
         $force = false;
-        if ($this->isParam('--force')) {
+        if ($this->isParam('force')) {
             
             $force = true;
         }

--- a/tests/CliArgumentParsingTest.php
+++ b/tests/CliArgumentParsingTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * How cli.php reads its command line.
+ *
+ * Three spellings are accepted, and the reason is worth stating: a switch and a
+ * value want different shapes. Nobody writes `dry-run=0` -- they leave it off --
+ * so a switch has to mean true by its presence. Values still need `key=value`.
+ *
+ * The third form exists only for compatibility. `--force=1` used to store a
+ * parameter whose NAME was literally `--force`, dashes included, because the
+ * parser kept whatever sat left of the '='. UpdatesApplyCli read it back that
+ * way. Anything relying on that now reads the undashed name.
+ */
+final class CliArgumentParsingTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /** @param string[] $args */
+    private function parse(array $args)
+    {
+        return \OWA\Core\Lib::parseCliArgs(array_merge(['cli.php'], $args));
+    }
+
+    /** A switch is true by its presence. */
+    public function testSwitchesAreTrue()
+    {
+        $this->assertSame(
+            ['cmd' => 'partition-rotate', 'dry-run' => true],
+            $this->parse(['cmd=partition-rotate', '--dry-run'])
+        );
+
+        $this->assertSame(
+            ['cmd' => 'update', 'listpending' => true, 'force' => true],
+            $this->parse(['cmd=update', '--listpending', '--force'])
+        );
+    }
+
+    /** Values work with or without the dashes. */
+    public function testValuesInBothSpellings()
+    {
+        $this->assertSame(
+            ['cmd' => 'partition-rotate', 'keep' => '24'],
+            $this->parse(['cmd=partition-rotate', 'keep=24'])
+        );
+
+        $this->assertSame(
+            ['cmd' => 'partition-rotate', 'keep' => '24'],
+            $this->parse(['cmd=partition-rotate', '--keep=24'])
+        );
+    }
+
+    /**
+     * The compatibility case: `--force=1` must arrive as `force`, since that is
+     * how invocations in the wild are written and how the controller reads it.
+     */
+    public function testTheLegacyDashedValueFormStillWorks()
+    {
+        foreach ([['--force'], ['--force=1'], ['force=1']] as $spelling) {
+
+            $parsed = $this->parse(array_merge(['cmd=update'], $spelling));
+
+            $this->assertArrayHasKey('force', $parsed, implode(' ', $spelling) . ' should set force');
+            $this->assertArrayNotHasKey('--force', $parsed, 'the dashes must not survive into the name');
+            $this->assertNotEmpty($parsed['force']);
+        }
+    }
+
+    /** A value may contain an '=' without being split at the wrong place. */
+    public function testValuesMayContainEquals()
+    {
+        $this->assertSame(
+            ['cmd' => 'add-site', 'domain' => 'https://example.com/?a=b'],
+            $this->parse(['cmd=add-site', 'domain=https://example.com/?a=b'])
+        );
+    }
+
+    /**
+     * A bare word is still an error. It is almost always a value whose key was
+     * forgotten, and guessing at intent there would be worse than refusing.
+     */
+    public function testABareWordIsRefused()
+    {
+        foreach (['bogus', '-x', '--', '=novalue'] as $bad) {
+
+            $result = $this->parse(['cmd=update', $bad]);
+
+            $this->assertIsString($result, var_export($bad, true) . ' should be refused');
+            $this->assertStringContainsString('key=value', $result, 'the message should name the accepted forms');
+        }
+    }
+
+    /** No arguments is an empty map, not an error -- cli.php checks that itself. */
+    public function testNoArgumentsIsEmpty()
+    {
+        $this->assertSame([], $this->parse([]));
+    }
+}


### PR DESCRIPTION
Split out of #994, which needed `--dry-run` but shouldn't carry a CLI-wide change.

## `--force` on `update` never worked

The [CLI wiki page](https://github.com/Open-Web-Analytics/Open-Web-Analytics/wiki/Command-Line-Interface-(CLI)) documents `--force` for the `update` command. It fails:

```
$ php cli.php cmd=update --force
Invalid argument '--force'. Syntax is key=value
```

`cli.php` required `key=value` for every argument. `UpdatesApplyCli` then checked `isParam('--force')` — a parameter whose **name** contained the dashes — which only matched because the parser kept whatever sat left of the `=`. So the working invocation was `cmd=update --force=1`, and the documented one errored.

## What changed

A leading `--` is now optional, and marks a switch when no value follows:

| Spelling | Result |
|---|---|
| `--dry-run` | `true` |
| `--keep=24` | `'24'` |
| `keep=24` | `'24'` |
| `bogus` | refused |

Nobody writes `dry-run=0`; they leave it off. So a switch means true by its presence, which is how a switch is expected to behave.

**Backwards compatibility.** Stripping the dashes would have silently broken `cmd=update --force=1`, since `isParam('--force')` can never match once they're gone. `UpdatesApplyCli` reads `force` instead, so all three spellings work.

## Sweep of every CLI command

I checked all 18 registered commands for genuine booleans rather than assuming. There are three:

| Command | Flag |
|---|---|
| `partition-init`, `partition-drop`, `partition-reorganize`, `partition-rotate` | `--dry-run`, `--force` |
| `update` | `--listpending`, `--force` |

Everything that *looked* like a flag — `apply`, `rollback` on `update`, `queues` and `interval` on the queue commands — is a value guarded by its own presence, and is unaffected. No other parameter anywhere carries dashes in its name.

## Testing

Parsing moves to `owa_lib::parseCliArgs()` so it can be tested directly rather than only through a shell. Six tests: each spelling, both switches together, the legacy `--force=1` form arriving as `force` with the dashes gone, a value containing an `=` not being split at the wrong place, a bare word still refused with a message naming the accepted forms, and no arguments being an empty map rather than an error.

429 tests, 3116 assertions. Three phpstan configurations clean.