### PR TITLE
fix(core): answer an unresolvable action instead of raising

### DIFF
--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -451,7 +451,7 @@ class CoreAPI {
 
             \OWA\Core\CoreAPI::notice( 'Refusing to resolve action: expected <module>.<action>.' );
 
-            throw new \Exception( 'Invalid action.' );
+            throw new \OWA\Core\Exception\InvalidAction( 'Invalid action.' );
         }
 
         list( $module, $file ) = $segments;
@@ -464,7 +464,7 @@ class CoreAPI {
                     sprintf( 'Refusing to resolve action: %s segment is not a bare identifier.', $part )
                 );
 
-                throw new \Exception( 'Invalid action.' );
+                throw new \OWA\Core\Exception\InvalidAction( 'Invalid action.' );
             }
         }
 
@@ -971,12 +971,76 @@ class CoreAPI {
         } else {
         
             // attempt to use old style convention
-            $controller = \OWA\Core\CoreAPI::moduleFactory($action, 'Controller', $params);
+            //
+            // This is the fallback for third-party modules that predate the
+            // action registry, and it is the only resolution path a request can
+            // reach with a name nothing answers to. Both ways it can fail --
+            // a name that is not a bare <module>.<action>, and one that is but
+            // names no controller -- raise, and until this was caught they left
+            // the request as an uncaught exception: a 500 and a PHP fatal for
+            // what is a missing page.
+            try {
+
+                $controller = \OWA\Core\CoreAPI::moduleFactory($action, 'Controller', $params);
+
+            } catch ( \OWA\Core\Exception\InvalidAction $e ) {
+
+                return self::actionNotResolved( $action, 400, $e );
+
+            } catch ( \Exception $e ) {
+
+                return self::actionNotResolved( $action, 404, $e );
+            }
         }
 		
 		return \OWA\Core\CoreAPI::runController( $controller );
     }
     
