### PR TITLE
Count fact keys one partition at a time, like the rewrite already does

### DIFF
--- a/modules/Base/Controller/RederiveDimensionIdsCli.php
+++ b/modules/Base/Controller/RederiveDimensionIdsCli.php
@@ -904,23 +904,48 @@ class RederiveDimensionIdsCli extends PartitionsCli {
             return $total;
         }
 
+        // Counted one partition at a time, for the same reason rewriteFactKeys()
+        // writes one partition at a time -- and it is not about how many rows are
+        // read, which is identical either way.
+        //
+        // The fact key has no index, so this is a scan whatever else changes, and
+        // every row scanned probes the map by ( entity, old_id ). Scanning a whole
+        // fact table evicts the map's index pages from the buffer pool, so those
+        // probes stop being memory reads and become disk reads. Measured on a real
+        // installation: 470,718 rows counted in 226 seconds, about 2,000 rows a
+        // second, while the identical join issued per partition by rewriteFactKeys()
+        // covered all nine tables in thirteen minutes. Same work, an order of
+        // magnitude apart, because a partition-sized scan leaves the map resident.
+        //
+        // Left whole, the verification of a migration outruns the rewrite it is
+        // verifying, and on a large installation outruns any sane timeout -- so a
+        // run that converted everything correctly gets killed before it can say so
+        // and clear the flag.
         foreach ( $this->factKeyColumns() as $table => $cols ) {
 
-            foreach ( $cols as $column => $entity_name ) {
+            $partitions = $db->listPartitions( $table );
+            $units      = $partitions ? $partitions : array( array( 'name' => null ) );
 
-                $n = $this->countOrNull( sprintf(
-                    "SELECT COUNT(*) AS n FROM %s f JOIN %s m ON m.entity = '%s' AND m.old_id = f.%s "
-                  . 'WHERE f.%s > 0 AND f.%s < %d',
-                    $table, $map, $db->prepare( $entity_name ), $column,
-                    $column, $column, self::NARROW_CEILING
-                ) );
+            foreach ( $units as $unit ) {
 
-                if ( $n === null ) {
+                $scope = $unit['name'] ? sprintf( ' PARTITION (%s)', $unit['name'] ) : '';
 
-                    return null;
+                foreach ( $cols as $column => $entity_name ) {
+
+                    $n = $this->countOrNull( sprintf(
+                        "SELECT COUNT(*) AS n FROM %s%s f JOIN %s m ON m.entity = '%s' AND m.old_id = f.%s "
+                      . 'WHERE f.%s > 0 AND f.%s < %d',
+                        $table, $scope, $map, $db->prepare( $entity_name ), $column,
+                        $column, $column, self::NARROW_CEILING
+                    ) );
+
+                    if ( $n === null ) {
+
+                        return null;
+                    }
+
+                    $total += $n;
                 }
-
-                $total += $n;
             }
         }
 
@@ -958,20 +983,31 @@ class RederiveDimensionIdsCli extends PartitionsCli {
         $map     = $this->mapTable();
         $total   = 0;
 
+        // Per partition, for the buffer-pool reason set out in countNarrowKeys().
+        // This one is only informational, but it reads the same fact tables the
+        // same way, so left whole it would undo there whatever was gained here.
         foreach ( $this->factKeyColumns() as $table => $cols ) {
 
-            foreach ( $cols as $column => $entity_name ) {
+            $partitions = $db->listPartitions( $table );
+            $units      = $partitions ? $partitions : array( array( 'name' => null ) );
 
-                $n = $this->countOrNull( sprintf(
-                    "SELECT COUNT(*) AS n FROM %s f LEFT JOIN %s m ON m.entity = '%s' AND m.old_id = f.%s "
-                  . 'WHERE f.%s > 0 AND f.%s < %d AND m.old_id IS NULL',
-                    $table, $map, $db->prepare( $entity_name ), $column,
-                    $column, $column, self::NARROW_CEILING
-                ) );
+            foreach ( $units as $unit ) {
 
-                // Reported for information only, so an unrunnable count is
-                // simply not counted rather than aborting the run.
-                $total += (int) $n;
+                $scope = $unit['name'] ? sprintf( ' PARTITION (%s)', $unit['name'] ) : '';
+
+                foreach ( $cols as $column => $entity_name ) {
+
+                    $n = $this->countOrNull( sprintf(
+                        "SELECT COUNT(*) AS n FROM %s%s f LEFT JOIN %s m ON m.entity = '%s' AND m.old_id = f.%s "
+                      . 'WHERE f.%s > 0 AND f.%s < %d AND m.old_id IS NULL',
+                        $table, $scope, $map, $db->prepare( $entity_name ), $column,
+                        $column, $column, self::NARROW_CEILING
+                    ) );
+
+                    // Reported for information only, so an unrunnable count is
+                    // simply not counted rather than aborting the run.
+                    $total += (int) $n;
+                }
             }
         }
 

--- a/tests/RederiveDimensionIdsTest.php
+++ b/tests/RederiveDimensionIdsTest.php
@@ -613,6 +613,53 @@ final class RederiveDimensionIdsTest extends TestCase
     }
 
     /**
+     * Every read of a fact table goes one partition at a time.
+     *
+     * Not an optimisation detail -- it decides whether a correct migration can
+     * report that it succeeded. The fact key carries no index, so each of these
+     * is a scan, and every row scanned probes the map by ( entity, old_id ).
+     * Scanning a whole fact table evicts the map's index pages from the buffer
+     * pool and those probes become disk reads: measured at 470,718 rows in 226
+     * seconds, against the identical join issued per partition by
+     * rewriteFactKeys() covering all nine tables in thirteen minutes.
+     *
+     * Whole-table, the verification outran the rewrite it was verifying and was
+     * killed by a timeout with everything already converted -- so the flag stayed
+     * set, ingestion kept deriving 32-bit ids against 63-bit data, and site
+     * lookups stayed broken. The rewrite was never the slow part.
+     */
+    public function testEveryFactTableReadIsScopedToOnePartition(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        // Every statement that reads or writes a fact table joined to the map.
+        // %s%s is the table followed by its PARTITION clause; a bare %s is a
+        // whole-table scan.
+        preg_match_all('/"(?:SELECT COUNT\(\*\) AS n|UPDATE) FROM |"UPDATE /', $source, $ignored);
+
+        foreach (['countNarrowKeys', 'countDanglingKeys', 'rewriteFactKeys'] as $method) {
+
+            $start = strpos($source, 'protected function ' . $method . '(');
+            $this->assertNotFalse($start, $method . ' must exist');
+
+            $body = substr($source, $start);
+            $body = substr($body, 0, strpos($body, "\n    }\n") + 6);
+
+            $this->assertStringContainsString('$db->listPartitions(', $body,
+                $method . ' must enumerate partitions rather than read the table whole');
+
+            $this->assertStringContainsString('PARTITION (%s)', $body,
+                $method . ' must scope each statement to one partition');
+
+            // An unpartitioned table still has to work: one statement, no clause.
+            $this->assertStringContainsString("array( array( 'name' => null ) )", $body,
+                $method . ' must still issue one unscoped statement for an unpartitioned table');
+        }
+    }
+
+    /**
      * The property that makes the migration re-runnable: crc32 ids are below
      * 2^32 and derived ids are 63-bit, so applying the map twice is a no-op and
      * "still narrow" is a usable definition of "still to do".


### PR DESCRIPTION
A migration that had converted everything correctly could not say so.

On demo the rewrite covered all nine fact tables in ~13 minutes. The completion check that follows it then settled into ~3 minutes per key column with ~50 to go — ~150 minutes against a 90-minute timeout. It would have been killed with the work already done, leaving `use_32bit_hash` set, ingestion deriving 32-bit ids against 63-bit data, and site lookups broken. **The rewrite was never the slow part; verifying it was.**

## Why it was slow

Not row volume — the same rows are read either way. `EXPLAIN` shows the fact key has no index, so this is a scan regardless:

```
UNSCOPED  tbl=f  type=ALL  key=(none)  rows=650561  parts=p20010101,p20020101,…
SCOPED    tbl=f  type=ALL  key=(none)  rows=67914   parts=p20160101
```

Every row scanned probes the map by `(entity, old_id)`. A whole-table scan evicts the map's index pages from the 512MB buffer pool, so those probes stop being memory reads and become disk reads:

| | rows | time |
|---|---|---|
| unscoped count, `owa_click.document_id` | 470,718 | 225.7s (~2,000 rows/sec) |
| same join, per partition (`rewriteFactKeys`) | all nine tables | ~13 min |

Same join, same data, an order of magnitude apart. A partition-sized scan leaves the map resident.

## The change

`countNarrowKeys()` and `countDanglingKeys()` now enumerate partitions and scope each statement, exactly as `rewriteFactKeys()` has always done. `countDanglingKeys()` is only informational, but it reads the same tables the same way — leaving it whole would have undone in one place what the other gained.

## Unpartitioned tables are unaffected

`listPartitions()` returns empty for an unpartitioned table — on MySQL because `PARTITION_NAME IS NOT NULL` filters them out, and on the base `Core/Db.php` driver always — so it takes the existing fallback of one statement with no `PARTITION` clause:

```php
$units = $partitions ? $partitions : array( array( 'name' => null ) );
$scope = $unit['name'] ? sprintf( ' PARTITION (%s)', $unit['name'] ) : '';
```

Verified against real tables:

```
owa_request      listPartitions -> 73  => scoped
owa_domstream    listPartitions -> 59  => scoped
owa_site_user    listPartitions ->  0  => fallback, one unscoped statement
owa_feed_request listPartitions ->  0  => fallback, one unscoped statement
```

Known limit, stated rather than hidden: a **fully unpartitioned** installation has no chunk boundary to use, so these counts remain whole-table scans there and the same thrash applies. Partitioning is what makes the chunking possible. Not addressed here rather than inventing an id-range chunker.

## Tests

`testEveryFactTableReadIsScopedToOnePartition` covers all three methods that touch a fact table — `countNarrowKeys`, `countDanglingKeys`, `rewriteFactKeys` — asserting each enumerates partitions, scopes its statement, **and** keeps the unpartitioned fallback. Mutation-checked: reverting `countNarrowKeys` to a whole-table read fails it.

631 tests green, all three phpstan configs clean.