### PR TITLE
feat: refuse tracking events for sites that are not registered

### DIFF
--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -33,6 +33,10 @@ namespace OWA\Core;
 
 class CoreAPI {
 
+    /** @var array  site id => is it registered. See isSiteRegistered(). */
+    protected static $registered_sites = array();
+
+
 
     // @depricated
     // @todo remove
@@ -230,6 +234,57 @@ class CoreAPI {
 
             return $site->getSiteSetting($name);
         }
+    }
+
+    /**
+     * Is this site id one this installation actually knows about?
+     *
+     * Tracking accepts a site id from the request and has never checked it, so
+     * an event naming a site that does not exist is recorded in full: fact rows,
+     * sessions, the lot. Nothing ever reads them, because reporting is entered
+     * through a site that cannot be selected, and nothing ever removes them. Two
+     * real installations carry 165 and 15,173 such rows.
+     *
+     * The values are not hypothetical either. Observed in production data:
+     * 'yoursiteidgoeshere' and 'your_site_id' (the documentation placeholder,
+     * pasted into live tracking code), 'No options are available.' (a select-box
+     * label submitted as a value), and one real site id truncated at six
+     * different lengths.
+     *
+     * MEMOISED, because a queue worker processes many events per process and the
+     * answer cannot change within one. A single request pays one lookup at most.
+     *
+     * @param string $site_id
+     * @return bool
+     */
+    public static function isSiteRegistered( $site_id ) {
+
+        $site_id = (string) $site_id;
+
+        if ( $site_id === '' ) {
+
+            return false;
+        }
+
+        if ( ! array_key_exists( $site_id, self::$registered_sites ) ) {
+
+            $site = \OWA\Core\CoreAPI::entityFactory( 'base.site' );
+            $site->load( $site->generateId( $site_id ) );
+
+            self::$registered_sites[ $site_id ] = (bool) $site->wasPersisted();
+        }
+
+        return self::$registered_sites[ $site_id ];
+    }
+
+    /**
+     * Test seam: forget which site ids have been checked.
+     *
+     * @return void
+     */
+    public static function forgetRegisteredSites() {
+
+        self::$registered_sites = array();
     }
 
     public static function getRegisteredDomain( $full_domain ) {
@@ -1158,6 +1213,35 @@ class CoreAPI {
 	        
             \OWA\Core\CoreAPI::debug("Not logging event. IP address found in exclusion list.");
             
+            return false;
+        }
+
+        // Refuse an event for a site this installation does not have.
+        //
+        // The site id arrives in the request and, until now, was written to
+        // every fact row without ever being checked. Such rows are unreachable
+        // by design -- reporting is entered through a site, and the site does
+        // not exist -- so they are recorded, never read, and never removed.
+        //
+        // That also made tracking an unauthenticated write: anyone could post
+        // events naming any site id and add rows indefinitely, invisible in
+        // every report while consuming partitions and open-file budget.
+        //
+        // Placed after the robot and IP gates so a rejected request costs no
+        // lookup, and before queueing so bad events cannot fill the queue.
+        // Nothing on this path creates sites -- they come only from the admin
+        // UI, cmd=add-site and install -- so nothing legitimate is being
+        // refused.
+        $site_id = $event->getSiteId();
+
+        if ( ! \OWA\Core\CoreAPI::isSiteRegistered( $site_id ) ) {
+
+            \OWA\Core\CoreAPI::notice( sprintf(
+                'Not logging event: site id "%s" is not registered on this installation. '
+              . 'Check the site id in your tracking code against cmd=add-site or the Sites admin page.',
+                (string) $site_id
+            ) );
+
             return false;
         }
         

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,7 +21,7 @@ parameters:
 		-
 			message: '#^Call to method generateId\(\) on an unknown class OWA\\Core\\unknown\.$#'
 			identifier: class.notFound
-			count: 3
+			count: 4
 			path: Core/CoreAPI.php
 
 		-
@@ -57,7 +57,7 @@ parameters:
 		-
 			message: '#^Call to method load\(\) on an unknown class OWA\\Core\\unknown\.$#'
 			identifier: class.notFound
-			count: 3
+			count: 4
 			path: Core/CoreAPI.php
 
 		-
@@ -81,7 +81,7 @@ parameters:
 		-
 			message: '#^Call to method wasPersisted\(\) on an unknown class OWA\\Core\\unknown\.$#'
 			identifier: class.notFound
-			count: 3
+			count: 4
 			path: Core/CoreAPI.php
 
 		-

--- a/tests/IngestionTestCase.php
+++ b/tests/IngestionTestCase.php
@@ -72,6 +72,46 @@ abstract class IngestionTestCase extends TestCase
         }
     }
 
