### PR TITLE
perf(cli): batch the id map inserts

### DIFF
--- a/modules/Base/Controller/RederiveDimensionIdsCli.php
+++ b/modules/Base/Controller/RederiveDimensionIdsCli.php
@@ -131,6 +131,20 @@ class RederiveDimensionIdsCli extends PartitionsCli {
     /** Rows sampled per table when checking for ids that were never converted. */
     const VERIFY_SAMPLE = 25;
 
+    /**
+     * Map rows per INSERT.
+     *
+     * One statement per row is what this replaced, and it is the whole cost of
+     * the planning phase: measured at roughly 145 rows a second on a real
+     * installation, which is about fifteen minutes to plan 136,462 ids and would
+     * be hours on an installation with millions of dimension rows.
+     *
+     * 500 keeps each statement comfortably inside any sane max_allowed_packet --
+     * four integers and a short entity name per row, so on the order of 30KB --
+     * while removing 499 round trips out of every 500.
+     */
+    const INSERT_BATCH = 500;
+
     /** Anything at or below this is a crc32 id and still needs converting. */
     const NARROW_CEILING = 4294967296;   // 2^32
 
@@ -542,7 +556,8 @@ class RederiveDimensionIdsCli extends PartitionsCli {
                 'SELECT * FROM %s WHERE id < %d', $table, self::NARROW_CEILING
             ) );
 
-            $n = 0;
+            $n      = 0;
+            $values = array();
 
             foreach ( (array) $rows as $row ) {
 
@@ -562,15 +577,27 @@ class RederiveDimensionIdsCli extends PartitionsCli {
                     continue;
                 }
 
-                $db->query( sprintf(
-                    "INSERT INTO %s (id, entity, old_id, new_id) VALUES (%d, '%s', %d, %s) "
-                  . "ON DUPLICATE KEY UPDATE new_id = VALUES(new_id)",
-                    $this->mapTable(),
+                $values[] = sprintf(
+                    "(%d, '%s', %d, %s)",
                     \OWA\Core\Lib::wideStringGuid( $entity_name . '|' . $row['id'] ),
                     $db->prepare( $entity_name ),
                     (int) $row['id'],
                     $new_id
-                ) );
+                );
+
+                if ( count( $values ) >= self::INSERT_BATCH ) {
+
+                    $this->insertMapRows( $values );
+
+                    $values = array();
+                }
+            }
+
+            if ( $values ) {
+
+                $this->insertMapRows( $values );
+
+                $values = array();
             }
 
             if ( $n ) {
@@ -582,6 +609,31 @@ class RederiveDimensionIdsCli extends PartitionsCli {
         }
 
         return $planned;
+    }
+
+    /**
+     * Write one batch of map rows.
+     *
+     * ON DUPLICATE KEY UPDATE keeps this re-runnable: a resumed run re-plans
+     * rows it already planned, and rewriting them with the same value is a
+     * no-op rather than a duplicate-key failure.
+     *
+     * @param string[] $values  pre-formatted VALUES tuples
+     * @return void
+     */
+    protected function insertMapRows( array $values ) {
+
+        if ( ! $values ) {
+
+            return;
+        }
+
+        \OWA\Core\CoreAPI::dbSingleton()->query( sprintf(
+            'INSERT INTO %s (id, entity, old_id, new_id) VALUES %s '
+          . 'ON DUPLICATE KEY UPDATE new_id = VALUES(new_id)',
+            $this->mapTable(),
+            implode( ', ', $values )
+        ) );
     }
 
     /**

--- a/tests/RederiveDimensionIdsTest.php
+++ b/tests/RederiveDimensionIdsTest.php
@@ -470,6 +470,58 @@ final class RederiveDimensionIdsTest extends TestCase
     }
 
     /**
+     * The map is written in batches, not one statement per row.
+     *
+     * One INSERT per dimension row was the entire cost of the planning phase:
+     * measured at about 145 rows a second on a real installation, so roughly
+     * fifteen minutes to plan 136,462 ids, and hours on an installation with
+     * millions of dimension rows. The work is trivial; the round trips are not.
+     */
+    public function testMapRowsAreInsertedInBatches(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        $start = strpos($source, 'protected function buildMap(');
+        $end   = strpos($source, 'protected function insertMapRows(');
+
+        $this->assertNotFalse($start);
+        $this->assertNotFalse($end);
+
+        $body = substr($source, $start, $end - $start);
+
+        $this->assertStringNotContainsString('INSERT INTO', $body,
+            'buildMap must accumulate rows, not issue an INSERT per row');
+        $this->assertStringContainsString('self::INSERT_BATCH', $body,
+            'it must flush on a batch size');
+
+        $batch = \OWA\Module\Base\Controller\RederiveDimensionIdsCli::INSERT_BATCH;
+
+        $this->assertGreaterThan(1, $batch);
+        $this->assertLessThanOrEqual(1000, $batch,
+            'large enough to matter, small enough to stay inside max_allowed_packet');
+    }
+
+    /**
+     * Batching must not cost the property that makes a killed run resumable:
+     * re-planning a row already in the map has to be a no-op, not a
+     * duplicate-key failure.
+     */
+    public function testABatchedInsertStillToleratesRePlanning(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        $start = strpos($source, 'protected function insertMapRows(');
+        $body  = substr($source, $start, 900);
+
+        $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $body,
+            'a resumed run re-plans rows it already planned, and that must be harmless');
+    }
+
+    /**
      * The property that makes the migration re-runnable: crc32 ids are below
      * 2^32 and derived ids are 63-bit, so applying the map twice is a no-op and
      * "still narrow" is a usable definition of "still to do".


### PR DESCRIPTION
`buildMap()` issued **one `INSERT` per dimension row**. The work per row is trivial — a hash and four integers — so the entire cost was round trips.

It showed the moment the migration met a real installation. Watching demo convert, the planning phase was crawling through 136,462 ids at about **145 rows a second**: roughly fifteen minutes before any data moved.

## Measured

3,000 rows, same machine, same database:

| | time | rate |
|---|---|---|
| one statement per row | 20.42s | 146 rows/sec |
| batched, 500 per statement | 0.21s | **13,979 rows/sec** |

**96× faster.** That turns demo's planning phase from ~15.6 minutes into about ten seconds, and an installation with millions of dimension rows from hours into minutes.

(The 146 rows/sec measured here matches the ~145 observed on the live demo run, so the benchmark reflects the real thing rather than a synthetic best case.)

## Why 500

Each statement carries four integers and a short entity name per row, so a batch is on the order of 30KB — comfortably inside any sane `max_allowed_packet` — while removing 499 round trips out of every 500.

## What does not change

`ON DUPLICATE KEY UPDATE` moves onto the batched statement unchanged. A resumed run re-plans rows it already planned, and rewriting them with the same value stays a no-op rather than a duplicate-key failure. That property is what makes a killed migration recoverable, so it is pinned by its own test.

## Verification

- Seeded 1,200 narrow rows — two full batches plus a partial third, which exercises the flush inside the loop and the flush after it. All 1,200 converted, none left narrow, none disagreeing with what ingestion now derives.
- Structural tests pin that `buildMap` no longer contains an `INSERT`, that it flushes on a batch size, and that the batch stays within a sane range.
- Full suite green (626 tests, 44,256 assertions); three phpstan configs clean.