### PR TITLE
ci: let the isolation sweep fail the run again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,11 +74,6 @@ jobs:
   isolation:
     name: Test isolation sweep (each file alone)
     runs-on: ubuntu-latest
-    # Advisory: a finding here is a real defect, but it is reported rather than
-    # used to gate a merge. The trade-off is that the run goes green either way,
-    # so the summary step below writes any finding to the run page where it is
-    # visible without opening the job.
-    continue-on-error: true
     # A test that passes in the suite but fails alone is inheriting state an
     # earlier test set up -- a registry the dispatcher builds lazily, or a legacy
     # owa_* alias that only exists once something has autoloaded it. PHPUnit runs
@@ -131,8 +126,8 @@ jobs:
           set -o pipefail
           composer run-script test:isolation 2>&1 | tee isolation.log
 
-      # The job is advisory, so its own red X is easy to miss. Put the verdict on
-      # the run summary page instead, where it is read without going looking.
+      # Put the verdict on the run summary page as well as in the job, so a
+      # finding is readable without opening the log.
       - name: Report the verdict
         if: always()
         run: |


### PR DESCRIPTION
Reverts the `continue-on-error` from #1002 and keeps the run-summary reporting that came with it.

## Why

The advisory decision rested on a premise that does not hold. `master` has **no branch protection**, so no status check has ever been able to stop a merge — `gh pr merge` succeeds over a red X today.

So blocking and advisory differ in exactly one respect: whether a finding turns the run red. Framed that way there is no case for green. If a finding turns out to be unrelated to the change under review, merging over it stays available and is a judgement call at the time, which is the right place for that judgement.

There is also a consistency argument. The branch this check arrived on existed because tests reported success while a defect was present: `OK (40 tests)` alongside exit 255, `instanceof` silently returning false, a green suite resting on test ordering. Configuring CI to report green when it has just found a bug is the same mistake one level up.

## What stays

The `Report the verdict` step. Writing the outcome to the run summary is useful whether or not the job can fail the run — it makes a finding readable without opening the job log.

## If it becomes noisy

Three runs so far, ~1m40s each, no flakes, and every finding real. If that changes, restoring `continue-on-error: true` is one line.