+    /**
+     * Answer a request whose action resolves to nothing.
+     *
+     * A name nothing answers to is a client error, not a server fault, so it
+     * gets a 4xx and the ordinary error page rather than a 500 and a fatal in
+     * the log. Which 4xx depends on how it failed: a malformed name was never a
+     * route anywhere (400), a well-formed one simply is not present here (404).
+     *
+     * The action is recorded server-side, where an administrator can see what
+     * was asked for, and deliberately kept out of the response: it is
+     * request-supplied, and reflecting it would put attacker-chosen text on the
+     * page.
+     *
+     * @param string     $action
+     * @param int        $code
+     * @param \Exception $exception
+     * @return string|null  the rendered page, or null under the CLI
+     */
+    public static function actionNotResolved( $action, $code, $exception = null ) {
+
+        self::notice( sprintf(
+            'No controller for action "%s" (%d): %s',
+            $action,
+            $code,
+            $exception ? $exception->getMessage() : 'not registered'
+        ) );
+
+        // The CLI has already reported through notice(); rendering an HTML
+        // error page into a terminal would help nobody.
+        if ( defined( 'OWA_CLI' ) ) {
+
+            return null;
+        }
+
+        if ( ! headers_sent() ) {
+
+            http_response_code( $code );
+        }
+
+        return self::displayView(
+            array( 'error_msg' => 'The page you requested could not be found.' ),
+            'base.error'
+        );
+    }
+
     public static function runController( $controller ) {
 	    
 	    if ( ! $controller || ! method_exists( $controller, 'doAction' ) ) {

--- a/Core/Exception/InvalidAction.php
+++ b/Core/Exception/InvalidAction.php
@@ -1,0 +1,23 @@
+<?php
+namespace OWA\Core\Exception;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * The requested action is not a well-formed action name.
+ *
+ * Distinct from "no controller answers to it": a name that is not
+ * <module>.<action>, or whose segments are not bare identifiers, was never a
+ * route on any installation, so it is a bad request rather than a missing page.
+ * The two are separated here because the caller turns them into different
+ * status codes, and matching on an exception message to tell them apart would
+ * break the moment the wording changed.
+ *
+ * The rejected value is deliberately not carried in the message that reaches a
+ * visitor -- it is request-supplied, and the response must not reflect it.
+ */
+class InvalidAction extends \Exception {
+
+}

--- a/modules/Base/Classes/Error.php
+++ b/modules/Base/Classes/Error.php
@@ -119,7 +119,7 @@ class Error {
             $this->make_console_logger();
         }
         
-        set_exception_handler( [ $this, 'logException' ] );
+        set_exception_handler( [ $this, 'handleUncaughtException' ] );
 
     }
 
@@ -133,6 +133,46 @@ class Error {
 
             $this->make_console_logger();
         }
+
+        set_exception_handler( [ $this, 'handleUncaughtException' ] );
+    }
+
+    /**
+     * Record an exception nothing else caught, and answer with a server error.
+     *
+     * Only the development handler used to register one, which had the effect
+     * backwards: the installation exposed to the internet was the one running
+     * without an exception handler. An uncaught exception there became a PHP
+     * fatal -- recorded in the web server's log rather than OWA's own, where an
+     * administrator would look for it -- and OWA_MAIL_EXCEPTIONS, whose whole
+     * purpose is to tell somebody about an error on a live installation, never
+     * fired anywhere but on a developer's machine.
+     *
+     * The status is set deliberately rather than inherited from PHP's fatal, and
+     * the response body is left empty: the message and stack trace go to the log,
+     * never to the visitor.
+     *
+     * @param \Throwable $exception
+     * @return void
+     */
+    function handleUncaughtException( $exception ) {
+
+        $this->logException( $exception );
+
+        // The CLI reports through its own console logger and exit status.
+        if ( defined( 'OWA_CLI' ) ) {
+
+            return;
+        }
+
+        // Output already began, so the status line is long gone; changing it
+        // now would emit a warning on top of the error being handled.
+        if ( headers_sent() ) {
+
+            return;
+        }
+
+        http_response_code( 500 );
     }
 
     function debug($message) {

--- a/tests/ActionResolutionTest.php
+++ b/tests/ActionResolutionTest.php
@@ -1,0 +1,285 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * What happens to a request naming an action that resolves to nothing.
+ *
+ * Every one of these is reachable by anyone who can type a URL, without
+ * credentials, so the question is not whether they can be sent but what they
+ * are answered with. Until this was fixed the answer was an uncaught exception:
+ * HTTP 500 and a PHP fatal in the web server's log, for what is a missing page.
+ *
+ * Two separate defects produced that, and both are covered here -- the action
+ * resolver raising with nothing to catch it, and the production error handler
+ * registering no exception handler at all.
+ */
+final class ActionResolutionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        // Each case asserts the status it produced, so start from a known one.
+        http_response_code(200);
+    }
+
+    /**
+     * A name that is not <module>.<action>, or whose halves are not bare
+     * identifiers, is refused before any filesystem path is built from it.
+     *
+     * This is the guard that stops a request parameter reaching require_once().
+     * It must raise the typed exception, because the caller turns that into a
+     * different status code than a merely absent controller.
+     */
+    public function testMalformedActionNamesAreRefusedByType()
+    {
+        $malformed = [
+            'base',                        // no action half
+            'base.foo.bar',                // too many halves
+            '',                            // nothing at all
+            'base.',                       // empty action
+            '.sites',                      // empty module
+            'base./../../etc/passwd',      // traversal in the action
+            '../../../../etc/passwd',      // traversal, no separator
+            'base.%2e%2e%2fconfig',        // encoded traversal
+            'base.owa config',             // space
+            "base.owa'config",             // quote
+            'base.owa/config',             // separator
+            'base.owa-config',             // hyphen is not an identifier char
+            'base.owa.config',             // extra dot
+            "base.owa\0config",            // null byte
+        ];
+
+        foreach ($malformed as $action) {
+            try {
+                \OWA\Core\CoreAPI::moduleFactory($action, 'Controller', []);
+                $this->fail(var_export($action, true) . ' should have been refused');
+            } catch (\OWA\Core\Exception\InvalidAction $e) {
+                $this->assertSame('Invalid action.', $e->getMessage(),
+                    'the message must not echo the rejected value back');
+                $this->assertStringNotContainsString(
+                    'passwd', $e->getMessage(),
+                    var_export($action, true) . ': the rejected value must not appear in the message'
+                );
+            }
+        }
+    }
+
+    /**
+     * A well-formed name that no controller answers to is a different failure,
+     * and must NOT be the typed one -- it is a missing page, not a bad request.
+     */
+    public function testAWellFormedButUnknownActionRaisesSeparately()
+    {
+        $this->expectException(\Exception::class);
+
+        try {
+            \OWA\Core\CoreAPI::moduleFactory('base.noSuchActionAnywhere', 'Controller', []);
+        } catch (\OWA\Core\Exception\InvalidAction $e) {
+            $this->fail('a well-formed name must not be reported as malformed');
+        }
+
+        // Re-raise for the expectation above.
+        \OWA\Core\CoreAPI::moduleFactory('base.noSuchActionAnywhere', 'Controller', []);
+    }
+
+    /**
+     * The status codes an unresolvable action produces.
+     *
+     * A malformed name was never a route on any installation (400); a
+     * well-formed one simply is not present on this one (404). Neither is a
+     * server fault, and neither may be a 500.
+     */
+    public function testUnresolvableActionsProduceAClientError()
+    {
+        foreach ([400, 404] as $code) {
+
+            \OWA\Core\CoreAPI::actionNotResolved('base.whatever', $code, new \Exception('x'));
+
+            $this->assertSame($code, http_response_code(), "should have set $code");
+        }
+    }
+
+    /**
+     * The response must not reflect the requested action.
+     *
+     * It is request-supplied, so echoing it into the error page would put
+     * attacker-chosen text on a page served from this origin. It belongs in the
+     * log, where an administrator can see what was asked for.
+     */
+    public function testTheErrorPageDoesNotReflectTheRequestedAction()
+    {
+        $marker = 'zzMarker' . bin2hex(random_bytes(4));
+        $probe  = 'base.' . $marker . '<script>alert(1)</script>';
+
+        $page = (string) \OWA\Core\CoreAPI::actionNotResolved($probe, 404, new \Exception('x'));
+
+        $this->assertNotSame('', $page, 'an error page should have been rendered');
+        $this->assertStringContainsString('could not be found', $page,
+            'the generic message is what the visitor gets');
+
+        // The page carries its own markup and scripts, so the check is for the
+        // probe specifically -- raw, entity-encoded and url-encoded, since any
+        // of those reaching the page would be a reflection.
+        foreach ([$marker, htmlspecialchars($marker), urlencode($marker), 'alert(1)'] as $needle) {
+            $this->assertStringNotContainsString($needle, $page,
+                'the requested action must not be reflected into the response');
+        }
+    }
+
+    /**
+     * The production error handler must register an exception handler.
+     *
+     * This is the defect that made the difference between installations: only
+     * the development handler registered one, so the installation facing the
+     * internet was the one where an uncaught exception became a PHP fatal.
+     */
+    public function testBothErrorHandlersRegisterAnExceptionHandler()
+    {
+        $original = set_exception_handler(null);
+
+        try {
+            foreach (['createProductionHandler', 'createDevelopmentHandler'] as $method) {
+
+                // Clear first. Without this the handler registered by the
+                // bootstrap -- or by the previous iteration -- is still
+                // installed, and the assertion below passes whether or not the
+                // method under test registers anything at all.
+                set_exception_handler(null);
+                $this->assertNull(set_exception_handler(null),
+                    'the slot must be empty before the method under test runs');
+
+                $e = \OWA\Core\CoreAPI::supportClassFactory('base', 'error');
+                $e->$method();
+
+                $handler = set_exception_handler(null);
+
+                $this->assertIsArray($handler, "$method must register an exception handler");
+                $this->assertSame('handleUncaughtException', $handler[1],
+                    "$method must register the handler that sets a status code");
+            }
+
+        } finally {
+            set_exception_handler($original);
+        }
+    }
+
+    /**
+     * The handler records the exception and answers 500 -- it does not swallow
+     * the error into a 200 with an empty body, which is what reusing the plain
+     * logger would have done.
+     */
+    public function testTheUncaughtHandlerLogsAndSetsAServerError()
+    {
+        $e = \OWA\Core\CoreAPI::supportClassFactory('base', 'error');
+
+        ob_start();
+        $e->handleUncaughtException(new \Exception('a marker for the log, not the page'));
+        $body = ob_get_clean();
+
+        // Under the CLI the status is left alone; the assertion that matters
+        // everywhere is that nothing about the exception reaches the output.
+        $this->assertStringNotContainsString('marker for the log', $body,
+            'an exception message must never be written to the response');
+        $this->assertStringNotContainsString('Stack trace', $body);
+    }
+
+    /**
+     * Under the CLI there is no page to render and no status to invent -- the
+     * command reports through notice(), and nothing else.
+     *
+     * Runs in a subprocess because it needs OWA_CLI defined, and a constant
+     * cannot be unset once set. PHPUnit's own process isolation is not used: it
+     * fails a test on any startup warning the PHP build happens to emit, which
+     * makes it a test of the environment rather than of the code.
+     *
+     * The result is base64 between two markers because OWA logs to stdout once
+     * OWA_CLI is defined, and its shutdown output lands after the payload.
+     */
+    public function testTheCliGetsNoPageAndNoStatus()
+    {
+        $bootstrap = var_export(__DIR__ . '/bootstrap_owa.php', true);
+
+        $script = "define('OWA_CLI', true);"
+                . "require $bootstrap;"
+                . "http_response_code(200);"
+                . "\$page = \\OWA\\Core\\CoreAPI::actionNotResolved('base.whatever', 404, new \\Exception('x'));"
+                . "\$e = \\OWA\\Core\\CoreAPI::supportClassFactory('base', 'error');"
+                . "ob_start();"
+                . "\$e->handleUncaughtException(new \\Exception('cli side'));"
+                . "\$body = ob_get_clean();"
+                . "fwrite(STDOUT, '<<' . base64_encode(json_encode(["
+                . "'page' => \$page, 'body' => \$body, 'status' => http_response_code()"
+                . "])) . '>>');";
+
+        $out = (string) shell_exec(
+            escapeshellarg(PHP_BINARY) . ' -d error_reporting=0 -r ' . escapeshellarg($script) . ' 2>/dev/null'
+        );
+
+        $this->assertSame(1, preg_match('/<<([A-Za-z0-9+\/=]+)>>/', $out, $m),
+            'subprocess produced no payload: ' . substr($out, 0, 300));
+
+        $result = json_decode((string) base64_decode($m[1]), true);
+
+        $this->assertIsArray($result);
+        $this->assertNull($result['page'], 'the CLI gets no rendered view');
+        $this->assertSame('', $result['body'], 'the CLI gets no output from the exception handler');
+        $this->assertSame(200, $result['status'],
+            'neither path may change the status under the CLI');
+    }
+
+    /**
+     * The whole point, end to end: performAction() must not let an
+     * unresolvable action escape as an exception.
+     *
+     * The other cases here test the pieces. This one tests the wiring, which is
+     * where the defect actually was -- the resolver has always raised, and
+     * nothing caught it.
+     */
+    public function testPerformActionAnswersInsteadOfRaising()
+    {
+        $cases = [
+            'base.noSuchActionAnywhere'   => 404,   // well-formed, absent
+            'base'                        => 400,   // malformed
+            'base./../../etc/passwd'      => 400,   // malformed, traversal
+            'base.foo.bar'                => 400,
+        ];
+
+        foreach ($cases as $action => $expected) {
+
+            http_response_code(200);
+
+            try {
+                $page = (string) \OWA\Core\CoreAPI::performAction($action, []);
+
+            } catch (\Throwable $t) {
+                $this->fail(sprintf(
+                    'performAction("%s") raised %s: %s -- an unresolvable action must be answered, not thrown',
+                    $action, get_class($t), $t->getMessage()
+                ));
+            }
+
+            $this->assertSame($expected, http_response_code(), "$action should answer $expected");
+            $this->assertStringContainsString('could not be found', $page,
+                "$action should render the error page");
+        }
+    }
+
+    /**
+     * A registered action still resolves -- the catch must not swallow real
+     * routes and turn the whole installation into a 404.
+     */
+    public function testARegisteredActionStillResolves()
+    {
+        http_response_code(200);
+
+        $page = (string) \OWA\Core\CoreAPI::performAction('base.loginForm', []);
+
+        $this->assertSame(200, http_response_code(), 'a real action must not be reported missing');
+        $this->assertStringNotContainsString('could not be found', $page);
+    }
+}

