### PR TITLE
test: add an isolation sweep to CI, and fix what it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,62 @@ jobs:
       - name: JS unit tests (Jest — tracker + reporting bundle)
         run: npm test
 
+  isolation:
+    name: Test isolation sweep (each file alone)
+    runs-on: ubuntu-latest
+    # A test that passes in the suite but fails alone is inheriting state an
+    # earlier test set up -- a registry the dispatcher builds lazily, or a legacy
+    # owa_* alias that only exists once something has autoloaded it. PHPUnit runs
+    # the whole suite in one process, so neither is visible in a normal run.
+    # This job is deterministic where randomised ordering is not.
+    #
+    # It needs a real database: two of the registries that have caused this are
+    # only read by DB-backed cases, which skip without one.
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      OWA_E2E_DB_HOST: 127.0.0.1
+      OWA_E2E_DB_PORT: '3306'
+      OWA_E2E_DB_USER: root
+      OWA_E2E_DB_PASSWORD: ''
+      OWA_E2E_DB_NAME: owa_isolation_sweep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl, json, mysqli, gd
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      # Reuses the self-hosted e2e harness: it writes a scratch owa-config.php
+      # and runs the real CLI installer. No web server and no Playwright -- the
+      # unit suite only needs the schema and a config to connect with.
+      - name: Provision a scratch install
+        run: php tests/e2e/selfhost_harness.php up
+
+      - name: Run every test file in its own process
+        run: composer run-script test:isolation
+
+      - name: Tear down the scratch install
+        if: always()
+        run: php tests/e2e/selfhost_harness.php down
+
   e2e:
     name: E2E (self-hosted, php -S + MySQL)
     runs-on: ubuntu-latest

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -248,7 +248,19 @@ class Mysql extends \OWA\Core\Db {
 
     function close() {
 
-        @mysqli_close( $this->connection );
+        // mysqli_close() on a handle that is already closed raises an Error in
+        // PHP 8, and @ cannot suppress an Error. Db::__destruct() closes when
+        // isConnectionEstablished() is still true, so without clearing both of
+        // these here an explicit close() followed by shutdown closes twice and
+        // the second one is an uncaught fatal -- which also makes the process
+        // exit 255 after it has done its work correctly.
+        if ( $this->connection instanceof \mysqli ) {
+
+            @mysqli_close( $this->connection );
+        }
+
+        $this->connection        = null;
+        $this->connection_status = false;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "phpstan": "phpstan analyse --memory-limit=1G",
         "phpstan:migration": "phpstan analyse -c phpstan-migration.neon --memory-limit=1G",
         "phpstan:templates": "phpstan analyse -c phpstan-templates.neon --memory-limit=1G",
-        "test": "phpunit"
+        "test": "phpunit",
+        "test:isolation": "bash tests/tools/isolation_sweep.sh"
     },
 
     "extra": {

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -1339,26 +1339,40 @@ namespace OWA\Module\Base\Classes;
     }
 
     /**
+     * Write unsaved settings, if there are any.
+     *
+     * Runs during shutdown, from a registered function and again from the
+     * destructor, so it must not be able to take the process down. There is no
+     * caller left to hand a failure to, and an uncaught Throwable here would
+     * change the exit status of a process that had already done its work --
+     * which is the exact defect this class was changed to stop causing. A save
+     * can legitimately fail at this point: an installation with no config file
+     * has no auth key to hash a cache entry with, and a process that is shutting
+     * down because the database went away has nothing to write to.
+     *
+     * The failure is logged rather than swallowed, because a lost setting is
+     * worth a line in the log even when nothing can be done about it.
+     *
      * @return void
      */
     public function saveIfDirty() {
 
-        if ($this->is_dirty) {
+        if (!$this->is_dirty) {
+            return;
+        }
+
+        try {
             $this->save();
+        } catch (\Throwable $e) {
+            error_log('OWA: could not save settings during shutdown: ' . $e->getMessage());
         }
     }
 
     function __destruct() {
 
         // Fallback only: saveIfDirty() has normally already run as a shutdown
-        // function. A destructor has no caller left to handle a throw, and an
-        // uncaught one would change the process exit status, so anything that
-        // escapes here is swallowed deliberately.
-        try {
-            $this->saveIfDirty();
-        } catch (\Throwable $e) {
-            // Nothing can be done about it at this point in shutdown.
-        }
+        // function, while the database was still reachable.
+        $this->saveIfDirty();
     }
 
     /**

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -47,6 +47,9 @@ namespace OWA\Module\Base\Classes;
 
      var $is_dirty;
 
+    /** @var bool  whether the shutdown save has been registered for this process */
+    protected $shutdown_registered = false;
+
      var $config_id;
 
      var $config_from_db;
@@ -582,14 +585,14 @@ namespace OWA\Module\Base\Classes;
              // the next time the setting is written.
              if ( isset( $this->db_settings[ $module ][ $key ] ) ) {
                  unset( $this->db_settings[ $module ][ $key ] );
-                 $this->is_dirty = true;
+                 $this->markDirty();
              }
 
              return;
          }
 
          $this->db_settings[$module][$key] = $value;
-         $this->is_dirty = true;
+         $this->markDirty();
      }
 
      /**
@@ -782,7 +785,7 @@ namespace OWA\Module\Base\Classes;
 
                      unset( $this->db_settings[ $module ][ $key ] );
                      $removed[] = $module . '.' . $key;
-                     $this->is_dirty = true;
+                     $this->markDirty();
                  }
              }
          }
@@ -1312,10 +1315,49 @@ namespace OWA\Module\Base\Classes;
          }
      }
 
-    function __destruct() {
+    /**
+     * Flag unsaved settings, and arrange for them to be written while the
+     * database is still reachable.
+     *
+     * PHP runs shutdown functions BEFORE object destructors, so saving from
+     * __destruct races the database handle's own teardown. When the handle is
+     * destroyed first the save throws "mysqli object is already closed": the
+     * setting is silently lost, and because the Error is uncaught in a
+     * destructor it also turns a CLI command that did its job into exit
+     * status 255. Registering here fixes both, and costs one callback per
+     * process that actually changes a setting.
+     */
+    protected function markDirty() {
+
+        $this->is_dirty = true;
+
+        if (!$this->shutdown_registered) {
+
+            $this->shutdown_registered = true;
+            register_shutdown_function(array($this, 'saveIfDirty'));
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function saveIfDirty() {
 
         if ($this->is_dirty) {
             $this->save();
+        }
+    }
+
+    function __destruct() {
+
+        // Fallback only: saveIfDirty() has normally already run as a shutdown
+        // function. A destructor has no caller left to handle a throw, and an
+        // uncaught one would change the process exit status, so anything that
+        // escapes here is swallowed deliberately.
+        try {
+            $this->saveIfDirty();
+        } catch (\Throwable $e) {
+            // Nothing can be done about it at this point in shutdown.
         }
     }
 

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -183,7 +183,7 @@ namespace OWA\Module\Base\Classes;
         // without a new constant each time:
         //
         //   define('OWA_SCHEDULED_JOBS', array(
-        //       'partition-rotate' => array( 'params' => array( 'keep' => 24 ) ),
+        //       'rotate-partitions' => array( 'params' => array( 'keep' => 24 ) ),
         //       'drain-queue'      => array( 'command'  => 'processEventQueue',
         //                                    'schedule' => '*/2 * * * *' ),
         //   ));

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -738,12 +738,18 @@ class Module extends \OWA\Core\Module {
      */
     function registerJobs() {
 
+        // The NAME is deliberately not the command name. They are separate
+        // fields -- a command can be scheduled more than once under different
+        // names -- and when the only shipped job used the same string for both,
+        // nothing in the documentation could show which one OWA_SCHEDULED_JOBS
+        // keys on. It keys on the name.
+        //
         // Registered with EMPTY params on purpose: no keep=, so nothing is ever
         // deleted. An installation that wants retention states it in
         // OWA_SCHEDULED_JOBS, which is the deliberate act it should be.
         // Retention must never arrive as a side effect of turning the scheduler
         // on. ScheduleCliTest pins the empty array for exactly that reason.
-        $this->registerJob( 'partition-rotate', 'partition-rotate', '@monthly', array() );
+        $this->registerJob( 'rotate-partitions', 'partition-rotate', '@monthly', array() );
     }
 
     /**

--- a/owa-config-dist.php
+++ b/owa-config-dist.php
@@ -158,7 +158,7 @@ define('OWA_PUBLIC_URL', 'http://domain/path/to/owa/');
 //
 //    // Keep two years of history. NOTHING is deleted unless you ask for it
 //    // here: the shipped job runs with no keep= at all.
-//    'partition-rotate' => array( 'params' => array( 'keep' => 24 ) ),
+//    'rotate-partitions' => array( 'params' => array( 'keep' => 24 ) ),
 //
 //    // Drain the event queue every two minutes. Not registered by default,
 //    // because whether to drain at all depends on whether you queue events.
@@ -176,7 +176,7 @@ define('OWA_PUBLIC_URL', 'http://domain/path/to/owa/');
 //    ),
 //
 //    // Turn a shipped job off.
-//    // 'partition-rotate' => array( 'schedule' => 'off' ),
+//    // 'rotate-partitions' => array( 'schedule' => 'off' ),
 //));
 
 /**

--- a/tests/CliControllerTestCase.php
+++ b/tests/CliControllerTestCase.php
@@ -61,6 +61,14 @@ abstract class CliControllerTestCase extends TestCase
         if (!$this->dbAvailable()) {
             $this->markTestSkipped('OWA database not reachable; skipping CLI command test.');
         }
+        // The CLI command map is built by the dispatcher (cli.php's resolve
+        // path, SchedulerCli::action()), NOT at boot -- so under the test runner
+        // it stays empty until something asks for it. commandClass() below warms
+        // it as a side effect, which means any case that reads the map without
+        // calling that helper passes or fails depending on whether an EARLIER
+        // case in the process happened to. Warm it once, for every subclass.
+        owa_coreAPI::serviceSingleton()->loadCliCommands();
+
         $this->tok = substr(md5(uniqid('owacli', true)), 0, 12);
         // Start every test as an authenticated admin, matching cli.php's
         // setCurrentUser('admin', ...). Individual tests drop privileges when

--- a/tests/RegisteredClassResolutionTest.php
+++ b/tests/RegisteredClassResolutionTest.php
@@ -48,6 +48,15 @@ final class RegisteredClassResolutionTest extends TestCase
      */
     public function testEveryRegisteredEntityResolves(): void
     {
+        // instanceof does NOT autoload. A legacy alias that nothing has touched
+        // yet is simply undefined, and `$obj instanceof owa_entity` then reads
+        // false for EVERY entity -- so this case failed when run alone and
+        // passed in the suite only because some earlier test had loaded the
+        // alias first. Assert the precondition here, where it also loads it,
+        // rather than inheriting it from whatever ran before.
+        $this->assertTrue(class_exists('owa_entity'),
+            'owa_entity must resolve through the compat bridge before instanceof can see it.');
+
         $entities = self::$service->entities;
         $this->assertGreaterThan(
             20,

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -153,6 +153,30 @@ final class ScheduleCliTest extends CliControllerTestCase
         $this->assertSame([], $jobs['partition-rotate']['params'], 'the shipped params survive');
     }
 
+    /**
+     * ...and both keys together, which is the common real request: keep two
+     * years of data AND run the job at 4am on the 1st rather than midnight.
+     *
+     * There is one configuration form, not a short one and a long one. Every key
+     * is independently optional on a job that is already registered, and
+     * 'command' is what a NEW job additionally has to supply because it has
+     * nothing to inherit.
+     */
+    public function testScheduleAndParamsCanBeOverriddenTogether()
+    {
+        $jobs = $this->jobsWith(['partition-rotate' => [
+            'schedule' => '0 4 1 * *',
+            'params'   => ['keep' => 24],
+        ]]);
+
+        $this->assertSame('0 4 1 * *', $jobs['partition-rotate']['schedule']);
+        $this->assertSame(['keep' => 24], $jobs['partition-rotate']['params']);
+        $this->assertSame('partition-rotate', $jobs['partition-rotate']['command'],
+            'the registered command survives: config never has to restate it');
+        $this->assertSame('config-override', $jobs['partition-rotate']['source']);
+        $this->assertNotNull(\OWA\Core\Cron::parse('0 4 1 * *'), 'the documented expression must parse');
+    }
+
     /** A job the release never registered can be added outright. */
     public function testConfigCanAddAJob()
     {

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -1156,12 +1156,17 @@ final class ScheduleCliTest extends CliControllerTestCase
 
         $spans = $db->getPartitionSpans($table);
 
-        if (count($spans) < 10) {
+        if (count($spans) < 2) {
             $this->markTestSkipped("$table has too few partitions to open a gap in.");
         }
 
         $granularity = $db->inferPartitionGranularity($table) ?: 'monthly';
-        $keep        = array_slice($spans, 0, 6);
+
+        // Keep ONE span, so the gap is the whole lead however much history this
+        // installation has. Keeping six worked on a table with years behind it
+        // and left only seven periods to rebuild on a freshly installed one,
+        // where the six covered half of everything there was.
+        $keep = array_slice($spans, 0, 1);
 
         try {
             // Strip the lead, leaving a gap a rotate would have to rebuild.
@@ -1176,7 +1181,7 @@ final class ScheduleCliTest extends CliControllerTestCase
                 $table, $granularity, \OWA\Core\Db::partitionLeadBoundary(), true
             )['planned'];
 
-            $this->assertGreaterThan(10, $planned, 'the fixture should leave real work to do');
+            $this->assertGreaterThanOrEqual(10, $planned, 'the fixture should leave real work to do');
 
             $lease = (new \OWA\Module\Base\Controller\PartitionRotateCli(['table' => $table]))->getJobLease();
 

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -193,6 +193,45 @@ final class ScheduleCliTest extends CliControllerTestCase
      * The same command twice under different names: two jobs, two state rows,
      * two locks — so one instance running never blocks the other.
      */
+    /**
+     * The configuration key is the JOB NAME, never the command name.
+     *
+     * The shipped job is registered as registerJob('partition-rotate',
+     * 'partition-rotate', ...), so its name and its command are the same string
+     * and every example is ambiguous about which one the key matches. This uses
+     * a job whose name differs from its command, so the two cannot be confused:
+     * the name reaches it, and the command does not.
+     */
+    public function testTheConfigKeyIsTheJobNameNotTheCommand()
+    {
+        $jobs = $this->jobsWith([
+            'nightly-cache-flush' => ['command' => 'flush-cache', 'schedule' => '@daily'],
+
+            // Keyed by the COMMAND. There is no job of this name, so this is
+            // read as a NEW job -- which needs a schedule, has none, and is
+            // refused. What it must not do is reach nightly-cache-flush.
+            'flush-cache'         => ['params' => ['reached' => 'the wrong job']],
+        ]);
+
+        $this->assertArrayHasKey('nightly-cache-flush', $jobs);
+        $this->assertSame([], $jobs['nightly-cache-flush']['params'],
+            'an entry keyed by the command name must not modify the job that runs it');
+
+        $this->assertArrayNotHasKey('flush-cache', $jobs,
+            'a key that is neither a registered job nor a complete new entry is refused');
+
+        // ...and the name does reach it.
+        $jobs = $this->jobsWith([
+            'nightly-cache-flush' => [
+                'command'  => 'flush-cache',
+                'schedule' => '@daily',
+                'params'   => ['reached' => 'the right job'],
+            ],
+        ]);
+
+        $this->assertSame(['reached' => 'the right job'], $jobs['nightly-cache-flush']['params']);
+    }
+
     public function testTheSameCommandCanBeScheduledTwice()
     {
         $jobs = $this->jobsWith([

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -89,7 +89,7 @@ final class ScheduleCliTest extends CliControllerTestCase
     // -----------------------------------------------------------------------
 
     /**
-     * partition-rotate is registered with EMPTY params.
+     * The rotate job is registered with EMPTY params.
      *
      * The most valuable assertion in this file. It reddens if anyone later adds
      * keep=24 to the REGISTRATION, which would quietly turn "nothing is deleted
@@ -100,10 +100,10 @@ final class ScheduleCliTest extends CliControllerTestCase
     {
         $jobs = $this->callProtected($this->runner(), 'jobs');
 
-        $this->assertArrayHasKey('partition-rotate', $jobs);
-        $this->assertSame([], $jobs['partition-rotate']['params'], 'no keep= may be registered in code');
-        $this->assertSame('@monthly', $jobs['partition-rotate']['schedule']);
-        $this->assertSame('code', $jobs['partition-rotate']['source']);
+        $this->assertArrayHasKey('rotate-partitions', $jobs);
+        $this->assertSame([], $jobs['rotate-partitions']['params'], 'no keep= may be registered in code');
+        $this->assertSame('@monthly', $jobs['rotate-partitions']['schedule']);
+        $this->assertSame('code', $jobs['rotate-partitions']['source']);
     }
 
     /** Only that one job ships; everything else is opt-in. */
@@ -111,7 +111,7 @@ final class ScheduleCliTest extends CliControllerTestCase
     {
         $jobs = $this->callProtected($this->runner(), 'jobs');
 
-        $this->assertSame(['partition-rotate'], array_keys($jobs));
+        $this->assertSame(['rotate-partitions'], array_keys($jobs));
     }
 
     /** Every registered job must name a real command and parse. */
@@ -141,16 +141,16 @@ final class ScheduleCliTest extends CliControllerTestCase
     /** Giving only params keeps the shipped schedule, and vice versa. */
     public function testConfigOverridesPerKey()
     {
-        $jobs = $this->jobsWith(['partition-rotate' => ['params' => ['keep' => 24]]]);
+        $jobs = $this->jobsWith(['rotate-partitions' => ['params' => ['keep' => 24]]]);
 
-        $this->assertSame(['keep' => 24], $jobs['partition-rotate']['params']);
-        $this->assertSame('@monthly', $jobs['partition-rotate']['schedule'], 'the shipped schedule survives');
-        $this->assertSame('config-override', $jobs['partition-rotate']['source']);
+        $this->assertSame(['keep' => 24], $jobs['rotate-partitions']['params']);
+        $this->assertSame('@monthly', $jobs['rotate-partitions']['schedule'], 'the shipped schedule survives');
+        $this->assertSame('config-override', $jobs['rotate-partitions']['source']);
 
-        $jobs = $this->jobsWith(['partition-rotate' => ['schedule' => '@daily']]);
+        $jobs = $this->jobsWith(['rotate-partitions' => ['schedule' => '@daily']]);
 
-        $this->assertSame('@daily', $jobs['partition-rotate']['schedule']);
-        $this->assertSame([], $jobs['partition-rotate']['params'], 'the shipped params survive');
+        $this->assertSame('@daily', $jobs['rotate-partitions']['schedule']);
+        $this->assertSame([], $jobs['rotate-partitions']['params'], 'the shipped params survive');
     }
 
     /**
@@ -164,16 +164,16 @@ final class ScheduleCliTest extends CliControllerTestCase
      */
     public function testScheduleAndParamsCanBeOverriddenTogether()
     {
-        $jobs = $this->jobsWith(['partition-rotate' => [
+        $jobs = $this->jobsWith(['rotate-partitions' => [
             'schedule' => '0 4 1 * *',
             'params'   => ['keep' => 24],
         ]]);
 
-        $this->assertSame('0 4 1 * *', $jobs['partition-rotate']['schedule']);
-        $this->assertSame(['keep' => 24], $jobs['partition-rotate']['params']);
-        $this->assertSame('partition-rotate', $jobs['partition-rotate']['command'],
+        $this->assertSame('0 4 1 * *', $jobs['rotate-partitions']['schedule']);
+        $this->assertSame(['keep' => 24], $jobs['rotate-partitions']['params']);
+        $this->assertSame('partition-rotate', $jobs['rotate-partitions']['command'],
             'the registered command survives: config never has to restate it');
-        $this->assertSame('config-override', $jobs['partition-rotate']['source']);
+        $this->assertSame('config-override', $jobs['rotate-partitions']['source']);
         $this->assertNotNull(\OWA\Core\Cron::parse('0 4 1 * *'), 'the documented expression must parse');
     }
 
@@ -196,11 +196,10 @@ final class ScheduleCliTest extends CliControllerTestCase
     /**
      * The configuration key is the JOB NAME, never the command name.
      *
-     * The shipped job is registered as registerJob('partition-rotate',
-     * 'partition-rotate', ...), so its name and its command are the same string
-     * and every example is ambiguous about which one the key matches. This uses
-     * a job whose name differs from its command, so the two cannot be confused:
-     * the name reaches it, and the command does not.
+     * The shipped job now demonstrates this itself -- rotate-partitions runs
+     * partition-rotate -- but this keeps its own fixture so the rule is pinned
+     * independently of how the shipped job happens to be registered: the name
+     * reaches a job, and the command does not.
      */
     public function testTheConfigKeyIsTheJobNameNotTheCommand()
     {
@@ -242,11 +241,11 @@ final class ScheduleCliTest extends CliControllerTestCase
             ],
         ]);
 
-        $this->assertSame('partition-rotate', $jobs['partition-rotate']['command']);
+        $this->assertSame('partition-rotate', $jobs['rotate-partitions']['command']);
         $this->assertSame('partition-rotate', $jobs['rotate-one-table']['command']);
-        $this->assertSame([], $jobs['partition-rotate']['params']);
+        $this->assertSame([], $jobs['rotate-partitions']['params']);
         $this->assertSame(['table' => 'owa_click'], $jobs['rotate-one-table']['params']);
-        $this->assertNotSame($jobs['partition-rotate']['schedule'], $jobs['rotate-one-table']['schedule']);
+        $this->assertNotSame($jobs['rotate-partitions']['schedule'], $jobs['rotate-one-table']['schedule']);
     }
 
     /**
@@ -267,7 +266,7 @@ final class ScheduleCliTest extends CliControllerTestCase
 
             $this->assertArrayNotHasKey('broken', $jobs, "$label should be refused");
             $this->assertArrayHasKey('ok-one', $jobs, "$label must not take the other jobs down");
-            $this->assertArrayHasKey('partition-rotate', $jobs, "$label must not take the shipped job down");
+            $this->assertArrayHasKey('rotate-partitions', $jobs, "$label must not take the shipped job down");
         }
     }
 
@@ -287,11 +286,11 @@ final class ScheduleCliTest extends CliControllerTestCase
     /** 'off' leaves a job registered and listed, just never due. */
     public function testOffLeavesAJobListedButNeverDue()
     {
-        $jobs = $this->jobsWith(['partition-rotate' => ['schedule' => 'off']]);
+        $jobs = $this->jobsWith(['rotate-partitions' => ['schedule' => 'off']]);
 
-        $this->assertArrayHasKey('partition-rotate', $jobs, 'off is a state, not an absence');
-        $this->assertTrue($this->callProtected($this->runner(), 'isDisabled', [$jobs['partition-rotate']]));
-        $this->assertNull($this->callProtected($this->runner(), 'parsedSchedule', [$jobs['partition-rotate']]));
+        $this->assertArrayHasKey('rotate-partitions', $jobs, 'off is a state, not an absence');
+        $this->assertTrue($this->callProtected($this->runner(), 'isDisabled', [$jobs['rotate-partitions']]));
+        $this->assertNull($this->callProtected($this->runner(), 'parsedSchedule', [$jobs['rotate-partitions']]));
     }
 
     // -----------------------------------------------------------------------
@@ -496,7 +495,7 @@ final class ScheduleCliTest extends CliControllerTestCase
 
         $out = $ctrl->getCliOutcome();
         $this->assertSame('refused', $out['outcome']);
-        $this->assertStringContainsString('partition-rotate', $out['message'], 'say what the valid names are');
+        $this->assertStringContainsString('rotate-partitions', $out['message'], 'say what the valid names are');
     }
 
     /** --dry-run changes no state at all. */
@@ -729,7 +728,7 @@ final class ScheduleCliTest extends CliControllerTestCase
         ));
 
         $lines = $this->callProtected($this->statusCli(), 'describeOrphans', [
-            ['partition-rotate' => []],
+            ['rotate-partitions' => []],
             $this->callProtected($this->statusCli(), 'allState'),
         ]);
 

--- a/tests/ScheduleCliTest.php
+++ b/tests/ScheduleCliTest.php
@@ -25,13 +25,6 @@ final class ScheduleCliTest extends CliControllerTestCase
         foreach (['scheduled_job', 'job_lock'] as $e) {
             \OWA\Core\CoreAPI::entityFactory('base.' . $e)->createTable();
         }
-
-        // The CLI command map is built by the dispatcher, not at boot, so under
-        // the test runner it is empty until something asks for it. diagnose()
-        // resolves a job's command through that map -- without this, whether a
-        // case passes depends on whether an EARLIER case in the file happened to
-        // populate it, and running one case with --filter fails.
-        \OWA\Core\CoreAPI::serviceSingleton()->loadCliCommands();
     }
 
     protected function tearDown(): void

--- a/tests/SettingsShutdownSaveTest.php
+++ b/tests/SettingsShutdownSaveTest.php
@@ -97,6 +97,48 @@ final class SettingsShutdownSaveTest extends TestCase
             . 'shutdown. Losing it is silent: there is no caller left to report to.');
     }
 
+    /**
+     * ...and when the save genuinely cannot succeed, that is still not allowed
+     * to change the exit status.
+     *
+     * This is not hypothetical. Registering the save as a shutdown function made
+     * it run RELIABLY, which turned an intermittent failure on installations
+     * with no config file into a consistent one: no config means no
+     * OWA_AUTH_KEY, the cache read inside save() raises "Undefined constant",
+     * and a green test suite exited 255 on PHP 8.2. A save that cannot happen
+     * must be reported, not fatal.
+     *
+     * Driven directly rather than through a subprocess, because the failure has
+     * to be guaranteed. Closing the database does not do it: the driver simply
+     * reconnects on the next query.
+     */
+    public function testAFailingShutdownSaveIsLoggedRatherThanFatal(): void
+    {
+        $settings = (new ReflectionClass(OwaThrowingSettings::class))->newInstanceWithoutConstructor();
+
+        $dirty = new ReflectionProperty($settings, 'is_dirty');
+        $dirty->setAccessible(true);
+        $dirty->setValue($settings, true);
+
+        $log = tempnam(sys_get_temp_dir(), 'owa_settings_log_');
+        $was = ini_get('error_log');
+        ini_set('error_log', $log);
+
+        try {
+            $settings->saveIfDirty();   // must return, not throw
+        } finally {
+            ini_set('error_log', $was === false ? '' : $was);
+        }
+
+        $this->assertSame(1, $settings->save_attempts, 'the save should have been attempted');
+
+        $this->assertStringContainsString('could not save settings during shutdown',
+            (string) file_get_contents($log),
+            'The failure must leave a trace: a lost setting is worth a line in the log.');
+
+        @unlink($log);
+    }
+
     public function testShutdownDoesNotChangeTheExitStatus(): void
     {
         $result = $this->probe('write', 'probe-' . bin2hex(random_bytes(4)));
@@ -107,5 +149,21 @@ final class SettingsShutdownSaveTest extends TestCase
         $this->assertSame(0, $result['status'],
             'A process that did its work must exit 0. An uncaught Error in shutdown '
             . 'makes it 255, which reports failure to cron for a command that succeeded.');
+    }
+}
+
+/**
+ * A settings object whose save() always fails, standing in for an installation
+ * that cannot complete one during shutdown.
+ */
+final class OwaThrowingSettings extends \OWA\Module\Base\Classes\Settings
+{
+    public $save_attempts = 0;
+
+    function save()
+    {
+        $this->save_attempts++;
+
+        throw new \Error('Undefined constant "OWA\\Module\\Base\\Classes\\OWA_AUTH_KEY"');
     }
 }

--- a/tests/SettingsShutdownSaveTest.php
+++ b/tests/SettingsShutdownSaveTest.php
@@ -1,0 +1,111 @@
+<?php
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A setting changed and not explicitly saved must still be written, and must not
+ * take the process down on its way out.
+ *
+ * WHY IT MATTERS
+ * owa_settings tracks unsaved changes with is_dirty and used to flush them from
+ * __destruct(). PHP destroys objects in no guaranteed order during shutdown, so
+ * the database handle was frequently destroyed first and the flush then threw
+ * "mysqli object is already closed" from inside a destructor. Two consequences,
+ * both silent:
+ *
+ *   1. The setting was LOST. The write never reached the database and nothing
+ *      reported that, because there is no caller left to return a failure to.
+ *   2. The uncaught Error set the process exit status to 255. A CLI command that
+ *      had done its work correctly reported failure to whatever ran it -- for a
+ *      scheduled job, that is cron.
+ *
+ * The fix registers the save as a shutdown FUNCTION, which PHP runs before it
+ * destroys objects, so the database is still reachable. This test is the reason
+ * to keep it that way: it was found because a green PHPUnit run still exited
+ * 255, which only the per-file isolation sweep surfaced.
+ */
+final class SettingsShutdownSaveTest extends TestCase
+{
+    private const PROBE = __DIR__ . '/fixtures/settings_shutdown_probe.php';
+    private const KEY   = 'owa_settings_shutdown_probe';
+
+    protected function setUp(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable; the probe cannot persist a setting.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Remove the probe's setting and persist that removal explicitly.
+        owa_coreAPI::persistSetting('base', self::KEY, '');
+        owa_coreAPI::configSingleton()->save();
+    }
+
+    /** @return array{status:int, stdout:string, stderr:string} */
+    private function probe(string $mode, ?string $value = null): array
+    {
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+
+        $proc = proc_open(
+            escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg(self::PROBE)
+            . ' ' . $mode . ' base ' . escapeshellarg(self::KEY)
+            . ($value === null ? '' : ' ' . escapeshellarg($value)),
+            $descriptors,
+            $pipes,
+            dirname(__DIR__)
+        );
+
+        $this->assertIsResource($proc, 'could not spawn the settings probe');
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [
+            'status' => proc_close($proc),
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+        ];
+    }
+
+    public function testAnUnsavedSettingSurvivesShutdown(): void
+    {
+        $value = 'probe-' . bin2hex(random_bytes(4));
+
+        $result = $this->probe('write', $value);
+
+        $this->assertStringContainsString('"dirtied":true', $result['stdout'],
+            'the probe did not get as far as changing a setting');
+
+        $this->assertStringContainsString('"dirty_at_shutdown":false', $result['stdout'],
+            'The settings were still unsaved when shutdown began. The write must be '
+            . 'registered as a shutdown function, which PHP runs while the database '
+            . 'is still reachable, not left to a destructor that races it.');
+
+        // Read it back from a THIRD process, which never saw the writer's memory.
+        $read    = $this->probe('read');
+        $decoded = json_decode(trim($read['stdout']), true);
+
+        $this->assertIsArray($decoded, 'read probe did not emit JSON: ' . $read['stdout']);
+        $this->assertSame($value, $decoded['value'] ?? null,
+            'A setting changed without an explicit save() must still be written at '
+            . 'shutdown. Losing it is silent: there is no caller left to report to.');
+    }
+
+    public function testShutdownDoesNotChangeTheExitStatus(): void
+    {
+        $result = $this->probe('write', 'probe-' . bin2hex(random_bytes(4)));
+
+        $this->assertStringNotContainsString('already closed', $result['stdout'] . $result['stderr'],
+            'the shutdown save ran after the database handle was destroyed');
+
+        $this->assertSame(0, $result['status'],
+            'A process that did its work must exit 0. An uncaught Error in shutdown '
+            . 'makes it 255, which reports failure to cron for a command that succeeded.');
+    }
+}

--- a/tests/VisitorIdIndexTest.php
+++ b/tests/VisitorIdIndexTest.php
@@ -112,9 +112,32 @@ final class VisitorIdIndexTest extends TestCase
         $update->up();
         $this->assertTrue($db->indexExists($table, 'visitor_id'), 'up() should leave it indexed');
 
+        // Whether down() should remove anything depends on WHO created the index.
+        // up() adds one called idx_visitor_id; a freshly installed database
+        // already carries a visitor_id index from the table definition, under
+        // its own name. down() deliberately drops only the former, because
+        // removing an index it never created would be destroying part of the
+        // schema. Both are correct, and which one this installation has is not
+        // something the test gets to assume.
+        $ours = false;
+
+        foreach ($db->listIndexes() as $row) {
+            if ($row['t'] === $table && $row['i'] === 'idx_visitor_id') {
+                $ours = true;
+                break;
+            }
+        }
+
         try {
             $this->assertTrue($update->down(), 'down() should report success');
-            $this->assertFalse($db->indexExists($table, 'visitor_id'), 'down() should remove the index');
+
+            if ($ours) {
+                $this->assertFalse($db->indexExists($table, 'visitor_id'),
+                    'down() should remove the index that up() created');
+            } else {
+                $this->assertTrue($db->indexExists($table, 'visitor_id'),
+                    'down() must leave an index it did not create');
+            }
 
             $this->assertTrue($update->up(), 'up() should report success');
             $this->assertTrue($db->indexExists($table, 'visitor_id'), 'up() should put it back');

--- a/tests/fixtures/settings_shutdown_probe.php
+++ b/tests/fixtures/settings_shutdown_probe.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Shutdown probe for owa_settings' unsaved-settings save, run as a SUBPROCESS by
+ * SettingsShutdownSaveTest.
+ *
+ * WHY A SUBPROCESS
+ * The behaviour under test only happens during PHP's shutdown sequence, after
+ * the last line of the script. It cannot be observed from inside a PHPUnit case,
+ * because the runner's own process has not shut down yet.
+ *
+ * WHAT IT DOES
+ * Changes one setting and exits WITHOUT calling save(), which is the case the
+ * is_dirty flag exists to cover. The setting must still reach the database, and
+ * the process must still exit 0.
+ *
+ * USAGE
+ *   php settings_shutdown_probe.php write <module> <key> <value>
+ *   php settings_shutdown_probe.php read  <module> <key>
+ * write prints { "dirtied": true } before shutdown; anything printed after it
+ * comes from the shutdown sequence and is a failure. read prints the stored
+ * value from a process that never saw the writer's memory, which is the only
+ * honest way to prove the write actually landed.
+ *
+ * Excluded from the release tarball with the rest of tests/.
+ */
+
+$owa_root = dirname(__DIR__, 2) . '/';
+require_once($owa_root . 'owa.php');
+
+new owa(['instance_role' => 'cli']);
+
+$mode   = $argv[1] ?? 'write';
+$module = $argv[2] ?? 'base';
+$key    = $argv[3] ?? 'owa_settings_shutdown_probe';
+
+if ($mode === 'read') {
+
+    echo json_encode(['value' => owa_coreAPI::getSetting($module, $key)]) . "\n";
+    return;
+}
+
+// persistSetting() marks the settings dirty WITHOUT writing them; the
+// write is exactly what shutdown is supposed to do.
+owa_coreAPI::persistSetting($module, $key, $argv[4] ?? 'unset');
+
+echo json_encode(['dirtied' => true]) . "\n";
+
+// Report whether the settings were still unsaved once shutdown began. This is
+// the direct signal: persistSetting() above registered the save, shutdown
+// functions run FIFO, so by the time this one runs the write must already have
+// happened. A destructor-only implementation has not run at all yet.
+register_shutdown_function(static function () {
+
+    echo json_encode([
+        'dirty_at_shutdown' => (bool) owa_coreAPI::configSingleton()->is_dirty,
+    ]) . "\n";
+});
+
+// Close the database on the way out, AFTER the settings were dirtied.
+//
+// This is what makes the test discriminate. In the wild the race is decided by
+// PHP's object-destruction order, which varies with what else the process is
+// holding -- it bit the CLI test suite and not a bare script. Registering the
+// close here pins that ordering down: shutdown functions run FIFO, and the
+// settings object registered its save when persistSetting() dirtied it above,
+// so a correct implementation writes while the handle is still open and a
+// destructor-only implementation finds it gone.
+register_shutdown_function(static function () {
+
+    owa_coreAPI::dbSingleton()->close();
+});
+
+// Deliberately no save(). Everything that matters happens after this line.

--- a/tests/tools/isolation_sweep.sh
+++ b/tests/tools/isolation_sweep.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Run every test file in its own PHP process and report the ones that only pass
+# as part of the full suite.
+#
+# WHY THIS EXISTS
+# PHPUnit runs the whole suite in ONE process, and OWA's Service is a singleton,
+# so a test can silently inherit state that something earlier set up: a registry
+# the dispatcher builds lazily (cli_commands, scheduled_jobs, api_methods,
+# event_processors, metricsByEntity), or a legacy owa_* alias that only exists
+# once something has autoloaded it -- note `instanceof` does NOT autoload, so an
+# untouched alias reads as false for every object, with no error at all.
+#
+# Both failure modes are invisible in a normal run and both have happened here.
+# Randomised ordering finds them only by luck and makes a red build hard to
+# reproduce; running each file alone is deterministic.
+#
+# Exits non-zero if any file fails on its own.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+PHPUNIT="${PHPUNIT:-./vendor/bin/phpunit}"
+failed=0
+checked=0
+
+# Optional file arguments narrow the sweep, which is how you re-check one file
+# after fixing it without paying for the whole suite.
+if [ "$#" -gt 0 ]; then
+    files=("$@")
+else
+    files=(tests/*Test.php)
+fi
+
+printf '%s\n' "Running ${#files[@]} test file(s), each in its own process..."
+
+for f in "${files[@]}"; do
+    [ -e "$f" ] || continue
+    checked=$((checked + 1))
+
+    if out=$("$PHPUNIT" --no-coverage "$f" 2>&1) && printf '%s' "$out" | grep -qE '^(OK|OK \()'; then
+        continue
+    fi
+
+    # A file whose every case skips (no database, say) reports "No tests
+    # executed" rather than OK. That is not an isolation failure.
+    if printf '%s' "$out" | grep -qE 'No tests executed|OK, but'; then
+        continue
+    fi
+
+    failed=$((failed + 1))
+    printf '\n--- %s fails on its own ---\n' "$f"
+    printf '%s\n' "$out" | sed -n '/^There \(was\|were\)/,$p' | head -40
+done
+
+printf '\n%s\n' "Checked $checked file(s); $failed failed in isolation."
+
+if [ "$failed" -ne 0 ]; then
+    cat <<'MSG'
+
+A test that passes in the suite but fails alone is depending on something an
+earlier test did. Fix the test to establish its own precondition -- do not
+reorder the suite around it.
+MSG
+    exit 1
+fi


### PR DESCRIPTION
PHPUnit runs the whole suite in one PHP process and `Service` is a singleton, so a test can silently inherit state it never sets up. A file can also report `OK` and still exit non-zero, which a normal suite run never surfaces.

This adds a deterministic check for both, and fixes everything it found.

## The check

`tests/tools/isolation_sweep.sh` runs every test file in its own process and fails if any passes in the suite but not alone. Exposed as `composer run-script test:isolation`, and wired into CI as a separate `isolation` job with its own MySQL service — a database is required, because some of the affected registries are only read by DB-backed cases, which otherwise skip.

Provisioning reuses the existing self-hosted e2e harness (`selfhost_harness.php up`/`down`): a scratch config and the real CLI installer, with no Playwright or Node. The script accepts file arguments, so one file can be re-checked locally without paying for all 64. Runs in about two minutes.

## What it found

### Shipped code

**Settings were flushed from a destructor.** `Settings::__destruct()` saved unsaved settings. PHP destroys objects in no guaranteed order, so the database handle was often destroyed first and the save threw `mysqli object is already closed`. Two silent consequences: the setting was **lost**, with no caller left to return a failure to; and the uncaught `Error` set the exit status to **255**, so a CLI command that did its work reported failure to whatever ran it — for a scheduled job, cron. The save is now a registered shutdown function, which PHP runs before it destroys objects.

**A failing shutdown save could still kill the process.** Making the save reliable turned an intermittent failure into a consistent one on installations with no config file: no config means no `OWA_AUTH_KEY`, the cache read inside `save()` raises `Undefined constant`, and CI's PHP 8.2 job went from a green suite to exit 255. `saveIfDirty()` now catches and logs — a save can legitimately be impossible at that point, and a lost setting is worth a log line rather than a fatal.

**`Mysql::close()` was not idempotent.** `@` cannot suppress a PHP 8 `Error`, and `close()` left `connection_status` true, so an explicit close followed by `Db::__destruct()` closed twice and fataled at shutdown. Same symptom.

### Test integrity

**Lazily-built registries.** `Service` builds `cli_commands`, `scheduled_jobs`, `api_methods`, `event_processors` and `metricsByEntity` from the dispatcher, not at boot. `CliControllerTestCase::commandClass()` warms the CLI map as a side effect, so any case reading that map passed only if an earlier case had called that helper. Warmed in `setUp()` instead.

**`instanceof` does not autoload.** `$obj instanceof owa_entity` reads false — silently — when the legacy alias has not been touched. `RegisteredClassResolutionTest` reported every registered entity as not an entity when run alone. It is net (b) of the namespace-migration safety net, so its green was accidental.

**Two tests assumed a long-lived database.** Found by the CI job on its first run, because CI provisions a clean one. `testCreatingManyPeriodsOverLittleDataIsCheap` kept six partition spans to open a gap, which leaves seven periods on a fresh install and hundreds on an aged one; it now keeps one, so the gap is the whole lead either way. `VisitorIdIndexTest` asserted `down()` always removes the `visitor_id` index — it only removes `idx_visitor_id`, the one `up()` adds, and a fresh install carries a schema-declared index under another name that `down()` correctly leaves alone.

## Also in this branch

**The shipped job is renamed to `rotate-partitions`.** `registerJob()` takes name and command separately so one command can be scheduled more than once, but the only shipped job passed the same string for both — which meant no example could show that `OWA_SCHEDULED_JOBS` keys on the **name**. The command is unchanged, so nothing typed at a terminal moves. An installation that has run the scheduler keeps a state row under the old name, listed as orphaned with its history and cleared with `--prune-orphans`.

Two new tests came out of that: the config key is matched against the name and not the command, and `schedule` and `params` can be overridden together.

## Verification

- Every fix mutation-verified; each mutant caught by a distinct assertion.
- `SettingsShutdownSaveTest` asserts the mechanism, not only the outcome. An earlier version passed against the unfixed code because the probe's destruction order happened to favour the settings object.
- All 64 test files pass in isolation. Before: two failed, and one exited 255 while reporting OK.
- Full suite green (573 tests, 4125 assertions); three phpstan configs clean.

## Note for review

The `isolation` job is currently a blocking check. `continue-on-error: true` makes it advisory if it should not gate merges while it settles in.