### PR TITLE
feat(scheduler): run jobs from a single cron entry

### DIFF
--- a/Core/Controller/Cli.php
+++ b/Core/Controller/Cli.php
@@ -57,7 +57,182 @@ class Cli extends \OWA\Core\AdminController {
         }
     }
 
+    /**
+     * What this command actually did: 'ok', 'refused' or 'failed'.
+     *
+     * doAction() returns $this->data and CLI actions return void, so until the
+     * scheduler existed a command that declined to act and one that did the work
+     * looked identical to a caller. That is fine for a person reading a terminal
+     * and useless to a dispatcher, which has to decide whether an occurrence was
+     * satisfied and record why.
+     *
+     * Defaults to 'ok': a command that never says otherwise ran to completion,
+     * which is what every existing command means today. Nothing had to be
+     * rewritten; commands opt in one at a time by calling refuse() or fail()
+     * where they already call notice().
+     *
+     * @var string
+     */
+    protected $cli_outcome = 'ok';
 
+    /** @var string */
+    protected $cli_message = '';
+
+    /**
+     * The job lock held for this run, when the scheduler is running us.
+     *
+     * @var \OWA\Module\Base\Classes\JobLease|null
+     */
+    protected $job_lease = null;
+
+    /**
+     * Declined to act, on purpose. Not an error.
+     *
+     * The occurrence is still consumed -- a refusal is an answer about it, not a
+     * failure to answer -- so the scheduler advances the slot and does not retry
+     * every minute.
+     *
+     * Returns null so a caller can write `return $this->refuse( ... );` -- which
+     * reads as the "say why, and stop" that it is, and keeps
+     * Controller::finishActionCall() on its existing falsy path.
+     *
+     * @param string $msg
+     * @return null
+     */
+    protected function refuse( $msg ) {
+
+        $this->cli_outcome = 'refused';
+        $this->cli_message = $this->cli_message ?: $msg;
+
+        \OWA\Core\CoreAPI::notice( $msg );
+
+        return null;
+    }
+
+    /**
+     * Tried and failed. The occurrence is left unsatisfied and retried.
+     *
+     * This matters more than it looks: Db::query() swallows SQL errors and
+     * returns falsy, so without commands calling this, a job whose ALTER TABLE
+     * was rejected by the server would record 'ok' indefinitely.
+     *
+     * @param string $msg
+     * @return null
+     */
+    protected function fail( $msg ) {
+
+        $this->cli_outcome = 'failed';
+        $this->cli_message = $this->cli_message ?: $msg;
+
+        \OWA\Core\CoreAPI::notice( $msg );
+
+        return null;
+    }
+
+    /**
+     * The outcome, for the dispatcher. The FIRST message wins, so what is
+     * recorded is the first thing that went wrong rather than the last.
+     *
+     * @return array
+     */
+    public function getCliOutcome() {
+
+        return array(
+            'outcome' => $this->cli_outcome,
+            'message' => $this->cli_message,
+        );
+    }
+
+    /**
+     * How long this command's lock should be trusted without proof of life.
+     *
+     * A CRASH-RECOVERY TIMEOUT, NOT A RUNTIME BUDGET: on any normal path the
+     * lock is released in a finally and this is never consulted. It decides only
+     * how long after a process dies before another run may assume it is really
+     * dead. Too short duplicates a long job; too long delays recovery. Those
+     * costs are asymmetric, so err long.
+     *
+     * Override to DERIVE the number from work the command can see up front --
+     * the estimate is read-only and happens before the lock is taken.
+     * Configuration deliberately cannot override it: an operator has strictly
+     * less information than code that has just planned the work, and the real
+     * need behind "I want a shorter lease" is answered by
+     * `schedule-run --force-release`.
+     *
+     * @return int seconds
+     */
+    public function getJobLease() {
+
+        return 21600;   // 6 hours
+    }
+
+    /**
+     * Give the lock proof of life, extending it.
+     *
+     * THE COMMAND CALLS THIS, NOT THE DISPATCHER. The dispatcher runs jobs
+     * in-process and synchronously, so while a job works it is blocked inside
+     * that call with no thread to refresh from; pcntl_alarm does not rescue it
+     * either, because signal handlers run between opcodes and a job blocked in
+     * mysqli never yields to one. Only the command knows where it has a safe
+     * point.
+     *
+     * A NO-OP when the command is run by hand, so a scheduled command and a
+     * hand-run one behave identically.
+     *
+     * Loop-shaped jobs should call this every N iterations. A command that is
+     * one long blocking statement -- partition-rotate is -- cannot, which is
+     * exactly why it wants a long lease instead.
+     *
+     * @return void
+     */
+    protected function heartbeat() {
+
+        if ( $this->job_lease ) {
+
+            $this->job_lease->refresh( $this->getJobLease() );
+        }
+    }
+
+    /**
+     * Hand this run its lock, so heartbeat() has something to refresh.
+     *
+     * @param \OWA\Module\Base\Classes\JobLease $lease
+     * @return void
+     */
+    public function setJobLease( $lease ) {
+
+        $this->job_lease = $lease;
+    }
+
+    /**
+     * Put report lines on standard output.
+     *
+     * Commands that CHANGE something report through CoreAPI::notice(), and
+     * should: what they did is a record worth keeping, and the console handler
+     * puts it on stdout as well as in the log. A report is not that. Routed
+     * through the logger it would be stamped with a timestamp, a pid and a level
+     * on every line, interleaved with debug output on an installation running
+     * the development handler, and written into the error log on each run --
+     * which, for a command sitting beside a job that runs from cron, would make
+     * the report the noisiest thing in it.
+     *
+     * Refusals still go through notice(), because those are events.
+     *
+     * @param string[] $lines
+     * @return void
+     */
+    protected function write( $lines ) {
+
+        // The constructor exits unless this is a CLI request, so STDOUT is the
+        // CLI SAPI's own constant. The fallback is for a test harness that has
+        // not defined it.
+        $out = defined( 'STDOUT' ) ? STDOUT : fopen( 'php://output', 'w' );
+
+        foreach ( (array) $lines as $line ) {
+
+            fwrite( $out, $line . PHP_EOL );
+        }
+    }
 }
 
 ?>

--- a/Core/Cron.php
+++ b/Core/Cron.php
@@ -1,0 +1,496 @@
+<?php
+namespace OWA\Core;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * Cron expressions, and deciding whether a schedule is due.
+ *
+ * Pure: no clock, no database, no settings. `$now` is always an argument, which
+ * is the only shape that can be tested honestly -- a schedule that can only be
+ * checked against the moment the check runs makes the assertion a copy of the
+ * implementation.
+ *
+ * THE DUE TEST IS LEVEL-TRIGGERED, NOT EDGE-TRIGGERED, and that is the whole
+ * design. Laravel asks "does this expression match the current minute"; miss the
+ * minute -- cron ran late, the box was busy, a long job held the tick -- and a
+ * monthly job waits another month. Here the caller keeps the occurrence its last
+ * run satisfied, and the question becomes "has a matching minute passed since
+ * then". A job stays due until it has actually run.
+ *
+ * No backfill: a job missed for three days runs ONCE at the next tick, not once
+ * per missed occurrence. That imposes a rule on what may be scheduled --
+ *
+ *   A SCHEDULED JOB MUST BE CONVERGENT, NOT INCREMENTAL.
+ *
+ * partition-rotate extends *to* a boundary computed from today, so one run after
+ * a gap leaves the same state as three would have. A job that processes
+ * "yesterday's data" is incremental and must not be registered without being
+ * made convergent first.
+ */
+class Cron {
+
+    /** Minute, hour, day-of-month, month, day-of-week. */
+    const FIELDS = array(
+        array( 0, 59 ),   // minute
+        array( 0, 23 ),   // hour
+        array( 1, 31 ),   // day of month
+        array( 1, 12 ),   // month
+        array( 0, 6 ),    // day of week, 0 = Sunday
+    );
+
+    /**
+     * The standard vixie-cron shorthands, so the readable forms are not an
+     * invention of ours that operators have to learn.
+     */
+    const ALIASES = array(
+        '@yearly'   => '0 0 1 1 *',
+        '@annually' => '0 0 1 1 *',
+        '@monthly'  => '0 0 1 * *',
+        '@weekly'   => '0 0 * * 0',
+        '@daily'    => '0 0 * * *',
+        '@midnight' => '0 0 * * *',
+        '@hourly'   => '0 * * * *',
+    );
+
+    /**
+     * How far back nextDueSince() will look for an unsatisfied occurrence.
+     *
+     * A job that has not run in years should still run once, but walking minute
+     * by minute back to 1970 to discover that is pointless: the answer is the
+     * same as "it is due now". Two years is longer than any plausible neglect
+     * and bounds the work.
+     */
+    const LOOKBACK_DAYS = 730;
+
+    /**
+     * Parse an expression into per-field sets of permitted values.
+     *
+     * Returns null rather than throwing, and null rather than guessing: the
+     * caller refuses the job. An expression that cannot be read must never fall
+     * back to a default, which would run something on a cadence nobody chose.
+     *
+     * @param string $expr
+     * @return array|null  five arrays of ints, or null
+     */
+    public static function parse( $expr ) {
+
+        $expr = strtolower( trim( (string) $expr ) );
+
+        if ( $expr === '' ) {
+
+            return null;
+        }
+
+        if ( isset( self::ALIASES[ $expr ] ) ) {
+
+            $expr = self::ALIASES[ $expr ];
+        }
+
+        // An unknown @something is a typo, not a cron expression.
+        if ( $expr[0] === '@' ) {
+
+            return null;
+        }
+
+        $fields = preg_split( '/\s+/', $expr );
+
+        if ( ! is_array( $fields ) || count( $fields ) !== 5 ) {
+
+            return null;
+        }
+
+        $parsed = array();
+
+        foreach ( $fields as $i => $field ) {
+
+            $values = self::parseField( $field, self::FIELDS[ $i ][0], self::FIELDS[ $i ][1] );
+
+            if ( $values === null ) {
+
+                return null;
+            }
+
+            $parsed[] = $values;
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * One field: `*`, `5`, `1-5`, `1,3,5`, and step syntax such as a star
+     * followed by slash-15. (Spelt out because the literal sequence would end
+     * this docblock.)
+     *
+     * @param string $field
+     * @param int    $min
+     * @param int    $max
+     * @return array|null  sorted, unique ints within [$min,$max]
+     */
+    protected static function parseField( $field, $min, $max ) {
+
+        $values = array();
+
+        foreach ( explode( ',', $field ) as $part ) {
+
+            if ( $part === '' ) {
+
+                return null;
+            }
+
+            $step  = 1;
+            $range = $part;
+
+            if ( strpos( $part, '/' ) !== false ) {
+
+                list( $range, $step ) = explode( '/', $part, 2 );
+
+                if ( ! ctype_digit( (string) $step ) || (int) $step < 1 ) {
+
+                    return null;
+                }
+
+                $step = (int) $step;
+            }
+
+            if ( $range === '*' ) {
+
+                $from = $min;
+                $to   = $max;
+
+            } elseif ( strpos( $range, '-' ) !== false ) {
+
+                list( $from, $to ) = explode( '-', $range, 2 );
+
+                if ( ! ctype_digit( (string) $from ) || ! ctype_digit( (string) $to ) ) {
+
+                    return null;
+                }
+
+                $from = (int) $from;
+                $to   = (int) $to;
+
+            } else {
+
+                if ( ! ctype_digit( (string) $range ) ) {
+
+                    return null;
+                }
+
+                $from = (int) $range;
+
+                // A bare number with a step means "from here to the end",
+                // matching cron: 5/10 in the minute field is 5,15,25,...
+                $to = ( $step > 1 ) ? $max : $from;
+            }
+
+            if ( $from < $min || $to > $max || $from > $to ) {
+
+                return null;
+            }
+
+            for ( $v = $from; $v <= $to; $v += $step ) {
+
+                $values[ $v ] = true;
+            }
+        }
+
+        if ( ! $values ) {
+
+            return null;
+        }
+
+        $values = array_keys( $values );
+        sort( $values );
+
+        return $values;
+    }
+
+    /**
+     * Does this expression match the given minute?
+     *
+     * Day-of-month and day-of-week are OR'd when both are restricted, which is
+     * cron's own rule and surprises everyone who has not met it: `0 0 1 * 1`
+     * means "the 1st, and every Monday", not "Mondays that fall on the 1st".
+     *
+     * @param array  $parsed
+     * @param int    $when      unix timestamp
+     * @param string $timezone
+     * @return bool
+     */
+    public static function matches( array $parsed, $when, $timezone ) {
+
+        $d = self::at( $when, $timezone );
+
+        if ( ! $d ) {
+
+            return false;
+        }
+
+        if ( ! in_array( (int) $d->format( 'i' ), $parsed[0], true ) ) { return false; }
+        if ( ! in_array( (int) $d->format( 'G' ), $parsed[1], true ) ) { return false; }
+        if ( ! in_array( (int) $d->format( 'n' ), $parsed[3], true ) ) { return false; }
+
+        $dom_restricted = count( $parsed[2] ) !== 31;
+        $dow_restricted = count( $parsed[4] ) !== 7;
+
+        $dom = in_array( (int) $d->format( 'j' ), $parsed[2], true );
+        $dow = in_array( (int) $d->format( 'w' ), $parsed[4], true );
+
+        if ( $dom_restricted && $dow_restricted ) {
+
+            return $dom || $dow;
+        }
+
+        return $dom && $dow;
+    }
+
+    /**
+     * Is this schedule due, given the occurrence its last run satisfied?
+     *
+     * @param array    $parsed
+     * @param int|null $last_slot  epoch of the last satisfied occurrence; 0/null if never
+     * @param int      $now
+     * @param string   $timezone
+     * @return bool
+     */
+    public static function isDue( array $parsed, $last_slot, $now, $timezone ) {
+
+        return self::dueSlot( $parsed, $last_slot, $now, $timezone ) !== null;
+    }
+
+    /**
+     * The occurrence that is due and unsatisfied, or null.
+     *
+     * The most recent matching minute at or before $now that is later than
+     * $last_slot. Recording *this* rather than "now" is what makes a run
+     * idempotent within its occurrence: every later tick in the same period
+     * computes the same slot, finds it satisfied, and does nothing.
+     *
+     * @param array    $parsed
+     * @param int|null $last_slot
+     * @param int      $now
+     * @param string   $timezone
+     * @return int|null
+     */
+    public static function dueSlot( array $parsed, $last_slot, $now, $timezone ) {
+
+        $slot = self::previousMatch( $parsed, $now, $timezone );
+
+        if ( $slot === null || $slot <= (int) $last_slot ) {
+
+            return null;
+        }
+
+        return $slot;
+    }
+
+    /**
+     * The latest matching minute at or before $when.
+     *
+     * Steps by DAY, not by minute. A monthly schedule checked a month after its
+     * last run would otherwise walk 43,200 minutes on every tick, which at a
+     * tick a minute is quadratic and would dominate the dispatcher.
+     *
+     * @param array  $parsed
+     * @param int    $when
+     * @param string $timezone
+     * @return int|null
+     */
+    public static function previousMatch( array $parsed, $when, $timezone ) {
+
+        $when = (int) $when;
+        $when = $when - ( $when % 60 );
+
+        // Anchored at midday so stepping between days is safe in zones whose
+        // DST transition lands on midnight.
+        $day = self::at( $when, $timezone );
+
+        if ( ! $day ) {
+
+            return null;
+        }
+
+        $day = $day->setTime( 12, 0, 0 );
+
+        for ( $i = 0; $i <= self::LOOKBACK_DAYS; $i++ ) {
+
+            if ( self::dayMatches( $parsed, $day ) ) {
+
+                foreach ( array_reverse( $parsed[1] ) as $h ) {
+
+                    foreach ( array_reverse( $parsed[0] ) as $m ) {
+
+                        $t = $day->setTime( $h, $m, 0 )->getTimestamp();
+
+                        // A candidate inside a skipped DST hour is rolled
+                        // forward by setTime and lands after $when, so it is
+                        // simply not a match -- that minute did not exist.
+                        if ( $t <= $when ) {
+
+                            return $t;
+                        }
+                    }
+                }
+            }
+
+            $day  = $day->modify( '-1 day' );
+            $when = $day->setTime( 23, 59, 0 )->getTimestamp();
+        }
+
+        return null;
+    }
+
+    /**
+     * The next matching minute strictly after $when. For reporting only.
+     *
+     * @param array  $parsed
+     * @param int    $when
+     * @param string $timezone
+     * @return int|null
+     */
+    public static function nextAfter( array $parsed, $when, $timezone ) {
+
+        $when = (int) $when;
+        $when = $when - ( $when % 60 );
+
+        $day = self::at( $when, $timezone );
+
+        if ( ! $day ) {
+
+            return null;
+        }
+
+        $day = $day->setTime( 12, 0, 0 );
+
+        for ( $i = 0; $i <= self::LOOKBACK_DAYS; $i++ ) {
+
+            if ( self::dayMatches( $parsed, $day ) ) {
+
+                foreach ( $parsed[1] as $h ) {
+
+                    foreach ( $parsed[0] as $m ) {
+
+                        $t = $day->setTime( $h, $m, 0 )->getTimestamp();
+
+                        if ( $t > $when ) {
+
+                            return $t;
+                        }
+                    }
+                }
+            }
+
+            $day  = $day->modify( '+1 day' );
+            $when = $day->setTime( 0, 0, 0 )->getTimestamp() - 60;
+        }
+
+        return null;
+    }
+
+    /**
+     * Does this date satisfy the month, day-of-month and day-of-week fields?
+     *
+     * Day-of-month and day-of-week are OR'd when both are restricted, which is
+     * cron's own rule and surprises everyone who has not met it: `0 0 1 * 1`
+     * means "the 1st, and every Monday", not "Mondays that fall on the 1st".
+     *
+     * @param array              $parsed
+     * @param \DateTimeImmutable $day
+     * @return bool
+     */
+    protected static function dayMatches( array $parsed, \DateTimeImmutable $day ) {
+
+        if ( ! in_array( (int) $day->format( 'n' ), $parsed[3], true ) ) {
+
+            return false;
+        }
+
+        $dom_restricted = count( $parsed[2] ) !== 31;
+        $dow_restricted = count( $parsed[4] ) !== 7;
+
+        $dom = in_array( (int) $day->format( 'j' ), $parsed[2], true );
+        $dow = in_array( (int) $day->format( 'w' ), $parsed[4], true );
+
+        if ( $dom_restricted && $dow_restricted ) {
+
+            return $dom || $dow;
+        }
+
+        return $dom && $dow;
+    }
+
+    /**
+     * A schedule in words, for the status report.
+     *
+     * Only the shapes an operator is likely to write get a phrase; anything else
+     * is shown as the expression itself, which is honest and still readable.
+     *
+     * @param string $expr  the original expression, aliases included
+     * @return string
+     */
+    public static function describe( $expr ) {
+
+        $expr = strtolower( trim( (string) $expr ) );
+
+        $words = array(
+            '@yearly'   => 'yearly, on 1 January',
+            '@annually' => 'yearly, on 1 January',
+            '@monthly'  => 'monthly, on the 1st at 00:00',
+            '@weekly'   => 'weekly, on Sunday at 00:00',
+            '@daily'    => 'daily at 00:00',
+            '@midnight' => 'daily at 00:00',
+            '@hourly'   => 'hourly, on the hour',
+        );
+
+        if ( isset( $words[ $expr ] ) ) {
+
+            return $words[ $expr ];
+        }
+
+        if ( preg_match( '#^\*/(\d+) \* \* \* \*$#', $expr, $m ) ) {
+
+            return sprintf( 'every %d minutes', (int) $m[1] );
+        }
+
+        if ( preg_match( '#^(\d+) \* \* \* \*$#', $expr, $m ) ) {
+
+            return sprintf( 'hourly, at %d past', (int) $m[1] );
+        }
+
+        if ( preg_match( '#^(\d+) (\d+) \* \* \*$#', $expr, $m ) ) {
+
+            return sprintf( 'daily at %02d:%02d', (int) $m[2], (int) $m[1] );
+        }
+
+        if ( preg_match( '#^(\d+) (\d+) (\d+) \* \*$#', $expr, $m ) ) {
+
+            return sprintf( 'monthly, on day %d at %02d:%02d', (int) $m[3], (int) $m[2], (int) $m[1] );
+        }
+
+        return $expr;
+    }
+
+    /**
+     * A timestamp in a given zone, or null if the zone is unusable.
+     *
+     * @param int    $when
+     * @param string $timezone
+     * @return \DateTimeImmutable|null
+     */
+    protected static function at( $when, $timezone ) {
+
+        try {
+
+            $tz = new \DateTimeZone( (string) $timezone );
+
+        } catch ( \Exception $e ) {
+
+            return null;
+        }
+
+        return ( new \DateTimeImmutable( '@' . (int) $when ) )->setTimezone( $tz );
+    }
+}

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -1131,6 +1131,124 @@ class Db extends \OWA\Core\Base {
     }
 
     /**
+     * The scheduler's lock table, resolved through the entity so the namespace
+     * prefix is not duplicated here.
+     *
+     * @return string
+     */
+    protected function jobLockTable() {
+
+        return \OWA\Core\CoreAPI::entityFactory( 'base.job_lock' )->getTableName();
+    }
+
+    /**
+     * Take a job lock. Fails, without raising, when someone already holds it.
+     *
+     * A plain INSERT: job_name is the primary key, so the database itself
+     * decides the race and the loser simply gets a falsy result. That is what
+     * makes this portable -- no advisory locks, no SELECT ... FOR UPDATE, no
+     * engine-specific syntax.
+     *
+     * @param string $job_name
+     * @param string $owner
+     * @param int    $now
+     * @param int    $expires_at
+     * @return bool
+     */
+    function insertJobLock( $job_name, $owner, $now, $expires_at ) {
+
+        return (bool) $this->query( sprintf(
+            "INSERT INTO %s (job_name, owner, acquired_at, expires_at) VALUES ('%s', '%s', %d, %d)",
+            $this->jobLockTable(),
+            $this->prepare( (string) $job_name ),
+            $this->prepare( (string) $owner ),
+            (int) $now,
+            (int) $expires_at
+        ) );
+    }
+
+    /**
+     * Clear an abandoned lock for one job.
+     *
+     * Scoped to a genuinely expired row, so it can never disturb a live holder.
+     * This is the only thing that ever frees a lock left behind by a process
+     * that died -- there is no reaper and no timer.
+     *
+     * @param string $job_name
+     * @param int    $now
+     * @return bool
+     */
+    function deleteJobLock( $job_name, $now ) {
+
+        return (bool) $this->query( sprintf(
+            "DELETE FROM %s WHERE job_name = '%s' AND expires_at <= %d",
+            $this->jobLockTable(),
+            $this->prepare( (string) $job_name ),
+            (int) $now
+        ) );
+    }
+
+    /**
+     * Extend a lock we still hold.
+     *
+     * Scoped to the owner token: a run that has already been taken over must
+     * not be able to extend a lock it no longer owns.
+     *
+     * @param string $job_name
+     * @param string $owner
+     * @param int    $expires_at
+     * @return bool
+     */
+    function refreshJobLock( $job_name, $owner, $expires_at ) {
+
+        return (bool) $this->query( sprintf(
+            "UPDATE %s SET expires_at = %d WHERE job_name = '%s' AND owner = '%s'",
+            $this->jobLockTable(),
+            (int) $expires_at,
+            $this->prepare( (string) $job_name ),
+            $this->prepare( (string) $owner )
+        ) );
+    }
+
+    /**
+     * Release a lock, but only our own.
+     *
+     * A job that overran its lease and was taken over finds its token no longer
+     * matches and deletes nothing, which is correct: a late finisher must not
+     * yank the lock from the run that replaced it.
+     *
+     * @param string $job_name
+     * @param string $owner
+     * @return bool
+     */
+    function releaseJobLock( $job_name, $owner ) {
+
+        return (bool) $this->query( sprintf(
+            "DELETE FROM %s WHERE job_name = '%s' AND owner = '%s'",
+            $this->jobLockTable(),
+            $this->prepare( (string) $job_name ),
+            $this->prepare( (string) $owner )
+        ) );
+    }
+
+    /**
+     * The lock row for a job, for reporting. Null when unheld.
+     *
+     * @param string $job_name
+     * @return array|null
+     */
+    function getJobLock( $job_name ) {
+
+        $row = $this->get_row( sprintf(
+            "SELECT job_name, owner, acquired_at, expires_at FROM %s WHERE job_name = '%s'",
+            $this->jobLockTable(),
+            $this->prepare( (string) $job_name )
+        ) );
+
+        return $row ? (array) $row : null;
+    }
+
+    /**
      * Row count and date range within one partition. Unknown, without support.
      *
      * @param string $table_name

--- a/Core/Module.php
+++ b/Core/Module.php
@@ -192,6 +192,13 @@ abstract class Module {
     var $cli_commands = array();
 
     /**
+     * Scheduled jobs this module contributes, keyed by job name.
+     *
+     * @var array
+     */
+    var $scheduled_jobs = array();
+
+    /**
      * API Methods
      *
      * @var array
@@ -258,6 +265,11 @@ abstract class Module {
          * Register CLI Commands
          */
         $this->registerCliCommands();
+
+        /**
+         * Register Scheduled Jobs -- after the commands they name
+         */
+        $this->registerJobs();
 
         /**
          * Register API Methods
@@ -990,6 +1002,48 @@ abstract class Module {
         $this->cli_commands[$command] = $class;
     }
 
+    /**
+     * Register a CLI command to be run on a schedule by cmd=schedule-run.
+     *
+     * A JOB IS A CLI COMMAND. Whatever the scheduler runs, an operator can run
+     * by hand with the same name and see the same output -- a job that cannot be
+     * reproduced from a terminal cannot be debugged from one either. It also
+     * means every job already has a capability check and its own tests.
+     *
+     * All four arguments are stated every time. $command is deliberately NOT
+     * defaulted to $name: a registration you can read without consulting the CLI
+     * registry to work out whether the first argument is a label or a command is
+     * worth two repeated words.
+     *
+     * $name is identity -- what the state row keys on, what schedule-status
+     * prints, what `schedule-run job=<name>` takes. $command is what runs. They
+     * are separate so one command can be scheduled more than once with different
+     * arguments and cadences.
+     *
+     * A SCHEDULED JOB MUST BE CONVERGENT, NOT INCREMENTAL. The scheduler does not
+     * backfill: a job missed for three days runs once, not three times. That is
+     * safe for partition-rotate, which extends *to* a boundary computed from
+     * today. A job that processes "yesterday's data" is incremental and will
+     * quietly skip days -- make it convergent before registering it.
+     *
+     * @param string $name      job identity, unique across all modules
+     * @param string $command   a name registered with registerCliCommand()
+     * @param string $schedule  a cron expression, an @alias, or 'off'
+     * @param array  $params    arguments passed to the controller verbatim
+     * @return void
+     */
+    function registerJob( $name, $command, $schedule, $params ) {
+
+        $this->scheduled_jobs[ $name ] = array(
+            'name'     => $name,
+            'command'  => $command,
+            'schedule' => $schedule,
+            'params'   => (array) $params,
+            'module'   => $this->name,
+            'source'   => 'code',
+        );
+    }
+
     function registerFormatter($type, $formatter) {
 
         $this->formatters[$type] = $formatter;
@@ -1107,6 +1161,16 @@ abstract class Module {
      * and should be redefined in a concrete module class.
      */
     function registerCliCommands() {
+
+        return false;
+    }
+
+    /**
+     * Abstract method for registering scheduled jobs.
+     *
+     * Called by a module's constructor; redefine in a concrete module class.
+     */
+    function registerJobs() {
 
         return false;
     }

--- a/modules/Base/Classes/JobLease.php
+++ b/modules/Base/Classes/JobLease.php
@@ -1,0 +1,118 @@
+<?php
+namespace OWA\Module\Base\Classes;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * A per-job lock, so a job can never overlap itself.
+ *
+ * The row's EXISTENCE is the lock and the primary key supplies the atomicity:
+ * acquiring is a plain INSERT, and the loser of a race gets a constraint
+ * violation. No transaction, no SELECT ... FOR UPDATE, no engine-specific
+ * syntax. Every database enforces uniqueness, so this behaves identically
+ * everywhere -- which is why it is used in preference to MySQL's GET_LOCK, that
+ * being a one-driver solution to a problem core scheduling should not have.
+ *
+ * This is Laravel's DatabaseLock design, minus the parts that solve problems we
+ * do not have: no pruning lottery, because job_name is the primary key so the
+ * table is bounded by the registry rather than by arbitrary cache keys.
+ */
+class JobLease {
+
+    /** @var string */
+    protected $job_name;
+
+    /** @var string */
+    protected $owner;
+
+    /** @var int */
+    protected $expires_at = 0;
+
+    /**
+     * @param string $job_name
+     */
+    function __construct( $job_name ) {
+
+        $this->job_name = (string) $job_name;
+
+        // Unique per attempt, so a taker-over and the original holder can never
+        // be confused for one another.
+        $this->owner = bin2hex( random_bytes( 8 ) );
+    }
+
+    /**
+     * @return string
+     */
+    public function getOwner() {
+
+        return $this->owner;
+    }
+
+    /**
+     * Take the lock, or report that someone else holds it.
+     *
+     * @param int $lease  seconds before a dead holder's lock may be taken over
+     * @return bool
+     */
+    public function acquire( $lease ) {
+
+        $db  = \OWA\Core\CoreAPI::dbSingleton();
+        $now = time();
+
+        $this->expires_at = $now + max( 60, (int) $lease );
+
+        // Clear an abandoned lock first. Scoped to THIS job and to a genuinely
+        // expired row, so it can never disturb a live holder.
+        $db->deleteJobLock( $this->job_name, $now );
+
+        return (bool) $db->insertJobLock(
+            $this->job_name, $this->owner, $now, $this->expires_at
+        );
+    }
+
+    /**
+     * Push the expiry out, for a job that can prove it is still alive.
+     *
+     * Scoped to our own owner token, so a run that has already been taken over
+     * cannot extend a lock it no longer holds.
+     *
+     * Returns whether we STILL HOLD IT, read back rather than inferred from the
+     * update: an UPDATE that matches no rows is still a successful statement,
+     * and getAffectedRows() would tell us the difference on MySQL only -- which
+     * is the portability this whole design is avoiding. The read-back costs one
+     * query on a call that is infrequent by nature, and turns a return value
+     * that could only ever say "the statement ran" into one a long job can act
+     * on by stopping early when it has been superseded.
+     *
+     * @param int $lease
+     * @return bool  false when the lock is no longer ours
+     */
+    public function refresh( $lease ) {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $this->expires_at = time() + max( 60, (int) $lease );
+
+        $db->refreshJobLock( $this->job_name, $this->owner, $this->expires_at );
+
+        $row = $db->getJobLock( $this->job_name );
+
+        return $row && isset( $row['owner'] ) && $row['owner'] === $this->owner;
+    }
+
+    /**
+     * Release, but only our own.
+     *
+     * A job that overran its lease and was taken over will find its token no
+     * longer matches, and delete nothing -- which is correct. A late finisher
+     * must not yank the lock out from under the run that replaced it.
+     *
+     * @return void
+     */
+    public function release() {
+
+        \OWA\Core\CoreAPI::dbSingleton()->releaseJobLock( $this->job_name, $this->owner );
+    }
+}

--- a/modules/Base/Classes/Service.php
+++ b/modules/Base/Classes/Service.php
@@ -229,6 +229,167 @@ class Service extends \OWA\Core\Base {
         $this->setMap('cli_commands', $command_map);
     }
 
+    /**
+     * Commands that must never be scheduled, however they are named.
+     *
+     * install and update re-run schema installation and mutate the schema out
+     * from under the running process; reset-secrets rewrites owa-config.php.
+     * Checked against the COMMAND rather than the job name, so a friendly label
+     * cannot smuggle one past.
+     */
+    const NEVER_SCHEDULE = array( 'install', 'update', 'reset-secrets' );
+
+    /**
+     * Build the job registry: what modules registered, overlaid with what
+     * OWA_SCHEDULED_JOBS says.
+     *
+     * Idempotent, and called only by the scheduler commands and tests -- there
+     * is no reason for every CLI invocation to build this map.
+     *
+     * A malformed entry disables THAT job and nothing else. A typo in one line
+     * of config must never stop the other jobs running, so every rejection here
+     * is per-entry and noticed by name.
+     *
+     * @return void
+     */
+    function loadJobs() {
+
+        // The merge validates commands, so the command map must be built first.
+        // Both are idempotent.
+        $this->loadCliCommands();
+
+        $jobs = array();
+
+        foreach ($this->modules as $k => $module) {
+
+            if (is_array($module->scheduled_jobs)) {
+                $jobs = array_merge($jobs, $module->scheduled_jobs);
+            }
+        }
+
+        $jobs = $this->applyConfiguredJobs( $jobs );
+
+        $this->setMap('scheduled_jobs', $jobs);
+    }
+
+    /**
+     * Overlay OWA_SCHEDULED_JOBS onto the registered jobs.
+     *
+     * Keyed by job name rather than a list of arrays each carrying a 'name', so
+     * a name cannot be missing and PHP itself rejects two entries claiming the
+     * same job -- a whole class of merge rule deleted rather than documented.
+     *
+     * Overrides are PER KEY: giving only 'params' keeps the registered schedule,
+     * giving only 'schedule' keeps the registered params. Forcing an operator to
+     * restate values they did not mean to change is how config drifts away from
+     * code.
+     *
+     * @param array $jobs  registered jobs, keyed by name
+     * @return array
+     */
+    protected function applyConfiguredJobs( $jobs ) {
+
+        $configured = \OWA\Core\CoreAPI::getSetting( 'base', 'scheduled_jobs' );
+
+        if ( ! is_array( $configured ) ) {
+
+            return $jobs;
+        }
+
+        foreach ( $configured as $name => $spec ) {
+
+            $name = trim( (string) $name );
+
+            if ( $name === '' || ! is_array( $spec ) ) {
+
+                \OWA\Core\CoreAPI::notice(
+                    'OWA_SCHEDULED_JOBS: entries must be keyed by job name with an array value. Skipping one.'
+                );
+
+                continue;
+            }
+
+            $known = isset( $jobs[ $name ] );
+
+            // A new job has nothing to inherit, so it must say what it runs and
+            // when. Guessing the command from the key is exactly the ambiguity
+            // separating name from command removes.
+            if ( ! $known ) {
+
+                foreach ( array( 'command', 'schedule' ) as $required ) {
+
+                    if ( empty( $spec[ $required ] ) ) {
+
+                        \OWA\Core\CoreAPI::notice( sprintf(
+                            'OWA_SCHEDULED_JOBS: "%s" is not a registered job, so it needs a "%s". Skipping it.',
+                            $name, $required
+                        ) );
+
+                        continue 2;
+                    }
+                }
+            }
+
+            $job = $known ? $jobs[ $name ] : array(
+                'name'   => $name,
+                'module' => 'config',
+                'params' => array(),
+            );
+
+            $job['source'] = $known ? 'config-override' : 'config';
+
+            if ( isset( $spec['command'] ) )  { $job['command']  = (string) $spec['command']; }
+            if ( isset( $spec['schedule'] ) ) { $job['schedule'] = (string) $spec['schedule']; }
+            if ( isset( $spec['params'] ) )   { $job['params']   = (array) $spec['params']; }
+
+            // A command nothing answers to would otherwise be listed as a
+            // healthy job with a next-due time, and only fail silently at
+            // dispatch. Refusing it here keeps the registry honest.
+            if ( ! $this->getCliCommandClass( $job['command'] ) ) {
+
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    'OWA_SCHEDULED_JOBS: "%s" names command "%s", which is not registered. Skipping it.',
+                    $name, $job['command']
+                ) );
+
+                continue;
+            }
+
+            if ( in_array( $job['command'], self::NEVER_SCHEDULE, true ) ) {
+
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    'OWA_SCHEDULED_JOBS: "%s" runs %s, which must never be scheduled. Skipping it.',
+                    $name, $job['command']
+                ) );
+
+                continue;
+            }
+
+            $jobs[ $name ] = $job;
+        }
+
+        return $jobs;
+    }
+
+    /**
+     * @param string $name
+     * @return array|false
+     */
+    function getJob( $name ) {
+
+        return $this->getMapValue('scheduled_jobs', $name);
+    }
+
+    /**
+     * @return array  every job, keyed by name
+     */
+    function getJobs() {
+
+        $jobs = $this->getMap('scheduled_jobs');
+
+        return is_array( $jobs ) ? $jobs : array();
+    }
+
     function _loadApiMethods() {
 
         $method_map = array();

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -172,6 +172,29 @@ namespace OWA\Module\Base\Classes;
             }
         }
 
