### PR TITLE
fix(partitioning): the rotate refusal read "no fact table is not partitioned"

### DIFF
--- a/modules/Base/Controller/PartitionRotateCli.php
+++ b/modules/Base/Controller/PartitionRotateCli.php
@@ -290,9 +290,11 @@ class PartitionRotateCli extends PartitionsCli {
         if ( ! $rotated ) {
 
             return $this->refuse( sprintf(
-                'Nothing to rotate: %s not partitioned. Run cmd=partition-init once, in a '
-              . 'maintenance window, and this will start doing its job.',
-                count( $tables ) === 1 ? 'that table is' : 'no fact table is'
+                'Nothing to rotate: %s. Run cmd=partition-init once, in a maintenance '
+              . 'window, and this will start doing its job.',
+                count( $tables ) === 1
+                    ? 'that table is not partitioned'
+                    : 'no fact table is partitioned'
             ) );
         }
     }

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -784,6 +784,18 @@ final class ScheduleCliTest extends CliControllerTestCase
             $this->assertSame('refused', $out['outcome'], 'skipping every table is not success');
             $this->assertStringContainsString('partition-init', $out['message'], 'name the missing step');
 
+            // The message is what an operator reads every month on an install
+            // that never ran partition-init, so it has to read as a sentence.
+            // The first version rendered "no fact table is not partitioned" --
+            // the plural branch supplied "no fact table is" into a template
+            // that already said "not partitioned".
+            $this->assertStringContainsString('that table is not partitioned', $out['message'],
+                'the single-table branch names the table it skipped');
+            $this->assertDoesNotMatchRegularExpression(
+                '/\bis not\b[^.]*\bnot\b/', $out['message'],
+                'no double negative in the sentence'
+            );
+
         } finally {
 
             // Put it back exactly as it was.

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -808,7 +808,16 @@ final class ScheduleCliTest extends CliControllerTestCase
             }
         }
 
-        $this->assertTrue($db->isPartitioned($table), 'the fixture must be restored');
+        // This case mutates a REAL fact table, which other tests also read, so
+        // it asserts its own restore rather than leaving a lossy one to surface
+        // later as an unrelated failure somewhere else in the suite. A
+        // misattributed failure costs far more to diagnose than the assertion
+        // costs to write.
+        $this->assertTrue($db->isPartitioned($table), 'the fixture must be repartitioned');
+        $this->assertSame(
+            count($spans), count($db->getPartitionSpans($table)),
+            'the fixture must be restored to the SAME layout, not merely to some layout'
+        );
     }
 
     /** ...and reports ok when it did rotate something. */


### PR DESCRIPTION
Found by running the new scheduler on the demo install, where no fact table is partitioned — which is exactly the path this message exists for.

```
Job "partition-rotate" finished: refused --
  Nothing to rotate: no fact table is not partitioned. Run cmd=partition-init once...
```

The plural branch supplied `"no fact table is"` into a template that already said `"not partitioned"`. The whole clause now comes from the branch:

- one table: *"that table is not partitioned"*
- all tables: *"no fact table is partitioned"*

This is the message an installation that never ran `partition-init` sees every month once the scheduler is in cron, so it is worth reading as a sentence.

## Tests

The wording is pinned, including a regex against reintroducing a double negative. My first attempt at that assertion was itself wrong — it forbade a substring the *correct* single-table message contains — so it is now written against the two forms rather than against a fragment.

Also strengthened the fixture: this case removes partitioning from a real fact table that other tests read, so it now asserts it restored the **same layout**, not merely some layout. A lossy restore would otherwise surface as an unrelated failure elsewhere in the suite, which is precisely the misattribution that cost time here.

550 tests, 4046 assertions; phpstan clean.