### PR TITLE
Drop the guid salt that was always discarded, and pin the id contract

### DIFF
--- a/modules/Base/src/common/Util.js
+++ b/modules/Base/src/common/Util.js
@@ -640,6 +640,27 @@ class Util {
         return this.crc32(value);
     }
     
+    /**
+     * A numeric id: 10 digits of unix seconds followed by 9 random digits.
+     *
+     * Takes no salt, and cannot. The result must fit a signed BIGINT -- a hard
+     * contract across this codebase -- and this construction already consumes
+     * 60.6 of the 63 available bits, so there is nothing to mix a salt into
+     * without either taking bits from the random half or making ids
+     * predictable from their inputs. Callers once passed one and it was
+     * silently discarded.
+     *
+     * The split between the time and random halves is not worth re-tuning
+     * either: coarsening the time bucket by k multiplies the ids sharing a
+     * bucket by k (candidate pairs by k^2), divides the bucket count by k and
+     * grows the random space by k, so k cancels and the collision rate is
+     * unchanged. It is a function of the total bit budget and the arrival rate
+     * alone -- roughly 0.8 expected collisions a year at 10 new visitors per
+     * second. Improving on that needs a wider id, which BIGINT forbids.
+     *
+     * The leading timestamp is load-bearing beyond ordering: it keeps inserts
+     * at the right edge of the primary key. See tests/js/GuidContract.test.js.
+     */
     static generateRandomGuid () {
 	    
         var time = this.getCurrentUnixTimestamp() + '';

--- a/modules/Base/src/tracker/Tracker.js
+++ b/modules/Base/src/tracker/Tracker.js
@@ -1699,7 +1699,7 @@ class OWATracker  {
         }
 
         if ( ! visitor_id ) {
-            visitor_id = Util.generateRandomGuid( this.siteId );
+            visitor_id = Util.generateRandomGuid();
 
             this.globalEventProperties.is_new_visitor = true;
             OWA.debug('Creating new visitor id');
@@ -1774,7 +1774,7 @@ class OWATracker  {
 
             this.resetSessionState();
 
-            session_id = Util.generateRandomGuid( this.getSiteId() );
+            session_id = Util.generateRandomGuid();
             // it's a new session. generate new session ID
                this.globalEventProperties.session_id = session_id;
                //mark new session flag on current request
@@ -1798,7 +1798,7 @@ class OWATracker  {
 
         // fail-safe just in case there is no session_id
         if ( ! this.getGlobalEventProperty( 'session_id' ) ) {
-            session_id = Util.generateRandomGuid( this.getSiteId() );
+            session_id = Util.generateRandomGuid();
             this.globalEventProperties.session_id = session_id;
             //mark new session flag on current request
             this.globalEventProperties.is_new_session = true;
@@ -2168,8 +2168,7 @@ class OWATracker  {
 
             // make an domstream_id if one does not exist. needed for upstream processing
             if ( ! this.domstream_guid ) {
-                var salt = 'domstream' + this.getCurrentUrl() + this.getSiteId();
-                this.domstream_guid = Util.generateRandomGuid( salt );
+                this.domstream_guid = Util.generateRandomGuid();
             }
             domstream.setEventType( 'dom.stream' );
             domstream.set( 'domstream_guid', this.domstream_guid );

--- a/tests/js/GuidContract.test.js
+++ b/tests/js/GuidContract.test.js
@@ -1,0 +1,99 @@
+import { Util } from '../../modules/Base/src/common/Util.js';
+
+/**
+ * The contract every OWA id must satisfy, and the limit it operates under.
+ *
+ * Ids are numeric and land in a signed BIGINT column -- that is a hard contract
+ * this project migrated *to* (the 32-bit to 63-bit dimension id conversion), so
+ * these tests exist to stop a future change from quietly breaking it.
+ *
+ * The generator is `<10-digit unix seconds><9 random digits>`, which uses 60.6
+ * of the 63 available bits. That leaves no room to widen the random component,
+ * and re-dividing the budget between the time and random halves is provably
+ * pointless: coarsening the time bucket by k multiplies the arrivals sharing a
+ * bucket by k (so candidate pairs by k^2), divides the bucket count by k, and
+ * grows the random space by k -- k cancels exactly, leaving the collision rate
+ * a function of the total bit budget and the arrival rate alone.
+ *
+ * What that costs, quantified rather than hand-waved: ~10^9 values per one-second
+ * bucket gives roughly 0.8 expected collisions per year at 10 new visitors per
+ * second (864k/day, a large self-hosted install), where a collision silently and
+ * permanently merges two visitors. The only way to improve it is a wider id
+ * space, which the BIGINT contract forbids.
+ *
+ * These tests pin the contract, not the internals -- they must keep passing if
+ * the digit split is ever revisited, and fail if the id stops being a
+ * BIGINT-safe, uniformly distributed, time-ordered number.
+ */
+describe('generateRandomGuid contract', () => {
+
+    const BIGINT_MAX = 9223372036854775807n;
+
+    test('is all digits, with no sign, separator or exponent', () => {
+        for (let i = 0; i < 200; i++) {
+            expect(Util.generateRandomGuid()).toMatch(/^\d+$/);
+        }
+    });
+
+    test('fits a signed BIGINT, with headroom', () => {
+        for (let i = 0; i < 200; i++) {
+            expect(BigInt(Util.generateRandomGuid())).toBeLessThan(BIGINT_MAX);
+        }
+    });
+
+    test('survives the round trip through Number without losing precision', () => {
+        // Ids exceed Number.MAX_SAFE_INTEGER, so anything that parses one as a
+        // float corrupts it. They must be carried as strings client-side.
+        const guid = Util.generateRandomGuid();
+        expect(guid.length).toBeGreaterThan(15);
+        expect(String(BigInt(guid))).toBe(guid);
+    });
+
+    test('leads with the unix timestamp, so ids are broadly time-ordered', () => {
+        // Insert locality depends on this: a monotonic prefix keeps new rows at
+        // the right edge of the primary key rather than scattering them. It is
+        // also what a v2 idempotent event would derive its partition date from.
+        const now = Math.floor(Date.now() / 1000);
+        const prefix = parseInt(Util.generateRandomGuid().substring(0, 10), 10);
+
+        expect(Math.abs(prefix - now)).toBeLessThan(5);
+    });
+
+    test('two ids minted in the same second still differ', () => {
+        const ids = new Set();
+
+        for (let i = 0; i < 2000; i++) {
+            ids.add(Util.generateRandomGuid());
+        }
+
+        expect(ids.size).toBe(2000);
+    });
+
+    test('the random component is uniform across its full range', () => {
+        // A biased or short random half would shrink the space well below the
+        // 10^9 the collision estimate above assumes.
+        const buckets = new Array(10).fill(0);
+        const runs = 20000;
+
+        for (let i = 0; i < runs; i++) {
+            const suffix = Util.generateRandomGuid().substring(10);
+            expect(suffix).toHaveLength(9);
+            buckets[parseInt(suffix.charAt(0), 10)]++;
+        }
+
+        // Each leading digit should land near a tenth of the runs. Generous
+        // bounds -- this catches a stuck or truncated generator, not drift.
+        buckets.forEach((count) => {
+            expect(count).toBeGreaterThan(runs / 20);
+            expect(count).toBeLessThan(runs / 5);
+        });
+    });
+
+    test('accepts no arguments -- there is no salt', () => {
+        // Every call site once passed a salt that the function never declared
+        // and silently discarded. It cannot be honoured: the budget is
+        // saturated, so mixing a salt in would either take bits from the random
+        // half or make ids predictable from their inputs.
+        expect(Util.generateRandomGuid).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
All four call sites passed a salt to `Util.generateRandomGuid()`, which declares **no parameters** and silently ignored it — one of them assembling the argument into a local variable first. The generator's third component is even named `client`, which says what it was meant to be, and is a random three-digit number instead.

**The salt cannot be honoured, so the dead arguments go rather than the implementation arriving.** Ids must fit a signed BIGINT — the contract this project spent five PRs migrating *to* — and the construction (`<10 digits unix seconds><9 random digits>`) already consumes **60.6 of the 63 available bits**. There is nothing to mix a salt into without either taking bits from the random half or making ids predictable from their inputs.

### The entropy question, settled with arithmetic

It is tempting to widen the random half, and the plan for 2.0 said to. It is not possible: a 1e10 multiplier would have overflowed BIGINT in **1999**.

It is then tempting to re-divide the budget — coarser time buckets, more random digits. That is provably worthless. Coarsening the bucket by *k* multiplies the ids sharing a bucket by *k* (candidate pairs by *k²*), divides the bucket count by *k*, and grows the random space by *k*. **k cancels exactly.**

| scheme | random space | collisions/yr @ 10/s | @ 100/s |
|---|---|---|---|
| second (current) | 1.9e9 | 0.8 | 83.2 |
| minute | 1.1e11 | 0.8 | 84.0 |
| hour | 6.8e12 | 0.8 | 84.0 |
| day | 1.6e14 | 0.8 | 84.0 |

The collision rate depends only on the total bit budget and the arrival rate. At ten new visitors a second — 864k/day, a large self-hosted install — that is ~0.8 expected collisions a year, each silently and permanently merging two visitors. Improving on it needs a wider id space, which the BIGINT contract forbids. The finding is documented at the generator so the next person does not repeat the analysis.

### Tests

New `GuidContract.test.js` (7 tests) pinning the contract rather than the internals, so it survives any future re-tuning of the digit split: digits only, BIGINT-safe with headroom, no precision loss through `Number`, a leading timestamp (load-bearing for primary-key insert locality), uniqueness within a single second, a uniform random half, and a zero-argument signature so the salt cannot be reintroduced without a deliberate decision.

Full JS suite 230 green across 26 suites; bundle builds clean.