### PR TITLE
A robot token at the start of a user agent must count as a robot

### DIFF
--- a/modules/Base/Classes/Browscap.php
+++ b/modules/Base/Classes/Browscap.php
@@ -159,11 +159,14 @@ class Browscap extends \OWA\Core\Base {
 
         foreach ( $robots as $k => $robot ) {
 
-            $match = stripos( $this->ua , $robot );
-
-            if ( $match ) {
+            // stripos() returns int 0 for a match at the start of the string,
+            // which is falsy -- so a truthy check here let any UA *beginning*
+            // with a robot token (curl/..., Wget/..., Java/...) pass as human.
+            if ( stripos( $this->ua , $robot ) !== false ) {
 
                 \OWA\Core\CoreAPI::debug('Robot detect string found: ' . $robot );
+
+                $match = true;
 
                 break;
             }

--- a/tests/BrowscapRobotDetectionTest.php
+++ b/tests/BrowscapRobotDetectionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A robot token at position 0 of the user agent must still count as a robot.
+ *
+ * Browscap::robotRegexCheck() did `$match = stripos($ua, $robot); if ($match)`,
+ * and stripos() returns int 0 -- falsy -- for a match at the start of the
+ * string. So any user agent that *begins* with a robot token passed as human:
+ * `curl/7.68.0`, `Wget/1.21.3` and `Java/17.0.1` were all undetected, while
+ * the very same tokens were caught mid-string. The affected tokens (curl,
+ * wget, java, php, perl, lwp, libwww) are exactly the ones that convention
+ * puts at the start of a UA.
+ *
+ * This matters more than its size suggests because reclassification is
+ * collection-time only: a bot logged as human today is human in the data
+ * forever.
+ */
+final class BrowscapRobotDetectionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function browscap(string $ua): \OWA\Module\Base\Classes\Browscap
+    {
+        return new \OWA\Module\Base\Classes\Browscap($ua);
+    }
+
+    /**
+     * The bug: tokens at position 0. Every one of these passed as human.
+     */
+    public function testUserAgentBeginningWithRobotTokenIsARobot(): void
+    {
+        $leading = [
+            'curl/7.68.0',
+            'Wget/1.21.3',
+            'Java/17.0.1',
+            'php-httpclient/2.0',
+            'perl-libwww/6.0',
+            'lwp-request/6.0',
+            'libwww-perl/6.67',
+            'Bot/1.0 (+http://example.com)',
+        ];
+
+        foreach ($leading as $ua) {
+            $this->assertTrue(
+                (bool) $this->browscap($ua)->isRobot(),
+                "UA beginning with a robot token passed as human: $ua"
+            );
+        }
+    }
+
+    /**
+     * Mid-string detection worked before the fix and must keep working.
+     */
+    public function testRobotTokenMidStringIsStillDetected(): void
+    {
+        $midString = [
+            'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+            'Mozilla/5.0 (compatible; YandexBot/3.0)',
+            'python-requests/2.31.0 curl',
+        ];
+
+        foreach ($midString as $ua) {
+            $this->assertTrue(
+                (bool) $this->browscap($ua)->isRobot(),
+                "Robot token mid-string went undetected: $ua"
+            );
+        }
+    }
+
+    /**
+     * Real browsers stay human -- the fix must not widen the match.
+     */
+    public function testOrdinaryBrowserUserAgentsAreNotRobots(): void
+    {
+        $browsers = [
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+            'Mozilla/5.0 (X11; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0',
+        ];
+
+        foreach ($browsers as $ua) {
+            $this->assertFalse(
+                (bool) $this->browscap($ua)->isRobot(),
+                "Ordinary browser misclassified as robot: $ua"
+            );
+        }
+    }
+
+    /**
+     * The return value is a clean boolean on both paths. Before the fix it was
+     * false | int -- a stripos position -- which happened to work for truthy
+     * checks at nonzero positions and silently failed at zero.
+     */
+    public function testRobotCheckReturnsABoolean(): void
+    {
+        $this->assertIsBool($this->browscap('curl/7.68.0')->robotRegexCheck());
+        $this->assertIsBool($this->browscap('Mozilla/5.0 (X11; Linux x86_64; rv:124.0) Gecko/20100101 Firefox/124.0')->robotRegexCheck());
+    }
+
+    /**
+     * An empty user agent is not a robot -- and must not warn or throw.
+     */
+    public function testEmptyUserAgentIsNotARobot(): void
+    {
+        $this->assertFalse((bool) $this->browscap('')->isRobot());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,3 +41,15 @@ if (!defined('OWA_DB_TYPE') && !file_exists(__DIR__ . '/../owa-config.php')) {
     // engine to load so the OWA_DTD_* column-type constants get defined.
     define('OWA_DB_TYPE', 'mysql');
 }
+
+if (!defined('OWA_AUTH_KEY') && !file_exists(__DIR__ . '/../owa-config.php')) {
+    // Same reason, different constant. Cache::makeCacheId() hashes with
+    // OWA_AUTH_KEY, so anything that touches the cache singleton -- Browscap
+    // does, in its constructor -- fatals without it. A developer machine has a
+    // config file supplying one, CI does not, which is exactly the shape of
+    // failure that passes locally and reddens on the runner.
+    //
+    // The value is irrelevant: nothing here verifies a signature, and no test
+    // may depend on a particular key.
+    define('OWA_AUTH_KEY', 'test-suite-not-a-real-key');
+}


### PR DESCRIPTION
`Browscap::robotRegexCheck()` checked the truthiness of `stripos()`, which returns int `0` — falsy — for a match at position 0 of the string. Any user agent *beginning* with a robot token therefore passed as human: `curl/7.68.0`, `Wget/1.21.3` and `Java/17.0.1` were all undetected, while the very same tokens were caught mid-string (`python-requests/2.31.0 curl` is detected). The affected tokens — curl, wget, java, php, perl, lwp, libwww — are exactly the ones that convention puts at the start of a UA.

The check is now `stripos() !== false`, and `robotRegexCheck()` returns a clean boolean instead of leaking the match position as its return value.

Bot classification happens at collection time only, so every day of this bug is bot traffic permanently recorded as human — which is why it is worth more than its one-operator size suggests.

**Tests**: new `BrowscapRobotDetectionTest` (5 tests, 17 assertions) covering leading-token detection, mid-string detection unchanged, ordinary browsers unaffected, boolean return, and the empty-UA edge. Mutation-checked: reverting the fix reddens the suite. Full suite 644 tests green; all three phpstan configs clean.