### PR TITLE
Record completion before anything optional runs

### DIFF
--- a/modules/Base/Controller/RederiveDimensionIdsCli.php
+++ b/modules/Base/Controller/RederiveDimensionIdsCli.php
@@ -330,17 +330,22 @@ class RederiveDimensionIdsCli extends PartitionsCli {
             ) );
         }
 
-        $dangling = $this->countDanglingKeys();
-
-        // Completion verified, so the map has done its job. It is only needed
-        // BETWEEN runs -- once nothing is left to resume and the flag is about to
-        // clear, keeping it would leave one row per converted dimension behind
-        // for good. Counted before dropping, since countDanglingKeys() reads it.
-        $this->dropMap();
-
+        // EVERYTHING ABOVE IS A GATE. EVERYTHING BELOW IS A REPORT.
+        //
+        // The gates have passed, so this installation IS converted, and the flag
+        // is how it knows. Write it now, before anything optional runs, because a
+        // report that is slow or interrupted must not be able to undo a
+        // conversion that has already been verified.
+        //
+        // It used to be written after countDanglingKeys(), and that was the third
+        // time work ABOUT the migration outran the migration itself: a run whose
+        // gates had all passed spent longer counting a number nobody had asked
+        // for than it had spent converting, was killed partway through, and left
+        // the installation pinned to 32-bit ids over 63-bit data.
         \OWA\Core\CoreAPI::persistSetting( 'base', 'use_32bit_hash', false );
 
         $this->write( '' );
+        $this->write( 'Done. This installation now derives 63-bit ids.' );
 
         $unconvertible = $this->countUnconvertibleDimensionRows();
 
@@ -354,17 +359,34 @@ class RederiveDimensionIdsCli extends PartitionsCli {
             ) );
         }
 
