### PR TITLE
ci: stop reinstalling OS packages on every e2e run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,13 +230,20 @@ jobs:
       - name: Build JS bundles
         run: npm run build
 
-      - name: Install Playwright Chromium + OS deps
-        # The step that hangs, so it carries its own ceiling as well as the
-        # job's. Healthy runs finish in a couple of minutes; failing here names
-        # the browser download directly instead of leaving a job that looks like
-        # the tests are slow.
+      # NO --with-deps. That flag runs apt-get update && apt-get install against
+      # Ubuntu's archive on every run, and that apt step is what has been
+      # hanging: five times in one day, latterly on every single run, stalling
+      # for the full ten minutes with no output after reaching noble-security.
+      # The browser download itself has never been the problem.
+      #
+      # The ubuntu-latest image already ships the shared libraries Chromium
+      # needs, so the flag was buying a re-check of packages that are present.
+      # If a future image drops one, Playwright fails immediately and loudly
+      # with the missing library named -- a better failure than a ten-minute
+      # stall in apt.
+      - name: Install Playwright Chromium
         timeout-minutes: 10
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
 
       # STEP 1: exercise the INSTALLER itself (web wizard + CLI), each into its own
       # scratch DB on the service, self-served by php -S. This certifies the exact


### PR DESCRIPTION
The Playwright install step has hung **five times today** and is now failing on **every** run, always in the same place:

```
06:42:35  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease
06:52:07  ##[error]The action 'Install Playwright Chromium + OS deps' has timed out after 10 minutes.
```

Nine and a half minutes of silence inside `apt-get`. **The browser download has never been the problem — `--with-deps` is.**

That flag runs `apt-get update && apt-get install` against Ubuntu's archive on every run. `ubuntu-latest` already ships the shared libraries Chromium needs, so it was paying a network round trip to re-check packages that are already installed.

Dropping it removes the failing step entirely.

If a future runner image does drop a library, Playwright fails immediately and names the missing one — a better failure than a ten-minute stall in apt, and one that tells you what to add back.

## Why this is urgent rather than tidy-up

CI is currently blocked for every pull request. #1007 has failed twice on this alone, and it is the only thing standing between a green run and merging.

The timeout from #1006 is what made this diagnosable: before it, the same hang held a runner for over an hour and looked like slow tests.