### PR TITLE
fix(js): stop building asset URLs with a doubled slash

### DIFF
--- a/modules/Base/src/common/owa.js
+++ b/modules/Base/src/common/owa.js
@@ -175,7 +175,7 @@ class OWA {
         var that = this;
         
         // load css for heatmap class
-        Util.loadCss(this.getSetting('baseUrl')+'/public/base/css/owa.overlay.css', function(){});
+        Util.loadCss(this.getSetting('baseUrl')+'public/base/css/owa.overlay.css', function(){});
         
         // dynamic import of the Heatmap class
 	    import(/* webpackChunkName: "owa.heatmap" */ '../tracker/Heatmap.js').then( ( { Heatmap } ) => { 
@@ -194,7 +194,7 @@ class OWA {
         
         var that = this;
 
-        Util.loadCss(this.getSetting('baseUrl')+'/public/base/css/owa.overlay.css', function(){});
+        Util.loadCss(this.getSetting('baseUrl')+'public/base/css/owa.overlay.css', function(){});
 
 	    // dynamic import of the Player class
 	    import(/* webpackChunkName: "owa.player" */ '../tracker/Player.js').then( ( { Player } ) => { 

--- a/modules/Base/src/reporting/v1/owa.resultSetExplorer.js
+++ b/modules/Base/src/reporting/v1/owa.resultSetExplorer.js
@@ -464,7 +464,7 @@ OWA.resultSetExplorer.prototype = {
     },
 
     showLoader: function() {
-        jQuery('#'+this.dom_id).append('<div class="loader"><img class="loading" src="'+OWA.getSetting('baseUrl')+'/public/base/i/loader.gif"></div>');
+        jQuery('#'+this.dom_id).append('<div class="loader"><img class="loading" src="'+OWA.getSetting('baseUrl')+'public/base/i/loader.gif"></div>');
     },
 
     hideLoader: function() {

--- a/modules/Base/src/tracker/Player.js
+++ b/modules/Base/src/tracker/Player.js
@@ -196,7 +196,7 @@ class Player {
         jQuery("#owa_overlay_hidden").hide();
 
         //add cursor
-        var cursor = '<div id="owa-cursor"><img src="'+OWA_instance.getSetting('baseUrl')+'/public/base/i/cursor2.png"></div>';
+        var cursor = '<div id="owa-cursor"><img src="'+OWA_instance.getSetting('baseUrl')+'public/base/i/cursor2.png"></div>';
         jQuery('body').append(cursor);
 
         jQuery('#owa_overlay_start').toggleClass('active');


### PR DESCRIPTION
Found while reading the access logs.

`baseUrl` is `public_url` and already ends in a slash — `https://example.com/owa/` — so concatenating `'/public/...'` produces `/owa//public/...`. Four call sites did it:

| file | asset |
|---|---|
| `src/reporting/v1/owa.resultSetExplorer.js` | the loading spinner |
| `src/tracker/Player.js` | the DOM-stream cursor |
| `src/common/owa.js` ×2 | the overlay stylesheet |

The sibling call sites that append `'api/'` already omit the leading slash, which is the convention this now follows.

## Why it is worth fixing

It resolves and serves 200 — the web server collapses the duplicate — so it has been invisible. But in one day's access log, `/owa//public/base/i/loader.gif` was requested **95 times from two client ranges alone**.

Two consequences:

- It is a **second URL for a byte-identical asset**, so neither the edge cache nor the browser can share one entry with the correct URL.
- It **defeats any path-based cache rule** written against `/owa/public/` — which matters, because that is exactly the rule worth adding: static assets under `/owa/public/` currently account for 19% of all requests to the box and 927 MB a day, none of it cached.

## Verified

Rebuilt and confirmed the doubled form is gone from every shipped bundle and the corrected form is present in `owa.reporting-combined-min.js` and `owa.player.js`. Jest green — 25 suites, 223 tests, including the bundle-staleness guard.

`public/` is gitignored, so the bundles are per-install build artifacts; each install rebuilds on deploy.