--- a/tests/ActionResolutionTest.php
+++ b/tests/ActionResolutionTest.php
@@ -216,12 +216,21 @@ final class ActionResolutionTest extends TestCase
                 . "'page' => \$page, 'body' => \$body, 'status' => http_response_code()"
                 . "])) . '>>');";
 
+        // The child runs the full bootstrap, which needs the database. Where
+        // there is none -- the unit job in CI -- skip alongside the rest of the
+        // suite rather than report a missing database as a broken behaviour.
+        if (! owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable; the subprocess cannot boot.');
+        }
+
+        // stderr is kept: without it a child that dies during boot reports as
+        // "no payload" with nothing to say why.
         $out = (string) shell_exec(
-            escapeshellarg(PHP_BINARY) . ' -d error_reporting=0 -r ' . escapeshellarg($script) . ' 2>/dev/null'
+            escapeshellarg(PHP_BINARY) . ' -d error_reporting=0 -r ' . escapeshellarg($script) . ' 2>&1'
         );
 
-        $this->assertSame(1, preg_match('/<<([A-Za-z0-9+\/=]+)>>/', $out, $m),
-            'subprocess produced no payload: ' . substr($out, 0, 300));
+        $this->assertSame(1, preg_match('/<<([A-Za-z0-9+\\/=]+)>>/', $out, $m),
+            'subprocess produced no payload. Output was: ' . substr($out, 0, 600));
 
         $result = json_decode((string) base64_decode($m[1]), true);
 


