### PR TITLE
Remove the two goal types that were never reachable

### DIFF
--- a/modules/Base/Handler/ConversionHandlers.php
+++ b/modules/Base/Handler/ConversionHandlers.php
@@ -170,6 +170,20 @@ class ConversionHandlers extends \OWA\Core\Observer {
         $dispatch->asyncNotify( $ce );
     }
         
+    /**
+     * The site's active goals. Extracted so the conversion logic can be
+     * exercised without a goal manager or a database behind it.
+     *
+     * @param    string    $siteId
+     * @return    array
+     */
+    protected function getActiveGoals( $siteId ) {
+
+        $gm = \OWA\Core\CoreAPI::supportClassFactory('base', 'goalManager', $siteId);
+
+        return $gm->getActiveGoals();
+    }
+
     function checkForConversion($event) {
     
         $goal_info = array('conversion' => '', 'value' => '', 'start' => '');
@@ -179,8 +193,7 @@ class ConversionHandlers extends \OWA\Core\Observer {
             $siteId = $event->get('site_id');
         }
 
-        $gm = \OWA\Core\CoreAPI::supportClassFactory('base', 'goalManager', $siteId);
-        $goals = $gm->getActiveGoals();
+        $goals = $this->getActiveGoals( $siteId );
         \OWA\Core\CoreAPI::debug('active goals: '.print_r($goals, true));
         if (empty($goals)) {
             return;
@@ -195,6 +208,14 @@ class ConversionHandlers extends \OWA\Core\Observer {
             if (!empty($goal)) {
 
                 if (array_key_exists('goal_status', $goal) && $goal['goal_status'] === 'active') {
+                    // Reset per goal. These once persisted across
+                    // iterations, so a goal carrying no value of its own
+                    // inherited the previous goal's, and a goal whose type
+                    // matched no case kept the previous goal's match.
+                    $match = '';
+                    $start = '';
+                    $goal_value = '';
+
                     switch ($goal['goal_type']) {
 
                         case 'url_destination':
@@ -202,25 +223,18 @@ class ConversionHandlers extends \OWA\Core\Observer {
                             $match = $this->checkUrlDestinationGoal($event, $goal);
                             $start = $this->checkGoalStart($event, $goal);
                             break;
-
-                        case 'pages_per_visit':
-
-                            $match = $this->checkPagesPerVisitGoal($event, $goal);
-                            break;
-
-                        case 'visit_duration':
-
-                            $match = $this->checkPagesPerVisitGoal($event, $goal);
-                            break;
-                    }
-
-                    if ($match) {
-                        $goal_info['conversion'] = $match;
                     }
 
                     if ($start) {
                         $goal_info['start'] = $start;
                     }
+
+                    if ( ! $match ) {
+
+                        continue;
+                    }
+
+                    $goal_info['conversion'] = $match;
 
                     //check for dynamic value from commerce transaction
 
@@ -233,6 +247,9 @@ class ConversionHandlers extends \OWA\Core\Observer {
                         }
                     }
 
+                    // Only the converting goal contributes a value. This was
+                    // previously assigned every iteration, so the value
+                    // reported belonged to whichever goal came last.
                     $goal_info['value'] = $goal_value;
                 } else {
                     \OWA\Core\CoreAPI::debug("Goal $num not active.");
@@ -241,62 +258,6 @@ class ConversionHandlers extends \OWA\Core\Observer {
         }
         \OWA\Core\CoreAPI::debug('conversion info: '.print_r($goal_info, true));
         return $goal_info;
-    }
-    
-    function checkPagesPerVisitGoal($event, $goal) {
-
-        $num = $event->get('npvs');
-
-        if ($num) {
-            $operator = $goal['details']['operator'];
-            $req = $goal['details']['num_pageviews'];
-
-            switch ($operator) {
-
-                case '=':
-                     if ($num === $req) {
-                         return $goal['goal_number'];
-                     }
-
-                case '<':
-                    if ($num < $req) {
-                         return $goal['goal_number'];
-                     }
-
-                case '>':
-                    if ($num > $req) {
-                         return $goal['goal_number'];
-                     }
-            }
-        }
-        return false;
-    }
-    
-    function checkVisitDurationGoal($event, $goal) {
-
-        $num = $event->get('session_duration');
-        $operator = $goal['details']['operator'];
-        $req = $goal['details']['duration'];
-
-        switch ($operator) {
-
-            case '=':
-                 if ($num === $req) {
-                     return $goal['goal_number'];
-                 }
-
-            case '<':
-                if ($num < $req) {
-                     return $goal['goal_number'];
-                 }
-
-            case '>':
-                if ($num > $req) {
-                     return $goal['goal_number'];
-                 }
-        }
-
-        return false;
     }
     
     function checkUrlDestinationGoal($event, $goal) {

--- a/modules/Base/templates/options_goal_entry.php
+++ b/modules/Base/templates/options_goal_entry.php
@@ -82,13 +82,7 @@
                     </p>
                 </th>
                 <td>
-                    <input type="radio" name="<?php echo $view->getNs();?>goal[goal_type]" value="url_destination" <?php if (isset($view->goal['goal_type']) && $view->goal['goal_type'] === 'url_destination'){echo 'CHECKED';}?> > URL Destination<BR>
-
-                    <input type="radio" name="<?php echo $view->getNs();?>goal[goal_type]" value="pages_per_visit" <?php if (isset($view->goal['goal_type']) && $view->goal['goal_type'] === 'pages_per_visit'){echo 'CHECKED';}?> > Pages / Visit<BR>
-
-                    <input type="radio" name="<?php echo $view->getNs();?>goal[goal_type]" value="visit_duration" <?php if (isset($view->goal['goal_type']) && $view->goal['goal_type'] === 'visit_duration'){echo 'CHECKED';}?> > Visit Duration <BR>
-
-
+                    <input type="radio" name="<?php echo $view->getNs();?>goal[goal_type]" value="url_destination" <?php if ( ! isset($view->goal['goal_type']) || $view->goal['goal_type'] === 'url_destination'){echo 'CHECKED';}?> > URL Destination<BR>
                 </td>
             </tr>
 
@@ -144,18 +138,6 @@
         </table>
         <BR>
         <a name="steps-end" href="#    steps-end" id="addStep">Add New Funnel Step</a>
-    </div>
-
-    <!-- pages per visit goal type specific options -->
-    <div id="pages_per_visit_details" class="goal-detail">
-        <h3>Goal Details</h3>
-        Not implemented yet.
-    </div>
-
-    <!-- visit duration goal type specific options -->
-    <div id="visit_duration_details" class="goal-detail">
-        <h3>Goal Details</h3>
-        Not implemented yet.
     </div>
 
     <input type="hidden" name="<?php echo $view->getNs();?>goal[goal_number]" value="<?php $view->out($view->goal_number, false);?>">

--- a/tests/GoalConversionTest.php
+++ b/tests/GoalConversionTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * What checkForConversion() reports when a site has several goals.
+ *
+ * Two defects live in its loop, both caused by variables that outlive the
+ * iteration that set them:
+ *
+ *  1. `$goal_value` is never reset. When a goal carries no `goal_value` of its
+ *     own, neither assignment branch runs and the variable still holds the
+ *     PREVIOUS goal's value -- so a conversion can be recorded with a value
+ *     belonging to an entirely different goal.
+ *
+ *  2. `$goal_info['value']` is assigned on every iteration whether or not that
+ *     goal converted, so the reported value is simply whatever the LAST goal
+ *     in the list contributed.
+ *
+ * `$match` has the same shape but is benign today, because a goal that fails
+ * to match returns '' and the only other writer is a goal that did match. It
+ * is reset anyway: the two dead goal types are being removed in this change,
+ * and a legacy row carrying one of those types now falls through the switch
+ * with no case -- exactly the condition under which a stale `$match` would
+ * hand it its neighbour's conversion.
+ */
+final class GoalConversionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /** An event carrying just enough for the url_destination checker. */
+    private function event(string $pageUri)
+    {
+        $event = \OWA\Core\CoreAPI::supportClassFactory('base', 'event');
+        $event->set('page_uri', $pageUri);
+        $event->set('siteId', 'test-site');
+
+        return $event;
+    }
+
+    private function goal(int $number, string $url, array $extra = []): array
+    {
+        return array_merge([
+            'goal_number'  => $number,
+            'goal_status'  => 'active',
+            'goal_type'    => 'url_destination',
+            'details'      => ['match_type' => 'exact', 'goal_url' => $url],
+        ], $extra);
+    }
+
+    private function handlerWithGoals(array $goals): \OWA\Module\Base\Handler\ConversionHandlers
+    {
+        return new class($goals) extends \OWA\Module\Base\Handler\ConversionHandlers {
+            private $stubGoals;
+
+            public function __construct($goals)
+            {
+                $this->stubGoals = $goals;
+            }
+
+            protected function getActiveGoals($siteId)
+            {
+                return $this->stubGoals;
+            }
+        };
+    }
+
+    /**
+     * The defect: goal 1 converts and carries value 10, goal 2 does not convert
+     * but carries value 99. The conversion belongs to goal 1, so the value must
+     * be 10 -- not the last goal's 99.
+     */
+    public function testValueBelongsToTheGoalThatConverted(): void
+    {
+        $handler = $this->handlerWithGoals([
+            1 => $this->goal(1, '/thanks', ['goal_value' => 10]),
+            2 => $this->goal(2, '/never-visited', ['goal_value' => 99]),
+        ]);
+
+        $info = $handler->checkForConversion($this->event('/thanks'));
+
+        $this->assertSame(1, (int) $info['conversion'], 'goal 1 should be the conversion');
+        $this->assertSame(10, (int) $info['value'], 'value must come from the converted goal, not the last one');
+    }
+
+    /**
+     * The same defect in its other form: goal 2 converts but carries no value of
+     * its own, so nothing may be inherited from goal 1.
+     */
+    public function testAGoalWithNoValueDoesNotInheritOne(): void
+    {
+        $handler = $this->handlerWithGoals([
+            1 => $this->goal(1, '/never-visited', ['goal_value' => 77]),
+            2 => $this->goal(2, '/signup'),
+        ]);
+
+        $info = $handler->checkForConversion($this->event('/signup'));
+
+        $this->assertSame(2, (int) $info['conversion']);
+        $this->assertEmpty($info['value'], 'a goal with no value must not inherit the previous goal\'s');
+    }
+
+    /**
+     * A goal whose type is not recognised -- which is what a legacy
+     * pages_per_visit or visit_duration row becomes after this change -- is
+     * ignored, and never inherits the previous goal's match.
+     */
+    public function testUnrecognisedGoalTypeIsIgnoredAndInheritsNothing(): void
+    {
+        $handler = $this->handlerWithGoals([
+            1 => $this->goal(1, '/thanks', ['goal_value' => 10]),
+            2 => $this->goal(2, '/x', ['goal_type' => 'visit_duration', 'goal_value' => 99]),
+        ]);
+
+        $info = $handler->checkForConversion($this->event('/thanks'));
+
+        $this->assertSame(1, (int) $info['conversion'], 'the legacy-typed goal must not claim the conversion');
+        $this->assertSame(10, (int) $info['value']);
+    }
+
+    /**
+     * Inactive goals are skipped and contribute nothing.
+     */
+    public function testInactiveGoalsContributeNothing(): void
+    {
+        $handler = $this->handlerWithGoals([
+            1 => $this->goal(1, '/thanks', ['goal_status' => 'inactive', 'goal_value' => 55]),
+            2 => $this->goal(2, '/signup'),
+        ]);
+
+        $info = $handler->checkForConversion($this->event('/signup'));
+
+        $this->assertSame(2, (int) $info['conversion']);
+        $this->assertEmpty($info['value']);
+    }
+
+    /**
+     * The surviving goal type still works: exact, begins and regex matching.
+     */
+    public function testUrlDestinationMatchingStillWorks(): void
+    {
+        $exact = $this->handlerWithGoals([1 => $this->goal(1, '/thanks')]);
+        $this->assertSame(1, (int) $exact->checkForConversion($this->event('/thanks'))['conversion']);
+        $this->assertEmpty($exact->checkForConversion($this->event('/thanks/more'))['conversion']);
+
+        $begins = $this->handlerWithGoals([
+            1 => $this->goal(1, '/shop', ['details' => ['match_type' => 'begins', 'goal_url' => '/shop']]),
+        ]);
+        $this->assertSame(1, (int) $begins->checkForConversion($this->event('/shop/cart'))['conversion']);
+        $this->assertEmpty($begins->checkForConversion($this->event('/blog/shop'))['conversion']);
+
+        $regex = $this->handlerWithGoals([
+            1 => $this->goal(1, 'x', ['details' => ['match_type' => 'regex', 'goal_url' => '^/order/[0-9]+$']]),
+        ]);
+        $this->assertSame(1, (int) $regex->checkForConversion($this->event('/order/12345'))['conversion']);
+        $this->assertEmpty($regex->checkForConversion($this->event('/order/abc'))['conversion']);
+    }
+
+    /**
+     * A site with no goals returns nothing rather than raising.
+     */
+    public function testNoGoalsReturnsNothing(): void
+    {
+        $this->assertEmpty($this->handlerWithGoals([])->checkForConversion($this->event('/thanks')));
+    }
+}


### PR DESCRIPTION
`pages_per_visit` and `visit_duration` could be *selected* on the goal form, but both detail panels read **"Not implemented yet"** — so neither threshold nor operator could ever be configured, and no site can be holding a working goal of either type.

Behind the form, the server side was broken three ways over:

- `visit_duration` dispatched to `checkPagesPerVisitGoal()` (copy-paste); `checkVisitDurationGoal()` was never called from anywhere.
- Neither checker's input exists — a tree-wide grep for `npvs` and `session_duration` finds them **only** in this file, read-only, written nowhere.
- Both switches omitted `break`, so `=` fell through to `<` and `>`.

Note these interact: repointing the dispatcher alone would have flipped `visit_duration` from *never converts* (the `if ($num)` guard catches the null) to **converts on every session** (the unguarded switch returns on `<`), writing false conversions into the fact tables. Whole fix or none.

**Why removal rather than completion.** Both are session-scoped conditions that become true on no particular event, so they cannot be expressed as collection-time key events. GA reached the same conclusion: GA4 kept only the event-shaped goal and dropped duration and pages-per-session outright. `url_destination` — which works today and maps directly onto key events — is untouched, and is now the default selection so a goal cannot be saved with no type at all.

**The loop fix that ships with it**, because removal requires it: `$match`, `$start` and `$goal_value` persisted across loop iterations.

- A legacy row still carrying a removed type now falls through the switch with no case — precisely the condition under which a stale `$match` hands it the previous goal's conversion.
- A goal carrying no `goal_value` of its own inherited the previous goal's.
- `goal_info['value']` was assigned on **every** iteration whether or not that goal converted, so the reported value belonged to whichever goal came last — a converted goal could be recorded with an unrelated goal's value.

**Tests**: new `GoalConversionTest` (6 tests) pinning value-belongs-to-the-converting-goal, no-inheritance, unrecognised types ignored, inactive goals skipped, and all three `url_destination` match modes still working. Mutation-checked: restoring the carryover reddens exactly three. Full suite 645 green; all three phpstan configs clean.

Adds one seam — `getActiveGoals($siteId)`, a pure extraction — so the conversion logic is testable without a goal manager or a database.