### PR TITLE
A refused database connection must not take down the request

### DIFF
--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -138,8 +138,25 @@ class Mysql extends \OWA\Core\Db {
             
             $this->connection = mysqli_init();
 
-            // get a connection
-            mysqli_real_connect(
+            // A FAILED CONNECT IS NOT A CONNECTION.
+            //
+            // mysqli_init() always returns an object, so `$this->connection`
+            // is truthy whether or not the connect below succeeds, and the
+            // guard at the end of this method -- which exists precisely to
+            // report a failure -- can never fire. What happened instead was
+            // that mysqli_set_charset() was called on a handle that was never
+            // connected, which in PHP 8 raises "mysqli object is not fully
+            // initialized": an Error, not an Exception, so query()'s catch does
+            // not see it either. A refused connection therefore took out the
+            // whole request with an uncaught fatal rather than degrading.
+            //
+            // Observed in production: RDS refused a connection for a few
+            // seconds and every page and tracking request during that window
+            // fataled instead of logging and moving on.
+            //
+            // So the return value decides, and the dead handle is released
+            // before anything can touch it.
+            $connected = mysqli_real_connect(
                 $this->connection,
                 $host,
                 $this->getConnectionParam('user'),
@@ -149,6 +166,16 @@ class Mysql extends \OWA\Core\Db {
                 $socket,
                 $client_flags
             );
+
+            if ( ! $connected ) {
+
+                $this->connection = null;
+                $this->connection_status = false;
+
+                $this->e->alert( 'Could not connect to database.' );
+
+                return false;
+            }
 
             // explicitly set the character set as UTF-8
             if (function_exists('mysqli_set_charset')) {
@@ -192,9 +219,22 @@ class Mysql extends \OWA\Core\Db {
 
               \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
 
-              $this->connect();
+              $connected = $this->connect();
 
               \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
+
+                // Without a connection there is nothing to run the query
+                // against, and every mysqli_* call below would raise on the
+                // released handle. Report it the way a failed query reports
+                // itself, so callers that already handle a falsy result --
+                // get_row() and get_results() both do -- degrade rather than
+                // die.
+                if ( ! $connected ) {
+
+                    $this->new_result = false;
+
+                    return false;
+                }
           }
   
           \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -106,7 +106,25 @@ define('OWA_DTD_TABLE_CHARACTER_ENCODING', 'CHARACTER SET = %s');
  */
 class Mysql extends \OWA\Core\Db {
 
+    /**
+     * A connect attempt has already failed and must not be repeated.
+     *
+     * Releasing the dead handle on failure is what stops it being mistaken for
+     * a connection -- but it also makes `! $this->connection` true again, so
+     * without this every query would re-dial a database that is down, and every
+     * attempt raises its own warning. Cleared by close(), so an explicit
+     * reconnect is still possible.
+     *
+     * @var bool
+     */
+    protected $connect_failed = false;
+
     function connect() {
+
+        if ( $this->connect_failed ) {
+
+            return false;
+        }
 
         if ( ! $this->connection ) {
 
@@ -171,6 +189,7 @@ class Mysql extends \OWA\Core\Db {
 
                 $this->connection = null;
                 $this->connection_status = false;
+                $this->connect_failed = true;
 
                 $this->e->alert( 'Could not connect to database.' );
 
@@ -301,6 +320,10 @@ class Mysql extends \OWA\Core\Db {
 
         $this->connection        = null;
         $this->connection_status = false;
+
+        // An explicit close is a deliberate reset, so a later connect() may try
+        // again -- unlike the per-query retries connect() refuses.
+        $this->connect_failed    = false;
     }
 
     /**

--- a/tests/DbConnectFailureTest.php
+++ b/tests/DbConnectFailureTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A refused database connection must degrade, not kill the request.
+ *
+ * This was observed in production: the database refused connections for a few
+ * seconds, and every page render and tracking request in that window died with
+ *
+ *   PHP Warning:  mysqli_real_connect(): (HY000/2002): Connection refused
+ *   PHP Fatal error: Uncaught Error: mysqli object is not fully initialized
+ *
+ * rather than logging "Could not connect to database" and moving on -- which is
+ * what connect() visibly intends to do, and could never do.
+ *
+ * Three separate things conspired, and each is pinned below:
+ *
+ *  1. mysqli_init() returns an object whether or not the subsequent connect
+ *     succeeds, so `if ( ! $this->connection )` was never true and the failure
+ *     branch was unreachable.
+ *  2. mysqli_real_connect()'s return value -- the only reliable signal -- was
+ *     discarded.
+ *  3. The handle was then used immediately by mysqli_set_charset(), which in
+ *     PHP 8 raises an Error rather than an Exception, so query()'s
+ *     `catch (\Exception)` could not have caught it either.
+ */
+final class DbConnectFailureTest extends TestCase
+{
+    private function source(): string
+    {
+        return (string) file_get_contents(dirname(__DIR__) . '/Core/Db/Mysql.php');
+    }
+
+    private function method(string $name): string
+    {
+        $src   = $this->source();
+        $start = strpos($src, 'function ' . $name . '(');
+        $this->assertNotFalse($start, $name . '() must exist');
+
+        $body = substr($src, $start);
+        $end  = strpos($body, "\n    }\n");
+
+        $this->assertNotFalse($end, $name . '() must be a complete method');
+
+        return substr($body, 0, $end + 6);
+    }
+
+    /**
+     * The connect result decides, not the truthiness of the handle.
+     */
+    public function testTheConnectResultIsWhatDecidesSuccess(): void
+    {
+        $connect = $this->method('connect');
+
+        $this->assertMatchesRegularExpression(
+            '/\$\w+\s*=\s*mysqli_real_connect\(/',
+            $connect,
+            'the return value of mysqli_real_connect() must be captured, since the handle is '
+          . 'truthy either way'
+        );
+    }
+
+    /**
+     * Nothing may touch the handle between a failed connect and the return.
+     *
+     * This is the assertion that actually prevents the fatal: charset selection
+     * on an unconnected handle is what raised, and any future statement added
+     * in that gap would raise the same way.
+     */
+    public function testAFailedConnectTouchesTheHandleNoFurther(): void
+    {
+        $connect = $this->method('connect');
+
+        $call  = strpos($connect, 'mysqli_real_connect(');
+        $guard = strpos($connect, 'if ( ! $connected )');
+
+        $this->assertNotFalse($guard, 'the failure must be handled explicitly');
+        $this->assertGreaterThan($call, $guard, 'and handled after the attempt');
+
+        // Between the guard and its return, the only permitted operations are
+        // releasing the handle, recording the status, and reporting.
+        $branch = substr($connect, $guard, strpos($connect, 'return false;', $guard) - $guard);
+
+        $this->assertStringNotContainsString('mysqli_', $branch,
+            'a handle that never connected must not be handed to any mysqli call');
+
+        $this->assertStringContainsString('$this->connection = null', $branch,
+            'the dead handle must be released so later code cannot mistake it for a connection');
+
+        $this->assertStringContainsString('$this->connection_status = false', $branch,
+            'and the status must say so');
+    }
+
+    /**
+     * query() must not run against a connection it failed to obtain.
+     *
+     * Releasing the handle in connect() moves the failure rather than fixing it
+     * unless query() stops as well: every mysqli_* call in query() would then
+     * be handed null.
+     */
+    public function testQueryStopsWhenTheConnectionCouldNotBeObtained(): void
+    {
+        $query = $this->method('query');
+
+        $this->assertMatchesRegularExpression(
+            '/\$\w+\s*=\s*\$this->connect\(\)/',
+            $query,
+            'query() must observe whether its reconnect succeeded'
+        );
+
+        $reconnect = strpos($query, '$this->connect()');
+        $first_use = strpos($query, 'mysqli_query(');
+
+        $this->assertNotFalse($first_use);
+
+        $guard = strpos($query, 'if ( ! $connected )', $reconnect);
+
+        $this->assertNotFalse($guard, 'a failed reconnect must be handled');
+        $this->assertLessThan($first_use, $guard,
+            'and handled before the connection is used');
+    }
+
+    /**
+     * The accessors above query() already degrade on a falsy result, which is
+     * what makes returning false safe rather than merely quieter. Pinned
+     * because the fix depends on it: if either started assuming a result
+     * object, a connection failure would fatal again one layer up.
+     */
+    public function testTheAccessorsAboveQueryTolerateAFalsyResult(): void
+    {
+        $this->assertStringContainsString('if (!$this->new_result) {', $this->method('get_results'),
+            'get_results() must return early when the query produced nothing');
+
+        $this->assertMatchesRegularExpression(
+            '/if\s*\(\s*!\s*\$result\s*\|\|/',
+            $this->method('get_row'),
+            'get_row() must return early when the query produced nothing'
+        );
+    }
+
+    /**
+     * The test suite decides whether a database is available by probing with a
+     * real round-trip, and 100+ tests skip on the result. Before this fix the
+     * probe worked by catching the fatal; it now gets a null row instead. Pin
+     * the property the probe actually relies on -- that a failed probe returns
+     * rather than escapes -- so a future change here cannot silently turn every
+     * DB-dependent test into an error on a runner with no database.
+     */
+    public function testTheDatabaseProbeReportsRatherThanRaises(): void
+    {
+        $bootstrap = (string) file_get_contents(__DIR__ . '/bootstrap_owa.php');
+
+        $this->assertStringContainsString('function owa_test_db_available', $bootstrap);
+
+        $this->assertStringContainsString('catch (\Throwable $e)', $bootstrap,
+            'the probe must remain total: it is how tests detect the absence of a database. '
+          . 'Before this fix a failed probe raised an Error and was caught here; it now returns '
+          . 'a null row instead, and both paths must keep producing a verdict rather than escaping');
+
+        $this->assertStringContainsString('return is_array($row)', $bootstrap,
+            'and the verdict must come from the round-trip result, not from connection_status, '
+          . 'which mysqli_init() makes unreliable');
+    }
+}

--- a/tests/DbConnectFailureTest.php
+++ b/tests/DbConnectFailureTest.php
@@ -124,6 +124,43 @@ final class DbConnectFailureTest extends TestCase
     }
 
     /**
+     * A failure must be sticky within the connection object.
+     *
+     * Releasing the dead handle is what stops it being mistaken for a
+     * connection, but it also makes `! $this->connection` true again -- so
+     * without this, every query re-dials a database that is down and every
+     * attempt raises its own warning. CI caught exactly that: the fix as first
+     * written turned one warning per request into one per query, which
+     * failOnWarning correctly rejected.
+     *
+     * The old code got this right by accident, having kept the dead handle.
+     */
+    public function testAFailedConnectIsNotRetriedOnEveryQuery(): void
+    {
+        $src     = $this->source();
+        $connect = $this->method('connect');
+
+        $this->assertStringContainsString('protected $connect_failed', $src,
+            'a failed connect must be remembered');
+
+        $guard = strpos($connect, 'if ( $this->connect_failed )');
+        $init  = strpos($connect, 'mysqli_init()');
+
+        $this->assertNotFalse($guard, 'connect() must refuse to re-dial after a failure');
+        $this->assertNotFalse($init);
+        $this->assertLessThan($init, $guard,
+            'and refuse before opening another handle, not after');
+
+        // The refusal has to be recorded where the failure is detected.
+        $this->assertStringContainsString('$this->connect_failed = true', $connect,
+            'the failure path must set the flag');
+
+        // ...and cleared by an explicit close, so a deliberate reconnect works.
+        $this->assertStringContainsString('$this->connect_failed    = false', $this->method('close'),
+            'close() must clear it, so an explicit reconnect is still possible');
+    }
+
+    /**
      * The accessors above query() already degrade on a falsy result, which is
      * what makes returning false safe rather than merely quieter. Pinned
      * because the fix depends on it: if either started assuming a result


### PR DESCRIPTION
Found while checking the error log after today's migrations. The database refused connections for a few seconds and every page render and tracking request in that window died:

```
PHP Warning:  mysqli_real_connect(): (HY000/2002): Connection refused
              in Core/Db/Mysql.php on line 142
PHP Fatal error: Uncaught Error: mysqli object is not fully initialized
```

`connect()` visibly intends to handle this — it ends with `alert('Could not connect to database.')` — and that branch has never been reachable.

## Three things conspired

```php
$this->connection = mysqli_init();          // always returns an object
mysqli_real_connect( ... );                 // return value discarded
mysqli_set_charset($this->connection, …);   // ← raises on an unconnected handle
…
if ( ! $this->connection ) {                // unreachable: the object always exists
    $this->e->alert('Could not connect to database.');
```

1. `mysqli_init()` returns an object regardless of whether the connect succeeds, so the guard could never fire.
2. The return value of `mysqli_real_connect()` — the only reliable signal — was thrown away.
3. The handle was used immediately by `mysqli_set_charset()`, which raises an **`Error`**, not an `Exception`, so `query()`'s `catch (\Exception)` could not have caught it either.

The test suite already knew: `tests/bootstrap_owa.php` documents that "`mysqli_init()` leaves a truthy handle even on a failed connect, so `connection_status` alone is unreliable" — worked around there, never fixed at source.

## The fix

- `connect()` captures the result, releases the dead handle, sets `connection_status = false`, alerts, and returns before anything can touch it.
- `query()` stops when its reconnect fails. Releasing the handle alone would only move the fatal one line down, since every `mysqli_*` call in `query()` would then be handed `null`.

## Compatibility — checked, since the failure mode was load-bearing

| dependent | before | after |
|---|---|---|
| `InstallManager` / `InstallConfig` | test `connection_status`, which could never be false → fatal on bad credentials | get the `false` they were written to expect → proper error |
| `get_row()` / `get_results()` | — | already return `null` on a falsy result; untouched |
| test DB probe (100+ tests skip on it) | detected "no database" by **catching this very fatal** | gets a `null` row; still returns a verdict |
| `query()` | reconnect result ignored | returns `false` instead of handing `null` to `mysqli_*` |

The probe is the subtle one, and it's now pinned by a test so nobody removes its `catch (\Throwable)` on the grounds that nothing throws any more.

**The install flow gains most**: bad database credentials have been producing an uncaught fatal instead of the error the wizard is written to display.

## Tests

`DbConnectFailureTest` pins all three causes separately — the result is captured, nothing touches the handle between failure and return, `query()` stops before first use — plus the two properties the fix depends on (the accessors tolerate a falsy result; the probe reports rather than raises).

Each mutation-checked: discarding the connect result, using the handle in the failure branch, and removing the `query()` guard each fail their test.

638 tests green, all three phpstan configs clean.