### PR DESCRIPTION
Found while watching the logs after deploying master to the demo install.

## What it looked like

```
/owa/index.php?owa_do=base.usersManage  → HTTP 500
Uncaught Exception: Class File .../modules/Base/owa_usersManageController.php
not existend! in .../Core/Lib.php:483
```

Unauthenticated, one query string, a PHP fatal in the web server's log. `base.usersManage` and `base.sitesManage` no longer exist — nothing in the tree links to them — so these are stale inbound links, and a missing page was being answered as a server fault.

## Two defects, and one confusing symptom

The same request behaved differently on two installs running identical code:

| `owa_do=` | production handler | development handler |
|---|---|---|
| `base.sites` (valid) | 200 | 200 |
| `base.usersManage` (gone) | **500** | 200 |
| `base.nosuchaction` | **500** | 200 |
| `base./../../etc/passwd` | **500** | 200 |

**1. The resolver raises and nothing caught it.** `moduleFactory()` throws for a name that is not a bare `<module>.<action>` — the guard that keeps a request parameter out of `require_once()` — and `Lib::factory()` throws when a well-formed name matches no controller. `performAction()` now answers instead: **400** for a name that was never a route anywhere, **404** for one that simply is not present here. Told apart by exception type (`OWA\Core\Exception\InvalidAction`) rather than by matching an exception message, which would break the moment the wording changed.