+        /* SCHEDULED JOBS */
+
+        // A single array rather than a constant per job, so an installation can
+        // retune a shipped job, add one the release never registered, or run the
+        // same command twice under different names -- without a code change and
+        // without a new constant each time:
+        //
+        //   define('OWA_SCHEDULED_JOBS', array(
+        //       'partition-rotate' => array( 'params' => array( 'keep' => 24 ) ),
+        //       'drain-queue'      => array( 'command'  => 'processEventQueue',
+        //                                    'schedule' => '*/2 * * * *' ),
+        //   ));
+        //
+        // Keyed by job name; see owa_service::applyConfiguredJobs() for how an
+        // entry is merged and why a bad one disables only itself.
+        if (defined('OWA_SCHEDULED_JOBS') && is_array(OWA_SCHEDULED_JOBS)) {
+            $this->set('base', 'scheduled_jobs', OWA_SCHEDULED_JOBS);
+        }
+
+        if (defined('OWA_SCHEDULER_ENABLED')) {
+            $this->set('base', 'scheduler_enabled', (bool) OWA_SCHEDULER_ENABLED);
+        }
+
         /* CONFIGURATION ID */
 
         if (defined('OWA_CONFIGURATION_ID')) {
@@ -1052,7 +1075,11 @@ namespace OWA\Module\Base\Classes;
                 'cacheType'                            => '', // file, memory, memcache
                 'disabledEndpoints'                    => array('queue.php'),
                 'disableAllEndpoints'                => false,
-                'processQueuesJobSchedule'            => '10 * * * *',
+                // Scheduler. Jobs themselves are registered in code by each
+                // module; this holds only what OWA_SCHEDULED_JOBS overlays on
+                // top. See owa_service::loadJobs().
+                'scheduled_jobs'                    => array(),
+                'scheduler_enabled'                    => true,
                 'maxCustomVars'                        => 5, //sdk
                 'update_session_user_name'            => true, // updates the session with latest user_name value
                 'log_owa_user_names'                => true,  // logs the OWA user name as the user_name property on events

--- a/modules/Base/Controller/PartitionDropCli.php
+++ b/modules/Base/Controller/PartitionDropCli.php
@@ -57,6 +57,8 @@ class PartitionDropCli extends PartitionsCli {
 
         \OWA\Core\CoreAPI::notice( sprintf( 'Retention cutoff: %s (from "%s").', $cutoff, $raw ) );
 
+        $touched = 0;
+
         foreach ( $this->factTables( $this->getParam( 'table' ) ?: null ) as $table ) {
 
             if ( ! $db->isPartitioned( $table ) ) {
@@ -66,7 +68,15 @@ class PartitionDropCli extends PartitionsCli {
                 continue;
             }
 
+            $touched++;
+
             $this->dropOlderThan( $table, $cutoff, $dry_run );
+        }
+
+        // Skipping everything is not success -- see partition-rotate.
+        if ( ! $touched ) {
+
+            $this->refuse( 'Nothing to drop: no fact table is partitioned. Run cmd=partition-init first.' );
         }
     }
 }

--- a/modules/Base/Controller/PartitionReorganizeCli.php
+++ b/modules/Base/Controller/PartitionReorganizeCli.php
@@ -68,6 +68,8 @@ class PartitionReorganizeCli extends PartitionsCli {
         $tables = $this->factTables( $this->getParam( 'table' ) ?: null );
         $budget = $this->factTableBudget();
 
+        $touched = 0;
+
         foreach ( $tables as $table ) {
 
             if ( ! $db->isPartitioned( $table ) ) {
@@ -78,6 +80,8 @@ class PartitionReorganizeCli extends PartitionsCli {
 
                 continue;
             }
+
+            $touched++;
 
             // Plan first so the count can be judged before anything is rewritten.
             $plan = $db->repartitionTable( $table, $granularity, true, $from, $to );
@@ -148,6 +152,14 @@ class PartitionReorganizeCli extends PartitionsCli {
                     $table, implode( '; ', $result['failed'] )
                 ) );
             }
+        }
+
+        // Same reasoning as partition-rotate: having skipped everything is not
+        // success, and a caller -- including the scheduler, since any command
+        // can be scheduled -- must be able to tell the difference.
+        if ( ! $touched ) {
+
+            $this->refuse( 'Nothing to reorganize: no fact table is partitioned. Run cmd=partition-init first.' );
         }
     }
 }