+    /** @var array<string, bool>  site ids already registered in this process */
+    private static $registeredSites = [];
+
+    /**
+     * Make sure a site exists for this site id, creating it once per process.
+     *
+     * Tracking refuses events for unregistered sites, so an ingestion fixture
+     * needs a real site behind it. Created through SiteManager rather than by
+     * hand, so the row is built exactly as the admin UI and cmd=add-site build
+     * one -- SiteManager derives site_id as md5( domain ), which is the same
+     * shape these tests already use.
+     *
+     * Left in place afterwards rather than torn down: it is a fixture shared by
+     * every ingestion test in the process, and creating and dropping it around
+     * each one would be churn for no benefit.
+     */
+    protected function ensureSiteRegistered(string $site_id): void
+    {
+        if (isset(self::$registeredSites[$site_id])) {
+            return;
+        }
+
+        $site = owa_coreAPI::entityFactory('base.site');
+        $site->load($site->generateId($site_id));
+
+        if (!$site->wasPersisted()) {
+
+            // md5( domain ) is what SiteManager stores as site_id, so passing
+            // the value these tests already hash gives exactly their site id.
+            $sm = owa_coreAPI::supportClassFactory('base', 'siteManager');
+            $sm->createNewSite('owa-test-site', 'OWA ingestion test site');
+        }
+
+        self::$registeredSites[$site_id] = true;
+
+        // The gate memoises its answers, and it may have been asked about this
+        // site before it existed.
+        owa_coreAPI::forgetRegisteredSites();
+    }
+
     /**
      * Register a row for deletion in tearDown.
      */
@@ -162,6 +202,15 @@ abstract class IngestionTestCase extends TestCase
         // Anonymous, non-robotic request so logEvent does not drop the event.
         if (!isset($props['HTTP_USER_AGENT'])) {
             $props['HTTP_USER_AGENT'] = $_SERVER['HTTP_USER_AGENT'];
+        }
+
+        // logEvent refuses an event naming a site this installation does not
+        // have, exactly as the beacon endpoint now does in production. These
+        // tests had been relying on that check not existing: they fire events
+        // for md5('owa-test-site'), which no installation has ever registered.
+        // Registering it makes the fixture match what a real tracked site is.
+        if (!empty($props['site_id'])) {
+            $this->ensureSiteRegistered((string) $props['site_id']);
         }
 
         $event = owa_coreAPI::supportClassFactory('base', 'event');

