### PR TITLE
Legacy rows in a converted table must not block the id migration

### DIFF
--- a/modules/Base/Controller/RederiveDimensionIdsCli.php
+++ b/modules/Base/Controller/RederiveDimensionIdsCli.php
@@ -504,21 +504,18 @@ class RederiveDimensionIdsCli extends PartitionsCli {
 
         $db = \OWA\Core\CoreAPI::dbSingleton();
 
-        foreach ( $this->dimensionNames() as $entity_name ) {
+        // Convertible rows only -- the same rule countNarrowKeys() applies, and
+        // for the same reason. A row with nothing to hash is not work: no run can
+        // ever plan it, so counting it here would mean this command never reaches
+        // its no-op path and re-migrates an already-converted installation on
+        // every invocation.
+        $tally = $this->tallyNarrowDimensionRows();
 
-            $table = \OWA\Core\CoreAPI::entityFactory( $entity_name )->getTableName();
+        // A query that did not run tells us nothing, so assume there IS work
+        // rather than concluding there is none.
+        if ( $tally['convertible'] === null || $tally['convertible'] > 0 ) {
 
-            $n = $this->countOrNull( sprintf(
-                'SELECT COUNT(*) AS n FROM %s WHERE id > 0 AND id < %d',
-                $table, self::NARROW_CEILING
-            ) );
-
-            // A query that did not run tells us nothing, so assume there IS work
-            // rather than concluding there is none.
-            if ( $n === null || $n > 0 ) {
-
-                return true;
-            }
+            return true;
         }
 
         if ( ! $db->get_results( sprintf( 'SHOW TABLES LIKE "%s"', $this->mapTable() ) ) ) {
@@ -535,6 +532,57 @@ class RederiveDimensionIdsCli extends PartitionsCli {
     protected function dimensionNames() {
 
         return array_merge( array_keys( self::DIMENSIONS ), array( 'base.location_dim' ) );
+    }
+
+    /**
+     * Split the narrow dimension rows into the ones this command can convert and
+     * the ones it never will.
+     *
+     * ONE place asks that question, because three places used to and they drifted.
+     * The rule "a row with nothing to hash is not outstanding work" was applied to
+     * countNarrowKeys() and not to workRemains(), so an installation whose only
+     * remaining rows were unconvertible converted everything it could, then failed
+     * its own completion check and stayed on 32-bit ids -- the exact failure the
+     * rule was introduced to fix, still reachable through the copy that was missed.
+     *
+     * @return array convertible int|null, unconvertible int. A null convertible
+     *               count means a query did not run, which is not the same as zero.
+     */
+    protected function tallyNarrowDimensionRows() {
+
+        $db            = \OWA\Core\CoreAPI::dbSingleton();
+        $convertible   = 0;
+        $unconvertible = 0;
+
+        foreach ( $this->dimensionNames() as $entity_name ) {
+
+            $table = \OWA\Core\CoreAPI::entityFactory( $entity_name )->getTableName();
+
+            $rows = $db->get_results( sprintf(
+                'SELECT * FROM %s WHERE id > 0 AND id < %d', $table, self::NARROW_CEILING
+            ) );
+
+            // Distinguish "no rows" from "the query did not run".
+            if ( $rows === null
+              && $this->countOrNull( sprintf( 'SELECT COUNT(*) AS n FROM %s', $table ) ) === null ) {
+
+                return array( 'convertible' => null, 'unconvertible' => $unconvertible );
+            }
+
+            foreach ( (array) $rows as $row ) {
+
+                if ( $this->deriveFor( $entity_name, (array) $row ) === null ) {
+
+                    $unconvertible++;
+
+                } else {
+
+                    $convertible++;
+                }
+            }
+        }
+
+        return array( 'convertible' => $convertible, 'unconvertible' => $unconvertible );
     }
 
     /**
@@ -842,28 +890,14 @@ class RederiveDimensionIdsCli extends PartitionsCli {
         // Nothing will ever derive those ids again either, since hashing empty
         // content yields no id at all, so leaving them where they are costs
         // nothing.
-        foreach ( $this->dimensionNames() as $entity_name ) {
+        $tally = $this->tallyNarrowDimensionRows();
 
-            $table = \OWA\Core\CoreAPI::entityFactory( $entity_name )->getTableName();
+        if ( $tally['convertible'] === null ) {
 
-            $rows = $db->get_results( sprintf(
-                'SELECT * FROM %s WHERE id > 0 AND id < %d', $table, self::NARROW_CEILING
-            ) );
-
-            // Distinguish "no rows" from "the query did not run".
-            if ( $rows === null && $this->countOrNull( sprintf( 'SELECT COUNT(*) AS n FROM %s', $table ) ) === null ) {
-
-                return null;
-            }
-
-            foreach ( (array) $rows as $row ) {
-
-                if ( $this->deriveFor( $entity_name, (array) $row ) !== null ) {
-
-                    $total++;
-                }
-            }
+            return null;
         }
+
+        $total += $tally['convertible'];
 
         if ( ! $have_map ) {
 
@@ -902,27 +936,9 @@ class RederiveDimensionIdsCli extends PartitionsCli {
      */
     protected function countUnconvertibleDimensionRows() {
 
-        $db    = \OWA\Core\CoreAPI::dbSingleton();
-        $total = 0;
+        $tally = $this->tallyNarrowDimensionRows();
 
-        foreach ( $this->dimensionNames() as $entity_name ) {
-
-            $table = \OWA\Core\CoreAPI::entityFactory( $entity_name )->getTableName();
-
-            $rows = $db->get_results( sprintf(
-                'SELECT * FROM %s WHERE id > 0 AND id < %d', $table, self::NARROW_CEILING
-            ) );
-
-            foreach ( (array) $rows as $row ) {
-
-                if ( $this->deriveFor( $entity_name, (array) $row ) === null ) {
-
-                    $total++;
-                }
-            }
-        }
-
-        return $total;
+        return $tally['unconvertible'];
     }
 
     /**
@@ -1033,10 +1049,47 @@ class RederiveDimensionIdsCli extends PartitionsCli {
 
             if ( $stale ) {
 
+                // A stale row proves this entity USED a content-derived id. It does
+                // not prove the entity was skipped -- and the difference decides
+                // whether the migration may finish.
+                //
+                // An entity that was skipped has no converted rows at all: that is
+                // the owa_site shape, and every lookup against it misses. An entity
+                // that was converted can still hold narrow rows keyed on a column
+                // ingestion no longer hashes. On a real installation 5,198 owa_host
+                // rows are keyed on crc32( ip_address ) from an older derivation,
+                // while the entity itself is 21,166 rows converted; host_id now
+                // comes from the registered domain, which is empty for an IP, so
+                // nothing will ever compute those ids again.
+                //
+                // Leaving those alone is not a compromise, it is the correct
+                // outcome: they were never planned, so their fact keys were never
+                // repointed, so fact rows still reference them and the joins still
+                // resolve. Converting them would break exactly what it looks like
+                // it would repair.
+                //
+                // Convertible leftovers are not let through here by accident --
+                // countNarrowKeys() counts those and blocks on them separately.
+                $converted = $this->countOrNull( sprintf(
+                    'SELECT COUNT(*) AS n FROM %s WHERE id >= %d', $table, self::NARROW_CEILING
+                ) );
+
+                if ( $converted ) {
+
+                    \OWA\Core\CoreAPI::notice( sprintf(
+                        '%s: %d sampled row(s) remain at a 32-bit id derived from their %s column, '
+                      . 'alongside %s converted row(s). Nothing derives that id any more, and their '
+                      . 'fact keys still point at it, so they are left as they are.',
+                        $table, $stale, $column, number_format( $converted )
+                    ) );
+
+                    continue;
+                }
+
                 \OWA\Core\CoreAPI::notice( sprintf(
                     '%s: at least %d sampled row(s) are still stored at a 32-bit id derived from '
-                  . 'their own %s column. This entity was not converted. Every lookup that computes '
-                  . 'that id will miss.',
+                  . 'their own %s column, and this table holds no converted rows at all. This entity '
+                  . 'was not converted. Every lookup that computes that id will miss.',
                     $table, $stale, $column
                 ) );
 

--- a/tests/RederiveDimensionIdsTest.php
+++ b/tests/RederiveDimensionIdsTest.php
@@ -452,13 +452,17 @@ final class RederiveDimensionIdsTest extends TestCase
             dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
         );
 
-        $start = strpos($source, 'protected function countNarrowKeys()');
-        $end   = strpos($source, 'protected function countUnconvertibleDimensionRows()');
+        $this->assertNotFalse(strpos($source, 'protected function countUnconvertibleDimensionRows()'),
+            'unconvertible rows must be counted separately');
 
+        // The convertibility question is now asked once, in the shared tally that
+        // countNarrowKeys() reads -- see
+        // testOneImplementationDecidesWhatCountsAsOutstandingWork for why it moved.
+        $start = strpos($source, 'protected function tallyNarrowDimensionRows()');
         $this->assertNotFalse($start);
-        $this->assertNotFalse($end, 'unconvertible rows must be counted separately');
 
-        $body = substr($source, $start, $end - $start);
+        $body = substr($source, $start);
+        $body = substr($body, 0, strpos($body, "\n    }\n") + 6);
 
         $this->assertStringContainsString('$this->deriveFor(', $body,
             'the count must ask whether each row CAN be converted, not just whether it is narrow');
@@ -519,6 +523,93 @@ final class RederiveDimensionIdsTest extends TestCase
 
         $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $body,
             'a resumed run re-plans rows it already planned, and that must be harmless');
+    }
+
+    /**
+     * A converted table may still hold rows on a narrow id, and that must not
+     * stop the migration finishing.
+     *
+     * This happened, and it is the second half of the same story as
+     * testDimensionRowsWithNoContentDoNotBlockCompletion. 5,198 owa_host rows are
+     * stored at crc32( ip_address ) from an older derivation -- host_id now comes
+     * from the registered domain, which is empty for a bare IP, so nothing will
+     * ever compute those ids again. The stale-id verifier sampled 25 rows, found
+     * all 25 reproducible from ip_address, and concluded the entity had not been
+     * converted -- while 21,166 rows of the same table had been.
+     *
+     * The result was an installation that converted everything it could and then
+     * refused to clear its own flag: dimension rows wide, ingestion still deriving
+     * narrow, site lookups missing.
+     *
+     * The discriminator is whether the table holds any converted rows at all. None
+     * is the owa_site shape -- the entity was skipped and every lookup misses.
+     * Some means the entity was converted and these are remnants keyed on a column
+     * nothing hashes any more.
+     */
+    public function testALegacyRemnantInAConvertedTableDoesNotBlockCompletion(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        $start = strpos($source, 'protected function findStaleDerivedIds(');
+        $this->assertNotFalse($start);
+
+        $body = substr($source, $start);
+        $body = substr($body, 0, strpos($body, "\n    }\n") + 6);
+
+        $this->assertStringContainsString('id >= %d', $body,
+            'the verifier must ask whether the table holds converted rows before blaming it');
+
+        // The failure must be conditional on there being NO converted rows. If the
+        // count is merely reported and the run fails anyway, the bug is unchanged.
+        $guard = strpos($body, 'id >= %d');
+        $fail  = strpos($body, '$tables++');
+
+        $this->assertNotFalse($fail);
+        $this->assertLessThan($fail, $guard,
+            'the converted-row count must be taken before the entity is condemned');
+
+        $this->assertStringContainsString('continue;', substr($body, $guard, $fail - $guard),
+            'a table with converted rows must be reported and skipped, not counted as unconverted');
+    }
+
+    /**
+     * One implementation decides what counts as outstanding work.
+     *
+     * Three methods used to scan the narrow dimension rows -- workRemains(),
+     * countNarrowKeys() and countUnconvertibleDimensionRows() -- each with its own
+     * copy of the rule. The rule "a row with nothing to hash is not work" was
+     * added to one of them and not the others, so a migration converted everything
+     * it could and then failed its own completion check through the copy that was
+     * missed. Two releases fixed that rule in two different places for the same
+     * underlying reason.
+     *
+     * A shared tally is what stops there being a third occasion.
+     */
+    public function testOneImplementationDecidesWhatCountsAsOutstandingWork(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        $this->assertSame(1, substr_count($source, 'id > 0 AND id < %d'),
+            'the narrow-dimension-row scan must exist in exactly one place');
+
+        $this->assertStringContainsString('protected function tallyNarrowDimensionRows(', $source,
+            'the shared tally is what the three callers agree through');
+
+        foreach (['workRemains', 'countNarrowKeys', 'countUnconvertibleDimensionRows'] as $method) {
+
+            $start = strpos($source, 'protected function ' . $method . '(');
+            $this->assertNotFalse($start, $method . ' must exist');
+
+            $body = substr($source, $start);
+            $body = substr($body, 0, strpos($body, "\n    }\n") + 6);
+
+            $this->assertStringContainsString('$this->tallyNarrowDimensionRows()', $body,
+                $method . ' must read the shared tally rather than scan the rows itself');
+        }
     }
 
     /**


### PR DESCRIPTION
Demo converted everything it could and then refused to clear its own flag: dimension rows wide, ingestion still deriving narrow ids, site lookups missing. This is the fix for that, and for the reason it was reachable twice.

## What blocked it

`findStaleDerivedIds()` samples rows and tries to reproduce the stored id with the old scheme. It exists to catch an entity left out of the migration entirely — the `owa_site` case, where there are no narrow *keys* to count because nothing ever planned any, so the only evidence is the rows themselves.

On demo it sampled 25 `owa_host` rows, reproduced all 25 from `ip_address`, and concluded the entity had not been converted. 21,166 rows of that table had:

```
id=126692  ip_address=66.49.183.145  host=""  full_host=66.49.183.145
crc32(66.49.183.145) = 126692

owa_host: 26,364 rows, 21,166 wide, 5,198 narrow
```

Those 5,198 are keyed on `crc32( ip_address )` from an older derivation. `host_id` now comes from `getHostDomain()`, the registered domain via the Public Suffix List, which is empty for a bare IP — so `generateDimensionId('')` returns null, `HostHandlers` refuses the event, and nothing computes those ids again.

**Leaving them narrow is correct, not a compromise.** They were never planned, so they have no map rows, so their fact keys were never repointed — fact rows still reference `crc32(ip)` and the joins still resolve. Converting them would break exactly what it looks like it would repair.

The discriminator is whether the table holds any converted rows:

| evidence | meaning | outcome |
|---|---|---|
| no converted rows | entity skipped (`owa_site` shape); every lookup misses | run still fails |
| converted rows present | entity converted; these are remnants on a column nothing hashes | reported, skipped |

Convertible leftovers are not let through by this — `countNarrowKeys()` counts those and blocks separately.

## Why it was reachable twice

Three methods scanned the narrow dimension rows, each with its own copy of the rule:

- `countNarrowKeys()` — got "a row with nothing to hash is not work" in #1010
- `countUnconvertibleDimensionRows()`
- `workRemains()` — did not

So an installation whose only remaining rows were unconvertible converted everything it could and then failed its own completion check through the copy that was missed. #1008 and #1010 were both this same shape in different places.

They now share one `tallyNarrowDimensionRows()`, so the next change to that rule cannot land in two places out of three. `workRemains()` reading the raw count also meant an already-converted installation would re-migrate on every invocation instead of reaching its no-op path.

## Tests

- `testALegacyRemnantInAConvertedTableDoesNotBlockCompletion` — the converted-row count is taken *before* the entity is condemned, and a table with converted rows is skipped rather than counted.
- `testOneImplementationDecidesWhatCountsAsOutstandingWork` — the narrow-row scan exists in exactly one place and all three callers read the shared tally.
- `testDimensionRowsWithNoContentDoNotBlockCompletion` (from #1010) updated to follow the rule to where it moved, keeping its original assertion.

Each new test mutation-checked in three ways — guard query removed, skip removed, divergence reintroduced — and each fails as it should. Two earlier mutation attempts silently patched the wrong `continue;` and passed; the checks above are the corrected ones.

630 tests green, all three phpstan configs clean.

## Verification on demo

`countNarrowKeys()` measured on demo before this change: dimension half 0 (every narrow row has empty content in its declared column), fact-key half 0 across every real FK column. So this was the only remaining blocker.