--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -36,6 +36,60 @@ namespace OWA\Module\Base\Controller;
  */
 class PartitionRotateCli extends PartitionsCli {
 
+    /**
+     * How long this job's lock should be trusted without proof of life.
+     *
+     * Derived rather than hardcoded, because the cost of a rotate is dominated
+     * by how many partitions it must add, merge or drop -- each an ALTER TABLE
+     * -- and that count is knowable before any of them runs. An installation
+     * catching up after a year of neglect legitimately needs far longer than one
+     * rotating on schedule, and guessing a single number for both would either
+     * duplicate the long run or leave the short one wedged after a crash.
+     *
+     * partition-rotate cannot call heartbeat() to extend as it goes: it spends
+     * its time inside one blocking ALTER TABLE and never returns to PHP
+     * mid-statement. That is exactly why it needs a generous estimate up front.
+     *
+     * The estimate is read-only and is taken before the lock, so two dispatchers
+     * asking at once is harmless.
+     *
+     * @return int seconds
+     */
+    public function getJobLease() {
+
+        $planned = 0;
+
+        try {
+
+            $db      = \OWA\Core\CoreAPI::dbSingleton();
+            $through = \OWA\Core\Db::partitionLeadBoundary();
+
+            foreach ( $this->factTables( $this->getParam( 'table' ) ?: null ) as $table ) {
+
+                if ( ! $db->isPartitioned( $table ) ) {
+
+                    continue;
+                }
+
+                $granularity = $db->inferPartitionGranularity( $table ) ?: 'monthly';
+                $plan        = $db->extendPartitions( $table, $granularity, $through, true );
+
+                $planned += (int) ( $plan['planned'] ?? 0 );
+                $planned += count( $db->getPartitionSpans( $table ) );
+            }
+
+        } catch ( \Throwable $t ) {
+
+            // An estimate that cannot be made must not stop the job running.
+            // Fall back to the base default, which errs long by design.
+            return parent::getJobLease();
+        }
+
+        // Roughly two minutes per partition touched, floored at half an hour so
+        // a trivial rotate still tolerates a slow instance.
+        return max( 1800, $planned * 120 );
+    }
+
     function action() {
 
         if ( ! $this->assertPartitioningSupported() ) {
@@ -58,12 +112,10 @@ class PartitionRotateCli extends PartitionsCli {
 
             if ( ! ctype_digit( (string) $keep ) || (int) $keep < 1 ) {
 
-                \OWA\Core\CoreAPI::notice(
+                return $this->refuse(
                     'keep must be a number of months to retain, such as keep=24. '
                   . 'Omit it entirely to retain everything.'
                 );
-
-                return;
             }
 
             // Expressed as a period rather than a date on purpose. A fixed date
@@ -73,7 +125,7 @@ class PartitionRotateCli extends PartitionsCli {
 
             if ( ! $cutoff ) {
 
-                \OWA\Core\CoreAPI::notice( sprintf( 'Could not work out a cutoff for keep=%s.', $keep ) );
+                return $this->refuse( sprintf( 'Could not work out a cutoff for keep=%s.', $keep ) );
 
                 return;
             }
@@ -88,20 +140,16 @@ class PartitionRotateCli extends PartitionsCli {
 
         if ( $granularity !== null && ! \OWA\Core\Db::isPartitionGranularity( $granularity ) ) {
 
-            \OWA\Core\CoreAPI::notice( sprintf(
+            return $this->refuse( sprintf(
                 'Unknown granularity "%s". Use one of: quarter-month, half-month, monthly.', $granularity
             ) );
-
-            return;
         }
 
         $tables = $this->factTables( $this->getParam( 'table' ) ?: null );
 
         if ( ! $tables ) {
 
-            \OWA\Core\CoreAPI::notice( 'No fact tables found.' );
-
-            return;
+            return $this->refuse( 'No fact tables found.' );
         }
 
         $through = \OWA\Core\Db::partitionLeadBoundary( $months_ahead );

--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -42,33 +42,35 @@ class PartitionRotateCli extends PartitionsCli {
      * A CRASH-RECOVERY TIMEOUT, not a runtime budget: on any normal path the
      * lock is released in a finally and this is never consulted. It decides only
      * how long after a process dies before another run may assume it is really
-     * dead.
+     * dead. Too short lets a second copy start alongside a run still working;
+     * too long merely delays recovery, for which --force-release exists. Those
+     * costs are asymmetric, so this errs long.
      *
-     * Derived from the work actually PLANNED -- the partitions this run will
-     * create and the groups it will merge, each of which is an ALTER TABLE.
-     * Counting the partitions a table already HAS would be wrong and was: a
-     * routine rotate with nothing to do would have asked for hours because the
-     * tables happen to hold a few hundred partitions between them, when the run
-     * takes seconds.
+     * WHAT MAKES A ROTATE SLOW IS DATA REWRITTEN, NOT PARTITIONS COUNTED.
+     * Extending the lead is ONE `REORGANIZE PARTITION pmax INTO (...)` however
+     * many periods it creates -- measured here at 1.52s to create 31 of them --
+     * and its cost is proportional to what is sitting in the catch-all. Each
+     * merge is a separate REORGANIZE over the partitions it combines. Drops are
+     * not counted at all: DROP PARTITION discards a file and returns.
      *
-     * Drops are deliberately not counted. DROP PARTITION discards a file and
-     * returns; it is not what makes a rotate slow.
+     * Charging per partition created was wrong twice over, and produced a lease
+     * of 2.6 hours for that 1.52-second extension.
      *
-     * Uncapped on purpose. Too long merely delays recovery, and
-     * `schedule-run --force-release` is there for that; too short lets a second
-     * copy start alongside a run that is still working, which is the direction
-     * worth avoiding. partition-rotate cannot call heartbeat() to extend as it
-     * goes -- it sits inside one blocking ALTER TABLE and never returns to PHP
-     * mid-statement -- so the estimate has to stand on its own.
+     * Row counts come from information_schema and are estimates, which is
+     * appropriate: this is an estimate, and an exact COUNT(*) over a large
+     * catch-all before every rotate would cost more than it informs.
      *
      * Read-only, and taken before the lock, so two dispatchers estimating at
-     * once is harmless.
+     * once is harmless. partition-rotate cannot call heartbeat() to extend as it
+     * goes -- it sits inside one blocking ALTER TABLE and never returns to PHP
+     * mid-statement -- so this estimate has to stand on its own.
      *
      * @return int seconds
      */
     public function getJobLease() {
 
-        $operations = 0;
+        $statements = 0;
+        $rows       = 0;
 
         try {
 
@@ -84,12 +86,42 @@ class PartitionRotateCli extends PartitionsCli {
                 }
 
                 $granularity = $db->inferPartitionGranularity( $table ) ?: 'monthly';
+                $sizes       = array();
+                $catch_all   = 0;
 
+                foreach ( $db->listPartitions( $table ) as $p ) {
+
+                    $sizes[ $p['name'] ] = (int) $p['rows'];
+
+                    if ( strtoupper( $p['less_than'] ) === OWA_DTD_PARTITION_MAXVALUE ) {
+
+                        $catch_all = (int) $p['rows'];
+                    }
+                }
+
+                // One statement, rewriting whatever has collected in the
+                // catch-all -- which is nothing on a maintained installation and
+                // everything on a neglected one.
                 $extend = $db->extendPartitions( $table, $granularity, $through, true );
+
+                if ( ! empty( $extend['planned'] ) ) {
+
+                    $statements++;
+                    $rows += $catch_all;
+                }
+
+                // One statement per merge, over the partitions it combines.
                 $compact = $db->planPartitionCompaction( $table, $budget['limit'] );
 
-                $operations += (int) ( $extend['planned'] ?? 0 );
-                $operations += count( $compact['merges'] ?? array() );
+                foreach ( (array) ( $compact['merges'] ?? array() ) as $merge ) {
+
+                    $statements++;
+
+                    foreach ( (array) ( $merge['names'] ?? array() ) as $name ) {
+
+                        $rows += isset( $sizes[ $name ] ) ? $sizes[ $name ] : 0;
+                    }
+                }
             }
 
         } catch ( \Throwable $t ) {
@@ -99,11 +131,31 @@ class PartitionRotateCli extends PartitionsCli {
             return parent::getJobLease();
         }
 
-        // Five minutes an operation is generous for a REORGANIZE, which is the
-        // right direction for a timeout whose only cost when too large is a
-        // slower recovery. Half an hour floor, so a rotate with nothing to do
-        // still tolerates a slow instance.
-        return max( 1800, $operations * 300 );
+        return self::leaseFor( $statements, $rows );
+    }
+
+    /**
+     * The lease arithmetic, separated so it can be tested at sizes this
+     * installation does not have.
+     *
+     * Two minutes per statement covers fixed overhead and lock acquisition.
+     * Five minutes per million rows rewritten is around sixty times the
+     * ~5s/million measured when this partitioning was built -- the margin a
+     * crash-recovery timeout should carry. Scaled smoothly rather than rounded
+     * up per million, so a few hundred rows do not cost the same as a million.
+     * Half an hour floor, so a rotate with nothing to do still tolerates a slow
+     * instance.
+     *
+     * @param int $statements  ALTER TABLE statements the run will issue
+     * @param int $rows        rows those statements will rewrite
+     * @return int seconds
+     */
+    public static function leaseFor( $statements, $rows ) {
+
+        $seconds = ( (int) $statements * 120 )
+                 + (int) round( max( 0, (int) $rows ) / 1000000 * 300 );
+
+        return max( 1800, $seconds );
     }
 
     function action() {

--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -167,6 +167,8 @@ class PartitionRotateCli extends PartitionsCli {
                 $months_ahead, $through )
         );
 
+        $rotated = 0;
+
         foreach ( $tables as $table ) {
 
             // Rotation maintains a table; it does not convert one. The first
@@ -180,6 +182,8 @@ class PartitionRotateCli extends PartitionsCli {
 
                 continue;
             }
+
+            $rotated++;
 
             $table_granularity = $granularity ?: ( $db->inferPartitionGranularity( $table ) ?: 'monthly' );
 
@@ -207,6 +211,21 @@ class PartitionRotateCli extends PartitionsCli {
 
                 $this->extendTableLead( $table, $table_granularity, $through, $budget, $dry_run );
             }
+        }
+
+        // Skipping every table is not success. Left as 'ok', a scheduled rotate
+        // on an installation that never ran partition-init would report a clean
+        // history forever while doing nothing at all -- exactly the silent
+        // failure this command exists to prevent, moved one level up. 'refused'
+        // rather than 'failed' so the occurrence is still consumed and the job
+        // is not retried every minute.
+        if ( ! $rotated ) {
+
+            return $this->refuse( sprintf(
+                'Nothing to rotate: %s not partitioned. Run cmd=partition-init once, in a '
+              . 'maintenance window, and this will start doing its job.',
+                count( $tables ) === 1 ? 'that table is' : 'no fact table is'
+            ) );
         }
     }
 }

--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -39,30 +39,42 @@ class PartitionRotateCli extends PartitionsCli {
     /**
      * How long this job's lock should be trusted without proof of life.
      *
-     * Derived rather than hardcoded, because the cost of a rotate is dominated
-     * by how many partitions it must add, merge or drop -- each an ALTER TABLE
-     * -- and that count is knowable before any of them runs. An installation
-     * catching up after a year of neglect legitimately needs far longer than one
-     * rotating on schedule, and guessing a single number for both would either
-     * duplicate the long run or leave the short one wedged after a crash.
+     * A CRASH-RECOVERY TIMEOUT, not a runtime budget: on any normal path the
+     * lock is released in a finally and this is never consulted. It decides only
+     * how long after a process dies before another run may assume it is really
+     * dead.
      *
-     * partition-rotate cannot call heartbeat() to extend as it goes: it spends
-     * its time inside one blocking ALTER TABLE and never returns to PHP
-     * mid-statement. That is exactly why it needs a generous estimate up front.
+     * Derived from the work actually PLANNED -- the partitions this run will
+     * create and the groups it will merge, each of which is an ALTER TABLE.
+     * Counting the partitions a table already HAS would be wrong and was: a
+     * routine rotate with nothing to do would have asked for hours because the
+     * tables happen to hold a few hundred partitions between them, when the run
+     * takes seconds.
      *
-     * The estimate is read-only and is taken before the lock, so two dispatchers
-     * asking at once is harmless.
+     * Drops are deliberately not counted. DROP PARTITION discards a file and
+     * returns; it is not what makes a rotate slow.
+     *
+     * Uncapped on purpose. Too long merely delays recovery, and
+     * `schedule-run --force-release` is there for that; too short lets a second
+     * copy start alongside a run that is still working, which is the direction
+     * worth avoiding. partition-rotate cannot call heartbeat() to extend as it
+     * goes -- it sits inside one blocking ALTER TABLE and never returns to PHP
+     * mid-statement -- so the estimate has to stand on its own.
+     *
+     * Read-only, and taken before the lock, so two dispatchers estimating at
+     * once is harmless.
      *
      * @return int seconds
      */
     public function getJobLease() {
 
-        $planned = 0;
+        $operations = 0;
 
         try {
 
             $db      = \OWA\Core\CoreAPI::dbSingleton();
             $through = \OWA\Core\Db::partitionLeadBoundary();
+            $budget  = $this->factTableBudget();
 
             foreach ( $this->factTables( $this->getParam( 'table' ) ?: null ) as $table ) {
 
@@ -72,22 +84,26 @@ class PartitionRotateCli extends PartitionsCli {
                 }
 
                 $granularity = $db->inferPartitionGranularity( $table ) ?: 'monthly';
-                $plan        = $db->extendPartitions( $table, $granularity, $through, true );
 
-                $planned += (int) ( $plan['planned'] ?? 0 );
-                $planned += count( $db->getPartitionSpans( $table ) );
+                $extend = $db->extendPartitions( $table, $granularity, $through, true );
+                $compact = $db->planPartitionCompaction( $table, $budget['limit'] );
+
+                $operations += (int) ( $extend['planned'] ?? 0 );
+                $operations += count( $compact['merges'] ?? array() );
             }
 
         } catch ( \Throwable $t ) {
 
             // An estimate that cannot be made must not stop the job running.
-            // Fall back to the base default, which errs long by design.
+            // The base default errs long by design.
             return parent::getJobLease();
         }
 
-        // Roughly two minutes per partition touched, floored at half an hour so
-        // a trivial rotate still tolerates a slow instance.
-        return max( 1800, $planned * 120 );
+        // Five minutes an operation is generous for a REORGANIZE, which is the
+        // right direction for a timeout whose only cost when too large is a
+        // slower recovery. Half an hour floor, so a rotate with nothing to do
+        // still tolerates a slow instance.
+        return max( 1800, $operations * 300 );
     }
 
     function action() {

--- a/modules/Base/Controller/PartitionStatusCli.php
+++ b/modules/Base/Controller/PartitionStatusCli.php
@@ -75,35 +75,6 @@ class PartitionStatusCli extends PartitionsCli {
         $this->write( $lines );
     }
 
-    /**
-     * Put the report on standard output.
-     *
-     * The other commands report through CoreAPI::notice(), and should: what they
-     * did is a record worth keeping, and the console handler puts it on stdout as
-     * well as in the log. A report is not that. It is terminal output, it is read
-     * once, and routing it through the logger would stamp every line with a
-     * timestamp, a pid and a level, interleave it with debug output on an
-     * installation running the development handler, and write fifty lines into
-     * the error log on each run -- which, scheduled beside partition-rotate,
-     * would make the status of the partitions the noisiest thing in it.
-     *
-     * Refusals still go through notice(), because those are events.
-     *
-     * @param string[] $lines
-     * @return void
-     */
-    protected function write( $lines ) {
-
-        // The base controller exits unless this is a CLI request, so STDOUT is
-        // the CLI SAPI's own constant. The fallback is for a test harness that
-        // has not defined it.
-        $out = defined( 'STDOUT' ) ? STDOUT : fopen( 'php://output', 'w' );
-
-        foreach ( $lines as $line ) {
-
-            fwrite( $out, $line . PHP_EOL );
-        }
-    }
 
     /**
      * One table's block of the report.

--- a/modules/Base/Controller/PartitionsCli.php
+++ b/modules/Base/Controller/PartitionsCli.php
@@ -277,7 +277,10 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
 
         if ( ! $done['added'] ) {
 
-            \OWA\Core\CoreAPI::notice( sprintf( '%s: FAILED to extend; see the database error above.', $table ) );
+            // fail(), not notice(): Db::query() swallows SQL errors and returns
+            // falsy, so a rotate whose ALTER TABLE the server rejected would
+            // otherwise be recorded as a success while the lead quietly expired.
+            $this->fail( sprintf( '%s: FAILED to extend; see the database error above.', $table ) );
 
             return false;
         }
@@ -362,7 +365,7 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
 
                 } else {
 
-                    \OWA\Core\CoreAPI::notice( sprintf( '%s: failed to drop %s.', $table, $partition ) );
+                    $this->fail( sprintf( '%s: failed to drop %s.', $table, $partition ) );
                 }
             }
 
@@ -445,7 +448,7 @@ abstract class PartitionsCli extends \OWA\Core\Controller\Cli {
 
             } else {
 
-                \OWA\Core\CoreAPI::notice( sprintf(
+                $this->fail( sprintf(
                     '%s: FAILED to reshape %s..%s; see the database error above.',
                     $table, $op['start'], $op['less_than']
                 ) );

--- a/modules/Base/Controller/ScheduleRunCli.php
+++ b/modules/Base/Controller/ScheduleRunCli.php
@@ -1,0 +1,512 @@
+<?php
+namespace OWA\Module\Base\Controller;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * Run whatever is due. The one command that belongs in cron.
+ *
+ *   * * * * * php /path/to/owa/cli.php cmd=schedule-run
+ *
+ * Every minute, matching Laravel, because the crontab line is not the schedule
+ * -- it is the RESOLUTION FLOOR. A minute is the finest thing cron expresses, so
+ * the floor never binds and an in-app schedule always means what it says. A
+ * coarser line would let an operator configure a job for `* * * * *` and have it
+ * silently run every five minutes, and configuration that quietly cannot do what
+ * it says is worse than none. A boot costs about 66ms, so the whole day's ticks
+ * are around 95 seconds of CPU.
+ *
+ *   cmd=schedule-run                        run everything due
+ *   cmd=schedule-run --dry-run              report what would run, change nothing
+ *   cmd=schedule-run job=NAME --force       run one job now, ignoring its schedule
+ *   cmd=schedule-run --force-release job=X  drop a lock left by a dead process
+ *   cmd=schedule-run --prune-orphans        forget jobs that are no longer registered
+ *
+ * A no-op tick is SILENT -- debug(), never notice(). At a tick a minute, a
+ * notice per tick would bury the one that matters within a week.
+ */
+class ScheduleRunCli extends SchedulerCli {
+
+    /**
+     * Wall-clock budget for starting new jobs, checked BEFORE each one and
+     * never mid-job. Past it, the rest stay due and run at the next tick, so
+     * nothing is lost -- this only stops one tick starting a long procession of
+     * heavy jobs on an instance shared with other people's sites.
+     */
+    const MAX_RUNTIME = 240;
+
+    function action() {
+
+        $started = time();
+
+        if ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'scheduler_enabled' ) ) {
+
+            return $this->refuse( 'The scheduler is disabled (OWA_SCHEDULER_ENABLED). Nothing will run.' );
+        }
+
+        // Checked once, here, rather than being discovered separately by every
+        // job: Controller::doAction() intercepts each controller with the same
+        // check and would render the update view once per job.
+        if ( \OWA\Core\CoreAPI::isUpdateRequired() ) {
+
+            return $this->refuse(
+                'Schema updates are pending, so no job can run. Apply them with cmd=update.'
+            );
+        }
+
+        $jobs = $this->jobs();
+
+        if ( $this->getParam( 'prune-orphans' ) ) {
+
+            $this->pruneOrphans( $jobs );
+
+            return;
+        }
+
+        if ( $this->getParam( 'force-release' ) ) {
+
+            $this->forceRelease();
+
+            return;
+        }
+
+        $only    = $this->getParam( 'job' ) ?: null;
+        $force   = (bool) $this->getParam( 'force' );
+        $dry_run = (bool) $this->getParam( 'dry-run' );
+
+        if ( $only && ! isset( $jobs[ $only ] ) ) {
+
+            return $this->refuse( sprintf(
+                'No job named "%s". Registered jobs: %s.',
+                $only, implode( ', ', array_keys( $jobs ) ) ?: '(none)'
+            ) );
+        }
+
+        if ( $only ) {
+
+            $jobs = array( $only => $jobs[ $only ] );
+        }
+
+        foreach ( $jobs as $name => $job ) {
+
+            if ( time() - $started > self::MAX_RUNTIME ) {
+
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    'Runtime budget reached; %s and anything after it stay due for the next tick.', $name
+                ) );
+
+                break;
+            }
+
+            $this->considerJob( $name, $job, $force, $dry_run );
+        }
+    }
+
+    /**
+     * Decide whether one job runs, and run it.
+     *
+     * @param string $name
+     * @param array  $job
+     * @param bool   $force
+     * @param bool   $dry_run
+     * @return void
+     */
+    protected function considerJob( $name, $job, $force, $dry_run ) {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        // Validated first: actionNotResolved() returns null under the CLI, so an
+        // unknown command would otherwise look like a silent success.
+        if ( ! \OWA\Core\CoreAPI::serviceSingleton()->getCliCommandClass( $job['command'] ) ) {
+
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Job "%s" names command "%s", which is not registered. Skipping it.', $name, $job['command']
+            ) );
+
+            return;
+        }
+
+        // Materialised for EVERY registered job, not only due ones. It is what
+        // lets "a state row exists" stand as proof the dispatcher has run, which
+        // is how schedule-status tells a missing crontab entry from a healthy
+        // but idle installation. Only due for the first time in a month, a job
+        // would otherwise leave nothing to look at for thirty days.
+        $state = $this->ensureState( $name, $dry_run );
+
+        if ( ! $state && ! $dry_run ) {
+
+            // Db::query() swallows errors and returns falsy, so a failed insert
+            // is silent. Without refusing here, a job whose state cannot be
+            // recorded would look due at every tick and hammer the database
+            // once a minute forever.
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Could not record state for "%s", so it will not be run.', $name
+            ) );
+
+            return;
+        }
+
+        $slot = null;
+
+        if ( ! $force ) {
+
+            if ( $this->isDisabled( $job ) ) {
+
+                \OWA\Core\CoreAPI::debug( sprintf( 'Job "%s" is off.', $name ) );
+
+                return;
+            }
+
+            $parsed = $this->parsedSchedule( $job );
+
+            if ( $parsed === null ) {
+
+                \OWA\Core\CoreAPI::notice( sprintf(
+                    'Job "%s" has an unreadable schedule "%s", so it will not run. '
+                  . 'It is deliberately not given a default -- running something on a cadence '
+                  . 'nobody chose is worse than not running it.',
+                    $name, $job['schedule']
+                ) );
+
+                return;
+            }
+
+            $slot = \OWA\Core\Cron::dueSlot(
+                $parsed,
+                $state ? (int) $state->get( 'last_run_slot' ) : 0,
+                time(),
+                $this->timezone()
+            );
+
+            if ( $slot === null ) {
+
+                \OWA\Core\CoreAPI::debug( sprintf( 'Job "%s" is not due.', $name ) );
+
+                return;
+            }
+        }
+
+        if ( $dry_run ) {
+
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Would run "%s" (%s%s).',
+                $name,
+                $job['command'],
+                $job['params'] ? ' ' . $this->encodeParams( $job['params'] ) : ''
+            ) );
+
+            return;
+        }
+
+        $this->runJob( $name, $job, $state, $slot );
+    }
+
+    /**
+     * Take the lock, run the command, record what happened.
+     *
+     * @param string $name
+     * @param array  $job
+     * @param object $state
+     * @param int|null $slot
+     * @return void
+     */
+    protected function runJob( $name, $job, $state, $slot ) {
+
+        $controller = $this->makeController( $job );
+
+        if ( ! $controller ) {
+
+            $this->record( $state, $job, 'failed', 'controller could not be constructed', time(), time(), null );
+
+            return;
+        }
+
+        $lease = new \OWA\Module\Base\Classes\JobLease( $name );
+
+        // The estimate is read-only and happens BEFORE the lock is taken, so two
+        // dispatchers estimating concurrently is harmless.
+        if ( ! $lease->acquire( $controller->getJobLease() ) ) {
+
+            \OWA\Core\CoreAPI::debug( sprintf( 'Job "%s" is already running; skipping this tick.', $name ) );
+
+            return;
+        }
+
+        $controller->setJobLease( $lease );
+
+        $began = time();
+
+        \OWA\Core\CoreAPI::notice( sprintf( 'Running "%s".', $name ) );
+
+        try {
+
+            $data    = $controller->doAction();
+            $outcome = $this->readOutcome( $controller, $data );
+
+        } catch ( \Throwable $t ) {
+
+            // A throw from one job is a fact about that job. Since the
+            // production error handler installs a global exception handler, an
+            // uncaught one would end the whole run and every job after it.
+            // \Throwable rather than \Exception: a TypeError from a third-party
+            // command must not take the dispatcher with it.
+            $outcome = array(
+                'outcome' => 'failed',
+                'message' => sprintf( '%s: %s', get_class( $t ), $t->getMessage() ),
+            );
+
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Job "%s" threw %s: %s', $name, get_class( $t ), $t->getMessage()
+            ) );
+
+        } finally {
+
+            $lease->release();
+        }
+
+        $this->record(
+            $state,
+            $job,
+            $outcome['outcome'],
+            $outcome['message'],
+            $began,
+            time(),
+            // Only ok and refused satisfy the occurrence. A refusal is an answer
+            // about it; a failure is not, so the job stays due and is retried.
+            in_array( $outcome['outcome'], array( 'ok', 'refused' ), true ) ? $slot : null
+        );
+    }
+
+    /**
+     * Construct the job's controller directly.
+     *
+     * Not through CoreAPI::handleRequest(), whose mergeParams() writes into the
+     * shared request container -- the dispatcher's own --dry-run would become
+     * every job's --dry-run. And not through performAction() either, because the
+     * object is needed afterwards to read its outcome.
+     *
+     * @param array $job
+     * @return object|null
+     */
+    protected function makeController( $job ) {
+
+        $s      = \OWA\Core\CoreAPI::serviceSingleton();
+        $action = $s->getCliCommandClass( $job['command'] );
+        $map    = $s->getMapValue( 'actions', $action );
+
+        if ( ! $map ) {
+
+            return null;
+        }
+
+        try {
+
+            return \OWA\Core\Lib::simpleFactory( $map['class_name'], $map['file'], (array) $job['params'] );
+
+        } catch ( \Throwable $t ) {
+
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Could not construct %s: %s', $job['command'], $t->getMessage()
+            ) );
+
+            return null;
+        }
+    }
+
+    /**
+     * What the command reported, allowing for commands that report nothing.
+     *
+     * @param object $controller
+     * @param mixed  $data
+     * @return array
+     */
+    protected function readOutcome( $controller, $data ) {
+
+        $data = is_array( $data ) ? $data : array();
+
+        // doAction() intercepts on its own account before reaching action().
+        if ( isset( $data['view'] ) && $data['view'] === 'base.error' ) {
+
+            return array( 'outcome' => 'failed', 'message' => 'capability check failed' );
+        }
+
+        if ( isset( $data['view'] ) && $data['view'] === 'base.genericCli' ) {
+
+            return array( 'outcome' => 'refused', 'message' => 'schema updates are pending' );
+        }
+
+        if ( method_exists( $controller, 'getCliOutcome' ) ) {
+
+            $outcome = $controller->getCliOutcome();
+
+            return array(
+                'outcome' => isset( $outcome['outcome'] ) ? $outcome['outcome'] : 'ok',
+                'message' => isset( $outcome['message'] ) ? $outcome['message'] : '',
+            );
+        }
+
+        return array( 'outcome' => 'ok', 'message' => '' );
+    }
+
+    /**
+     * Create the state row if it is missing, and hand it back.
+     *
+     * @param string $name
+     * @param bool   $dry_run
+     * @return object|null
+     */
+    protected function ensureState( $name, $dry_run = false ) {
+
+        $state = $this->state( $name );
+
+        if ( $state || $dry_run ) {
+
+            return $state;
+        }
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.scheduled_job' );
+
+        $entity->set( 'id', $entity->generateId( $name ) );
+        $entity->set( 'job_name', $name );
+        $entity->set( 'last_status', 'never run' );
+        $entity->set( 'last_message', '-' );
+        $entity->set( 'last_params', '-' );
+        $entity->create();
+
+        // Read back rather than trusting the insert: query() returns falsy on
+        // error without raising, so "it worked" has to be confirmed.
+        return $this->state( $name );
+    }
+
+    /**
+     * Write the outcome of a run.
+     *
+     * Only monotonic values and non-empty strings are ever written, because
+     * Entity::set() silently drops falsy ones -- which is also why there is no
+     * consecutive-failures counter to reset.
+     *
+     * @param object   $state
+     * @param array    $job
+     * @param string   $outcome
+     * @param string   $message
+     * @param int      $began
+     * @param int      $ended
+     * @param int|null $slot
+     * @return void
+     */
+    protected function record( $state, $job, $outcome, $message, $began, $ended, $slot ) {
+
+        if ( ! $state ) {
+
+            return;
+        }
+
+        $state->set( 'last_run_at', $began );
+        $state->set( 'last_finished_at', $ended );
+        $state->set( 'last_duration', max( 1, $ended - $began ) );
+        $state->set( 'last_status', $outcome );
+        $state->set( 'last_message', substr( $message ?: '-', 0, 250 ) );
+        $state->set( 'last_params', $this->encodeParams( $job['params'] ) );
+        $state->set( 'run_count', (int) $state->get( 'run_count' ) + 1 );
+
+        if ( $slot ) {
+
+            $state->set( 'last_run_slot', $slot );
+        }
+
+        if ( $outcome === 'failed' ) {
+
+            $state->set( 'last_failure_at', $ended );
+            $state->set( 'failure_count', (int) $state->get( 'failure_count' ) + 1 );
+
+        } else {
+
+            $state->set( 'last_success_at', $ended );
+        }
+
+        $state->update();
+
+        \OWA\Core\CoreAPI::notice( sprintf(
+            'Job "%s" finished: %s%s (%ds).',
+            $state->get( 'job_name' ),
+            $outcome,
+            $message ? ' -- ' . $message : '',
+            max( 1, $ended - $began )
+        ) );
+    }
+
+    /**
+     * Forget state for jobs that are no longer registered.
+     *
+     * Never automatic. A typo in OWA_SCHEDULED_JOBS de-registers a real job, and
+     * auto-pruning would then delete its entire run record -- turning an obvious
+     * mistake into an unrecoverable one. Deactivating a module is usually
+     * temporary too, and losing last_run_slot makes the job read as never-run
+     * when it comes back.
+     *
+     * @param array $jobs
+     * @return void
+     */
+    protected function pruneOrphans( $jobs ) {
+
+        $db      = \OWA\Core\CoreAPI::dbSingleton();
+        $pruned  = 0;
+
+        foreach ( $this->allState() as $name => $row ) {
+
+            if ( isset( $jobs[ $name ] ) ) {
+
+                continue;
+            }
+
+            \OWA\Core\CoreAPI::entityFactory( 'base.scheduled_job' )->delete( $name, 'job_name' );
+            $db->releaseJobLock( $name, $row['owner'] ?? '' );
+            $db->deleteJobLock( $name, time() + 86400 * 3650 );
+
+            \OWA\Core\CoreAPI::notice( sprintf( 'Pruned orphaned job "%s".', $name ) );
+
+            $pruned++;
+        }
+
+        \OWA\Core\CoreAPI::notice( sprintf( '%d orphaned job(s) pruned.', $pruned ) );
+    }
+
+    /**
+     * Drop a lock left behind by a process that died.
+     *
+     * The deliberate answer to "this lock is stuck and I want it back now",
+     * which is the real need behind wanting a shorter lease -- and a far better
+     * one, since it carries no standing risk of a duplicate run.
+     *
+     * @return void
+     */
+    protected function forceRelease() {
+
+        $name = $this->getParam( 'job' );
+
+        if ( ! $name ) {
+
+            return $this->refuse( 'Say which job: cmd=schedule-run --force-release job=NAME' );
+        }
+
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+        $lock = $db->getJobLock( $name );
+
+        if ( ! $lock ) {
+
+            \OWA\Core\CoreAPI::notice( sprintf( 'No lock held for "%s".', $name ) );
+
+            return;
+        }
+
+        $db->releaseJobLock( $name, $lock['owner'] );
+
+        \OWA\Core\CoreAPI::notice( sprintf(
+            'Released the lock on "%s", held since %s. If that job is in fact still running, '
+          . 'it may now run twice.',
+            $name, $this->readable( $lock['acquired_at'] )
+        ) );
+    }
+}