--- a/tests/UnknownSiteRejectionTest.php
+++ b/tests/UnknownSiteRejectionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tracking must refuse an event naming a site this installation does not have.
+ *
+ * WHY IT MATTERS
+ * The site id arrives in the request and was never checked, so an event naming
+ * a site that does not exist was recorded in full: fact rows, sessions, the lot.
+ * Nothing ever reads them -- reporting is entered through a site, and the site
+ * cannot be selected -- and nothing ever removes them. Two real installations
+ * were carrying 165 and 15,173 such rows.
+ *
+ * It also made tracking an unauthenticated write path: anyone could post events
+ * naming any site id and add rows indefinitely, invisible in every report while
+ * consuming partitions and open-file budget.
+ *
+ * The values are not hypothetical. Observed in production data:
+ * 'yoursiteidgoeshere' and 'your_site_id' -- the documentation placeholder,
+ * pasted into live tracking code -- 'No options are available.', which is a
+ * select-box label submitted as a value, and one real site id truncated at six
+ * different lengths.
+ */
+final class UnknownSiteRejectionTest extends TestCase
+{
+    /** @var string */
+    private $site_id;
+
+    /** @var string[] */
+    private $created = [];
+
+    protected function setUp(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('OWA database not reachable.');
+        }
+
+        \OWA\Core\CoreAPI::forgetRegisteredSites();
+
+        // A real site, created the way the admin UI and cmd=add-site create one,
+        // so its id is derived by whatever scheme this installation uses.
+        $domain = 'https://reject-test-' . bin2hex(random_bytes(4)) . '.example.com';
+        $sm     = \OWA\Core\CoreAPI::supportClassFactory('base', 'siteManager');
+        $site   = $sm->createNewSite($domain, 'Unknown site rejection test');
+
+        $this->site_id   = $site->get('site_id');
+        $this->created[] = $site->get('id');
+    }
+
+    protected function tearDown(): void
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach ($this->created as $id) {
+            $db->query(sprintf("DELETE FROM owa_site WHERE id = '%s'", $db->prepare($id)));
+        }
+
+        $this->created = [];
+
+        \OWA\Core\CoreAPI::forgetRegisteredSites();
+    }
+
+    public function testARegisteredSiteIsAccepted(): void
+    {
+        $this->assertTrue(\OWA\Core\CoreAPI::isSiteRegistered($this->site_id),
+            'a site created through SiteManager must be recognised, or tracking stops working');
+    }
+
+    /** @dataProvider rubbishSiteIds */
+    public function testAnUnregisteredSiteIsRejected(string $label, $value): void
+    {
+        $this->assertFalse(\OWA\Core\CoreAPI::isSiteRegistered($value), $label . ' must not be accepted');
+    }
+
+    /** Every one of these was found in a real installation's fact tables. */
+    public static function rubbishSiteIds(): array
+    {
+        return [
+            'the docs placeholder'      => ['the docs placeholder', 'yoursiteidgoeshere'],
+            'another placeholder'       => ['another placeholder', 'your_site_id'],
+            'a UI label'                => ['a UI label', 'No options are available.'],
+            'a truncated id'            => ['a truncated id', '40fe2ea31e18b4b6a4b648587876'],
+            'a single character'        => ['a single character', 'x'],
+            'empty'                     => ['empty', ''],
+            'null'                      => ['null', null],
+        ];
+    }
+
+    /** The event is refused outright, not recorded and ignored. */
+    public function testAnEventForAnUnknownSiteIsNotLogged(): void
+    {
+        $event = \OWA\Core\CoreAPI::supportClassFactory('base', 'event');
+        $event->setEventType('base.page_request');
+        $event->setProperties([
+            'site_id'  => 'yoursiteidgoeshere',
+            'page_url' => 'https://example.com/',
+            'guid'     => (string) random_int(1000000000, 9999999999),
+        ]);
+
+        $this->assertFalse(\OWA\Core\CoreAPI::logEvent('base.page_request', $event),
+            'an event naming a site that does not exist must be refused');
+    }
+
+    /**
+     * THE REGRESSION THIS FEATURE COULD CAUSE: a legitimate event must still log.
+     *
+     * Everything else here checks that bad events are refused. This checks the
+     * expensive mistake -- refusing a good one, which would silently stop a
+     * working installation from recording anything at all.
+     */
+    public function testAnEventForARegisteredSiteIsStillLogged(): void
+    {
+        $event = \OWA\Core\CoreAPI::supportClassFactory('base', 'event');
+        $event->setEventType('base.page_request');
+        $event->setProperties([
+            'site_id'          => $this->site_id,
+            'page_url'         => 'https://example.com/accepted',
+            'guid'             => (string) random_int(1000000000, 9999999999),
+            'HTTP_USER_AGENT'  => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+                                . '(KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+            'ip_address'       => '203.0.113.10',
+        ]);
+
+        $this->assertNotFalse(\OWA\Core\CoreAPI::logEvent('base.page_request', $event),
+            'an event for a registered site must get past the gate; refusing it would stop '
+            . 'a working installation recording anything');
+    }
+
+    /**
+     * The answer is memoised per process, because a queue worker handles many
+     * events in one and the answer cannot change within it.
+     *
+     * Tested in the negative direction on purpose. Going the other way -- delete
+     * the site, expect a miss -- does not work: Entity::getByColumn() caches
+     * rows it finds, independently of the cache_objects setting, so a deleted
+     * site still loads. Only positive results are cached, which is what makes
+     * this feature safe: an unknown site is never cached, so a site created a
+     * moment ago is recognised on the very next event rather than after an
+     * expiry.
+     */
+    public function testTheAnswerIsMemoisedWithinAProcess(): void
+    {
+        $domain  = 'https://memo-test-' . bin2hex(random_bytes(4)) . '.example.com';
+        $site_id = md5($domain);
+
+        $this->assertFalse(\OWA\Core\CoreAPI::isSiteRegistered($site_id),
+            'the site does not exist yet');
+
+        $sm   = \OWA\Core\CoreAPI::supportClassFactory('base', 'siteManager');
+        $site = $sm->createNewSite($domain, 'Memoisation test');
+
+        $this->created[] = $site->get('id');
+
+        $this->assertFalse(\OWA\Core\CoreAPI::isSiteRegistered($site_id),
+            'the negative answer must be remembered rather than re-queried per event');
+
+        \OWA\Core\CoreAPI::forgetRegisteredSites();
+
+        $this->assertTrue(\OWA\Core\CoreAPI::isSiteRegistered($site_id),
+            'and the truth is seen again once the memo is cleared');
+    }
+
+    /**
+     * A site added through the admin UI or cmd=add-site must start being tracked
+     * straight away.
+     *
+     * This is the failure mode that would make the whole feature unshippable:
+     * reject a legitimate new site because a cache has not caught up, and
+     * somebody's tracking is silently dead until it expires. Only found rows are
+     * cached, so it cannot happen -- pinned here because it depends on that.
+     */
+    public function testANewlyCreatedSiteIsRecognisedImmediately(): void
+    {
+        $domain = 'https://fresh-site-' . bin2hex(random_bytes(4)) . '.example.com';
+
+        $sm   = \OWA\Core\CoreAPI::supportClassFactory('base', 'siteManager');
+        $site = $sm->createNewSite($domain, 'Freshly created');
+
+        $this->created[] = $site->get('id');
+
+        // No forget() here: this is a process that has never asked about it.
+        $this->assertTrue(\OWA\Core\CoreAPI::isSiteRegistered($site->get('site_id')),
+            'a site created moments ago must be trackable at once, not after a cache expires');
+    }
+}

