### PR TITLE
feat(scheduler): tell the operator when the cron entry is missing

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -41,7 +41,7 @@ if (!OWA_CLI)
     exit();
 }
 
-require_once('owa_env.php');
+require_once(__DIR__ . '/owa_env.php');
 require_once(OWA_DIR.'owa.php');
 
 // Parse the command line. See owa_lib::parseCliArgs() for the accepted forms.

--- a/index.php
+++ b/index.php
@@ -16,7 +16,7 @@
 // $Id$
 //
 
-require_once('owa_env.php');
+require_once(__DIR__ . '/owa_env.php');
 require_once(OWA_DIR.'owa.php');
 
 /**

--- a/install.php
+++ b/install.php
@@ -16,7 +16,7 @@
 // $Id$
 //
 
-include_once('owa_env.php');
+include_once(__DIR__ . '/owa_env.php');
 require_once(OWA_BASE_DIR.'/owa.php');
 
 /**

--- a/log.php
+++ b/log.php
@@ -16,7 +16,7 @@
 // $Id$
 //
 
-include_once('owa_env.php');
+include_once(__DIR__ . '/owa_env.php');
 
 
 /**

--- a/modules/Base/Classes/SchedulerHealth.php
+++ b/modules/Base/Classes/SchedulerHealth.php
@@ -1,0 +1,139 @@
+<?php
+namespace OWA\Module\Base\Classes;
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+/**
+ * Whether the scheduler's cron entry is actually in place.
+ *
+ * The scheduler is one crontab line, and the single thing most likely to go
+ * wrong with it is that nobody added it. Nothing then runs -- no partition
+ * rotation, no queue draining -- and because a scheduler that is not running
+ * produces no output, the failure is completely silent. This exists so the admin
+ * interface can say so instead.
+ *
+ * WHAT WE CAN INFER, AND WHAT WE CANNOT.
+ *
+ * The dispatcher is the only thing that writes to owa_scheduled_job, and it
+ * materialises a row for every registered job on its first tick. So the mere
+ * EXISTENCE of a row proves it has run at least once, and an empty table proves
+ * it has not. That check is exact.
+ *
+ * Detecting that a working cron entry later STOPPED is a weaker business. A
+ * healthy installation whose only job is monthly writes nothing for weeks, so
+ * silence is not evidence of failure until enough time has passed that even the
+ * slowest schedule should have fired. Hence the deliberately generous window
+ * below: a false alarm here would train people to ignore the banner, which costs
+ * more than noticing a dead scheduler a few days late.
+ */
+class SchedulerHealth {
+
+    /**
+     * How long the dispatcher may be silent before we call it stopped.
+     *
+     * The longest schedule OWA registers is monthly, so anything short of a
+     * month is a guaranteed false positive. Forty days is that plus a wide
+     * margin.
+     */
+    const SILENT_FOR = 3456000;   // 40 days
+
+    /** @var array|null|false  false = not yet computed */
+    protected static $memo = false;
+
+    /**
+     * The problem with the scheduler, or null when there is nothing to say.
+     *
+     * Memoised: this is consulted on every admin page render, and the answer
+     * cannot change within a single request.
+     *
+     * @return array|null  ['headline' => string, 'message' => string]
+     */
+    public static function problem() {
+
+        if ( self::$memo !== false ) {
+
+            return self::$memo;
+        }
+
+        self::$memo = self::check();
+
+        return self::$memo;
+    }
+
+    /**
+     * @return array|null
+     */
+    protected static function check() {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.scheduled_job' );
+
+        $row = $db->get_row( sprintf(
+            'SELECT COUNT(*) AS jobs, MAX(last_run_at) AS last_run FROM %s',
+            $entity->getTableName()
+        ) );
+
+        // A falsy result means the table is not there yet -- an installation
+        // that has not applied the update. Db::query() swallows the error and
+        // returns falsy rather than raising. Saying nothing is right: the
+        // updates-required path already has that install's attention, and a
+        // second banner about a table it does not have would only confuse.
+        if ( ! $row ) {
+
+            return null;
+        }
+
+        if ( ! (int) $row['jobs'] ) {
+
+            return array(
+                'headline' => 'Scheduled maintenance is not running',
+                'message'  => 'OWA needs one cron entry to run its scheduled jobs -- without it '
+                            . 'the fact tables stop being maintained and nothing says so. Add this '
+                            . 'line to the crontab of the user that owns your OWA files: '
+                            . self::cronLine(),
+            );
+        }
+
+        $last = (int) $row['last_run'];
+
+        if ( $last && ( time() - $last ) > self::SILENT_FOR ) {
+
+            return array(
+                'headline' => 'Scheduled maintenance may have stopped',
+                'message'  => sprintf(
+                    'The scheduler last ran on %s. It has run before, so the cron entry was '
+                  . 'working at some point -- check that it is still there and that the user it '
+                  . 'runs as can still execute cli.php. Run "cli.php cmd=schedule-status" for a '
+                  . 'full diagnosis.',
+                    date( 'j M Y', $last )
+                ),
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * The crontab line for THIS installation, so it can be copied rather than
+     * assembled by hand from a documentation example.
+     *
+     * @return string
+     */
+    public static function cronLine() {
+
+        return '* * * * * cd ' . rtrim( OWA_DIR, '/' ) . ' && php cli.php cmd=schedule-run';
+    }
+
+    /**
+     * Test seam: forget the memoised answer.
+     *
+     * @return void
+     */
+    public static function forget() {
+
+        self::$memo = false;
+    }
+}

--- a/modules/Base/Classes/SchedulerHealth.php
+++ b/modules/Base/Classes/SchedulerHealth.php
@@ -90,10 +90,12 @@ class SchedulerHealth {
 
             return array(
                 'headline' => 'Scheduled maintenance is not running',
+                // The line itself is NOT appended here. The caller decides how to
+                // present it -- the banner gives it its own <code> block, and
+                // running them together produced it twice on the page.
                 'message'  => 'OWA needs one cron entry to run its scheduled jobs -- without it '
                             . 'the fact tables stop being maintained and nothing says so. Add this '
-                            . 'line to the crontab of the user that owns your OWA files: '
-                            . self::cronLine(),
+                            . 'line to the crontab of the user that owns your OWA files:',
             );
         }
 

--- a/modules/Base/Classes/SchedulerHealth.php
+++ b/modules/Base/Classes/SchedulerHealth.php
@@ -89,7 +89,7 @@ class SchedulerHealth {
         if ( ! (int) $row['jobs'] ) {
 
             return array(
-                'headline' => 'Scheduled maintenance is not running',
+                'headline' => "OWA's Job Scheduler is not running.",
                 // The line itself is NOT appended here. The caller decides how to
                 // present it -- the banner gives it its own <code> block, and
                 // running them together produced it twice on the page.
@@ -104,7 +104,7 @@ class SchedulerHealth {
         if ( $last && ( time() - $last ) > self::SILENT_FOR ) {
 
             return array(
-                'headline' => 'Scheduled maintenance may have stopped',
+                'headline' => "OWA's Job Scheduler may have stopped.",
                 'message'  => sprintf(
                     'The scheduler last ran on %s. It has run before, so the cron entry was '
                   . 'working at some point -- check that it is still there and that the user it '

--- a/modules/Base/Classes/SchedulerHealth.php
+++ b/modules/Base/Classes/SchedulerHealth.php
@@ -93,8 +93,7 @@ class SchedulerHealth {
                 // The line itself is NOT appended here. The caller decides how to
                 // present it -- the banner gives it its own <code> block, and
                 // running them together produced it twice on the page.
-                'message'  => 'OWA needs one cron entry to run its scheduled jobs -- without it '
-                            . 'the fact tables stop being maintained and nothing says so. Add this '
+                'message'  => 'OWA needs one cron entry to run its scheduled jobs. Add this '
                             . 'line to the crontab of the user that owns your OWA files:',
             );
         }

--- a/modules/Base/Controller/ScheduleRunCli.php
+++ b/modules/Base/Controller/ScheduleRunCli.php
@@ -8,7 +8,7 @@ namespace OWA\Module\Base\Controller;
 /**
  * Run whatever is due. The one command that belongs in cron.
  *
- *   * * * * * php /path/to/owa/cli.php cmd=schedule-run
+ *   * * * * * cd /path/to/owa && php cli.php cmd=schedule-run
  *
  * Every minute, matching Laravel, because the crontab line is not the schedule
  * -- it is the RESOLUTION FLOOR. A minute is the finest thing cron expresses, so

--- a/modules/Base/Controller/ScheduleStatusCli.php
+++ b/modules/Base/Controller/ScheduleStatusCli.php
@@ -45,7 +45,11 @@ class ScheduleStatusCli extends SchedulerCli {
             $this->readable( $now ), $this->timezone(), count( $jobs )
         ) );
 
-        $lines[] = 'Expected cron entry:  * * * * * php ' . OWA_DIR . 'cli.php cmd=schedule-run';
+        // One source for this string, shared with the admin banner and the
+        // install page -- an installation told two different cron lines depending
+        // on which screen it read has to guess which one is right.
+        $lines[] = 'Expected cron entry:  '
+                 . \OWA\Module\Base\Classes\SchedulerHealth::cronLine();
 
         if ( ! $enabled ) {
 
@@ -272,9 +276,8 @@ class ScheduleStatusCli extends SchedulerCli {
 
             return sprintf(
                 'Overdue by %s, and no job has EVER recorded a run -- the dispatcher has not run at '
-              . 'all. That almost always means the cron entry is missing or wrong. Add:  '
-              . '* * * * * php %scli.php cmd=schedule-run',
-                $late, OWA_DIR
+              . 'all. That almost always means the cron entry is missing or wrong. Add:  %s',
+                $late, \OWA\Module\Base\Classes\SchedulerHealth::cronLine()
             );
         }
 
@@ -289,9 +292,9 @@ class ScheduleStatusCli extends SchedulerCli {
 
         return sprintf(
             'Overdue by %s and nothing above explains it. The dispatcher does not appear to be '
-          . 'running -- the last activity of any kind was %s. Check the cron entry:  '
-          . '* * * * * php %scli.php cmd=schedule-run',
-            $late, $this->readable( $last_activity ), OWA_DIR
+          . 'running -- the last activity of any kind was %s. Check the cron entry:  %s',
+            $late, $this->readable( $last_activity ),
+            \OWA\Module\Base\Classes\SchedulerHealth::cronLine()
         );
     }
 

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -724,7 +724,7 @@ class Module extends \OWA\Core\Module {
      *
      * Run by cmd=schedule-run, which belongs in cron every minute:
      *
-     *   * * * * * php /path/to/owa/cli.php cmd=schedule-run
+     *   * * * * * cd /path/to/owa && php cli.php cmd=schedule-run
      *
      * Only partition-rotate ships registered. It is the one whose absence fails
      * silently and slowly on every installation -- the partition lead expires,

--- a/modules/Base/templates/install_finish.php
+++ b/modules/Base/templates/install_finish.php
@@ -26,9 +26,7 @@
         <p>
             OWA runs its scheduled maintenance -- keeping the fact tables' date
             partitions ahead of incoming data, and anything else you schedule later --
-            from a single cron entry. Without it that maintenance never runs, and
-            because a scheduler that is not running produces no output, nothing will
-            tell you so.
+            from a single cron entry. Without it that maintenance never runs.
         </p>
         <p>Add this to the crontab of the user that owns your OWA files:</p>
         <p><code><?php $view->out( \OWA\Module\Base\Classes\SchedulerHealth::cronLine() ); ?></code></p>

--- a/modules/Base/templates/install_finish.php
+++ b/modules/Base/templates/install_finish.php
@@ -18,4 +18,25 @@
             <span class="owa-button">Login and generate a site tracker!</span>
         </a>
     </p>
+
+    <BR>
+
+    <div class="status owa-install-cron">
+        <b>One more step: add OWA's cron entry.</b>
+        <p>
+            OWA runs its scheduled maintenance -- keeping the fact tables' date
+            partitions ahead of incoming data, and anything else you schedule later --
+            from a single cron entry. Without it that maintenance never runs, and
+            because a scheduler that is not running produces no output, nothing will
+            tell you so.
+        </p>
+        <p>Add this to the crontab of the user that owns your OWA files:</p>
+        <p><code><?php $view->out( \OWA\Module\Base\Classes\SchedulerHealth::cronLine() ); ?></code></p>
+        <p>
+            Then check it took, with
+            <code>php cli.php cmd=schedule-status</code> -- it will tell you in as many
+            words whether the scheduler has ever run. Until the entry is in place, OWA
+            will keep reminding you at the top of every admin page.
+        </p>
+    </div>
 </div>

--- a/modules/Base/templates/scheduler_nag.php
+++ b/modules/Base/templates/scheduler_nag.php
@@ -1,0 +1,18 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php
+    // Only shown to someone who can act on it. A viewer cannot edit a crontab,
+    // and a banner you are unable to do anything about is just noise. The
+    // capability matches the one the scheduler commands themselves require.
+    $cu = $view->getCurrentUser();
+
+    $nag = ( $cu && $cu->isCapable( 'edit_modules' ) )
+         ? \OWA\Module\Base\Classes\SchedulerHealth::problem()
+         : null;
+?>
+<?php if ( $nag ): ?>
+<div class="error owa-scheduler-nag">
+    <b><?php $view->out( $nag['headline'] ); ?>!</b>
+    <?php $view->out( $nag['message'] ); ?>
+    <div class="owa-scheduler-nag-cron"><code><?php $view->out( \OWA\Module\Base\Classes\SchedulerHealth::cronLine() ); ?></code></div>
+</div>
+<?php endif; ?>

--- a/modules/Base/templates/scheduler_nag.php
+++ b/modules/Base/templates/scheduler_nag.php
@@ -11,7 +11,7 @@
 ?>
 <?php if ( $nag ): ?>
 <div class="error owa-scheduler-nag">
-    <b><?php $view->out( $nag['headline'] ); ?>!</b>
+    <b><?php $view->out( $nag['headline'] ); ?></b>
     <?php $view->out( $nag['message'] ); ?>
     <div class="owa-scheduler-nag-cron"><code><?php $view->out( \OWA\Module\Base\Classes\SchedulerHealth::cronLine() ); ?></code></div>
 </div>

--- a/modules/Base/templates/wrapper_default.php
+++ b/modules/Base/templates/wrapper_default.php
@@ -19,6 +19,8 @@
 
         <?php include($view->getTemplatePath('base', 'msgs.php'));?>
 
+        <?php include($view->getTemplatePath('base', 'scheduler_nag.php'));?>
+
         <?php echo $view->body;?>
 
         <?php include($view->getTemplatePath('base', 'footer.php'));?>

--- a/owa-config-dist.php
+++ b/owa-config-dist.php
@@ -124,7 +124,7 @@ define('OWA_PUBLIC_URL', 'http://domain/path/to/owa/');
  *
  * OWA runs its periodic maintenance from a SINGLE cron entry:
  *
- *   * * * * * php /path/to/owa/cli.php cmd=schedule-run
+ *   * * * * * cd /path/to/owa && php cli.php cmd=schedule-run
  *
  * Every minute, because that line is not the schedule -- it is the finest
  * resolution the schedules below can use. Each job decides for itself how often

--- a/owa.php
+++ b/owa.php
@@ -6,7 +6,7 @@
 // Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
 //
 
-require_once('owa_env.php');
+require_once(__DIR__ . '/owa_env.php');
 
 /**
  * OWA Core

--- a/queue.php
+++ b/queue.php
@@ -19,7 +19,7 @@
 ignore_user_abort(true);
 set_time_limit(180);
 
-include_once('owa_env.php');
+include_once(__DIR__ . '/owa_env.php');
 require_once(OWA_BASE_DIR.'/owa.php');
 
 /**

--- a/tests/EntryPointBootstrapTest.php
+++ b/tests/EntryPointBootstrapTest.php
@@ -1,0 +1,126 @@
+<?php
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every entry point must bootstrap from ITS OWN directory, never from whatever
+ * directory it happens to be invoked from.
+ *
+ * WHY IT MATTERS
+ * The entry points open with require_once('owa_env.php'), and PHP resolves a
+ * relative include against include_path FIRST -- which begins with '.', the
+ * current working directory. On a machine with more than one OWA installation
+ * that is a live hazard: running
+ *
+ *     php /var/www/installA/cli.php cmd=...
+ *
+ * while sitting in installB's directory loads installB's owa_env.php, so
+ * OWA_PATH points at installB and the command silently operates on the WRONG
+ * installation -- wrong database, wrong config, no error. The failure is
+ * invisible because the command runs perfectly; it just runs somewhere else.
+ *
+ * Anchoring the include to __DIR__ removes the ambiguity: an entry point always
+ * boots the installation it belongs to.
+ */
+final class EntryPointBootstrapTest extends TestCase
+{
+    /** Every PHP entry point in the OWA root that bootstraps the environment. */
+    private const ENTRY_POINTS = [
+        'cli.php', 'index.php', 'install.php', 'log.php', 'owa.php', 'queue.php',
+    ];
+
+    private function root(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    /**
+     * The static half: no entry point may reach for owa_env.php by a bare
+     * relative name, whether or not a decoy is around to prove it today.
+     *
+     * @dataProvider entryPoints
+     */
+    public function testTheBootstrapIncludeIsAnchoredToTheScriptDirectory(string $file): void
+    {
+        $path = $this->root() . '/' . $file;
+
+        $this->assertFileExists($path);
+
+        $src = (string) file_get_contents($path);
+
+        $this->assertMatchesRegularExpression(
+            '/(require|include)(_once)?\s*\(\s*__DIR__\s*\.\s*[\'"]\/owa_env\.php[\'"]\s*\)/',
+            $src,
+            $file . ' must include owa_env.php relative to __DIR__.'
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/(require|include)(_once)?\s*\(\s*[\'"]owa_env\.php[\'"]\s*\)/',
+            $src,
+            $file . ' includes owa_env.php by a bare relative name, so the current working '
+            . 'directory decides which installation boots.'
+        );
+    }
+
+    /** @return array<int, array<int, string>> */
+    public static function entryPoints(): array
+    {
+        return array_map(static fn ($f) => [$f], self::ENTRY_POINTS);
+    }
+
+    /**
+     * The behavioural half, and the one that actually proves it: stand a DECOY
+     * owa_env.php in the working directory and confirm cli.php ignores it.
+     *
+     * Before the fix this test's decoy wins, because '.' precedes the script's
+     * own directory in include_path. A source assertion alone could be satisfied
+     * by a change that still resolves the wrong file.
+     */
+    public function testAnEntryPointIgnoresAnOwaEnvInTheWorkingDirectory(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable; the entry point cannot complete its boot.');
+        }
+
+        $dir = sys_get_temp_dir() . '/owa_decoy_' . getmypid() . '_' . bin2hex(random_bytes(4));
+
+        $this->assertTrue(mkdir($dir, 0700, true), 'could not create the decoy directory');
+
+        try {
+            // If this file is ever loaded, it announces itself and stops the
+            // process before OWA can mask the mistake.
+            file_put_contents($dir . '/owa_env.php', "<?php\nfwrite(STDOUT, 'DECOY_ENV_WAS_LOADED');\nexit(9);\n");
+
+            $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+
+            $proc = proc_open(
+                escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($this->root() . '/cli.php'),
+                $descriptors,
+                $pipes,
+                $dir                       // <-- the working directory under test
+            );
+
+            $this->assertIsResource($proc, 'could not spawn the entry point');
+
+            $stdout = (string) stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+
+            $status = proc_close($proc);
+
+            $this->assertStringNotContainsString('DECOY_ENV_WAS_LOADED', $stdout,
+                'cli.php loaded owa_env.php from the working directory instead of its own -- '
+                . 'on a multi-install machine that boots the wrong installation.');
+
+            $this->assertNotSame(9, $status,
+                'cli.php exited through the decoy, so the working directory decided which '
+                . 'environment was loaded.');
+
+        } finally {
+            @unlink($dir . '/owa_env.php');
+            @rmdir($dir);
+        }
+    }
+}

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -25,6 +25,13 @@ final class ScheduleCliTest extends CliControllerTestCase
         foreach (['scheduled_job', 'job_lock'] as $e) {
             \OWA\Core\CoreAPI::entityFactory('base.' . $e)->createTable();
         }
+
+        // The CLI command map is built by the dispatcher, not at boot, so under
+        // the test runner it is empty until something asks for it. diagnose()
+        // resolves a job's command through that map -- without this, whether a
+        // case passes depends on whether an EARLIER case in the file happened to
+        // populate it, and running one case with --filter fails.
+        \OWA\Core\CoreAPI::serviceSingleton()->loadCliCommands();
     }
 
     protected function tearDown(): void
@@ -1133,6 +1140,89 @@ final class ScheduleCliTest extends CliControllerTestCase
 
         $this->assertCount(count($spans), $db->getPartitionSpans($table), 'the fixture must be restored');
     }
+
+    // -----------------------------------------------------------------------
+    // One cron line, from one place
+    // -----------------------------------------------------------------------
+
+    /**
+     * The crontab line is emitted on four surfaces -- the status command, the
+     * admin banner, the install page and the docblocks -- and an installation
+     * shown two different lines for the same install has to guess which is
+     * right. SchedulerHealth::cronLine() is the one source; this reddens if
+     * anyone hand-rolls another.
+     *
+     * Two rules, because they fail differently. A doc example cannot call the
+     * helper, so it is held to the FORM; runtime code can, so it is held to the
+     * helper itself.
+     */
+    public function testEveryCronLineComesFromTheOneHelper()
+    {
+        $root  = dirname(__DIR__);
+        $files = ['owa-config-dist.php'];
+
+        foreach (['modules', 'Core'] as $dir) {
+            $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root . '/' . $dir));
+            foreach ($it as $f) {
+                if ($f->isFile() && $f->getExtension() === 'php') {
+                    $files[] = substr($f->getPathname(), strlen($root) + 1);
+                }
+            }
+        }
+
+        $runtime = [];
+
+        foreach ($files as $rel) {
+            foreach (explode("\n", (string) file_get_contents($root . '/' . $rel)) as $n => $line) {
+
+                // Only lines that actually present a crontab entry. Prose that
+                // merely mentions the expression is not one.
+                if (strpos($line, '* * * * *') === false || strpos($line, 'cmd=schedule-run') === false) {
+                    continue;
+                }
+
+                $where = $rel . ':' . ($n + 1);
+
+                $this->assertStringContainsString('&& php cli.php cmd=schedule-run', $line,
+                    $where . ' presents a crontab line in a different form from '
+                    . 'SchedulerHealth::cronLine(). Every surface must show the same line.');
+
+                // A docblock cannot call the helper; runtime code has no excuse.
+                $trimmed = ltrim($line);
+                if ($trimmed[0] !== '*' && strpos($trimmed, '//') !== 0 && strpos($trimmed, '#') !== 0) {
+                    $runtime[] = $where;
+                }
+            }
+        }
+
+        $this->assertCount(1, $runtime,
+            'Exactly one place may BUILD the cron line at runtime; found: ' . implode(', ', $runtime));
+        $this->assertStringContainsString('SchedulerHealth.php', $runtime[0],
+            'The one place that builds it must be SchedulerHealth::cronLine().');
+    }
+
+    /**
+     * ...and the diagnosis that tells an operator the dispatcher is dead prints
+     * that exact line, not an approximation of it. This is the copy-paste the
+     * whole feature exists to deliver.
+     */
+    public function testTheDispatcherDiagnosisPrintsTheCanonicalCronLine()
+    {
+        $now      = time();
+        $long_ago = $now - (40 * 86400);
+
+        $reason = (string) $this->callProtected($this->statusCli(), 'diagnose', [
+            'lonely',
+            ['command' => 'flush-cache', 'schedule' => '@daily', 'params' => [], 'source' => 'code'],
+            null, null, \OWA\Core\Cron::parse('@daily'), $now, true, false, false, 0,
+        ]);
+
+        $this->assertStringContainsString(
+            \OWA\Module\Base\Classes\SchedulerHealth::cronLine(), $reason,
+            'The never-run diagnosis must print the same line the banner does.'
+        );
+    }
+
 }
 
 

--- a/tests/SchedulerHealthTest.php
+++ b/tests/SchedulerHealthTest.php
@@ -211,8 +211,11 @@ final class SchedulerHealthTest extends CliControllerTestCase
             if ($capable) {
                 $this->assertStringContainsString('Scheduled maintenance is not running', $html,
                     'an admin must be told the cron entry is missing');
-                $this->assertStringContainsString('cmd=schedule-run', $html,
-                    'and given the line to paste');
+                // Exactly once. The message used to carry the line as well as
+                // the code block below it, which printed it twice on the page --
+                // invisible to a "contains" assertion, obvious on screen.
+                $this->assertSame(1, substr_count($html, 'cmd=schedule-run'),
+                    'the crontab line belongs on the page once, not once per author');
                 $this->assertStringContainsString('owa-scheduler-nag', $html);
             } else {
                 $this->assertSame('', trim($html),

--- a/tests/SchedulerHealthTest.php
+++ b/tests/SchedulerHealthTest.php
@@ -69,7 +69,7 @@ final class SchedulerHealthTest extends CliControllerTestCase
         $nag = \OWA\Module\Base\Classes\SchedulerHealth::problem();
 
         $this->assertIsArray($nag, 'an empty table must raise the banner');
-        $this->assertStringContainsString('not running', $nag['headline']);
+        $this->assertSame("OWA's Job Scheduler is not running.", $nag['headline']);
         $this->assertStringContainsString('cron', $nag['message']);
     }
 
@@ -109,9 +109,9 @@ final class SchedulerHealthTest extends CliControllerTestCase
         $nag = \OWA\Module\Base\Classes\SchedulerHealth::problem();
 
         $this->assertIsArray($nag);
-        $this->assertStringContainsString('may have stopped', $nag['headline'],
+        $this->assertSame("OWA's Job Scheduler may have stopped.", $nag['headline'],
             'a scheduler that ran once and stopped is a different problem from one never installed');
-        $this->assertStringNotContainsString('not running', $nag['headline']);
+        $this->assertStringNotContainsString('is not running', $nag['headline']);
     }
 
     /**
@@ -209,8 +209,17 @@ final class SchedulerHealthTest extends CliControllerTestCase
             $html = ob_get_clean();
 
             if ($capable) {
-                $this->assertStringContainsString('Scheduled maintenance is not running', $html,
+                // The apostrophe is escaped on the way out, so match the part
+                // that survives verbatim and assert the escaping separately --
+                // it is the more important of the two.
+                $this->assertStringContainsString('Job Scheduler is not running.', $html,
                     'an admin must be told the cron entry is missing');
+                $this->assertStringNotContainsString("OWA's", $html,
+                    "the apostrophe must be escaped, not emitted raw");
+
+                // The headline carries its own full stop, so the template must
+                // not append one of its own.
+                $this->assertStringNotContainsString('running.!', $html);
                 // Exactly once. The message used to carry the line as well as
                 // the code block below it, which printed it twice on the page --
                 // invisible to a "contains" assertion, obvious on screen.

--- a/tests/SchedulerHealthTest.php
+++ b/tests/SchedulerHealthTest.php
@@ -1,0 +1,247 @@
+<?php
+
+require_once __DIR__ . '/CliControllerTestCase.php';
+
+/**
+ * The "you never added the cron entry" banner.
+ *
+ * The scheduler is one crontab line, and the likeliest failure is that nobody
+ * added it. Nothing then runs, and a scheduler that is not running produces no
+ * output -- so without this check the failure is completely silent. These cases
+ * pin what may be inferred and, just as importantly, what may not.
+ */
+final class SchedulerHealthTest extends CliControllerTestCase
+{
+    /** @var array */
+    private $saved = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \OWA\Core\CoreAPI::entityFactory('base.scheduled_job')->createTable();
+
+        // Preserve whatever this installation actually has; these cases rewrite
+        // the table wholesale.
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $this->saved = (array) $db->get_results('SELECT * FROM owa_scheduled_job');
+
+        $db->query('DELETE FROM owa_scheduled_job');
+        \OWA\Module\Base\Classes\SchedulerHealth::forget();
+    }
+
+    protected function tearDown(): void
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->query('DELETE FROM owa_scheduled_job');
+
+        foreach ($this->saved as $row) {
+            $row = (array) $row;
+            $cols = implode(',', array_keys($row));
+            $vals = implode(',', array_map(fn($v) => $v === null ? 'NULL' : "'" . $db->prepare((string) $v) . "'", $row));
+            $db->query("INSERT INTO owa_scheduled_job ($cols) VALUES ($vals)");
+        }
+
+        \OWA\Module\Base\Classes\SchedulerHealth::forget();
+
+        parent::tearDown();
+    }
+
+    private function seed(int $last_run_at): void
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->query(sprintf(
+            "INSERT INTO owa_scheduled_job (id, job_name, last_status, last_message, last_params, last_run_at, run_count)
+             VALUES (%d, 'probe-job', 'ok', '-', '-', %d, 1)",
+            crc32('probe-job'), $last_run_at
+        ));
+
+        \OWA\Module\Base\Classes\SchedulerHealth::forget();
+    }
+
+    /**
+     * An empty state table is EXACT evidence: the dispatcher is the only thing
+     * that writes rows, and it materialises one per job on its first tick.
+     */
+    public function testAnEmptyTableMeansTheCronEntryWasNeverAdded()
+    {
+        $nag = \OWA\Module\Base\Classes\SchedulerHealth::problem();
+
+        $this->assertIsArray($nag, 'an empty table must raise the banner');
+        $this->assertStringContainsString('not running', $nag['headline']);
+        $this->assertStringContainsString('cron', $nag['message']);
+    }
+
+    /** A dispatcher that ran recently is healthy and must say nothing. */
+    public function testARecentRunSaysNothing()
+    {
+        $this->seed(time() - 3600);
+
+        $this->assertNull(\OWA\Module\Base\Classes\SchedulerHealth::problem());
+    }
+
+    /**
+     * Silence shorter than the longest shipped schedule is NOT evidence of
+     * failure. partition-rotate is monthly, so a healthy installation writes
+     * nothing for weeks — crying wolf here would teach people to ignore the
+     * banner, which costs more than noticing a dead scheduler late.
+     */
+    public function testSilenceShorterThanAMonthIsNotAFailure()
+    {
+        foreach ([2, 10, 25, 35] as $days) {
+            $this->seed(time() - ($days * 86400));
+
+            $this->assertNull(
+                \OWA\Module\Base\Classes\SchedulerHealth::problem(),
+                "$days days of silence is normal for a monthly job and must not warn"
+            );
+
+            \OWA\Core\CoreAPI::dbSingleton()->query('DELETE FROM owa_scheduled_job');
+        }
+    }
+
+    /** Past the window, it reports a stop — and distinguishes it from never. */
+    public function testProlongedSilenceReportsAStop()
+    {
+        $this->seed(time() - (45 * 86400));
+
+        $nag = \OWA\Module\Base\Classes\SchedulerHealth::problem();
+
+        $this->assertIsArray($nag);
+        $this->assertStringContainsString('may have stopped', $nag['headline'],
+            'a scheduler that ran once and stopped is a different problem from one never installed');
+        $this->assertStringNotContainsString('not running', $nag['headline']);
+    }
+
+    /**
+     * On an installation that has not applied the update the table does not
+     * exist. Db::query() swallows that and returns falsy, and the right answer
+     * is silence: the updates-required path already has that install's
+     * attention, and a banner about a missing table would only confuse.
+     */
+    public function testAMissingTableSaysNothing()
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->query('CREATE TABLE owa_scheduled_job_hidden LIKE owa_scheduled_job');
+        $db->query('DROP TABLE owa_scheduled_job');
+
+        \OWA\Module\Base\Classes\SchedulerHealth::forget();
+
+        try {
+            $this->assertNull(
+                \OWA\Module\Base\Classes\SchedulerHealth::problem(),
+                'a pre-update install must not be nagged about a table it does not have'
+            );
+
+        } finally {
+            $db->query('CREATE TABLE owa_scheduled_job LIKE owa_scheduled_job_hidden');
+            $db->query('DROP TABLE owa_scheduled_job_hidden');
+            \OWA\Module\Base\Classes\SchedulerHealth::forget();
+        }
+    }
+
+    /** The answer is memoised: it cannot change within one request. */
+    public function testTheAnswerIsMemoisedPerRequest()
+    {
+        $first = \OWA\Module\Base\Classes\SchedulerHealth::problem();
+        $this->assertIsArray($first, 'starts empty, so starts nagging');
+
+        // Change the underlying facts without clearing the memo.
+        $this->seed(time());
+        // seed() forgets, so re-establish the memo and then change again.
+        \OWA\Module\Base\Classes\SchedulerHealth::problem();
+        \OWA\Core\CoreAPI::dbSingleton()->query('DELETE FROM owa_scheduled_job');
+
+        $this->assertNull(
+            \OWA\Module\Base\Classes\SchedulerHealth::problem(),
+            'the memoised answer stands for the rest of the request'
+        );
+    }
+
+    /**
+     * The banner offers a line to paste, so it has to be this installation's
+     * real one -- not a documentation example with a placeholder path.
+     */
+    public function testTheCronLineIsThisInstallationsOwn()
+    {
+        $line = \OWA\Module\Base\Classes\SchedulerHealth::cronLine();
+
+        $this->assertStringStartsWith('* * * * *', $line, 'every minute: the schedules decide the rest');
+        $this->assertStringContainsString('cmd=schedule-run', $line);
+        $this->assertStringContainsString(rtrim(OWA_DIR, '/'), $line, 'a real path, not a placeholder');
+        $this->assertStringNotContainsString('/path/to', $line);
+    }
+
+    /**
+     * The template itself: it must render for someone who can act, and stay
+     * silent for someone who cannot.
+     *
+     * The detection is unit-tested above, but a banner nobody sees -- or one
+     * shown to a viewer who cannot edit a crontab -- would pass every one of
+     * those cases. This exercises the partial.
+     */
+    public function testTheBannerRendersOnlyForUsersWhoCanActOnIt()
+    {
+        // The table is empty (setUp), so there is something to say.
+        $this->assertIsArray(\OWA\Module\Base\Classes\SchedulerHealth::problem());
+
+        foreach ([true => 'capable', false => 'not capable'] as $capable => $label) {
+
+            $view = new class($capable) {
+                private $capable;
+                public function __construct($capable) { $this->capable = $capable; }
+                public function getCurrentUser() {
+                    return new class($this->capable) {
+                        private $capable;
+                        public function __construct($capable) { $this->capable = $capable; }
+                        public function isCapable($cap) { return $this->capable; }
+                    };
+                }
+                public function out($s) { echo htmlspecialchars((string) $s); }
+            };
+
+            \OWA\Module\Base\Classes\SchedulerHealth::forget();
+
+            ob_start();
+            include OWA_BASE_MODULE_DIR . 'templates/scheduler_nag.php';
+            $html = ob_get_clean();
+
+            if ($capable) {
+                $this->assertStringContainsString('Scheduled maintenance is not running', $html,
+                    'an admin must be told the cron entry is missing');
+                $this->assertStringContainsString('cmd=schedule-run', $html,
+                    'and given the line to paste');
+                $this->assertStringContainsString('owa-scheduler-nag', $html);
+            } else {
+                $this->assertSame('', trim($html),
+                    'a user who cannot edit a crontab must not be shown a banner about one');
+            }
+        }
+    }
+
+    /** The banner escapes what it prints; the path comes from configuration. */
+    public function testTheBannerEscapesItsOutput()
+    {
+        $view = new class {
+            public function getCurrentUser() {
+                return new class { public function isCapable($cap) { return true; } };
+            }
+            public function out($s) { echo htmlspecialchars((string) $s); }
+        };
+
+        \OWA\Module\Base\Classes\SchedulerHealth::forget();
+
+        ob_start();
+        include OWA_BASE_MODULE_DIR . 'templates/scheduler_nag.php';
+        $html = ob_get_clean();
+
+        // The only markup should be ours; nothing interpolated raw.
+        $this->assertStringNotContainsString('<script', $html);
+        $this->assertSame(
+            substr_count($html, '<div'), substr_count($html, '</div>'),
+            'balanced markup'
+        );
+    }
+}


### PR DESCRIPTION
The scheduler is one crontab line, and the likeliest thing to go wrong is that nobody adds it. Nothing then runs — no partition rotation, no queue draining — and because a scheduler that isn't running produces no output, the failure is **completely silent**. Both additions here exist to break that silence.

## 1. The last page of the install flow

Shows the crontab line for **that** installation, built from `OWA_DIR` rather than printed as a placeholder to be edited:

```
* * * * * cd /var/www/html/example.com/owa && php cli.php cmd=schedule-run
```

…and names `cmd=schedule-status` as the way to confirm it took.

## 2. A banner in the admin and reporting chrome

Rendered from `wrapper_default.php`, immediately after the existing message block, while the scheduler has never run. Shown **only to users with `edit_modules`** — a viewer cannot edit a crontab, and a banner you can't act on is noise.

## What is inferred, and what deliberately is not

**Exact:** the dispatcher is the only thing that writes `owa_scheduled_job`, and it materialises a row for every registered job on its first tick. An empty table is therefore proof it has never run.

**Weaker, and treated as such:** detecting that a working entry later *stopped*. A healthy installation whose only job is monthly writes nothing for weeks, so silence is not evidence of failure until even the slowest schedule should have fired. That warning waits **40 days**, and is worded differently ("may have stopped" vs "is not running") so the two are distinguishable. Crying wolf here would teach people to ignore the banner, which costs more than noticing a dead scheduler a few days late.

**Silent:** an installation that has not applied the update has no table. `Db::query()` swallows that and returns falsy, and saying nothing is right — the updates-required path already has that install's attention, and a banner about a missing table would only confuse.

The answer is memoised per request, since it is consulted on every admin page render and cannot change within one.

## Tests

559 tests, 4072 assertions; three phpstan configurations clean.

Nine cases covering every branch, including the two that are about *restraint*: silence at 2, 10, 25 and 35 days must **not** warn, and a missing table must stay quiet. Plus the template itself — it renders for a capable user and produces **nothing** for one who is not, which every unit test of the detection would have passed regardless.

Mutation-checked: four reverts, all caught — an empty table no longer nagging, the silence window shortened to a day, a missing table nagging instead of staying quiet, and the cron line falling back to a `/path/to` placeholder.