--- a/modules/Base/Controller/ScheduleStatusCli.php
+++ b/modules/Base/Controller/ScheduleStatusCli.php
@@ -1,0 +1,398 @@
+<?php
+namespace OWA\Module\Base\Controller;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * What the scheduler is doing, and why a job is not running.
+ *
+ *   php cli.php cmd=schedule-status
+ *
+ * Read-only. NEVER WRITES A ROW -- if it materialised state it would manufacture
+ * the very evidence it is being read for: run it once before cron has ever
+ * fired, and it would report that cron had fired.
+ *
+ * Saying only "this job is behind" makes the reader guess. This walks an ordered
+ * list of causes and names the first that holds, which works because every way a
+ * LIVE dispatcher can leave a job behind is directly observable -- so eliminating
+ * them makes "the scheduler is not running" a conclusion rather than a shrug.
+ *
+ * Nothing here alerts; a human has to run it. Real alerting is the ping-hook and
+ * mail-on-failure route, deliberately out of scope for now.
+ */
+class ScheduleStatusCli extends SchedulerCli {
+
+    /**
+     * How late an occurrence must be before it counts as behind rather than
+     * merely waiting for the next tick. One occurrence, or a quarter of an hour,
+     * whichever is longer -- so a daily job has to miss a whole day, and an
+     * every-minute job is flagged inside fifteen minutes.
+     */
+    const MIN_GRACE = 900;
+
+    function action() {
+
+        $now     = time();
+        $jobs    = $this->jobs();
+        $state   = $this->allState();
+        $enabled = (bool) \OWA\Core\CoreAPI::getSetting( 'base', 'scheduler_enabled' );
+        $pending = \OWA\Core\CoreAPI::isUpdateRequired();
+
+        $lines = array( sprintf(
+            'Scheduler status, %s (%s). %d job(s) registered.',
+            $this->readable( $now ), $this->timezone(), count( $jobs )
+        ) );
+
+        $lines[] = 'Expected cron entry:  * * * * * php ' . OWA_DIR . 'cli.php cmd=schedule-run';
+
+        if ( ! $enabled ) {
+
+            $lines[] = '';
+            $lines[] = 'The scheduler is DISABLED by OWA_SCHEDULER_ENABLED. No job will run.';
+        }
+
+        if ( $pending ) {
+
+            $lines[] = '';
+            $lines[] = 'ACTION: schema updates are pending, so the dispatcher refuses every job. '
+                     . 'Apply them with cmd=update. Nothing below will run until you do.';
+        }
+
+        // Any state row is proof the dispatcher has run at least once, because
+        // it is the only thing that writes them. That is what separates "cron
+        // was never installed" from "healthy, nothing due yet".
+        $ever = (bool) $state;
+        $last_activity = 0;
+
+        foreach ( $state as $row ) {
+
+            $last_activity = max( $last_activity, (int) ( $row['last_run_at'] ?? 0 ) );
+        }
+
+        foreach ( $jobs as $name => $job ) {
+
+            $lines[] = '';
+            $lines   = array_merge( $lines, $this->describeJob(
+                $name, $job, $state[ $name ] ?? null, $now, $enabled, $pending, $ever, $last_activity
+            ) );
+        }
+
+        $lines = array_merge( $lines, $this->describeOrphans( $jobs, $state ) );
+        $lines = array_merge( $lines, $this->summarise( $jobs, $state, $ever, $last_activity, $now ) );
+
+        $this->write( $lines );
+    }
+
+    /**
+     * One job's block.
+     *
+     * @return string[]
+     */
+    protected function describeJob( $name, $job, $row, $now, $enabled, $pending, $ever, $last_activity ) {
+
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+        $lock   = $db->getJobLock( $name );
+        $parsed = $this->parsedSchedule( $job );
+
+        $lines = array( sprintf(
+            '%s    %s (%s)',
+            $name,
+            $this->isDisabled( $job ) ? 'off' : \OWA\Core\Cron::describe( $job['schedule'] ),
+            $job['source']
+        ) );
+
+        $lines[] = sprintf( '  runs         %s%s',
+            $job['command'],
+            $job['params'] ? ' ' . $this->encodeParams( $job['params'] ) : ' (no arguments)'
+        );
+
+        if ( $parsed ) {
+
+            $next = \OWA\Core\Cron::nextAfter( $parsed, $now, $this->timezone() );
+
+            $lines[] = sprintf( '  next due     %s', $this->readable( $next, 'unknown' ) );
+        }
+
+        if ( ! $row ) {
+
+            $lines[] = '  last run     never';
+
+        } else {
+
+            $lines[] = sprintf( '  last run     %s, %s%s',
+                $this->readable( $row['last_run_at'] ),
+                $row['last_status'] ?: 'unknown',
+                ( $row['last_duration'] ?? 0 ) ? sprintf( ' (%ds)', (int) $row['last_duration'] ) : ''
+            );
+
+            if ( ! empty( $row['last_message'] ) && $row['last_message'] !== '-' ) {
+
+                $lines[] = sprintf( '               %s', $row['last_message'] );
+            }
+
+            $lines[] = sprintf( '  history      %d run(s), %d failed',
+                (int) ( $row['run_count'] ?? 0 ), (int) ( $row['failure_count'] ?? 0 ) );
+
+            // The arguments a run used are recorded, so a change is visible
+            // BEFORE it takes effect rather than diagnosed afterwards.
+            $current = $this->encodeParams( $job['params'] );
+
+            if ( ! empty( $row['last_params'] ) && $row['last_params'] !== $current ) {
+
+                $lines[] = sprintf(
+                    '  NOTE         arguments have changed since the last run: was "%s", now "%s".',
+                    $row['last_params'], $current
+                );
+            }
+        }
+
+        $reason = $this->diagnose( $name, $job, $row, $lock, $parsed, $now, $enabled, $pending, $ever, $last_activity );
+
+        if ( $reason ) {
+
+            $lines[] = '  ACTION       ' . $reason;
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Why is this job not running? The first cause that holds, in order.
+     *
+     * @return string|null  null when there is nothing to say
+     */
+    protected function diagnose( $name, $job, $row, $lock, $parsed, $now, $enabled, $pending, $ever, $last_activity ) {
+
+        // Global causes outrank everything: nothing else can be true while they
+        // are, and they are already stated at the top of the report.
+        if ( $pending || ! $enabled ) {
+
+            return null;
+        }
+
+        if ( ! \OWA\Core\CoreAPI::serviceSingleton()->getCliCommandClass( $job['command'] ) ) {
+
+            // Reachable for a job registered in code naming a command that has
+            // since been removed; config entries are refused before they get
+            // this far.
+            return sprintf(
+                'Names command "%s", which is not registered, so it can never run.', $job['command']
+            );
+        }
+
+        if ( $this->isDisabled( $job ) ) {
+
+            return null;   // not behind; deliberately not running
+        }
+
+        if ( $parsed === null ) {
+
+            return sprintf(
+                'The schedule "%s" cannot be read, so this job will never run. It is deliberately '
+              . 'not given a default.', $job['schedule']
+            );
+        }
+
+        if ( $lock && (int) $lock['expires_at'] > $now ) {
+
+            return sprintf( 'Running now, since %s.', $this->readable( $lock['acquired_at'] ) );
+        }
+
+        if ( $lock ) {
+
+            return sprintf(
+                'A lock from %s is still present and its lease expired at %s -- the run holding it '
+              . 'died. It will be taken over on the next tick, or drop it now with '
+              . 'cmd=schedule-run --force-release job=%s',
+                $this->readable( $lock['acquired_at'] ), $this->readable( $lock['expires_at'] ), $name
+            );
+        }
+
+        // Is it actually behind, or just waiting for the next tick?
+        $slot = \OWA\Core\Cron::dueSlot(
+            $parsed, $row ? (int) $row['last_run_slot'] : 0, $now, $this->timezone()
+        );
+
+        if ( $slot === null ) {
+
+            return null;   // up to date
+        }
+
+        $next     = \OWA\Core\Cron::nextAfter( $parsed, $slot, $this->timezone() );
+        $interval = $next ? $next - $slot : self::MIN_GRACE;
+        $last     = $row ? (int) $row['last_run_slot'] : 0;
+
+        // Has a WHOLE occurrence been missed, or has this one merely just come
+        // due? Measuring "how long since the newest missed occurrence" would be
+        // wrong: a daily job forty days behind still has a slot from this
+        // morning, and would read as minutes late rather than weeks.
+        $missed_earlier = $last > 0
+            && \OWA\Core\Cron::dueSlot( $parsed, $last, $slot - 60, $this->timezone() ) !== null;
+
+        if ( ! $missed_earlier && $now - $slot <= self::MIN_GRACE ) {
+
+            return null;   // due, but within the tolerance of a normal tick
+        }
+
+        // Lateness runs from when it SHOULD have next run after its last
+        // satisfied occurrence, which is what a person means by "overdue by".
+        $late = $this->howLate( $last > 0 ? max( 60, $now - ( $last + $interval ) ) : $now - $slot );
+
+        if ( $row && (int) $row['last_finished_at'] && (int) $row['last_finished_at'] < (int) $row['last_run_at'] ) {
+
+            return sprintf(
+                'Overdue by %s. The last run started %s and never finished -- a fatal error or the '
+              . 'process being killed, which nothing inside PHP could have caught.',
+                $late, $this->readable( $row['last_run_at'] )
+            );
+        }
+
+        if ( $row && (int) $row['last_failure_at'] > (int) $row['last_success_at'] ) {
+
+            return sprintf(
+                'Overdue by %s. Failing since %s: %s. It is retried at every tick.',
+                $late, $this->readable( $row['last_failure_at'] ), $row['last_message'] ?: 'no message recorded'
+            );
+        }
+
+        if ( $row && $row['last_status'] === 'refused' ) {
+
+            return sprintf(
+                'Overdue by %s. The last run declined to act: %s',
+                $late, $row['last_message'] ?: 'no reason recorded'
+            );
+        }
+
+        // Everything a running dispatcher could be doing about this job has been
+        // excluded, which is what makes the remaining conclusion sound rather
+        // than a guess.
+        if ( ! $ever ) {
+
+            return sprintf(
+                'Overdue by %s, and no job has EVER recorded a run -- the dispatcher has not run at '
+              . 'all. That almost always means the cron entry is missing or wrong. Add:  '
+              . '* * * * * php %scli.php cmd=schedule-run',
+                $late, OWA_DIR
+            );
+        }
+
+        if ( $last_activity && $now - $last_activity < self::MIN_GRACE ) {
+
+            return sprintf(
+                'Overdue by %s, but another job ran at %s, so the dispatcher is alive. The problem '
+              . 'is specific to this job.',
+                $late, $this->readable( $last_activity )
+            );
+        }
+
+        return sprintf(
+            'Overdue by %s and nothing above explains it. The dispatcher does not appear to be '
+          . 'running -- the last activity of any kind was %s. Check the cron entry:  '
+          . '* * * * * php %scli.php cmd=schedule-run',
+            $late, $this->readable( $last_activity ), OWA_DIR
+        );
+    }
+
+    /**
+     * @param int $seconds
+     * @return string
+     */
+    protected function howLate( $seconds ) {
+
+        if ( $seconds >= 86400 ) {
+
+            return sprintf( '%d day(s)', intdiv( $seconds, 86400 ) );
+        }
+
+        if ( $seconds >= 3600 ) {
+
+            return sprintf( '%d hour(s)', intdiv( $seconds, 3600 ) );
+        }
+
+        return sprintf( '%d minute(s)', max( 1, intdiv( $seconds, 60 ) ) );
+    }
+
+    /**
+     * State rows for jobs nothing registers any more.
+     *
+     * Kept rather than deleted, so a job that vanished through a config typo is
+     * visible instead of silently gone.
+     *
+     * @return string[]
+     */
+    protected function describeOrphans( $jobs, $state ) {
+
+        $orphans = array_diff_key( $state, $jobs );
+
+        if ( ! $orphans ) {
+
+            return array();
+        }
+
+        $lines = array( '', sprintf( 'Orphaned (%d) -- no longer registered, never run, kept for their history:', count( $orphans ) ) );
+
+        foreach ( $orphans as $name => $row ) {
+
+            $lines[] = sprintf( '  %-28s last run %s, %s',
+                $name, $this->readable( $row['last_run_at'] ), $row['last_status'] ?: 'unknown' );
+        }
+
+        $lines[] = '  Remove them with cmd=schedule-run --prune-orphans (never automatic: a typo in';
+        $lines[] = '  OWA_SCHEDULED_JOBS de-registers a real job, and auto-pruning would delete its history).';
+
+        return $lines;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function summarise( $jobs, $state, $ever, $last_activity, $now ) {
+
+        $lines = array( '' );
+
+        if ( ! $jobs ) {
+
+            $lines[] = 'No jobs are registered.';
+
+            return $lines;
+        }
+
+        if ( ! $ever ) {
+
+            $lines[] = 'The dispatcher has never run. Until the cron entry above is in place, nothing here happens.';
+
+            return $lines;
+        }
+
+        $lines[] = sprintf(
+            '%d job(s) registered. Last activity of any kind: %s.',
+            count( $jobs ), $this->readable( $last_activity )
+        );
+
+        // A hint about a job that could exist, rather than a report about one
+        // that does: queue processing is not shipped registered, because whether
+        // to drain at all depends on the installation.
+        if ( \OWA\Core\CoreAPI::getSetting( 'base', 'queue_events' ) ) {
+
+            $drains = false;
+
+            foreach ( $jobs as $job ) {
+
+                if ( stripos( $job['command'], 'queue' ) !== false ) {
+
+                    $drains = true;
+                }
+            }
+
+            if ( ! $drains ) {
+
+                $lines[] = 'NOTE: event queueing is enabled but no job drains the queue. If nothing else '
+                         . 'processes it, add one -- see OWA_SCHEDULED_JOBS in owa-config.php.';
+            }
+        }
+
+        return $lines;
+    }
+}

--- a/modules/Base/Controller/SchedulerCli.php
+++ b/modules/Base/Controller/SchedulerCli.php
@@ -1,0 +1,184 @@
+<?php
+namespace OWA\Module\Base\Controller;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * Shared behaviour for schedule-run and schedule-status.
+ *
+ * The job registry comes from the module registrations overlaid with
+ * OWA_SCHEDULED_JOBS, and the state rows come from owa_scheduled_job. Both
+ * commands need to resolve the same jobs the same way, so that lives here
+ * rather than being written twice and drifting.
+ */
+abstract class SchedulerCli extends \OWA\Core\Controller\Cli {
+
+    function __construct( $params ) {
+
+        $this->setRequiredCapability( 'edit_modules' );
+
+        parent::__construct( $params );
+    }
+
+    /**
+     * Every registered job, keyed by name.
+     *
+     * @return array
+     */
+    protected function jobs() {
+
+        $s = \OWA\Core\CoreAPI::serviceSingleton();
+
+        $s->loadCliCommands();
+        $s->loadJobs();
+
+        return $s->getJobs();
+    }
+
+    /**
+     * The timezone schedules are read in.
+     *
+     * The installation's own, the same one reports render in, so "04:00" means
+     * what the person reading the reports means by it.
+     *
+     * @return string
+     */
+    protected function timezone() {
+
+        $tz = \OWA\Core\CoreAPI::getSetting( 'base', 'timezone' );
+
+        return $tz ? $tz : date_default_timezone_get();
+    }
+
+    /**
+     * A job's parsed schedule, or null when it is off or unreadable.
+     *
+     * @param array $job
+     * @return array|null
+     */
+    protected function parsedSchedule( $job ) {
+
+        $expr = isset( $job['schedule'] ) ? strtolower( trim( (string) $job['schedule'] ) ) : '';
+
+        if ( $expr === '' || $expr === 'off' ) {
+
+            return null;
+        }
+
+        return \OWA\Core\Cron::parse( $expr );
+    }
+
+    /**
+     * Is this job switched off rather than merely unreadable?
+     *
+     * @param array $job
+     * @return bool
+     */
+    protected function isDisabled( $job ) {
+
+        $expr = isset( $job['schedule'] ) ? strtolower( trim( (string) $job['schedule'] ) ) : '';
+
+        return $expr === '' || $expr === 'off';
+    }
+
+    /**
+     * The state row for a job, or null.
+     *
+     * READ BY job_name, NEVER BY id. Lib::setStringGuid() branches on the
+     * use_64bit_hash setting, so flipping that on a live installation would
+     * change what generateId() returns for the same name -- a read by id would
+     * then miss the existing row and insert a second one, colliding on job_name
+     * but not on id.
+     *
+     * @param string $name
+     * @return \OWA\Core\Entity|null
+     */
+    protected function state( $name ) {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.scheduled_job' );
+
+        $entity->getByColumn( 'job_name', $name );
+
+        return $entity->wasPersisted() ? $entity : null;
+    }
+
+    /**
+     * Every state row, keyed by job name.
+     *
+     * @return array
+     */
+    protected function allState() {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.scheduled_job' );
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+
+        $rows = $db->get_results( sprintf( 'SELECT * FROM %s', $entity->getTableName() ) );
+        $out  = array();
+
+        foreach ( (array) $rows as $row ) {
+
+            $row = (array) $row;
+
+            if ( isset( $row['job_name'] ) ) {
+
+                $out[ $row['job_name'] ] = $row;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * A timestamp as a person reads it, in the installation's zone.
+     *
+     * @param int|null $ts
+     * @param string   $absent
+     * @return string
+     */
+    protected function readable( $ts, $absent = 'never' ) {
+
+        if ( ! $ts ) {
+
+            return $absent;
+        }
+
+        try {
+
+            return ( new \DateTimeImmutable( '@' . (int) $ts ) )
+                ->setTimezone( new \DateTimeZone( $this->timezone() ) )
+                ->format( 'Y-m-d H:i' );
+
+        } catch ( \Exception $e ) {
+
+            return (string) $ts;
+        }
+    }
+
+    /**
+     * Params rendered for the record, never for re-parsing.
+     *
+     * '-' rather than '' when there are none, because Entity::set() drops falsy
+     * values and an empty string would silently fail to write.
+     *
+     * @param array $params
+     * @return string
+     */
+    protected function encodeParams( $params ) {
+
+        if ( ! $params ) {
+
+            return '-';
+        }
+
+        $pairs = array();
+
+        foreach ( (array) $params as $k => $v ) {
+
+            $pairs[] = $k . '=' . ( is_scalar( $v ) ? $v : json_encode( $v ) );
+        }
+
+        return substr( implode( ' ', $pairs ), 0, 250 );
+    }
+}

--- a/modules/Base/Entity/JobLock.php
+++ b/modules/Base/Entity/JobLock.php
@@ -1,0 +1,64 @@
+<?php
+namespace OWA\Module\Base\Entity;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * One lock per scheduled job, so a job can never overlap itself.
+ *
+ * THE ROW'S EXISTENCE IS THE LOCK, and its primary key supplies the atomicity.
+ * Acquiring is a plain INSERT; the loser of a race gets a constraint violation
+ * and simply does not run. No transaction, no SELECT ... FOR UPDATE, no
+ * engine-specific syntax -- every database enforces uniqueness, so this behaves
+ * identically everywhere. This is Laravel's cache_locks design, and it is why
+ * MySQL's GET_LOCK was rejected: that works on one driver only, and baking a
+ * driver dependency into core scheduling is the portability regression to avoid.
+ *
+ * Per job rather than one global scheduler lock, so a long queue drain cannot
+ * starve partition-rotate while still guaranteeing no drain overlaps another.
+ *
+ * NOTHING PRUNES THIS TABLE, because nothing accumulates: job_name is the
+ * primary key, so there is at most one row per job and the table is bounded by
+ * the registry. An expired row is not litter either -- the next acquire for that
+ * name takes it over rather than leaving it behind. Laravel needs a pruning
+ * lottery because cache_locks is keyed by arbitrary strings and is unbounded;
+ * that condition does not hold here. The only row that can genuinely linger
+ * belongs to a job that no longer exists, which schedule-run --prune-orphans
+ * removes along with its state row.
+ */
+class JobLock extends \OWA\Core\Entity {
+
+    function __construct() {
+
+        $this->setTableName('job_lock');
+
+        // The lock itself. Not an auto-increment id: uniqueness of the JOB NAME
+        // is the mutual exclusion, so the name must be the primary key.
+        $job_name = new \OWA\Module\Base\Classes\DbColumn( 'job_name', OWA_DTD_VARCHAR255 );
+        $job_name->setPrimaryKey();
+        $this->setProperty($job_name);
+
+        // A token unique to the acquiring process. Release deletes only your
+        // own row, so a process that took over an expired lock cannot be
+        // released by the original holder finishing late and tidying up.
+        $owner = new \OWA\Module\Base\Classes\DbColumn( 'owner', OWA_DTD_VARCHAR255 );
+        $this->setProperty($owner);
+
+        $acquired_at = new \OWA\Module\Base\Classes\DbColumn( 'acquired_at', OWA_DTD_INT );
+        $this->setProperty($acquired_at);
+
+        // A CRASH-RECOVERY TIMEOUT, NOT A RUNTIME BUDGET. Nothing enforces it:
+        // there is no timer and no reaper. It is consulted only when another
+        // process tries to acquire -- present and unexpired means skip, present
+        // and expired means treat as abandoned and take over. A job that
+        // outruns its lease is not killed; it keeps going, unaware, while a
+        // later tick stops respecting its lock. Too short duplicates a long
+        // job; too long delays recovery after a crash. Asymmetric, so the
+        // default errs long.
+        $expires_at = new \OWA\Module\Base\Classes\DbColumn( 'expires_at', OWA_DTD_INT );
+        $this->setProperty($expires_at);
+
+    }
+}

--- a/modules/Base/Entity/ScheduledJob.php
+++ b/modules/Base/Entity/ScheduledJob.php
@@ -1,0 +1,96 @@
+<?php
+namespace OWA\Module\Base\Entity;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * What the scheduler knows about each job it has run.
+ *
+ * One row per job, materialised by the dispatcher. It exists primarily for ONE
+ * column -- last_run_slot -- which is what makes the scheduler level-triggered:
+ * without it the only question that could be asked is "does the expression match
+ * this minute", and a missed minute would mean a missed month. Everything else
+ * here is observability, and is what schedule-status reads.
+ *
+ * NO SCHEDULE OR PARAMS COLUMNS. Both are resolved fresh at every tick from the
+ * module registry plus OWA_SCHEDULED_JOBS, so there is no second source of truth
+ * to drift and nothing to migrate when either changes. last_params is a record
+ * of what a past run used, never an input to the next one.
+ *
+ * EVERY COLUMN IS EITHER A NON-EMPTY STRING OR MONOTONIC. That is a constraint,
+ * not an accident: Entity::set() skips falsy values, and partialUpdate() carries
+ * the same guard, so nothing in the entity layer can write 0, '' or null. A
+ * counter that had to be reset to zero would be unwritable. Hence
+ * last_success_at / last_failure_at rather than a consecutive_failures field --
+ * which also carries more information: "currently failing" is
+ * last_failure_at > last_success_at, and "failing since" is last_failure_at.
+ */
+class ScheduledJob extends \OWA\Core\Entity {
+
+    function __construct() {
+
+        $this->setTableName('scheduled_job');
+
+        // Derived from the job name so a duplicate state row is impossible at
+        // the storage layer. NEVER USED AS A LOOKUP KEY: Lib::setStringGuid()
+        // branches on the use_64bit_hash setting, so flipping that on a live
+        // install would change what generateId() returns for the same name, and
+        // a read by id would miss the existing row and then insert a second one
+        // colliding on job_name but not on id. Every read and write keys on
+        // job_name.
+        $id = new \OWA\Module\Base\Classes\DbColumn( 'id', OWA_DTD_BIGINT );
+        $id->setPrimaryKey();
+        $this->setProperty($id);
+
+        $job_name = new \OWA\Module\Base\Classes\DbColumn( 'job_name', OWA_DTD_VARCHAR255 );
+        $job_name->setIndex();
+        $this->setProperty($job_name);
+
+        // The occurrence the last run satisfied -- NOT when it ran. The due
+        // test reads this and nothing else. Keeping it separate from
+        // last_run_at makes the decision independent of how long a run took.
+        $last_run_slot = new \OWA\Module\Base\Classes\DbColumn( 'last_run_slot', OWA_DTD_INT );
+        $this->setProperty($last_run_slot);
+
+        $last_run_at = new \OWA\Module\Base\Classes\DbColumn( 'last_run_at', OWA_DTD_INT );
+        $this->setProperty($last_run_at);
+
+        // last_finished_at < last_run_at means the process died mid-job. A
+        // crash detector that needs no shutdown handler -- which could itself
+        // fail to run, which is the whole problem with shutdown handlers.
+        $last_finished_at = new \OWA\Module\Base\Classes\DbColumn( 'last_finished_at', OWA_DTD_INT );
+        $this->setProperty($last_finished_at);
+
+        $last_duration = new \OWA\Module\Base\Classes\DbColumn( 'last_duration', OWA_DTD_INT );
+        $this->setProperty($last_duration);
+
+        // 'ok' | 'refused' | 'failed'. Always non-empty.
+        $last_status = new \OWA\Module\Base\Classes\DbColumn( 'last_status', OWA_DTD_VARCHAR255 );
+        $this->setProperty($last_status);
+
+        $last_message = new \OWA\Module\Base\Classes\DbColumn( 'last_message', OWA_DTD_VARCHAR255 );
+        $this->setProperty($last_message);
+
+        // The arguments the last run actually used. Scheduling never reads it;
+        // it is here so the history can answer WHY a run behaved as it did. Add
+        // keep=24 in config and a rotate starts deleting partitions -- without
+        // this the row would say 'ok' and nothing else.
+        $last_params = new \OWA\Module\Base\Classes\DbColumn( 'last_params', OWA_DTD_VARCHAR255 );
+        $this->setProperty($last_params);
+
+        $last_success_at = new \OWA\Module\Base\Classes\DbColumn( 'last_success_at', OWA_DTD_INT );
+        $this->setProperty($last_success_at);
+
+        $last_failure_at = new \OWA\Module\Base\Classes\DbColumn( 'last_failure_at', OWA_DTD_INT );
+        $this->setProperty($last_failure_at);
+
+        $run_count = new \OWA\Module\Base\Classes\DbColumn( 'run_count', OWA_DTD_INT );
+        $this->setProperty($run_count);
+
+        $failure_count = new \OWA\Module\Base\Classes\DbColumn( 'failure_count', OWA_DTD_INT );
+        $this->setProperty($failure_count);
+
+    }
+}

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -46,7 +46,7 @@ class Module extends \OWA\Core\Module {
         $this->version = 11;
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
-        $this->required_schema_version = 14;
+        $this->required_schema_version = 15;
         return parent::__construct();
     }
 
@@ -585,6 +585,8 @@ class Module extends \OWA\Core\Module {
         $this->registerAction( 'base.processRequest',                'OWA\\Module\\Base\\Controller\\ProcessRequest',               'Controller/ProcessRequest.php' );
         $this->registerAction( 'base.pruneEventQueueArchivesCli',    'OWA\\Module\\Base\\Controller\\PruneEventQueueArchivesCli',   'Controller/PruneEventQueueArchivesCli.php' );
         $this->registerAction( 'base.partitionStatusCli',            'OWA\\Module\\Base\\Controller\\PartitionStatusCli',         'Controller/PartitionStatusCli.php' );
+        $this->registerAction( 'base.scheduleRunCli',                'OWA\\Module\\Base\\Controller\\ScheduleRunCli',             'Controller/ScheduleRunCli.php' );
+        $this->registerAction( 'base.scheduleStatusCli',             'OWA\\Module\\Base\\Controller\\ScheduleStatusCli',          'Controller/ScheduleStatusCli.php' );
         $this->registerAction( 'base.partitionInitCli',              'OWA\\Module\\Base\\Controller\\PartitionInitCli',           'Controller/PartitionInitCli.php' );
         $this->registerAction( 'base.partitionDropCli',              'OWA\\Module\\Base\\Controller\\PartitionDropCli',           'Controller/PartitionDropCli.php' );
         $this->registerAction( 'base.partitionReorganizeCli',        'OWA\\Module\\Base\\Controller\\PartitionReorganizeCli',     'Controller/PartitionReorganizeCli.php' );
@@ -713,6 +715,35 @@ class Module extends \OWA\Core\Module {
         $this->registerCliCommand('update-referral', 'base.crawlReferralCli');
         $this->registerCliCommand('update-document', 'base.crawlDocumentCli');
         $this->registerCliCommand('reset-secrets', 'base.resetSecretsCli');
+        $this->registerCliCommand('schedule-run', 'base.scheduleRunCli');
+        $this->registerCliCommand('schedule-status', 'base.scheduleStatusCli');
+    }
+
+    /**
+     * Register Scheduled Jobs
+     *
+     * Run by cmd=schedule-run, which belongs in cron every minute:
+     *
+     *   * * * * * php /path/to/owa/cli.php cmd=schedule-run
+     *
+     * Only partition-rotate ships registered. It is the one whose absence fails
+     * silently and slowly on every installation -- the partition lead expires,
+     * rows pile into the catch-all, reports keep working, and nobody notices
+     * until a rotate has to rewrite a year of data with writes blocked.
+     *
+     * Queue processing is deliberately NOT shipped: whether to drain the queue
+     * at all, and how often, depends on an installation's traffic and on whether
+     * it queues in the first place. It is added in OWA_SCHEDULED_JOBS when
+     * wanted -- see owa_settings::applyConfigConstants().
+     */
+    function registerJobs() {
+
+        // Registered with EMPTY params on purpose: no keep=, so nothing is ever
+        // deleted. An installation that wants retention states it in
+        // OWA_SCHEDULED_JOBS, which is the deliberate act it should be.
+        // Retention must never arrive as a side effect of turning the scheduler
+        // on. ScheduleCliTest pins the empty array for exactly that reason.
+        $this->registerJob( 'partition-rotate', 'partition-rotate', '@monthly', array() );
     }
 
     /**
@@ -2518,6 +2549,8 @@ class Module extends \OWA\Core\Module {
                 'commerce_transaction_fact',
                 'commerce_line_item_fact',
                 'queue_item',
+                'scheduled_job',
+                'job_lock',
                 'site_user')
             );
 

--- a/modules/Base/Update/Update015.php
+++ b/modules/Base/Update/Update015.php
@@ -1,0 +1,62 @@
+<?php
+namespace OWA\Module\Base\Update;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * The scheduler's two tables.
+ *
+ * owa_scheduled_job holds per-job state -- above all last_run_slot, which is
+ * what lets the scheduler stay due until it has actually run rather than only
+ * at the exact minute an expression matches.
+ *
+ * owa_job_lock holds one row per running job, where the row's existence IS the
+ * lock.
+ *
+ * Creating two small tables is fast and takes no locks worth worrying about, so
+ * this does not require CLI mode -- unlike the updates that rewrite fact tables.
+ *
+ * The DDL is CREATE TABLE IF NOT EXISTS, so this is idempotent and converges
+ * with a fresh install, which creates both through Core\Module::install()'s
+ * entity loop rather than through here.
+ *
+ * It deliberately creates the tables and NOT their contents. Rows are written
+ * only by the dispatcher, which is what lets "any state row exists" stand as
+ * proof that the dispatcher has run at least once -- the check schedule-status
+ * uses to tell a missing crontab entry from a healthy but idle installation.
+ */
+class Update015 extends \OWA\Core\Update {
+
+    var $schema_version = 15;
+
+    var $is_cli_mode_required = false;
+
+    function up($force = false) {
+
+        foreach ( array( 'scheduled_job', 'job_lock' ) as $name ) {
+
+            $entity = \OWA\Core\CoreAPI::entityFactory( 'base.' . $name );
+
+            if ( $entity->createTable() === false ) {
+
+                $this->e->notice( sprintf( 'Create table %s failed', $name ) );
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    function down() {
+
+        foreach ( array( 'scheduled_job', 'job_lock' ) as $name ) {
+
+            \OWA\Core\CoreAPI::entityFactory( 'base.' . $name )->dropTable();
+        }
+
+        return true;
+    }
+}

--- a/owa-config-dist.php
+++ b/owa-config-dist.php
@@ -118,4 +118,73 @@ define('OWA_PUBLIC_URL', 'http://domain/path/to/owa/');
 
 //define('OWA_USE_STATIC_CONFIG_ONLY', true);
 
+
+/**
+ * SCHEDULED JOBS
+ *
+ * OWA runs its periodic maintenance from a SINGLE cron entry:
+ *
+ *   * * * * * php /path/to/owa/cli.php cmd=schedule-run
+ *
+ * Every minute, because that line is not the schedule -- it is the finest
+ * resolution the schedules below can use. Each job decides for itself how often
+ * it actually runs. A boot costs about 66ms, so a day of ticks is roughly 95
+ * seconds of CPU.
+ *
+ * Out of the box exactly one job is registered: partition-rotate, monthly, with
+ * NO arguments -- it extends the fact tables' partition lead and merges old
+ * periods to stay within the open-file budget, and never deletes anything.
+ *
+ * Use OWA_SCHEDULED_JOBS to retune what ships, to add jobs the release does not
+ * register, or to turn one off. It is keyed by JOB NAME; 'command' is the CLI
+ * command that actually runs. They are separate so one command can be scheduled
+ * more than once with different arguments.
+ *
+ * Overrides are per key: giving only 'params' keeps the shipped schedule, and
+ * giving only 'schedule' keeps the shipped arguments.
+ *
+ * Schedules are standard five-field cron expressions, or the usual @hourly,
+ * @daily, @weekly, @monthly and @yearly shorthands, or 'off'. They are read in
+ * this installation's configured timezone. An entry that cannot be read disables
+ * THAT job and nothing else -- it is never given a default, because running
+ * something on a cadence nobody chose is worse than not running it.
+ *
+ * Check what is registered, and why anything is not running, with:
+ *
+ *   php cli.php cmd=schedule-status
+ */
+
+//define('OWA_SCHEDULED_JOBS', array(
+//
+//    // Keep two years of history. NOTHING is deleted unless you ask for it
+//    // here: the shipped job runs with no keep= at all.
+//    'partition-rotate' => array( 'params' => array( 'keep' => 24 ) ),
+//
+//    // Drain the event queue every two minutes. Not registered by default,
+//    // because whether to drain at all depends on whether you queue events.
+//    'drain-queue' => array(
+//        'command'  => 'processEventQueue',
+//        'schedule' => '*/2 * * * *',
+//    ),
+//
+//    // The same command a second time, under its own name, with its own
+//    // arguments and cadence.
+//    'rotate-request-table' => array(
+//        'command'  => 'partition-rotate',
+//        'params'   => array( 'table' => 'owa_request' ),
+//        'schedule' => '@weekly',
+//    ),
+//
+//    // Turn a shipped job off.
+//    // 'partition-rotate' => array( 'schedule' => 'off' ),
+//));
+
+/**
+ * DISABLE THE SCHEDULER
+ *
+ * Stops every job without touching crontab -- for a migration or an incident.
+ */
+
+//define('OWA_SCHEDULER_ENABLED', false);
+
 ?>

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -154,6 +154,8 @@ function owa_compat_class_map(): array
         'owa_location_dim' => 'OWA\\Module\\Base\\Entity\\LocationDim',
         'owa_os' => 'OWA\\Module\\Base\\Entity\\Os',
         'owa_queue_item' => 'OWA\\Module\\Base\\Entity\\QueueItem',
+        'owa_job_lock' => 'OWA\\Module\\Base\\Entity\\JobLock',
+        'owa_scheduled_job' => 'OWA\\Module\\Base\\Entity\\ScheduledJob',
         'owa_referer' => 'OWA\\Module\\Base\\Entity\\Referer',
         'owa_request' => 'OWA\\Module\\Base\\Entity\\Request',
         'owa_search_term_dim' => 'OWA\\Module\\Base\\Entity\\SearchTermDim',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -49,6 +49,12 @@ parameters:
 			path: Core/CoreAPI.php
 
 		-
+			message: '#^Call to method getTableName\(\) on an unknown class OWA\\Core\\unknown\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Core/Db.php
+
+		-
 			message: '#^Call to method load\(\) on an unknown class OWA\\Core\\unknown\.$#'
 			identifier: class.notFound
 			count: 3
@@ -147,7 +153,7 @@ parameters:
 		-
 			message: '#^Call to an undefined method OWA\\Core\\Db\:\:query\(\)\.$#'
 			identifier: method.notFound
-			count: 22
+			count: 26
 			path: Core/Db.php
 
 		-
@@ -227,6 +233,12 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: Core/View.php
+
+		-
+			message: '#^Call to an undefined method OWA\\Core\\Db\:\:get_row\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Core/Db.php
 
 		-
 			message: '#^Call to an undefined method OWA\\Core\\Db\:\:get_row\(\)\.$#'

--- a/phpstan-migration-baseline.neon
+++ b/phpstan-migration-baseline.neon
@@ -61,9 +61,15 @@ parameters:
 			path: Core/Db.php
 
 		-
+			message: '#^Call to an undefined method OWA\\Core\\Db\:\:get_row\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: Core/Db.php
+
+		-
 			message: '#^Call to an undefined method OWA\\Core\\Db\:\:query\(\)\.$#'
 			identifier: method.notFound
-			count: 22
+			count: 26
 			path: Core/Db.php
 
 		-

--- a/tests/CronTest.php
+++ b/tests/CronTest.php
@@ -1,0 +1,445 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Cron parsing and the level-triggered due test.
+ *
+ * Pure: no database, no clock, no settings — so unlike most of this suite it
+ * runs everywhere, including the CI job that has no database and skips 232
+ * tests. That matters, because this is where the scheduler's correctness lives.
+ *
+ * The expectations are written out as literal dates rather than recomputed with
+ * the same expression the implementation uses. A test that says
+ * `assertSame(date('Ymd', strtotime($x)), subject($x))` asserts nothing except
+ * that PHP is consistent with itself.
+ */
+final class CronTest extends TestCase
+{
+    /** The zone every case is expressed in, chosen because it observes DST. */
+    private const TZ = 'America/Los_Angeles';
+
+    private function at(string $iso): int
+    {
+        return (new DateTimeImmutable($iso, new DateTimeZone(self::TZ)))->getTimestamp();
+    }
+
+    private function parse(string $expr): array
+    {
+        $parsed = \OWA\Core\Cron::parse($expr);
+        $this->assertIsArray($parsed, "should have parsed: $expr");
+
+        return $parsed;
+    }
+
+    // -----------------------------------------------------------------------
+    // Parsing
+    // -----------------------------------------------------------------------
+
+    public function testParsesEveryFieldForm()
+    {
+        $cases = [
+            // expression          field index  expected values
+            ['* * * * *',          0, range(0, 59)],
+            ['5 * * * *',          0, [5]],
+            ['0,30 * * * *',       0, [0, 30]],
+            ['1-5 * * * *',        0, [1, 2, 3, 4, 5]],
+            ['*/15 * * * *',       0, [0, 15, 30, 45]],
+            ['0-10/5 * * * *',     0, [0, 5, 10]],
+            ['5/10 * * * *',       0, [5, 15, 25, 35, 45, 55]],
+            ['1,3,5-7 * * * *',    0, [1, 3, 5, 6, 7]],
+            ['* 0 * * *',          1, [0]],
+            ['* 9-17 * * *',       1, range(9, 17)],
+            ['* * 1 * *',          2, [1]],
+            ['* * * 6 *',          3, [6]],
+            ['* * * * 1-5',        4, [1, 2, 3, 4, 5]],
+        ];
+
+        foreach ($cases as [$expr, $field, $expected]) {
+            $this->assertSame($expected, $this->parse($expr)[$field], $expr);
+        }
+    }
+
+    /** The @ shorthands are vixie-cron's own, not an invention of ours. */
+    public function testParsesTheStandardAliases()
+    {
+        foreach ([
+            '@hourly'   => '0 * * * *',
+            '@daily'    => '0 0 * * *',
+            '@midnight' => '0 0 * * *',
+            '@weekly'   => '0 0 * * 0',
+            '@monthly'  => '0 0 1 * *',
+            '@yearly'   => '0 0 1 1 *',
+            '@annually' => '0 0 1 1 *',
+        ] as $alias => $equivalent) {
+            $this->assertSame(
+                \OWA\Core\Cron::parse($equivalent),
+                \OWA\Core\Cron::parse($alias),
+                "$alias should be identical to $equivalent"
+            );
+        }
+
+        // Case and surrounding whitespace are forgiven; the value comes from a
+        // config file a human typed.
+        $this->assertSame(\OWA\Core\Cron::parse('@daily'), \OWA\Core\Cron::parse('  @DAILY '));
+    }
+
+    /**
+     * Anything unreadable yields null, never a guess.
+     *
+     * The caller refuses the job on null. Were this to fall back to a default
+     * the installation would run something on a cadence nobody chose, which is
+     * worse than not running it at all.
+     */
+    public function testRefusesWhatItCannotRead()
+    {
+        foreach ([
+            '',                 // nothing
+            '   ',              // whitespace
+            '* * * *',          // four fields
+            '* * * * * *',      // six fields
+            '@yearlyish',       // unknown alias
+            '@',                // bare
+            'daily',            // alias without the @
+            '60 * * * *',       // minute out of range
+            '* 24 * * *',       // hour out of range
+            '* * 0 * *',        // day-of-month is 1-based
+            '* * 32 * *',
+            '* * * 0 *',        // month is 1-based
+            '* * * 13 *',
+            '* * * * 7',        // day-of-week is 0-6
+            '5-1 * * * *',      // inverted range
+            '*/0 * * * *',      // zero step
+            '*/-5 * * * *',
+            'a * * * *',
+            '* * * * a',
+            '1,, * * * *',      // empty list member
+            '1- * * * *',
+            '- * * * *',
+        ] as $bad) {
+            $this->assertNull(
+                \OWA\Core\Cron::parse($bad),
+                var_export($bad, true) . ' should not parse'
+            );
+        }
+    }
+
+    /** Two identical calls agree, and nothing reads a clock. */
+    public function testParsingIsPure()
+    {
+        $a = \OWA\Core\Cron::parse('*/7 3 * * 2');
+        $b = \OWA\Core\Cron::parse('*/7 3 * * 2');
+
+        $this->assertSame($a, $b);
+    }
+
+    // -----------------------------------------------------------------------
+    // Matching
+    // -----------------------------------------------------------------------
+
+    public function testMatchesTheMinutesItShould()
+    {
+        $hourly = $this->parse('0 * * * *');
+
+        $this->assertTrue(\OWA\Core\Cron::matches($hourly, $this->at('2026-08-17 14:00:00'), self::TZ));
+        $this->assertFalse(\OWA\Core\Cron::matches($hourly, $this->at('2026-08-17 14:01:00'), self::TZ));
+
+        $monthly = $this->parse('@monthly');
+
+        $this->assertTrue(\OWA\Core\Cron::matches($monthly, $this->at('2026-09-01 00:00:00'), self::TZ));
+        $this->assertFalse(\OWA\Core\Cron::matches($monthly, $this->at('2026-09-02 00:00:00'), self::TZ));
+        $this->assertFalse(\OWA\Core\Cron::matches($monthly, $this->at('2026-09-01 00:01:00'), self::TZ));
+    }
+
+    /**
+     * Cron's own day-of-month / day-of-week rule, which surprises people:
+     * when BOTH are restricted they are OR'd, not AND'd.
+     */
+    public function testDayOfMonthAndDayOfWeekAreOredWhenBothRestricted()
+    {
+        // The 1st, and every Monday.
+        $both = $this->parse('0 0 1 * 1');
+
+        // 2026-09-01 is a Tuesday -- matches on day-of-month alone.
+        $this->assertTrue(\OWA\Core\Cron::matches($both, $this->at('2026-09-01 00:00:00'), self::TZ));
+
+        // 2026-09-07 is a Monday -- matches on day-of-week alone.
+        $this->assertTrue(\OWA\Core\Cron::matches($both, $this->at('2026-09-07 00:00:00'), self::TZ));
+
+        // 2026-09-08 is a Tuesday and not the 1st -- neither.
+        $this->assertFalse(\OWA\Core\Cron::matches($both, $this->at('2026-09-08 00:00:00'), self::TZ));
+
+        // With only one restricted, it is a plain AND.
+        $dom_only = $this->parse('0 0 1 * *');
+        $this->assertFalse(\OWA\Core\Cron::matches($dom_only, $this->at('2026-09-07 00:00:00'), self::TZ));
+    }
+
+    // -----------------------------------------------------------------------
+    // The due test -- the part that proves the design
+    // -----------------------------------------------------------------------
+
+    /**
+     * Run a simulated stretch of ticks and return the occurrences that fired.
+     *
+     * This is the scheduler's actual loop: at each tick ask for a due slot, and
+     * if there is one, record it as satisfied. Everything below is a statement
+     * about the result of this loop rather than about a single call.
+     *
+     * @return int[] the slots that ran, in order
+     */
+    private function simulate(array $parsed, string $from, string $to, int $tick, ?int $last_slot = null): array
+    {
+        $ran  = [];
+        $now  = $this->at($from);
+        $end  = $this->at($to);
+
+        // Default: treat everything before the window as already satisfied, so
+        // the result counts occurrences INSIDE the window. Passing 0 explicitly
+        // means "never run", which correctly fires once at the first tick for
+        // the most recent occurrence -- even one that precedes the window.
+        $last_slot = $last_slot ?? ($now - 60);
+
+        for (; $now <= $end; $now += $tick) {
+            $slot = \OWA\Core\Cron::dueSlot($parsed, $last_slot, $now, self::TZ);
+
+            if ($slot !== null) {
+                $ran[]     = $slot;
+                $last_slot = $slot;
+            }
+        }
+
+        return $ran;
+    }
+
+    private function readable(array $slots): array
+    {
+        return array_map(
+            fn($t) => (new DateTimeImmutable('@' . $t))
+                ->setTimezone(new DateTimeZone(self::TZ))->format('Y-m-d H:i'),
+            $slots
+        );
+    }
+
+    /**
+     * A month of one-minute ticks fires each occurrence exactly once.
+     *
+     * The single most important test here. It is also the one that would catch
+     * anyone "simplifying" dueSlot() back into a match-this-minute check, which
+     * would pass every single-call test and fail this.
+     */
+    public function testEachOccurrenceFiresExactlyOnce()
+    {
+        $daily = $this->parse('0 4 * * *');
+
+        $ran = $this->simulate($daily, '2026-09-01 00:00:00', '2026-09-30 23:59:00', 60);
+
+        $this->assertCount(30, $ran, 'one run per day in September');
+        $this->assertSame($ran, array_unique($ran), 'no occurrence fired twice');
+        $this->assertSame('2026-09-01 04:00', $this->readable($ran)[0]);
+        $this->assertSame('2026-09-30 04:00', $this->readable($ran)[29]);
+    }
+
+    /**
+     * The result does not depend on how often the dispatcher is invoked.
+     *
+     * This is what makes the crontab line a resolution floor rather than part
+     * of the schedule, and what would break immediately under an
+     * edge-triggered design.
+     */
+    public function testResultIsIndependentOfTickInterval()
+    {
+        $daily = $this->parse('0 4 * * *');
+
+        $one   = $this->simulate($daily, '2026-09-01 00:00:00', '2026-09-10 23:59:00', 60);
+        $five  = $this->simulate($daily, '2026-09-01 00:00:00', '2026-09-10 23:59:00', 300);
+        $fifty = $this->simulate($daily, '2026-09-01 00:00:00', '2026-09-10 23:59:00', 900);
+
+        $this->assertCount(10, $one);
+        $this->assertSame($one, $five, '5-minute ticks give the same occurrences');
+        $this->assertSame($one, $fifty, '15-minute ticks give the same occurrences');
+    }
+
+    /**
+     * A job missed for days runs ONCE when the dispatcher returns, not once per
+     * missed occurrence. This is the difference from Laravel, and the reason
+     * a scheduled job must be convergent.
+     */
+    public function testAMissedJobCatchesUpExactlyOnce()
+    {
+        $daily = $this->parse('0 4 * * *');
+
+        // Last satisfied ten days ago; the dispatcher comes back on the 15th.
+        $last = $this->at('2026-09-05 04:00:00');
+        $ran  = $this->simulate($daily, '2026-09-15 09:00:00', '2026-09-15 23:59:00', 60, $last);
+
+        $this->assertCount(1, $ran, 'ten missed days must produce one run, not ten');
+        $this->assertSame('2026-09-15 04:00', $this->readable($ran)[0]);
+    }
+
+    /** A monthly job neglected for half a year likewise runs once. */
+    public function testALongNeglectedMonthlyJobRunsOnce()
+    {
+        $monthly = $this->parse('@monthly');
+
+        $last = $this->at('2026-03-01 00:00:00');
+        $ran  = $this->simulate($monthly, '2026-09-15 00:00:00', '2026-09-16 00:00:00', 60, $last);
+
+        $this->assertCount(1, $ran);
+        $this->assertSame('2026-09-01 00:00', $this->readable($ran)[0], 'the most recent occurrence, not the oldest missed one');
+    }
+
+    /** Never run before: due at the first tick, for every shape of schedule. */
+    public function testANeverRunJobIsDueImmediately()
+    {
+        foreach (['@hourly', '@daily', '@weekly', '@monthly', '*/5 * * * *'] as $expr) {
+            $ran = $this->simulate($this->parse($expr), '2026-09-15 13:07:00', '2026-09-15 13:08:00', 60, 0);
+
+            $this->assertCount(1, $ran, "$expr should fire exactly once, not once per missed occurrence");
+
+            $this->assertNotEmpty($ran, "$expr should be due when it has never run");
+        }
+    }
+
+    /** Within one occurrence, repeated ticks change nothing. */
+    public function testIsIdempotentWithinAnOccurrence()
+    {
+        $monthly = $this->parse('@monthly');
+
+        $ran = $this->simulate($monthly, '2026-09-01 00:00:00', '2026-09-01 23:59:00', 60);
+
+        $this->assertCount(1, $ran, '1440 ticks inside one monthly occurrence run it once');
+    }
+
+    // -----------------------------------------------------------------------
+    // Daylight saving -- the two failures Laravel's docs warn about
+    // -----------------------------------------------------------------------
+
+    /**
+     * Autumn: 01:00-02:00 happens twice on 2026-11-01 in America/Los_Angeles.
+     * A job scheduled inside it must not run twice.
+     */
+    public function testTheRepeatedHourDoesNotRunTwice()
+    {
+        $ran = $this->simulate($this->parse('30 1 * * *'), '2026-11-01 00:00:00', '2026-11-01 23:59:00', 60);
+
+        $this->assertCount(1, $ran, '01:30 exists twice on this date but is one occurrence');
+    }
+
+    /**
+     * Spring: 02:00-03:00 does not exist on 2026-03-08. A job scheduled inside
+     * the missing hour must still run that day rather than being skipped.
+     */
+    public function testTheSkippedHourStillRunsOnce()
+    {
+        $ran = $this->simulate($this->parse('30 2 * * *'), '2026-03-08 00:00:00', '2026-03-08 23:59:00', 60);
+
+        $this->assertCount(1, $ran, '02:30 does not exist on this date, but the day must not be skipped');
+    }
+
+    /** Across either transition, a daily job still runs once per calendar day. */
+    public function testDailyJobsRunOncePerDayAcrossBothTransitions()
+    {
+        $daily = $this->parse('0 4 * * *');
+
+        $spring = $this->simulate($daily, '2026-03-06 00:00:00', '2026-03-10 23:59:00', 60);
+        $this->assertCount(5, $spring, 'five calendar days across spring forward');
+
+        $autumn = $this->simulate($daily, '2026-10-30 00:00:00', '2026-11-03 23:59:00', 60);
+        $this->assertCount(5, $autumn, 'five calendar days across fall back');
+    }
+
+    // -----------------------------------------------------------------------
+    // Calendar edges
+    // -----------------------------------------------------------------------
+
+    /** Month lengths, including February in a leap and a non-leap year. */
+    public function testHandlesMonthLengths()
+    {
+        $daily = $this->parse('0 12 * * *');
+
+        foreach ([
+            ['2026-02-01', '2026-02-28', 28],   // 2026 is not a leap year
+            ['2028-02-01', '2028-02-29', 29],   // 2028 is
+            ['2026-04-01', '2026-04-30', 30],
+            ['2026-07-01', '2026-07-31', 31],
+        ] as [$from, $to, $days]) {
+            $ran = $this->simulate($daily, $from . ' 00:00:00', $to . ' 23:59:00', 3600);
+
+            $this->assertCount($days, $ran, "$from to $to");
+        }
+    }
+
+    /**
+     * A day-of-month that some months do not have simply does not fire in those
+     * months — cron's behaviour, and the reason the plan warns against 29-31.
+     */
+    public function testADayOfMonthBeyondTheMonthLengthIsSkipped()
+    {
+        $ran = $this->simulate($this->parse('0 0 31 * *'), '2026-01-01 00:00:00', '2026-06-30 23:59:00', 3600);
+
+        // Jan, Mar, May have a 31st in that window; Feb, Apr, Jun do not.
+        $this->assertSame(
+            ['2026-01-31 00:00', '2026-03-31 00:00', '2026-05-31 00:00'],
+            $this->readable($ran)
+        );
+    }
+
+    /** Weekly across a year boundary. */
+    public function testWeeklyAcrossAYearBoundary()
+    {
+        $ran = $this->simulate($this->parse('@weekly'), '2026-12-20 00:00:00', '2027-01-17 23:59:00', 3600);
+
+        $this->assertSame(
+            ['2026-12-20 00:00', '2026-12-27 00:00', '2027-01-03 00:00', '2027-01-10 00:00', '2027-01-17 00:00'],
+            $this->readable($ran)
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Reporting helpers
+    // -----------------------------------------------------------------------
+
+    public function testNextAfterFindsTheFollowingOccurrence()
+    {
+        $monthly = $this->parse('@monthly');
+
+        $this->assertSame(
+            $this->at('2026-10-01 00:00:00'),
+            \OWA\Core\Cron::nextAfter($monthly, $this->at('2026-09-15 12:00:00'), self::TZ)
+        );
+
+        // Exactly on an occurrence, "after" means strictly after.
+        $this->assertSame(
+            $this->at('2026-10-01 00:00:00'),
+            \OWA\Core\Cron::nextAfter($monthly, $this->at('2026-09-01 00:00:00'), self::TZ)
+        );
+    }
+
+    public function testDescribesCommonSchedulesInWords()
+    {
+        foreach ([
+            '@monthly'      => 'monthly, on the 1st at 00:00',
+            '@daily'        => 'daily at 00:00',
+            '@hourly'       => 'hourly, on the hour',
+            '*/5 * * * *'   => 'every 5 minutes',
+            '10 * * * *'    => 'hourly, at 10 past',
+            '0 4 * * *'     => 'daily at 04:00',
+            '30 2 1 * *'    => 'monthly, on day 1 at 02:30',
+        ] as $expr => $words) {
+            $this->assertSame($words, \OWA\Core\Cron::describe($expr), $expr);
+        }
+
+        // Anything unusual is shown as itself rather than mis-described.
+        $this->assertSame('0 4 * * 1-5', \OWA\Core\Cron::describe('0 4 * * 1-5'));
+    }
+
+    /** An unusable timezone yields no match rather than an exception. */
+    public function testAnUnusableTimezoneDoesNotThrow()
+    {
+        $parsed = $this->parse('@daily');
+
+        $this->assertFalse(\OWA\Core\Cron::matches($parsed, 1789000000, 'Not/AZone'));
+        $this->assertNull(\OWA\Core\Cron::previousMatch($parsed, 1789000000, 'Not/AZone'));
+        $this->assertNull(\OWA\Core\Cron::nextAfter($parsed, 1789000000, 'Not/AZone'));
+    }
+}

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -38,6 +38,11 @@ final class ScheduleCliTest extends CliControllerTestCase
 
         $this->jobs = [];
 
+        // The stub command is registered on the module, which is a singleton
+        // shared with every later test.
+        $s = \OWA\Core\CoreAPI::serviceSingleton();
+        unset($s->modules['base']->cli_commands['owa-test-lease-stub']);
+
         // Settings are global; restore anything a case changed.
         \OWA\Core\CoreAPI::setSetting('base', 'scheduled_jobs', []);
         \OWA\Core\CoreAPI::setSetting('base', 'scheduler_enabled', true);
@@ -746,5 +751,249 @@ final class ScheduleCliTest extends CliControllerTestCase
         $ctrl->action();
 
         $this->assertSame('ok', $ctrl->getCliOutcome()['outcome']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Overrun: the lease running out while a job is still working
+    // -----------------------------------------------------------------------
+
+    /**
+     * heartbeat() is what PREVENTS an overrun, and is the command's own job to
+     * call -- the dispatcher is blocked inside the job and has no thread to do
+     * it from.
+     */
+    public function testHeartbeatExtendsTheLease()
+    {
+        $name = $this->track('owa_test_hb_' . bin2hex(random_bytes(3)));
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+
+        $lease = new \OWA\Module\Base\Classes\JobLease($name);
+        $this->assertTrue($lease->acquire(300));
+
+        $before = (int) $db->getJobLock($name)['expires_at'];
+
+        $ctrl = new \OWA\Module\Base\Controller\PartitionStatusCli([]);
+        $ctrl->setJobLease($lease);
+
+        $this->callProtected($ctrl, 'heartbeat');
+
+        $after = (int) $db->getJobLock($name)['expires_at'];
+
+        $this->assertGreaterThan($before, $after, 'a heartbeat must push the expiry out');
+        $this->assertSame(
+            $lease->getOwner(), $db->getJobLock($name)['owner'],
+            'and must not change who holds it'
+        );
+
+        $lease->release();
+    }
+
+    /**
+     * A heartbeat from a run that has already been superseded reports false, so
+     * a long job can notice it lost the lock and stop rather than carrying on
+     * alongside its replacement.
+     */
+    public function testHeartbeatReportsWhenTheLockHasBeenLost()
+    {
+        $name = $this->track('owa_test_hb_' . bin2hex(random_bytes(3)));
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+
+        $overrunning = new \OWA\Module\Base\Classes\JobLease($name);
+        $this->assertTrue($overrunning->acquire(300));
+
+        // Its lease runs out while it is still working, and the next tick takes
+        // the lock over.
+        $db->query(sprintf(
+            "UPDATE owa_job_lock SET expires_at = %d WHERE job_name = '%s'",
+            time() - 10, $db->prepare($name)
+        ));
+
+        $replacement = new \OWA\Module\Base\Classes\JobLease($name);
+        $this->assertTrue($replacement->acquire(300));
+
+        $this->assertFalse(
+            $overrunning->refresh(300),
+            'the superseded run must be told it no longer holds the lock'
+        );
+
+        $this->assertSame(
+            $replacement->getOwner(), $db->getJobLock($name)['owner'],
+            'and must not have stolen it back'
+        );
+
+        $replacement->release();
+    }
+
+    /** Run by hand, with no lease injected, heartbeat() does nothing at all. */
+    public function testHeartbeatIsANoOpWhenRunByHand()
+    {
+        $ctrl = new \OWA\Module\Base\Controller\PartitionStatusCli([]);
+
+        // No setJobLease() call: this is the hand-run case. It must not raise,
+        // because a scheduled command and a hand-run one have to behave alike.
+        $this->assertNull($this->callProtected($ctrl, 'heartbeat'));
+    }
+
+    /**
+     * The dispatcher skips a job whose lock is live -- it does not wait, and it
+     * does not start a second copy.
+     *
+     * This is the overrun case as the dispatcher sees it: a job that is still
+     * working when the next tick arrives.
+     */
+    public function testTheDispatcherSkipsAJobThatIsStillRunning()
+    {
+        $name = $this->track('owa_test_busy_' . bin2hex(random_bytes(3)));
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduled_jobs', [
+            $name => ['command' => 'flush-cache', 'schedule' => '* * * * *'],
+        ]);
+
+        $ctrl = $this->runner();
+        $jobs = $this->callProtected($ctrl, 'jobs');
+
+        // Someone else is mid-run.
+        $held = new \OWA\Module\Base\Classes\JobLease($name);
+        $this->assertTrue($held->acquire(3600));
+
+        $this->callProtected($ctrl, 'considerJob', [$name, $jobs[$name], false, false]);
+
+        $state = $this->callProtected($ctrl, 'state', [$name]);
+
+        $this->assertNotNull($state, 'the state row is still materialised');
+        $this->assertSame(0, (int) $state->get('run_count'), 'but no run was recorded');
+        $this->assertSame(
+            $held->getOwner(), $db->getJobLock($name)['owner'],
+            'the running job keeps its lock'
+        );
+
+        $held->release();
+    }
+
+    /**
+     * ...and once the lock is gone, the same job runs on the next tick. The
+     * skip is a deferral, not a loss: the occurrence stays unsatisfied.
+     */
+    public function testASkippedJobRunsOnceTheLockClears()
+    {
+        $name = $this->track('owa_test_defer_' . bin2hex(random_bytes(3)));
+
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduled_jobs', [
+            $name => ['command' => 'flush-cache', 'schedule' => '* * * * *'],
+        ]);
+
+        $ctrl = $this->runner();
+        $jobs = $this->callProtected($ctrl, 'jobs');
+
+        $held = new \OWA\Module\Base\Classes\JobLease($name);
+        $held->acquire(3600);
+        $this->callProtected($ctrl, 'considerJob', [$name, $jobs[$name], false, false]);
+        $held->release();
+
+        $this->callProtected($ctrl, 'considerJob', [$name, $jobs[$name], false, false]);
+
+        $state = $this->callProtected($ctrl, 'state', [$name]);
+
+        $this->assertSame(1, (int) $state->get('run_count'), 'the deferred occurrence still ran');
+        $this->assertSame('ok', $state->get('last_status'));
+    }
+
+    /**
+     * The lock is taken with the COMMAND's lease, not a fixed default -- which
+     * is what lets partition-rotate ask for longer when it has more to do.
+     *
+     * Goes through the dispatcher on purpose. Constructing a JobLease directly
+     * and handing it a number only proves the lease object honours what it is
+     * given; it says nothing about whether runJob() asked the controller. That
+     * distinction is not academic -- hardcoding the lease in the dispatcher
+     * passed an earlier version of this test.
+     */
+    public function testTheDispatcherTakesTheLockWithTheCommandsOwnLease()
+    {
+        $name = $this->track('owa_test_lease_' . bin2hex(random_bytes(3)));
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+        $s    = \OWA\Core\CoreAPI::serviceSingleton();
+
+        // A command whose lease is unmistakable, so a hardcoded one cannot
+        // masquerade as it.
+        // Registered on the MODULE, not just the service map: loadJobs()
+        // rebuilds the command map from the modules on every call, so anything
+        // set only on the map is wiped before the registry is read.
+        $s->modules['base']->cli_commands['owa-test-lease-stub'] = 'base.owaTestLeaseStub';
+        $s->setMapValue('actions', 'base.owaTestLeaseStub', [
+            'class_name' => 'OwaTestLeaseStubCli',
+            'file'       => '',
+        ]);
+
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduled_jobs', [
+            $name => ['command' => 'owa-test-lease-stub', 'schedule' => '* * * * *'],
+        ]);
+
+        $ctrl = $this->runner();
+        $jobs = $this->callProtected($ctrl, 'jobs');
+
+        $this->assertArrayHasKey($name, $jobs, 'the stub job should be registered');
+
+        // Hold the lock ourselves so the dispatcher's acquire fails and the row
+        // it would have written is the one we can inspect... no: instead let it
+        // run, and read the lock back from inside the job.
+        OwaTestLeaseStubCli::$seen_expiry = 0;
+
+        $this->callProtected($ctrl, 'considerJob', [$name, $jobs[$name], false, false]);
+
+        $this->assertGreaterThan(
+            0, OwaTestLeaseStubCli::$seen_expiry,
+            'the job should have observed its own lock while running'
+        );
+
+        $this->assertEqualsWithDelta(
+            time() + OwaTestLeaseStubCli::LEASE,
+            OwaTestLeaseStubCli::$seen_expiry,
+            10,
+            'the lock must expire at the lease the COMMAND asked for, not a fixed default'
+        );
+    }
+
+}
+
+/**
+ * A command with a distinctive lease, used to prove the dispatcher asks the
+ * controller rather than using a constant. It records the lock's expiry as it
+ * sees it from inside its own run.
+ */
+class OwaTestLeaseStubCli extends \OWA\Core\Controller\Cli {
+
+    const LEASE = 4321;
+
+    /** @var int */
+    public static $seen_expiry = 0;
+
+    function __construct( $params ) {
+
+        $this->setRequiredCapability( 'edit_modules' );
+
+        parent::__construct( $params );
+    }
+
+    public function getJobLease() {
+
+        return self::LEASE;
+    }
+
+    function action() {
+
+        $lock = \OWA\Core\CoreAPI::dbSingleton()->getJobLock( 'x' );
+
+        // The dispatcher names the lock after the JOB, which this stub does not
+        // know -- so find the one held right now.
+        $rows = \OWA\Core\CoreAPI::dbSingleton()->get_results(
+            'SELECT expires_at FROM owa_job_lock ORDER BY acquired_at DESC LIMIT 1'
+        );
+
+        foreach ( (array) $rows as $row ) {
+
+            self::$seen_expiry = (int) ( (array) $row )['expires_at'];
+        }
     }
 }

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -665,4 +665,86 @@ final class ScheduleCliTest extends CliControllerTestCase
             );
         }
     }
+
+    /**
+     * A scheduled rotate on an installation that never ran partition-init must
+     * report a REFUSAL, not success.
+     *
+     * This is the silent failure the scheduler exists to remove, relocated one
+     * level up: left as 'ok', a monthly rotate would show a clean history and a
+     * rising run count forever while skipping every table, and the operator
+     * would have no signal that partition-init is the missing step.
+     *
+     * 'refused' rather than 'failed' so the occurrence is still consumed and it
+     * is not retried every minute for a condition that will not change on its
+     * own.
+     */
+    public function testRotateRefusesWhenNothingIsPartitioned()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        // A fact table that is real but empty, so removing partitioning is
+        // cheap and reversible within the test.
+        $table = 'owa_commerce_line_item_fact';
+
+        if (! $db->isPartitioned($table)) {
+            $this->markTestSkipped("$table is not partitioned to begin with.");
+        }
+
+        if ((int) $db->get_row("SELECT COUNT(*) AS n FROM $table")['n'] > 0) {
+            $this->markTestSkipped("$table has rows; not rewriting it in a test.");
+        }
+
+        $granularity = $db->inferPartitionGranularity($table) ?: 'monthly';
+        $spans       = $db->getPartitionSpans($table);
+
+        try {
+            $db->query("ALTER TABLE $table REMOVE PARTITIONING");
+            $this->assertFalse($db->isPartitioned($table), 'the fixture should be unpartitioned now');
+
+            $ctrl = new \OWA\Module\Base\Controller\PartitionRotateCli(['table' => $table]);
+            $ctrl->action();
+
+            $out = $ctrl->getCliOutcome();
+
+            $this->assertSame('refused', $out['outcome'], 'skipping every table is not success');
+            $this->assertStringContainsString('partition-init', $out['message'], 'name the missing step');
+
+        } finally {
+
+            // Put it back exactly as it was.
+            if ($spans) {
+                $db->partitionTable($table, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+                    $spans[0]['start'],
+                    date('Ymd', strtotime(end($spans)['less_than'] . ' -1 day')),
+                    $granularity
+                ));
+            }
+        }
+
+        $this->assertTrue($db->isPartitioned($table), 'the fixture must be restored');
+    }
+
+    /** ...and reports ok when it did rotate something. */
+    public function testRotateReportsOkWhenItActuallyRotates()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $partitioned = null;
+
+        $ctrl = new \OWA\Module\Base\Controller\PartitionRotateCli([]);
+
+        foreach ($this->callProtected($ctrl, 'factTables') as $t) {
+            if ($db->isPartitioned($t)) { $partitioned = $t; break; }
+        }
+
+        if (! $partitioned) {
+            $this->markTestSkipped('no partitioned fact table to rotate.');
+        }
+
+        $ctrl = new \OWA\Module\Base\Controller\PartitionRotateCli(['table' => $partitioned, 'dry-run' => true]);
+        $ctrl->action();
+
+        $this->assertSame('ok', $ctrl->getCliOutcome()['outcome']);
+    }
 }

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -331,13 +331,57 @@ final class ScheduleCliTest extends CliControllerTestCase
         $this->assertSame('refused', $ctrl->getCliOutcome()['outcome']);
     }
 