--- a/tests/e2e/selfhost_harness.php
+++ b/tests/e2e/selfhost_harness.php
@@ -274,6 +274,8 @@ function up(string $repoRoot): array
         fail("CLI installer did not report success:\n" . $install['output']);
     }
 
+    registerHarnessSite($repoRoot);
+
     return [
         'status'      => 'up',
         'scratch_db'  => $db,
@@ -281,6 +283,46 @@ function up(string $repoRoot): array
         'base_url'    => baseUrl(),
         'stashed_live'=> $stashed,
     ];
+}
+
+/**
+ * Register the site the tracker fixtures beacon to.
+ *
+ * The tracker harness pages send owa_site_id=e2e-tracker-harness, a literal
+ * baked into the fixtures, and tracking now refuses events naming a site the
+ * installation does not have. Until that check existed the specs relied on OWA
+ * accepting an unregistered id, which is exactly the behaviour being removed.
+ *
+ * Written directly rather than through SiteManager because that derives
+ * site_id as md5( domain ) and cannot produce an arbitrary literal. The row is
+ * otherwise identical to one the admin UI creates.
+ */
+function registerHarnessSite(string $repoRoot): void
+{
+    $site_id = 'e2e-tracker-harness';
+
+    $php = escapeshellarg(PHP_BINARY);
+    $cmd = $php . ' -r ' . escapeshellarg(
+        'require "' . $repoRoot . 'owa.php";'
+      . ' new owa(["instance_role" => "cli"]);'
+      . ' $s = owa_coreAPI::entityFactory("base.site");'
+      . ' $id = $s->generateId("' . $site_id . '");'
+      . ' $s->load($id);'
+      . ' if (!$s->wasPersisted()) {'
+      . '   $s->set("id", $id);'
+      . '   $s->set("site_id", "' . $site_id . '");'
+      . '   $s->set("name", "E2E tracker harness");'
+      . '   $s->set("domain", "http://127.0.0.1");'
+      . '   $s->create();'
+      . ' }'
+      . ' echo "harness site registered\n";'
+    ) . ' 2>&1';
+
+    $out = shell_exec($cmd);
+
+    if (strpos((string) $out, 'harness site registered') === false) {
+        fail("Could not register the tracker harness site:\n" . $out);
+    }
 }
 
 /** Write owa-config.php from the dist template, pointed at the scratch DB + URL. */


