### PR TITLE
fix(cli): a dimension row with nothing to hash must not block completion

### DIFF
--- a/modules/Base/Controller/RederiveDimensionIdsCli.php
+++ b/modules/Base/Controller/RederiveDimensionIdsCli.php
@@ -328,6 +328,18 @@ class RederiveDimensionIdsCli extends PartitionsCli {
 
         $this->write( '' );
 
+        $unconvertible = $this->countUnconvertibleDimensionRows();
+
+        if ( $unconvertible ) {
+
+            $this->write( sprintf(
+                '%s dimension row(s) hold no content to derive an id from -- an owa_host row with '
+              . 'only an IP, for instance -- so nothing can convert them. Nothing will ever derive '
+              . 'those ids again either, so they are left where they are.',
+                number_format( $unconvertible )
+            ) );
+        }
+
         if ( $dangling ) {
 
             $this->write( sprintf(
@@ -764,22 +776,41 @@ class RederiveDimensionIdsCli extends PartitionsCli {
         // subsequent run refuse on a perfectly healthy database.
         $have_map = (bool) $db->get_results( sprintf( 'SHOW TABLES LIKE "%s"', $map ) );
 
-        // A dimension row on a narrow id always has content to re-derive from,
-        // so it always counts.
+        // A dimension row only counts if its content can still produce an id.
+        //
+        // Some cannot: 5,198 owa_host rows on a real installation carry an empty
+        // host and nothing else but an IP, so deriveFor() has nothing to hash and
+        // the row can never be planned. Counting those as outstanding work makes
+        // completion unreachable -- the migration converts everything it can,
+        // refuses to clear the flag because the count is non-zero, and the
+        // installation is stuck part-converted for good. That is not theoretical:
+        // it is what happened, and it left site lookups broken because owa_site
+        // HAD converted while the flag still said 32-bit.
+        //
+        // Nothing will ever derive those ids again either, since hashing empty
+        // content yields no id at all, so leaving them where they are costs
+        // nothing.
         foreach ( $this->dimensionNames() as $entity_name ) {
 
             $table = \OWA\Core\CoreAPI::entityFactory( $entity_name )->getTableName();
 
-            $n = $this->countOrNull( sprintf(
-                'SELECT COUNT(*) AS n FROM %s WHERE id > 0 AND id < %d', $table, self::NARROW_CEILING
+            $rows = $db->get_results( sprintf(
+                'SELECT * FROM %s WHERE id > 0 AND id < %d', $table, self::NARROW_CEILING
             ) );
 
-            if ( $n === null ) {
+            // Distinguish "no rows" from "the query did not run".
+            if ( $rows === null && $this->countOrNull( sprintf( 'SELECT COUNT(*) AS n FROM %s', $table ) ) === null ) {
 
                 return null;
             }
 
-            $total += $n;
+            foreach ( (array) $rows as $row ) {
+
+                if ( $this->deriveFor( $entity_name, (array) $row ) !== null ) {
+
+                    $total++;
+                }
+            }
         }
 
         if ( ! $have_map ) {
@@ -804,6 +835,38 @@ class RederiveDimensionIdsCli extends PartitionsCli {
                 }
 
                 $total += $n;
+            }
+        }
+
+        return $total;
+    }
+
+    /**
+     * Dimension rows still on a narrow id that have nothing to re-derive from.
+     *
+     * Reported so the number is visible rather than silently skipped.
+     *
+     * @return int
+     */
+    protected function countUnconvertibleDimensionRows() {
+
+        $db    = \OWA\Core\CoreAPI::dbSingleton();
+        $total = 0;
+
+        foreach ( $this->dimensionNames() as $entity_name ) {
+
+            $table = \OWA\Core\CoreAPI::entityFactory( $entity_name )->getTableName();
+
+            $rows = $db->get_results( sprintf(
+                'SELECT * FROM %s WHERE id > 0 AND id < %d', $table, self::NARROW_CEILING
+            ) );
+
+            foreach ( (array) $rows as $row ) {
+
+                if ( $this->deriveFor( $entity_name, (array) $row ) === null ) {
+
+                    $total++;
+                }
             }
         }
 

--- a/tests/RederiveDimensionIdsTest.php
+++ b/tests/RederiveDimensionIdsTest.php
@@ -433,6 +433,43 @@ final class RederiveDimensionIdsTest extends TestCase
     }
 
     /**
+     * A dimension row with nothing to hash must not block completion.
+     *
+     * On a real installation 5,198 owa_host rows carry an empty host and nothing
+     * but an IP, so there is no content to derive an id from and the row can
+     * never be planned. Counting them as outstanding work made completion
+     * unreachable: the migration converted everything it could, refused to clear
+     * the flag because the count stayed non-zero, and the installation was stuck
+     * part-converted -- with site lookups broken, because owa_site HAD converted
+     * while the flag still said 32-bit.
+     *
+     * Same treatment as a dangling fact key: nothing can fix it, nothing will
+     * ever derive that id again, so report it and move on.
+     */
+    public function testDimensionRowsWithNoContentDoNotBlockCompletion(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        $start = strpos($source, 'protected function countNarrowKeys()');
+        $end   = strpos($source, 'protected function countUnconvertibleDimensionRows()');
+
+        $this->assertNotFalse($start);
+        $this->assertNotFalse($end, 'unconvertible rows must be counted separately');
+
+        $body = substr($source, $start, $end - $start);
+
+        $this->assertStringContainsString('$this->deriveFor(', $body,
+            'the count must ask whether each row CAN be converted, not just whether it is narrow');
+
+        // And the operator is told, rather than the rows being silently skipped.
+        $action = substr($source, strpos($source, 'function action()'));
+        $this->assertStringContainsString('countUnconvertibleDimensionRows()', $action,
+            'the number left behind must be reported');
+    }
+
+    /**
      * The property that makes the migration re-runnable: crc32 ids are below
      * 2^32 and derived ids are 63-bit, so applying the map twice is a no-op and
      * "still narrow" is a usable definition of "still to do".


### PR DESCRIPTION
Demo got stuck part-converted overnight. This is why.

**5,198 `owa_host` rows carry an empty `host`** and nothing but an IP:

```
id=126692   host=''  full_host='66.49.183.145'  ip_address='66.49.183.145'
```

`deriveFor()` has no content to hash, so those rows can never be planned — but `countNarrowKeys()` counted them as outstanding work anyway. The migration converted everything it could, refused to clear the flag because the count stayed non-zero, and would have refused **forever**, however many times it ran.

## Why that mattered more than it sounds

It left the installation in the one state the design exists to avoid. `owa_site` **had** converted, while the flag still said 32-bit — so every `generateId( site_id )` lookup missed, including the one inside `makeUrlCanonical`. Site lookups on demo read BROKEN.

The migration is safe to interrupt at any point *except* between converting the site row and clearing the flag, and an unreachable completion condition parks it exactly there.

## The fix

Unconvertible dimension rows get the same treatment as dangling fact keys, which was already handled: nothing can fix them, nothing will ever derive those ids again (hashing empty content yields no id at all), so they are **reported and left where they are**.

```
5,199 dimension row(s) hold no content to derive an id from -- an owa_host row with
only an IP, for instance -- so nothing can convert them.
```

I had already reasoned this through for fact keys and simply failed to apply it to dimension rows.

## Not weakening #1008

The count still distinguishes an empty result from a query that did not run, so a dead connection cannot masquerade as "nothing left" through this path either.

## Verification

- Full suite green (626 tests, 44,255 assertions); three phpstan configs clean.
- The real fixture is demo itself: 5,198 host rows plus one `owa_ua` row with an empty `ua`, which is what this was diagnosed against.