-    /** Rotate derives a lease from the work it can see, not a constant. */
-    public function testRotateDerivesItsLeaseFromPlannedWork()
+    /**
+     * Rotate's lease reflects the work PLANNED, not the partitions that happen
+     * to exist.
+     *
+     * The distinction is the whole point, and getting it wrong is not
+     * theoretical: an earlier version added the count of existing partitions on
+     * every table, so a routine rotate with nothing whatsoever to do asked for
+     * 8.3 hours on an installation whose rotate takes 3 seconds. Asserting only
+     * "at least the floor" would have passed that happily.
+     */
+    public function testRotateDerivesItsLeaseFromPlannedWorkNotExistingPartitions()
     {
-        $lease = (new \OWA\Module\Base\Controller\PartitionRotateCli([]))->getJobLease();
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+        $ctrl = new \OWA\Module\Base\Controller\PartitionRotateCli([]);
 
-        $this->assertGreaterThanOrEqual(1800, $lease, 'never below the floor');
-        $this->assertIsInt($lease);
+        // How much work is genuinely outstanding right now?
+        $through = \OWA\Core\Db::partitionLeadBoundary();
+        $budget  = $this->callProtected($ctrl, 'factTableBudget');
+
+        $operations = 0;
+        $existing   = 0;
+
+        foreach ($this->callProtected($ctrl, 'factTables') as $table) {
+
+            if (! $db->isPartitioned($table)) {
+                continue;
+            }
+
+            $granularity = $db->inferPartitionGranularity($table) ?: 'monthly';
+
+            $operations += (int) ($db->extendPartitions($table, $granularity, $through, true)['planned'] ?? 0);
+            $operations += count($db->planPartitionCompaction($table, $budget['limit'])['merges'] ?? []);
+            $existing   += count($db->getPartitionSpans($table));
+        }
+
+        $lease = $ctrl->getJobLease();
+
+        $this->assertSame(max(1800, $operations * 300), $lease, 'the lease must follow planned operations');
+
+        if ($operations === 0) {
+            $this->assertSame(1800, $lease, 'nothing to do means the floor, however many partitions exist');
+        }
+
+        // The guard that would have caught the original defect: an installation
+        // with hundreds of partitions and nothing to do must not ask for hours.
+        if ($existing > 50 && $operations === 0) {
+            $this->assertLessThan(
+                3600, $lease,
+                sprintf('%d existing partitions with no work planned must not inflate the lease', $existing)
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -332,26 +332,29 @@ final class ScheduleCliTest extends CliControllerTestCase
     }
 
     /**
-     * Rotate's lease reflects the work PLANNED, not the partitions that happen
-     * to exist.
+     * Rotate's lease reflects the DATA a run will rewrite, not the partitions
+     * that happen to exist and not the number of periods it will create.
      *
-     * The distinction is the whole point, and getting it wrong is not
-     * theoretical: an earlier version added the count of existing partitions on
-     * every table, so a routine rotate with nothing whatsoever to do asked for
-     * 8.3 hours on an installation whose rotate takes 3 seconds. Asserting only
-     * "at least the floor" would have passed that happily.
+     * Both mistakes were made and both were expensive. Counting existing
+     * partitions gave 8.3 hours for a rotate with nothing to do. Counting
+     * created partitions gave 2.6 hours for an extension measured at 1.52
+     * seconds -- because extending the lead is ONE statement however many
+     * periods it produces, and its cost follows what is in the catch-all.
+     *
+     * A test asserting only "at least the floor" passed both.
      */
-    public function testRotateDerivesItsLeaseFromPlannedWorkNotExistingPartitions()
+    public function testRotateLeaseFollowsDataRewrittenNotPartitionCount()
     {
         $db   = \OWA\Core\CoreAPI::dbSingleton();
         $ctrl = new \OWA\Module\Base\Controller\PartitionRotateCli([]);
 
-        // How much work is genuinely outstanding right now?
         $through = \OWA\Core\Db::partitionLeadBoundary();
         $budget  = $this->callProtected($ctrl, 'factTableBudget');
 
-        $operations = 0;
+        $statements = 0;
+        $rows       = 0;
         $existing   = 0;
+        $creating   = 0;
 
         foreach ($this->callProtected($ctrl, 'factTables') as $table) {
 
@@ -360,27 +363,49 @@ final class ScheduleCliTest extends CliControllerTestCase
             }
 
             $granularity = $db->inferPartitionGranularity($table) ?: 'monthly';
+            $sizes       = [];
+            $catch_all   = 0;
 
-            $operations += (int) ($db->extendPartitions($table, $granularity, $through, true)['planned'] ?? 0);
-            $operations += count($db->planPartitionCompaction($table, $budget['limit'])['merges'] ?? []);
-            $existing   += count($db->getPartitionSpans($table));
+            foreach ($db->listPartitions($table) as $p) {
+                $sizes[$p['name']] = (int) $p['rows'];
+
+                if (strtoupper($p['less_than']) === OWA_DTD_PARTITION_MAXVALUE) {
+                    $catch_all = (int) $p['rows'];
+                }
+            }
+
+            $extend = $db->extendPartitions($table, $granularity, $through, true);
+
+            if (! empty($extend['planned'])) {
+                $statements++;
+                $rows     += $catch_all;
+                $creating += (int) $extend['planned'];
+            }
+
+            foreach ((array) ($db->planPartitionCompaction($table, $budget['limit'])['merges'] ?? []) as $merge) {
+                $statements++;
+
+                foreach ((array) ($merge['names'] ?? []) as $n) {
+                    $rows += $sizes[$n] ?? 0;
+                }
+            }
+
+            $existing += count($db->getPartitionSpans($table));
         }
 
-        $lease = $ctrl->getJobLease();
+        $expected = max(1800, ($statements * 120) + (int) ceil($rows / 1000000) * 300);
 
-        $this->assertSame(max(1800, $operations * 300), $lease, 'the lease must follow planned operations');
+        $this->assertSame($expected, $ctrl->getJobLease(), 'the lease must follow statements and rows');
 
-        if ($operations === 0) {
-            $this->assertSame(1800, $lease, 'nothing to do means the floor, however many partitions exist');
+        // The two guards that would each have caught a past defect.
+        if ($existing > 50 && $statements === 0) {
+            $this->assertSame(1800, $ctrl->getJobLease(),
+                sprintf('%d existing partitions with nothing planned must give the floor', $existing));
         }
 
-        // The guard that would have caught the original defect: an installation
-        // with hundreds of partitions and nothing to do must not ask for hours.
-        if ($existing > 50 && $operations === 0) {
-            $this->assertLessThan(
-                3600, $lease,
-                sprintf('%d existing partitions with no work planned must not inflate the lease', $existing)
-            );
+        if ($creating > 10 && $rows < 100000) {
+            $this->assertLessThan(3600, $ctrl->getJobLease(),
+                sprintf('creating %d periods over %d rows is one cheap statement', $creating, $rows));
         }
     }
 
@@ -999,7 +1024,96 @@ final class ScheduleCliTest extends CliControllerTestCase
         );
     }
 
+    /**
+     * The lease arithmetic at sizes this installation does not have.
+     *
+     * Tested through leaseFor() because the interesting terms are both zero on
+     * a maintained install -- so a test that only recomputes the estimate from
+     * live state agrees with every wrong version of the formula. Two mutants
+     * survived exactly that way before this was split out.
+     */
+    public function testTheLeaseArithmetic()
+    {
+        $lease = fn(int $st, int $rows) => \OWA\Module\Base\Controller\PartitionRotateCli::leaseFor($st, $rows);
+
+        // Nothing to do, and a few hundred rows, are both the floor.
+        $this->assertSame(1800, $lease(0, 0));
+        $this->assertSame(1800, $lease(1, 569), 'one cheap statement is still the floor');
+        $this->assertSame(1800, $lease(0, 999999), 'sub-million never reaches the floor');
+
+        // Rows drive it, and drive it smoothly.
+        $this->assertSame(3120, $lease(1, 10000000), '10M rows: 120 + 3000');
+        $this->assertSame(15120, $lease(1, 50000000), '50M rows: 120 + 15000');
+        $this->assertGreaterThan($lease(1, 10000000), $lease(1, 20000000), 'more data means a longer lease');
+
+        // Statements matter, but far less than data -- which is the whole point.
+        $this->assertSame(1800, $lease(5, 0), 'five empty merges are still the floor');
+        $this->assertLessThan($lease(1, 50000000), $lease(20, 0), 'twenty statements cost less than 50M rows');
+
+        // Never negative, never below the floor.
+        $this->assertSame(1800, $lease(0, -1));
+        $this->assertSame(1800, $lease(-3, 0));
+    }
+
+    /**
+     * A real lead gap: one statement creating many periods over a tiny table
+     * must NOT be priced per period.
+     *
+     * This is the case that produced a 2.6-hour lease for 1.52 seconds of work.
+     */
+    public function testCreatingManyPeriodsOverLittleDataIsCheap()
+    {
+        $db    = \OWA\Core\CoreAPI::dbSingleton();
+        $table = 'owa_domstream';
+
+        if (! $db->isPartitioned($table)) {
+            $this->markTestSkipped("$table is not partitioned.");
+        }
+
+        $spans = $db->getPartitionSpans($table);
+
+        if (count($spans) < 10) {
+            $this->markTestSkipped("$table has too few partitions to open a gap in.");
+        }
+
+        $granularity = $db->inferPartitionGranularity($table) ?: 'monthly';
+        $keep        = array_slice($spans, 0, 6);
+
+        try {
+            // Strip the lead, leaving a gap a rotate would have to rebuild.
+            $db->query("ALTER TABLE $table REMOVE PARTITIONING");
+            $db->partitionTable($table, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+                $keep[0]['start'],
+                date('Ymd', strtotime(end($keep)['less_than'] . ' -1 day')),
+                $granularity
+            ));
+
+            $planned = (int) $db->extendPartitions(
+                $table, $granularity, \OWA\Core\Db::partitionLeadBoundary(), true
+            )['planned'];
+
+            $this->assertGreaterThan(10, $planned, 'the fixture should leave real work to do');
+
+            $lease = (new \OWA\Module\Base\Controller\PartitionRotateCli(['table' => $table]))->getJobLease();
+
+            $this->assertSame(
+                1800, $lease,
+                sprintf('%d periods over a few hundred rows is one cheap statement, not %ds of work', $planned, $lease)
+            );
+
+        } finally {
+            $db->query("ALTER TABLE $table REMOVE PARTITIONING");
+            $db->partitionTable($table, 'yyyymmdd', \OWA\Core\Db::makePartitionRanges(
+                $spans[0]['start'],
+                date('Ymd', strtotime(end($spans)['less_than'] . ' -1 day')),
+                $granularity
+            ));
+        }
+
+        $this->assertCount(count($spans), $db->getPartitionSpans($table), 'the fixture must be restored');
+    }
 }