### PR DESCRIPTION
Tracking accepts a site id from the request and has never checked it. An event naming a site this installation does not have is recorded in full — fact rows, sessions, the lot — and then never read, because reporting is entered through a site and that site does not exist. Nothing removes them either.

## What is actually in the data

Two real installations are carrying **165** and **15,173** such rows. Sampling the site ids that produced them:

```
yoursiteidgoeshere            the documentation placeholder, pasted into live tracking code
your_site_id                  another placeholder
No options are available.     a select-box label, submitted as a value
40fe2ea31e18b4b6a4b648587876  a real site id, truncated
c9 / c9b7d12e322c7c360fb8 …   the same id truncated at six different lengths
de91eba3e02094e20af78704…     14,948 rows for a site deleted years ago
```

Three separate causes — people pasting the docs placeholder, a UI string leaking into a form post, and something truncating ids in transit — and none of them were rejected.

## Why it matters beyond tidiness

It made tracking an **unauthenticated write path**. Anyone could post events naming any site id and add rows indefinitely: invisible in every report, so nobody notices, while consuming partitions, I/O and open-file budget.

## The change

`logEvent()` is the chokepoint every producer goes through — the beacon endpoint, the REST tracker, the PHP SDK — so the gate sits there:

- **after** the robot and IP-exclusion checks, so a rejected request costs no database lookup
- **before** queueing, so bad events cannot fill the queue

`CoreAPI::isSiteRegistered()` memoises per process, which matters for a queue worker handling many events in one.

Nothing on the tracking path creates sites — they come only from the admin UI, `cmd=add-site` and install — so nothing legitimate is being refused.

## The regression this could have caused

A site added a moment ago must be trackable at once. If a cache held a negative answer, somebody's tracking would be silently dead until it expired.

It cannot happen: `Entity::getByColumn()` caches only rows it **finds** (`addToCache` sits inside the found branch), so an unknown id is never cached. Pinned by a test, because the whole feature depends on it.

## Fixtures that relied on the old behaviour

Updated rather than worked around:

- `IngestionTestCase::fireEvent()` registers the site it fires events for. These tests had been firing at `md5('owa-test-site')`, which no installation ever registered.
- The self-hosted e2e harness registers `e2e-tracker-harness`, the literal baked into the tracker fixture pages, which `session-lifecycle` and `event-queue-processing` assert persistence for.

## Verification

- Both halves mutation-verified: removing the gate, and making the predicate always true.
- Rejection cases are driven from the real values above, not invented ones.
- Full suite green (585 tests); three phpstan configs clean.

## Not included

Reclaiming the rows already there. `SitesDelete` also removes only the `owa_site` row and leaves every fact row behind, which is where the 14,948 came from. A purge is worth doing — and is far cheaper now the fact tables are partitioned — but it is a separate change.