-        if ( $dangling ) {
+        // ASKED FOR, NOT ASSUMED, BECAUSE IT COSTS A SECOND FULL PASS.
+        //
+        // The gates above already read every fact table once. This reads them all
+        // again to produce a number that changes nothing and prompts no action:
+        // dangling keys were unresolvable before this command ran and stay that
+        // way after it. On a real installation the second pass cost as much as
+        // the entire rest of the migration, so a routine conversion no longer
+        // pays for it.
+        if ( $this->getParam( 'report-dangling' ) ) {
 
-            $this->write( sprintf(
-                '%s fact key(s) reference a dimension row that does not exist. They were already '
-              . 'unresolvable before this ran and are left alone: there is no content to derive '
-              . 'an id from, and inventing a row would be inventing data.',
-                number_format( $dangling )
-            ) );
+            $dangling = $this->countDanglingKeys();
+
+            if ( $dangling ) {
+
+                $this->write( sprintf(
+                    '%s fact key(s) reference a dimension row that does not exist. They were already '
+                  . 'unresolvable before this ran and are left alone: there is no content to derive '
+                  . 'an id from, and inventing a row would be inventing data.',
+                    number_format( $dangling )
+                ) );
+            }
         }
 
-        $this->write( 'Done. This installation now derives 63-bit ids.' );
+        // The map has done its job. Dropped last because countDanglingKeys()
+        // reads it, and after the flag is cleared so that an interrupted report
+        // leaves a stray table rather than an installation that still looks
+        // unconverted. A later --force run drops it.
+        $this->dropMap();
     }
 
     /**

--- a/tests/RederiveDimensionIdsTest.php
+++ b/tests/RederiveDimensionIdsTest.php
@@ -660,6 +660,79 @@ final class RederiveDimensionIdsTest extends TestCase
     }
 
     /**
+     * Completion is recorded before anything optional runs.
+     *
+     * The third time work ABOUT the migration outran the migration. A run on a
+     * real installation passed every gate -- nothing left to convert, nothing
+     * stale -- and then spent longer counting dangling keys than it had spent
+     * converting, was killed by a timeout partway through, and left the flag set.
+     * The installation was fully converted and could not say so, so ingestion
+     * kept deriving 32-bit ids against 63-bit data and site lookups stayed broken.
+     *
+     * Gates decide whether the migration succeeded. Reports describe it. A report
+     * must never be positioned where it can withhold a verified success.
+     */
+    public function testCompletionIsRecordedBeforeAnythingOptional(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        $action = substr($source, strpos($source, 'function action()'));
+        $action = substr($action, 0, strpos($action, 'protected function deriveFor'));
+
+        $clears  = strrpos($action, "persistSetting( 'base', 'use_32bit_hash', false )");
+        $reports = strpos($action, '$this->countDanglingKeys()');
+
+        $this->assertNotFalse($clears, 'the flag must be cleared on the completion path');
+        $this->assertNotFalse($reports, 'the dangling report must still exist');
+
+        $this->assertLessThan($reports, $clears,
+            'the flag must be cleared before the dangling count, or a slow report can '
+          . 'withhold a conversion that already passed every gate');
+
+        // The gates themselves must still come first -- this must not become
+        // "clear the flag early and check afterwards".
+        foreach (['countNarrowKeys()', 'findStaleDerivedIds()'] as $gate) {
+
+            $at = strpos($action, $gate);
+            $this->assertNotFalse($at, $gate . ' must still gate the completion path');
+            $this->assertLessThan($clears, $at, $gate . ' must run before the flag is cleared');
+        }
+    }
+
+    /**
+     * The dangling count is asked for, not assumed.
+     *
+     * It reads every fact table a second time to produce a number that changes
+     * nothing and prompts no action: a dangling key was unresolvable before this
+     * command ran and stays that way after. On a real installation that second
+     * pass cost about as much as the entire rest of the migration.
+     */
+    public function testTheDanglingCountIsOptIn(): void
+    {
+        $source = (string) file_get_contents(
+            dirname(__DIR__) . '/modules/Base/Controller/RederiveDimensionIdsCli.php'
+        );
+
+        $action = substr($source, strpos($source, 'function action()'));
+        $action = substr($action, 0, strpos($action, 'protected function deriveFor'));
+
+        $guard = strpos($action, "getParam( 'report-dangling' )");
+        $call  = strpos($action, '$this->countDanglingKeys()');
+
+        $this->assertNotFalse($guard, 'the dangling count must be behind an opt-in flag');
+        $this->assertNotFalse($call);
+
+        $this->assertLessThan($call, $guard,
+            'the opt-in must be tested before the count is issued, not after');
+
+        // A routine conversion must not pay for it.
+        $this->assertSame(1, substr_count($action, '$this->countDanglingKeys()'),
+            'exactly one call site, and it is the guarded one');
+    }
+
+    /**
      * The property that makes the migration re-runnable: crc32 ids are below
      * 2^32 and derived ids are 63-bit, so applying the map twice is a no-op and
      * "still narrow" is a usable definition of "still to do".


### PR DESCRIPTION
A run on demo passed every gate — nothing left to convert, nothing stale — and was then killed by a timeout partway through counting dangling keys. The installation was fully converted and could not say so: the flag stayed set, ingestion kept deriving 32-bit ids against 63-bit data, site lookups stayed broken.

Reaching `countDanglingKeys()` is itself proof the gates passed — it runs only after `countNarrowKeys()` and `findStaleDerivedIds()` both return zero. The conversion was verified. Only the recording of it was blocked, by a statistic.

## The rule, made explicit

This is the third time work *about* the migration outran the migration:

| | what outran what |
|---|---|
| #1008 | a dead connection read as a finished migration |
| #1010 | rows that could never be planned counted as outstanding work |
| #1011 | a sampled check condemned a table that had converted |
| #1012 | verification cost ten times the rewrite it verified |
| this | an optional statistic gated a verified success |

**Everything above the flag is a gate and decides whether the migration succeeded. Everything below it is a report and merely describes it.** A report must never sit where it can withhold a verified success.

## Changes

- `persistSetting( 'use_32bit_hash', false )` moves up to immediately after the last gate, followed by `Done.`
- The dangling count becomes opt-in behind `--report-dangling`. It reads every fact table a second time for a number that changes nothing and prompts no action — a dangling key was unresolvable before the migration and stays that way after.
- `dropMap()` moves last, since `countDanglingKeys()` reads the map. An interrupted report now leaves a stray table rather than an installation that still looks unconverted; a later `--force` run drops it.

## Tests

- `testCompletionIsRecordedBeforeAnythingOptional` — the flag clears before the dangling count, **and** `countNarrowKeys` / `findStaleDerivedIds` still run before the flag clears, so this cannot drift into "clear early, check later".
- `testTheDanglingCountIsOptIn` — the guard precedes the call, and there is exactly one call site.

Both mutation-checked: restoring the old ordering fails the first, making the count unconditional fails the second. The existing `testTheMapIsDroppedOnlyAfterCompletionIsVerified` still passes legitimately — it asserts `dropMap()` follows the gates, and this moves it later, not earlier.

633 tests green, all three phpstan configs clean.

## Confirmed on demo

The killed run's own output confirms #1011 working as designed, as a notice rather than a failure:

```
[NOTICE] owa_host: 25 sampled row(s) remain at a 32-bit id derived from their
ip_address column, alongside 21,166 converted row(s). Nothing derives that id
any more, and their fact keys still point at it, so they are left as they are.
```