+
 
 /**
  * A command with a distinctive lease, used to prove the dispatcher asks the

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -1,0 +1,668 @@
+<?php
+
+require_once __DIR__ . '/CliControllerTestCase.php';
+
+/**
+ * The scheduler's own decisions: what it runs, what it refuses, what it records,
+ * and what it says when a job is not running.
+ *
+ * CronTest covers the schedule arithmetic and runs everywhere. This covers the
+ * layer above -- the registry, the config merge, the lock, outcome recording and
+ * the diagnosis -- and needs a database, so it skips in CI alongside its 232
+ * siblings.
+ */
+final class ScheduleCliTest extends CliControllerTestCase
+{
+    /** @var string[] job names to clean up */
+    private $jobs = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach (['scheduled_job', 'job_lock'] as $e) {
+            \OWA\Core\CoreAPI::entityFactory('base.' . $e)->createTable();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach ($this->jobs as $name) {
+            $db->query(sprintf("DELETE FROM owa_scheduled_job WHERE job_name = '%s'", $db->prepare($name)));
+            $db->query(sprintf("DELETE FROM owa_job_lock WHERE job_name = '%s'", $db->prepare($name)));
+        }
+
+        $this->jobs = [];
+
+        // Settings are global; restore anything a case changed.
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduled_jobs', []);
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduler_enabled', true);
+
+        parent::tearDown();
+    }
+
+    /** @return mixed */
+    private function callProtected(object $ctrl, string $method, array $args = [])
+    {
+        $m = new ReflectionMethod($ctrl, $method);
+        $m->setAccessible(true);
+
+        return $m->invokeArgs($ctrl, $args);
+    }
+
+    private function runner(array $params = []): object
+    {
+        return new \OWA\Module\Base\Controller\ScheduleRunCli($params);
+    }
+
+    private function statusCli(array $params = []): object
+    {
+        return new \OWA\Module\Base\Controller\ScheduleStatusCli($params);
+    }
+
+    /** Load the registry with a given OWA_SCHEDULED_JOBS-shaped override. */
+    private function jobsWith(array $configured): array
+    {
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduled_jobs', $configured);
+
+        return $this->callProtected($this->runner(), 'jobs');
+    }
+
+    private function track(string $name): string
+    {
+        $this->jobs[] = $name;
+
+        return $name;
+    }
+
+    // -----------------------------------------------------------------------
+    // What ships
+    // -----------------------------------------------------------------------
+
+    /**
+     * partition-rotate is registered with EMPTY params.
+     *
+     * The most valuable assertion in this file. It reddens if anyone later adds
+     * keep=24 to the REGISTRATION, which would quietly turn "nothing is deleted
+     * by default" into a retention policy that starts deleting data on upgrade.
+     * Adding keep in config is the supported path and has its own case below.
+     */
+    public function testRotateShipsWithNoArgumentsSoNothingIsEverDeleted()
+    {
+        $jobs = $this->callProtected($this->runner(), 'jobs');
+
+        $this->assertArrayHasKey('partition-rotate', $jobs);
+        $this->assertSame([], $jobs['partition-rotate']['params'], 'no keep= may be registered in code');
+        $this->assertSame('@monthly', $jobs['partition-rotate']['schedule']);
+        $this->assertSame('code', $jobs['partition-rotate']['source']);
+    }
+
+    /** Only that one job ships; everything else is opt-in. */
+    public function testOnlyPartitionRotateIsRegisteredByDefault()
+    {
+        $jobs = $this->callProtected($this->runner(), 'jobs');
+
+        $this->assertSame(['partition-rotate'], array_keys($jobs));
+    }
+
+    /** Every registered job must name a real command and parse. */
+    public function testEveryRegisteredJobIsUsable()
+    {
+        $s = \OWA\Core\CoreAPI::serviceSingleton();
+
+        foreach ($this->callProtected($this->runner(), 'jobs') as $name => $job) {
+            $this->assertNotEmpty($s->getCliCommandClass($job['command']), "$name names an unregistered command");
+            $this->assertIsArray(\OWA\Core\Cron::parse($job['schedule']), "$name has an unparseable schedule");
+        }
+    }
+
+    /** Building the registry twice does not duplicate or drop anything. */
+    public function testLoadingJobsIsIdempotent()
+    {
+        $once  = $this->callProtected($this->runner(), 'jobs');
+        $twice = $this->callProtected($this->runner(), 'jobs');
+
+        $this->assertSame($once, $twice);
+    }
+
+    // -----------------------------------------------------------------------
+    // OWA_SCHEDULED_JOBS -- every row of the merge table
+    // -----------------------------------------------------------------------
+
+    /** Giving only params keeps the shipped schedule, and vice versa. */
+    public function testConfigOverridesPerKey()
+    {
+        $jobs = $this->jobsWith(['partition-rotate' => ['params' => ['keep' => 24]]]);
+
+        $this->assertSame(['keep' => 24], $jobs['partition-rotate']['params']);
+        $this->assertSame('@monthly', $jobs['partition-rotate']['schedule'], 'the shipped schedule survives');
+        $this->assertSame('config-override', $jobs['partition-rotate']['source']);
+
+        $jobs = $this->jobsWith(['partition-rotate' => ['schedule' => '@daily']]);
+
+        $this->assertSame('@daily', $jobs['partition-rotate']['schedule']);
+        $this->assertSame([], $jobs['partition-rotate']['params'], 'the shipped params survive');
+    }
+
+    /** A job the release never registered can be added outright. */
+    public function testConfigCanAddAJob()
+    {
+        $jobs = $this->jobsWith([
+            'nightly-flush' => ['command' => 'flush-cache', 'schedule' => '@daily'],
+        ]);
+
+        $this->assertArrayHasKey('nightly-flush', $jobs);
+        $this->assertSame('flush-cache', $jobs['nightly-flush']['command']);
+        $this->assertSame('config', $jobs['nightly-flush']['source']);
+    }
+
+    /**
+     * The same command twice under different names: two jobs, two state rows,
+     * two locks — so one instance running never blocks the other.
+     */
+    public function testTheSameCommandCanBeScheduledTwice()
+    {
+        $jobs = $this->jobsWith([
+            'rotate-one-table' => [
+                'command'  => 'partition-rotate',
+                'params'   => ['table' => 'owa_click'],
+                'schedule' => '@weekly',
+            ],
+        ]);
+
+        $this->assertSame('partition-rotate', $jobs['partition-rotate']['command']);
+        $this->assertSame('partition-rotate', $jobs['rotate-one-table']['command']);
+        $this->assertSame([], $jobs['partition-rotate']['params']);
+        $this->assertSame(['table' => 'owa_click'], $jobs['rotate-one-table']['params']);
+        $this->assertNotSame($jobs['partition-rotate']['schedule'], $jobs['rotate-one-table']['schedule']);
+    }
+
+    /**
+     * A bad entry disables itself and nothing else. A typo in one line of
+     * config must never stop the other jobs running.
+     */
+    public function testABadEntryDisablesOnlyItself()
+    {
+        $cases = [
+            'no command'        => ['schedule' => '@daily'],
+            'no schedule'       => ['command' => 'flush-cache'],
+            'unknown command'   => ['command' => 'no-such-command', 'schedule' => '@daily'],
+            'not an array'      => 'nonsense',
+        ];
+
+        foreach ($cases as $label => $spec) {
+            $jobs = $this->jobsWith(['broken' => $spec, 'ok-one' => ['command' => 'flush-cache', 'schedule' => '@daily']]);
+
+            $this->assertArrayNotHasKey('broken', $jobs, "$label should be refused");
+            $this->assertArrayHasKey('ok-one', $jobs, "$label must not take the other jobs down");
+            $this->assertArrayHasKey('partition-rotate', $jobs, "$label must not take the shipped job down");
+        }
+    }
+
+    /**
+     * The denylist is checked against the COMMAND, not the job name, so a
+     * friendly label cannot smuggle one past.
+     */
+    public function testDangerousCommandsAreRefusedEvenFromConfig()
+    {
+        foreach (['install', 'update', 'reset-secrets'] as $command) {
+            $jobs = $this->jobsWith(['harmless-sounding' => ['command' => $command, 'schedule' => '@daily']]);
+
+            $this->assertArrayNotHasKey('harmless-sounding', $jobs, "$command must never be schedulable");
+        }
+    }
+
+    /** 'off' leaves a job registered and listed, just never due. */
+    public function testOffLeavesAJobListedButNeverDue()
+    {
+        $jobs = $this->jobsWith(['partition-rotate' => ['schedule' => 'off']]);
+
+        $this->assertArrayHasKey('partition-rotate', $jobs, 'off is a state, not an absence');
+        $this->assertTrue($this->callProtected($this->runner(), 'isDisabled', [$jobs['partition-rotate']]));
+        $this->assertNull($this->callProtected($this->runner(), 'parsedSchedule', [$jobs['partition-rotate']]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Locking
+    // -----------------------------------------------------------------------
+
+    public function testALockIsExclusiveAndReleasableOnlyByItsOwner()
+    {
+        $name = $this->track('owa_test_lock_' . bin2hex(random_bytes(3)));
+
+        $mine   = new \OWA\Module\Base\Classes\JobLease($name);
+        $theirs = new \OWA\Module\Base\Classes\JobLease($name);
+
+        $this->assertTrue($mine->acquire(3600));
+        $this->assertFalse($theirs->acquire(3600), 'a second holder must be refused');
+
+        $this->assertTrue($mine->refresh(3600), 'the owner may extend');
+        $this->assertFalse($theirs->refresh(3600), 'a stranger may not');
+
+        $theirs->release();
+        $this->assertNotNull(\OWA\Core\CoreAPI::dbSingleton()->getJobLock($name), 'a stranger cannot release it');
+
+        $mine->release();
+        $this->assertNull(\OWA\Core\CoreAPI::dbSingleton()->getJobLock($name));
+    }
+
+    /**
+     * An expired lock is taken over, and the original holder finishing late
+     * cannot then release the lock belonging to the run that replaced it.
+     */
+    public function testAnExpiredLockIsTakenOverSafely()
+    {
+        $name = $this->track('owa_test_lock_' . bin2hex(random_bytes(3)));
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+
+        $dead = new \OWA\Module\Base\Classes\JobLease($name);
+        $this->assertTrue($dead->acquire(3600));
+
+        $db->query(sprintf(
+            "UPDATE owa_job_lock SET expires_at = %d WHERE job_name = '%s'",
+            time() - 10, $db->prepare($name)
+        ));
+
+        $next = new \OWA\Module\Base\Classes\JobLease($name);
+        $this->assertTrue($next->acquire(3600), 'an abandoned lock must be reclaimable');
+
+        $dead->release();
+        $this->assertNotNull($db->getJobLock($name), 'the late finisher must not release the new holder');
+
+        $next->release();
+    }
+
+    // -----------------------------------------------------------------------
+    // Outcome recording
+    // -----------------------------------------------------------------------
+
+    /** The default: a command that says nothing ran to completion. */
+    public function testACommandThatSaysNothingReportsOk()
+    {
+        $ctrl = new \OWA\Module\Base\Controller\PartitionStatusCli([]);
+
+        $this->assertSame('ok', $ctrl->getCliOutcome()['outcome']);
+    }
+
+    /** refuse() and fail() are distinct, and the FIRST message wins. */
+    public function testRefuseAndFailAreDistinctAndKeepTheFirstMessage()
+    {
+        $ctrl = $this->runner();
+
+        $this->callProtected($ctrl, 'refuse', ['first reason']);
+        $this->callProtected($ctrl, 'refuse', ['second reason']);
+
+        $out = $ctrl->getCliOutcome();
+        $this->assertSame('refused', $out['outcome']);
+        $this->assertSame('first reason', $out['message'], 'the first thing that went wrong is what is recorded');
+
+        $ctrl2 = $this->runner();
+        $this->callProtected($ctrl2, 'fail', ['it broke']);
+        $this->assertSame('failed', $ctrl2->getCliOutcome()['outcome']);
+    }
+
+    /**
+     * partition-rotate reports a refusal rather than looking like a success.
+     *
+     * Before the outcome channel, a refused run and a completed one were
+     * indistinguishable to any caller.
+     */
+    public function testRotateReportsItsRefusals()
+    {
+        foreach (['abc', '0', '-4'] as $bad) {
+            $ctrl = new \OWA\Module\Base\Controller\PartitionRotateCli(['keep' => $bad]);
+            $ctrl->action();
+
+            $this->assertSame('refused', $ctrl->getCliOutcome()['outcome'], "keep=$bad should be refused");
+        }
+
+        $ctrl = new \OWA\Module\Base\Controller\PartitionRotateCli(['granularity' => 'fortnightly']);
+        $ctrl->action();
+
+        $this->assertSame('refused', $ctrl->getCliOutcome()['outcome']);
+    }
+
+    /** Rotate derives a lease from the work it can see, not a constant. */
+    public function testRotateDerivesItsLeaseFromPlannedWork()
+    {
+        $lease = (new \OWA\Module\Base\Controller\PartitionRotateCli([]))->getJobLease();
+
+        $this->assertGreaterThanOrEqual(1800, $lease, 'never below the floor');
+        $this->assertIsInt($lease);
+    }
+
+    // -----------------------------------------------------------------------
+    // The dispatcher
+    // -----------------------------------------------------------------------
+
+    /** A disabled scheduler runs nothing and says so. */
+    public function testADisabledSchedulerRefusesToRun()
+    {
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduler_enabled', false);
+
+        $ctrl = $this->runner();
+        $ctrl->action();
+
+        $this->assertSame('refused', $ctrl->getCliOutcome()['outcome']);
+        $this->assertStringContainsString('disabled', $ctrl->getCliOutcome()['message']);
+    }
+
+    /** An unknown job name is refused, with the valid names offered. */
+    public function testAnUnknownJobNameIsRefused()
+    {
+        $ctrl = $this->runner(['job' => 'no-such-job']);
+        $ctrl->action();
+
+        $out = $ctrl->getCliOutcome();
+        $this->assertSame('refused', $out['outcome']);
+        $this->assertStringContainsString('partition-rotate', $out['message'], 'say what the valid names are');
+    }
+
+    /** --dry-run changes no state at all. */
+    public function testDryRunWritesNothing()
+    {
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+        $before = $db->get_results('SELECT * FROM owa_scheduled_job ORDER BY job_name');
+
+        $this->runner(['dry-run' => true])->action();
+
+        $this->assertEquals(
+            $before,
+            $db->get_results('SELECT * FROM owa_scheduled_job ORDER BY job_name'),
+            'a dry run must leave the state table untouched'
+        );
+    }
+
+    /**
+     * The state row is materialised for EVERY registered job, not only due
+     * ones -- which is what lets "a row exists" prove the dispatcher has run.
+     */
+    public function testStateIsMaterialisedForEveryJob()
+    {
+        $name = $this->track('owa_test_never_due_' . bin2hex(random_bytes(3)));
+
+        // Registered but never due: a schedule in the past cannot recur.
+        \OWA\Core\CoreAPI::setSetting('base', 'scheduled_jobs', [
+            $name => ['command' => 'flush-cache', 'schedule' => '0 0 1 1 *'],
+        ]);
+
+        $ctrl = $this->runner(['dry-run' => false, 'job' => $name]);
+        $this->callProtected($ctrl, 'ensureState', [$name, false]);
+
+        $this->assertNotNull(
+            $this->callProtected($ctrl, 'state', [$name]),
+            'a row must exist even before the job is ever due'
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Diagnosis
+    // -----------------------------------------------------------------------
+
+    /**
+     * A job registered in code whose command has been removed can never run,
+     * and must say so rather than reporting a next-due time.
+     */
+    public function testDiagnosisNamesAnUnregisteredCommand()
+    {
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'ghost',
+            ['command' => 'no-such-command', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            null, null, \OWA\Core\Cron::parse('@daily'), time(), true, false, true, time(),
+        ]);
+
+        $this->assertStringContainsString('not registered', (string) $reason);
+    }
+
+    /** A held lock reads as "running now", not as a fault. */
+    public function testDiagnosisReportsARunningJob()
+    {
+        $now = time();
+
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'busy',
+            ['command' => 'flush-cache', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            null,
+            ['job_name' => 'busy', 'owner' => 'x', 'acquired_at' => $now - 60, 'expires_at' => $now + 3600],
+            \OWA\Core\Cron::parse('@daily'), $now, true, false, true, $now,
+        ]);
+
+        $this->assertStringContainsString('Running now', (string) $reason);
+    }
+
+    /** An expired lock names the fix. */
+    public function testDiagnosisReportsAStuckLock()
+    {
+        $now = time();
+
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'stuck',
+            ['command' => 'flush-cache', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            null,
+            ['job_name' => 'stuck', 'owner' => 'x', 'acquired_at' => $now - 99999, 'expires_at' => $now - 60],
+            \OWA\Core\Cron::parse('@daily'), $now, true, false, true, $now,
+        ]);
+
+        $this->assertStringContainsString('died', (string) $reason);
+        $this->assertStringContainsString('--force-release', (string) $reason);
+    }
+
+    /**
+     * By elimination: overdue, with nothing else true, means the dispatcher is
+     * not running -- and it must say so and print the crontab line.
+     */
+    public function testDiagnosisBlamesTheDispatcherOnlyByElimination()
+    {
+        $now  = time();
+        $long_ago = $now - (40 * 86400);
+
+        $row = [
+            'job_name' => 'lonely', 'last_run_slot' => $long_ago, 'last_run_at' => $long_ago,
+            'last_finished_at' => $long_ago, 'last_status' => 'ok', 'last_message' => '-',
+            'last_success_at' => $long_ago, 'last_failure_at' => 0, 'run_count' => 1, 'failure_count' => 0,
+        ];
+
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'lonely',
+            ['command' => 'flush-cache', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            $row, null, \OWA\Core\Cron::parse('@daily'), $now, true, false, true, $long_ago,
+        ]);
+
+        $this->assertStringContainsString('does not appear to be running', (string) $reason);
+        $this->assertStringContainsString('cmd=schedule-run', (string) $reason, 'print the fix');
+    }
+
+    /**
+     * ...and its inverse: with a sibling having run moments ago, the dispatcher
+     * is demonstrably alive and must NOT be blamed.
+     */
+    public function testDiagnosisDoesNotBlameTheDispatcherWhenAnotherJobJustRan()
+    {
+        $now      = time();
+        $long_ago = $now - (40 * 86400);
+
+        $row = [
+            'job_name' => 'lonely', 'last_run_slot' => $long_ago, 'last_run_at' => $long_ago,
+            'last_finished_at' => $long_ago, 'last_status' => 'ok', 'last_message' => '-',
+            'last_success_at' => $long_ago, 'last_failure_at' => 0, 'run_count' => 1, 'failure_count' => 0,
+        ];
+
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'lonely',
+            ['command' => 'flush-cache', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            $row, null, \OWA\Core\Cron::parse('@daily'), $now, true, false, true, $now - 30,
+        ]);
+
+        $this->assertStringNotContainsString('does not appear to be running', (string) $reason);
+        $this->assertStringContainsString('specific to this job', (string) $reason);
+    }
+
+    /** A failing job is reported as failing, with when and why. */
+    public function testDiagnosisReportsAFailingJob()
+    {
+        $now      = time();
+        $long_ago = $now - (40 * 86400);
+
+        $row = [
+            'job_name' => 'sad', 'last_run_slot' => $long_ago, 'last_run_at' => $long_ago,
+            'last_finished_at' => $long_ago, 'last_status' => 'failed', 'last_message' => 'the disk is full',
+            'last_success_at' => $long_ago - 100, 'last_failure_at' => $long_ago,
+            'run_count' => 9, 'failure_count' => 3,
+        ];
+
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'sad',
+            ['command' => 'flush-cache', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            $row, null, \OWA\Core\Cron::parse('@daily'), $now, true, false, true, $long_ago,
+        ]);
+
+        $this->assertStringContainsString('Failing since', (string) $reason);
+        $this->assertStringContainsString('the disk is full', (string) $reason);
+    }
+
+    /** A crashed run is distinguishable from a failed one. */
+    public function testDiagnosisReportsARunThatNeverFinished()
+    {
+        $now      = time();
+        $long_ago = $now - (40 * 86400);
+
+        $row = [
+            'job_name' => 'gone', 'last_run_slot' => $long_ago, 'last_run_at' => $long_ago,
+            'last_finished_at' => $long_ago - 500,      // finished BEFORE it started == died mid-run
+            'last_status' => 'ok', 'last_message' => '-',
+            'last_success_at' => $long_ago, 'last_failure_at' => 0, 'run_count' => 1, 'failure_count' => 0,
+        ];
+
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'gone',
+            ['command' => 'flush-cache', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            $row, null, \OWA\Core\Cron::parse('@daily'), $now, true, false, true, $long_ago,
+        ]);
+
+        $this->assertStringContainsString('never finished', (string) $reason);
+    }
+
+    /** Due but inside the tolerance of a normal tick is not a fault. */
+    public function testAJobDueMomentsAgoIsNotReportedAsBehind()
+    {
+        $now = time();
+
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'fresh',
+            ['command' => 'flush-cache', 'schedule' => '* * * * *', 'params' => [], 'source' => 'code'],
+            null, null, \OWA\Core\Cron::parse('* * * * *'), $now, true, false, true, $now,
+        ]);
+
+        $this->assertNull($reason, 'a job due within the grace period is simply waiting for the next tick');
+    }
+
+    /** An unreadable schedule is named as the reason, never defaulted. */
+    public function testDiagnosisNamesAnUnreadableSchedule()
+    {
+        $reason = $this->callProtected($this->statusCli(), 'diagnose', [
+            'wonky',
+            ['command' => 'flush-cache', 'schedule' => 'every thursday-ish', 'params' => [], 'source' => 'config'],
+            null, null, null, time(), true, false, true, time(),
+        ]);
+
+        $this->assertStringContainsString('cannot be read', (string) $reason);
+    }
+
+    // -----------------------------------------------------------------------
+    // Job lifecycle
+    // -----------------------------------------------------------------------
+
+    /**
+     * A de-registered job keeps its row, is never run, and is listed as
+     * orphaned. Auto-deleting would let a config typo destroy real history.
+     */
+    public function testAnOrphanedJobKeepsItsRowAndIsListed()
+    {
+        $name = $this->track('owa_test_orphan_' . bin2hex(random_bytes(3)));
+        $db   = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->query(sprintf(
+            "INSERT INTO owa_scheduled_job (id, job_name, last_status, last_message, last_params, last_run_at, run_count)
+             VALUES (%d, '%s', 'ok', '-', '-', %d, 4)",
+            crc32($name), $db->prepare($name), time() - 100
+        ));
+
+        $lines = $this->callProtected($this->statusCli(), 'describeOrphans', [
+            ['partition-rotate' => []],
+            $this->callProtected($this->statusCli(), 'allState'),
+        ]);
+
+        $this->assertStringContainsString($name, implode("\n", $lines));
+        $this->assertStringContainsString('Orphaned', implode("\n", $lines));
+
+        // Still there: nothing pruned it behind our back.
+        $this->assertNotNull($this->callProtected($this->statusCli(), 'state', [$name]));
+    }
+
+    /**
+     * A re-registered job resumes from its stored occurrence: due ONCE when the
+     * slot is stale, rather than reading as never-run or firing repeatedly.
+     */
+    public function testAReRegisteredJobResumesFromItsStoredSlot()
+    {
+        $parsed = \OWA\Core\Cron::parse('@daily');
+        $tz     = $this->callProtected($this->statusCli(), 'timezone');
+        $stale  = time() - (10 * 86400);
+
+        $slot = \OWA\Core\Cron::dueSlot($parsed, $stale, time(), $tz);
+        $this->assertNotNull($slot, 'a ten-day-old slot must be due');
+
+        // Once satisfied, not due again until the next occurrence.
+        $this->assertNull(
+            \OWA\Core\Cron::dueSlot($parsed, $slot, time(), $tz),
+            'it must run once on return, not repeatedly'
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Documentation is a fixture
+    // -----------------------------------------------------------------------
+
+    /**
+     * The OWA_SCHEDULED_JOBS example in the shipped config template must satisfy
+     * the merge rules it documents.
+     *
+     * Documentation fails silently: the prose says one thing and the
+     * copy-pasteable block says another. While this feature was being designed
+     * the example twice acquired a defect the rules forbid -- a duplicated key,
+     * then an entry with no command.
+     */
+    public function testTheDocumentedExampleObeysItsOwnRules()
+    {
+        $template = OWA_DIR . 'owa-config-dist.php';
+
+        if (! is_readable($template)) {
+            $this->markTestSkipped('no config template to check');
+        }
+
+        $body = file_get_contents($template);
+
+        if (strpos($body, 'OWA_SCHEDULED_JOBS') === false) {
+            $this->markTestSkipped('the template does not document OWA_SCHEDULED_JOBS');
+        }
+
+        // Every commented example line naming a command must name a real one.
+        preg_match_all("/'command'\s*=>\s*'([^']+)'/", $body, $m);
+
+        $this->assertNotEmpty($m[1], 'the example should show at least one command');
+
+        $s = \OWA\Core\CoreAPI::serviceSingleton();
+        $s->loadCliCommands();
+
+        foreach ($m[1] as $command) {
+            $this->assertNotEmpty(
+                $s->getCliCommandClass($command),
+                "the documented example names '$command', which is not a registered command"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Laravel's model: one crontab line, jobs registered in code, schedules configurable per installation.

```
* * * * * php /path/to/owa/cli.php cmd=schedule-run
```

## Why now

`partition-rotate` shipped in #989/#994 and nothing runs it. Every install is coasting on the twelve months of partition lead a fresh install is born with — after which rows pile into the catch-all, reports keep working, and nobody notices until a rotate has to rewrite a year of data with writes blocked.

## Schema: two new tables (`Update015`, schema version 15)

`modules/Base/Update/Update015.php` creates both. `is_cli_mode_required = false` — two small tables, no fact-table rewrite. The DDL is `CREATE TABLE IF NOT EXISTS`, so it is idempotent and converges with a fresh install, which creates them through `Core\Module::install()`'s entity loop instead. It creates the tables and **not their contents** — that is load-bearing, see "liveness" below.

**`owa_scheduled_job`** — one row per job. Exists primarily for **one column**:

| column | type | why |
|---|---|---|
| `id` | BIGINT PK | from `generateId(job_name)`; makes a duplicate row impossible. **Never a lookup key** — `use_64bit_hash` can change what it returns for the same name |
| `job_name` | VARCHAR(255), indexed | what every read and write keys on |
| `last_run_slot` | INT | **the due test reads this and nothing else** — the occurrence the last run satisfied, which is what makes the scheduler level-triggered |
| `last_run_at` / `last_finished_at` | INT | `last_finished_at < last_run_at` means the process **died mid-job** — a crash detector needing no shutdown handler |
| `last_duration` | INT | seconds |
| `last_status` / `last_message` | VARCHAR(255) | `ok` / `refused` / `failed`, and why |
| `last_params` | VARCHAR(255) | the arguments a run actually used, so history can answer *why* it behaved as it did |
| `last_success_at` / `last_failure_at` | INT | "currently failing" is `last_failure_at > last_success_at` |
| `run_count` / `failure_count` | INT | monotonic |

Every column is a non-empty string or monotonic **by constraint**: `Entity::set()` skips falsy values and `partialUpdate()` carries the same guard, so a counter that had to reset to zero would be unwritable. Hence timestamps rather than a `consecutive_failures` field — which also says more.

No `schedule` or `params` columns: both are resolved fresh each tick from code plus config, so there is no second source of truth to drift and nothing to migrate when either changes.

**`owa_job_lock`** — one row per running job. `job_name` is the **primary key, and the row's existence is the lock**:

```
job_name    VARCHAR PRIMARY KEY
owner       VARCHAR        -- token; release only your own
acquired_at INT
expires_at  INT
```

## Two new CLI commands

**`cmd=schedule-run`** — the dispatcher, the only thing that belongs in cron.

| flag | effect |
|---|---|
| *(none)* | run everything due |
| `--dry-run` | report what would run, write nothing |
| `job=NAME --force` | run one job now, ignoring its schedule, still taking the lock |
| `--force-release job=NAME` | drop a lock left by a dead process |
| `--prune-orphans` | forget state for jobs no longer registered |

**`cmd=schedule-status`** — read-only, writes to stdout, **never writes a row**. Diagnoses rather than reports.

## Job configuration: `OWA_SCHEDULED_JOBS`

One constant, keyed by job name. Documented in `owa-config-dist.php`.

```php
define( 'OWA_SCHEDULED_JOBS', array(

    // Retune what ships: keep the @monthly schedule, add a retention window.
    'partition-rotate' => array( 'params' => array( 'keep' => 24 ) ),

    // Add a job the release does not register. New keys need both.
    'drain-queue' => array(
        'command'  => 'processEventQueue',
        'schedule' => '*/2 * * * *',
    ),

    // The same command a second time, its own name, arguments and cadence.
    'rotate-request-table' => array(
        'command'  => 'partition-rotate',
        'params'   => array( 'table' => 'owa_request' ),
        'schedule' => '@weekly',
    ),

    // Turn a shipped job off.
    'prune-archives' => array( 'schedule' => 'off' ),
) );
```

Keys are `command`, `schedule`, `params`. Schedules are five-field cron expressions, the standard `@hourly`/`@daily`/`@weekly`/`@monthly`/`@yearly` aliases, or `off`, read in the installation's configured timezone.

| case | behaviour |
|---|---|
| key matches a registered job | **per-key override** — only `params` keeps the shipped schedule, only `schedule` keeps the shipped params |
| key is new | added; `command` and `schedule` both required |
| `command` not registered | refused, named; **every other job still runs** |
| `command` in `NEVER_SCHEDULE` | refused — `install`, `update`, `reset-secrets`. Checked against the *command*, so a friendly label cannot smuggle one past |
| `schedule` unreadable | that job refused; **never given a default** |
| `schedule` is `off` | registered and listed, never due |

Registration in code is `registerJob( $name, $command, $schedule, $params )` — all four stated every time. `$command` is deliberately not defaulted to `$name`: a registration should be readable without consulting the CLI registry.

`OWA_SCHEDULER_ENABLED` stops everything without touching crontab. The lease is **not** configurable — it is mechanism, not policy, and `--force-release` answers the real need behind wanting a shorter one.

## What ships enabled

**One job: `partition-rotate`, monthly, no arguments.** It extends the lead and merges old periods, and deletes nothing. A test pins the empty params array, because adding `keep=` to the *registration* would quietly turn "nothing is deleted by default" into a retention policy that starts deleting on upgrade. Queue processing is deliberately not registered — whether to drain at all depends on the installation.

## Design notes

**Every minute, because the crontab line is a resolution floor, not a schedule.** A minute is the finest thing cron expresses, so the floor never binds and an in-app schedule always means what it says. Shipping `*/5` would let someone configure `* * * * *` and have it silently run every five minutes. Measured: ~66ms per boot, ~95 CPU-seconds/day.

**The due test is level-triggered.** Laravel asks whether an expression matches *this minute*; miss it and a monthly job waits another month. Each job stores the occurrence its last run satisfied, so it stays due until it has run. No backfill — three missed days produce one run — which imposes the rule that a scheduled job must be **convergent**, stated in `registerJob()`'s docblock.

**Locking uses the primary key for atomicity** — acquiring is a plain `INSERT`, the loser gets a constraint violation. Laravel's `DatabaseLock` design, portable to any driver, unlike `GET_LOCK`. No pruning lottery: `job_name` is the primary key, so the table is bounded by the registry rather than by arbitrary cache keys. The lease is a crash-recovery timeout that nothing enforces — a job outrunning it is not killed, but a later tick stops respecting its lock. `partition-rotate` derives its lease from the plan it already builds.

**CLI commands gain `refuse()` / `fail()`.** Every existing command is untouched and still reports `ok`. Converting the partition commands' three `FAILED` notices matters most: `Db::query()` swallows SQL errors and returns falsy, so a rotate whose `ALTER TABLE` the server rejected would otherwise have recorded `ok` while the lead quietly expired. And `partition-rotate` now **refuses** rather than reporting success when it skipped every table for want of partitioning — otherwise a scheduled rotate on an un-partitioned install shows a clean history forever while doing nothing.

**Liveness needs no heartbeat row and no recurring write.** The dispatcher materialises a state row for **every** registered job, so any row existing is proof it has run; `max(last_run_at)` says how recently. `schedule-status` never writes, or it would manufacture the evidence it is being read for.

**`schedule-status` diagnoses.** It walks an ordered list of causes — updates pending, scheduler disabled, job off, orphaned, running now, stuck lock, died mid-run, failing, refused — and names the first that holds. Because every way a *live* dispatcher can leave a job behind is directly observable, eliminating them makes "the dispatcher is not running" a conclusion rather than a guess, and it prints the crontab line to add:

```
partition-rotate    monthly, on the 1st at 00:00 (code)
  runs         partition-rotate (no arguments)
  next due     2026-09-01 00:00
  last run     never

The dispatcher has never run. Until the cron entry above is in place, nothing here happens.
```

## Verified

542 tests, 4015 assertions; three phpstan configurations clean; CI green on 8.2/8.3/8.4, self-hosted e2e and Jest.

`CronTest` is pure — no database — so it runs in CI where 232 tests skip. It simulates a month of one-minute ticks asserting exact occurrence counts, proves the result is independent of tick interval (60s/300s/900s agree), and covers both DST failures Laravel's docs warn about: the repeated hour must not double-run, the skipped hour must still run once.

Mutation-checked: twelve reverts applied across the two suites, all caught — including reverting the due test to Laravel's edge-triggered match (5 failures), adding `keep=24` to the shipped registration (3), emptying `NEVER_SCHEDULE`, letting config replace rather than merge per key, letting a stranger release someone else's lock, and letting a rotate that skipped everything report `ok`.

Exercised end to end on a live install: first run, idempotency across three ticks, `--dry-run`, `job=... --force`, a lock held by another process causing a skip rather than a block, `--force-release`, every merge rule, failure isolation across three jobs, and all four partition commands against a genuinely unpartitioned fact table.

The documented `OWA_SCHEDULED_JOBS` example in `owa-config-dist.php` is itself a test fixture — parsed and asserted to satisfy the rules it documents, because while this was being designed the example twice acquired a defect those rules forbid.

## Upgrading

`cmd=update` is required before the scheduler — or anything else — will run; `schedule-status` leads with that if it is outstanding. Install the crontab entry only after that, and **run `partition-rotate` by hand once first** on any install whose lead has already expired, so the expensive catch-up happens in a chosen window rather than at midnight on the 1st. Remove any standalone `partition-rotate` crontab line.