**2. Only the development handler registered `set_exception_handler()`.** That is backwards: the install facing the internet was the one running without one. Consequences beyond this bug — uncaught exceptions landed in the web server's log rather than OWA's own, where an administrator looks; and `OWA_MAIL_EXCEPTIONS`, whose entire purpose is to report an error on a live install, only ever fired on a developer's machine. Both handlers now register one that logs and sets a deliberate 500.

## Not affected

- **Traversal was already blocked** and stays blocked. `../../../../etc/passwd` and `%2e%2e%2f` are refused before any path is built. The bug was that a *successful* security check surfaced as a server error.
- **Nothing leaked to the client.** The 500 body was 0 bytes. The new error page is generic, and a test asserts the requested action is not reflected into it — raw, entity-encoded or url-encoded — since it is attacker-controlled text.

## Verified

485 tests, 3779 assertions, three phpstan configurations clean.

Nine new tests covering both defects and the wiring between them. Mutation-checked: seven reverts applied, and the two that initially survived were both tests passing for the wrong reason — one never exercised `performAction()` at all, and the handler test saw a handler registered earlier by the bootstrap, so it passed whether or not the method under test registered anything. Both rewritten until the mutants died.

Confirmed end to end under a forced production handler:

```
base.noSuchActionAnywhere  → 404   (no throw, no leak)
base                       → 400   (no throw, no leak)
base./../../etc/passwd     → 400   (no throw, no leak)
```