### PR TITLE
Rebuild the site-access form so a submission cannot revoke everyone

### DIFF
--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -1415,8 +1415,12 @@ namespace OWA\Module\Base\Classes;
 
         $this->set('base', 'capabilities', $caps);
 
-        // make site access is required, if role is not 'everyone'
-        if ( ! $role === 'everyone' && $isSiteAccessRequired ) {
+        // make site access required, if role is not 'everyone'.
+        // this read `! $role === 'everyone'`, which PHP parses as
+        // `(! $role) === 'everyone'` -- a boolean compared identically against
+        // a string, so always false, so the body never ran and no caller could
+        // ever add a capability to the site-access list.
+        if ( $role !== 'everyone' && $isSiteAccessRequired ) {
             $sar = $this->get('base', 'capabilitiesThatRequireSiteAccess');
             $sar[] = $capability;
             // unique the array

--- a/modules/Base/Controller/SitesEditAllowedUsers.php
+++ b/modules/Base/Controller/SitesEditAllowedUsers.php
@@ -1,7 +1,6 @@
 <?php
 namespace OWA\Module\Base\Controller;
 
-
 //
 // Open Web Analytics - An Open Source Web Analytics Framework
 //
@@ -15,44 +14,39 @@ namespace OWA\Module\Base\Controller;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// $Id$
-//
-
 
 /**
- * Edit Sites allowed Users
- * 
- * @author     Daniel Pötzinger <poetzinger@aoemedia.de>
- * @license     http://www.gnu.org/copyleft/gpl.html GPL v2.0
- * @category    owa
- * @package     owa
- * @version        $Revision$
- * @since        owa 1.0.0
+ * Applies a change to which users may see a site's data.
+ *
+ * The submission is a delta, not a replacement: the form posts the ids it
+ * rendered alongside the ids that were checked, and only users appearing in
+ * the rendered list can be affected. That is what makes an empty submission
+ * mean "everyone shown was unchecked" rather than "revoke every user of this
+ * site", which is what it meant when the form was a multi-select and the
+ * absence of a field was indistinguishable from a deliberate clearing.
  */
 class SitesEditAllowedUsers extends \OWA\Module\Base\Controller\SitesEditSettings {
-
-
 
     function action() {
 
         $site_id = $this->getParam( 'siteId' );
+
         $siteEntity = \OWA\Core\CoreAPI::entityFactory( 'base.site' );
         $siteEntity->load( $siteEntity->generateId( $site_id ) );
-        \OWA\Core\CoreAPI::debug( $siteEntity->_getProperties());
-        if ($this->getParam( 'allowed_users' ) ) {
-            $siteEntity->updateAssignedUserIds($this->getParam( 'allowed_users' ));
-        }
-        else {
-            $siteEntity->updateAssignedUserIds( array() );
-        }
-        //set variables for view
+
+        $rendered = $this->getParam( 'rendered_users' );
+        $checked  = $this->getParam( 'allowed_users' );
+
+        $siteEntity->applyAssignedUserChanges(
+            is_array( $rendered ) ? $rendered : array(),
+            is_array( $checked )  ? $checked  : array()
+        );
+
         $this->set('siteId', $site_id);
         $this->set('edit', true);
         $this->setStatusCode( 3201 );
         $this->setRedirectAction( 'base.sitesProfile' );
-
     }
-
 }
 
 ?>

--- a/modules/Base/Entity/Site.php
+++ b/modules/Base/Entity/Site.php
@@ -112,7 +112,98 @@ class Site extends \OWA\Core\Entity {
     }
 
     /**
-     * Updates the allowed Sites for the current loaded user
+     * Works out which grants a form submission actually changes.
+     *
+     * The caller passes the ids the form *rendered* alongside the ids the
+     * operator *checked*. Anything outside the rendered set is invisible to
+     * this submission and is left exactly as it was -- which is what stops an
+     * empty or truncated POST from revoking every user of a site, and what
+     * makes it safe to render the form filtered or partially.
+     *
+     * Pure set arithmetic: no database, no entity state.
+     *
+     * @param    array    $current    user ids holding a grant now
+     * @param    array    $rendered    user ids the form offered
+     * @param    array    $checked    user ids the operator ticked
+     * @return    array    [ 'grant' => int[], 'revoke' => int[] ]
+     */
+    public static function computeGrantChanges( array $current, array $rendered, array $checked ) {
+
+        $toInt = function( $ids ) {
+
+            return array_values( array_unique( array_map( 'intval', $ids ) ) );
+        };
+
+        $current  = $toInt( $current );
+        $rendered = $toInt( $rendered );
+
+        // A checked id the form never rendered did not come from this page,
+        // so it is either stale or forged. Ignore it.
+        $checked = array_intersect( $toInt( $checked ), $rendered );
+
+        return array(
+            'grant'  => array_values( array_diff( $checked, $current ) ),
+            'revoke' => array_values( array_intersect( array_diff( $rendered, $checked ), $current ) ),
+        );
+    }
+
+    /**
+     * Applies a form submission to this site's grants as a delta.
+     *
+     * Only users the form rendered can be affected, and only rows that
+     * actually change are written -- unlike updateAssignedUserIds(), which
+     * deletes every grant for the site before reinserting the survivors, so
+     * the common edit passes through a state where nobody has access at all.
+     *
+     * @param    array    $rendered    user ids the form offered
+     * @param    array    $checked    user ids the operator ticked
+     * @return    array    the changes applied
+     */
+    public function applyAssignedUserChanges( array $rendered, array $checked ) {
+
+        if ( ! $this->get('id') ) {
+
+            throw new \Exception('no site data loaded!');
+        }
+
+        $current = array();
+
+        foreach ( $this->getAssignedUsers() as $user ) {
+
+            $current[] = $user->get('id');
+        }
+
+        $changes = self::computeGrantChanges( $current, $rendered, $checked );
+
+        foreach ( $changes['grant'] as $id ) {
+
+            $relation = \OWA\Core\CoreAPI::entityFactory('base.site_user');
+            $relation->set( 'user_id', $id );
+            $relation->set( 'site_id', $this->get('id') );
+            $relation->save();
+        }
+
+        foreach ( $changes['revoke'] as $id ) {
+
+            $db = \OWA\Core\CoreAPI::dbSingleton();
+            $db->deleteFrom('owa_site_user');
+            $db->where( 'site_id', $this->get('id') );
+            $db->where( 'user_id', $id );
+            $db->executeQuery();
+        }
+
+        unset ( self::$cachedAssignedUsers[$this->get('id')] );
+
+        return $changes;
+    }
+
+    /**
+     * Replaces the whole grant set for this site.
+     *
+     * Prefer applyAssignedUserChanges(): this deletes every grant before
+     * reinserting, so a caller that computes the set wrongly -- or a form that
+     * submits nothing -- removes everyone.
+     *
      * @param array $siteIds
      */
     public function updateAssignedUserIds(array $userIds) {

--- a/modules/Base/templates/sites_addoredit.php
+++ b/modules/Base/templates/sites_addoredit.php
@@ -109,18 +109,88 @@
     <fieldset name="owa-allowedusers" class="options">
     <legend>Allowed Users</legend>
 
-            <select multiple="multiple" size="10" name="<?php echo $view->getNs();?>allowed_users[]" >
-                <?php foreach ($view->users as $user):?>
-                <option <?php if( $view->edit && $view->siteEntity->isUserAssigned($user['id']) ): echo 'SELECTED="SELECTED" style="background-color:#90ee90"'; endif;?> value="<?php $view->out( $user['id'] );?>"><?php $view->out( $user['user_id']. ' / '.$user['real_name']. ' ('.$user['role'].')' );?></option>
-                <?php endforeach;?>
-            </select>
-            <br>
-            <?php echo $view->createNonceFormField('base.sitesEditAllowedUsers');?>
-            <input type="hidden" name="<?php echo $view->getNs();?>siteId" value="<?php $view->out( $view->site['site_id'] ?? '' );?>">
-            <input type="hidden" name="<?php echo $view->getNs();?>module" value="base">
-            <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.sitesEditAllowedUsers">
-            <input type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Save Users" class="owa-button">
-    </fieldset>
+        <div class="description">
+            Users ticked here can see this site's reports. Access controls three
+            capabilities &mdash; viewing reports, viewing e-commerce reports, and
+            editing this site. Administrators always have access and cannot be
+            changed here.
+        </div>
 
+        <?php if ( $view->edit ): ?>
+
+        <div class="field">
+            <input type="text" id="owa-user-filter" class="owa-user-filter"
+                placeholder="Filter by name, login or role" autocomplete="off">
+        </div>
+
+        <table class="management owa-allowed-users">
+            <tr>
+                <th style="width:1%"></th>
+                <th>Login</th>
+                <th>Name</th>
+                <th>Role</th>
+            </tr>
+            <?php foreach ($view->users as $user):
+                $isAdmin   = ( $user['role'] ?? '' ) === 'admin';
+                $isAllowed = $view->siteEntity->isUserAssigned( $user['id'] );
+            ?>
+            <tr class="owa-user-row">
+                <td>
+                    <?php if ( $isAdmin ): ?>
+                        <input type="checkbox" checked disabled title="Administrators always have access">
+                    <?php else: ?>
+                        <input type="checkbox"
+                            name="<?php echo $view->getNs();?>allowed_users[]"
+                            value="<?php $view->out( $user['id'] );?>"
+                            id="owa-user-<?php $view->out( $user['id'] );?>"
+                            <?php if ( $isAllowed ): ?>checked<?php endif;?>>
+                        <input type="hidden"
+                            name="<?php echo $view->getNs();?>rendered_users[]"
+                            value="<?php $view->out( $user['id'] );?>">
+                    <?php endif;?>
+                </td>
+                <td><label for="owa-user-<?php $view->out( $user['id'] );?>"><?php $view->out( $user['user_id'] );?></label></td>
+                <td><?php $view->out( $user['real_name'] );?></td>
+                <td>
+                    <?php $view->out( $user['role'] );?>
+                    <?php if ( $isAdmin ): ?><span class="owa-always">always has access</span><?php endif;?>
+                </td>
+            </tr>
+            <?php endforeach;?>
+        </table>
+
+        <br>
+        <?php echo $view->createNonceFormField('base.sitesEditAllowedUsers');?>
+        <input type="hidden" name="<?php echo $view->getNs();?>siteId" value="<?php $view->out( $view->site['site_id'] ?? '' );?>">
+        <input type="hidden" name="<?php echo $view->getNs();?>module" value="base">
+        <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.sitesEditAllowedUsers">
+        <input type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Save Users" class="owa-button">
+
+        <?php else: ?>
+
+        <div class="description">
+            Save this site first, then choose which users can see its reports.
+        </div>
+
+        <?php endif;?>
+
+    </fieldset>
 </form>
+
+<style>
+.owa-allowed-users td { vertical-align: middle; }
+.owa-user-filter { width: 22em; }
+.owa-always { color: #767676; font-size: 0.9em; margin-left: 0.5em; }
+</style>
+
+<script>
+jQuery(document).ready(function() {
+    jQuery('#owa-user-filter').on('keyup', function() {
+        var needle = jQuery(this).val().toLowerCase();
+        jQuery('.owa-allowed-users tr.owa-user-row').each(function() {
+            jQuery(this).toggle( jQuery(this).text().toLowerCase().indexOf( needle ) !== -1 );
+        });
+    });
+});
+</script>
 </div>

--- a/tests/CapabilitySiteAccessTest.php
+++ b/tests/CapabilitySiteAccessTest.php
@@ -1,0 +1,117 @@
+<?php
+
+require_once( __DIR__ . '/SettingsSingletonSnapshot.php' );
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * addCapabilityToRole()'s third argument was unreachable.
+ *
+ * The guard read
+ *
+ *     if ( ! $role === 'everyone' && $isSiteAccessRequired )
+ *
+ * which PHP parses as `(! $role) === 'everyone'` -- a boolean compared
+ * identically against a string, so always false. The whole condition was
+ * therefore always false and the body never ran: a capability could never be
+ * added to `capabilitiesThatRequireSiteAccess`, whatever the caller asked for.
+ *
+ * Nothing in the tree passes `true` today, so the list is populated entirely
+ * from the hard-coded default and the defect has never bitten. It would have
+ * bitten the first caller that tried -- silently, by leaving a capability
+ * ungated by site access while the code plainly says otherwise. That is the
+ * kind of failure worth a test rather than a comment.
+ *
+ * The intent was `$role !== 'everyone'`: the 'everyone' role is the
+ * unauthenticated one, and site access cannot be required of it.
+ */
+final class CapabilitySiteAccessTest extends TestCase
+{
+    use SettingsSingletonSnapshot;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        $this->snapshotSettings();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreSettings();
+    }
+
+    private function siteAccessList(): array
+    {
+        $list = $this->settings()->get('base', 'capabilitiesThatRequireSiteAccess');
+
+        return is_array($list) ? $list : [];
+    }
+
+    /**
+     * The defect: this asked for the capability to be site-access gated, and
+     * before the fix the request was silently dropped.
+     */
+    public function testACapabilityCanBeAddedToTheSiteAccessList(): void
+    {
+        $c = $this->settings();
+
+        $this->assertNotContains('test_gated_capability', $this->siteAccessList());
+
+        $c->addCapabilityToRole('analyst', 'test_gated_capability', true);
+
+        $this->assertContains(
+            'test_gated_capability',
+            $this->siteAccessList(),
+            'a capability registered as site-access-required must land in the list'
+        );
+    }
+
+    /**
+     * Not requesting the gating leaves the list alone -- the fix must not
+     * add everything.
+     */
+    public function testACapabilityIsNotGatedUnlessAsked(): void
+    {
+        $c = $this->settings();
+
+        $c->addCapabilityToRole('analyst', 'test_ungated_capability');
+
+        $this->assertNotContains('test_ungated_capability', $this->siteAccessList());
+    }
+
+    /**
+     * The 'everyone' role is unauthenticated, so site access cannot be
+     * required of it -- this is the case the broken guard was reaching for.
+     */
+    public function testTheEveryoneRoleNeverRequiresSiteAccess(): void
+    {
+        $c = $this->settings();
+
+        $c->addCapabilityToRole('everyone', 'test_public_capability', true);
+
+        $this->assertNotContains(
+            'test_public_capability',
+            $this->siteAccessList(),
+            "site access cannot be required of the unauthenticated 'everyone' role"
+        );
+    }
+
+    /**
+     * The capability still reaches the role itself either way -- the guard
+     * governs only the site-access list.
+     */
+    public function testTheCapabilityIsGrantedToTheRoleRegardless(): void
+    {
+        $c = $this->settings();
+
+        $c->addCapabilityToRole('analyst', 'test_gated_capability', true);
+
+        $caps = $c->get('base', 'capabilities');
+
+        $this->assertContains('test_gated_capability', $caps['analyst']);
+    }
+}

--- a/tests/SiteAccessGrantsTest.php
+++ b/tests/SiteAccessGrantsTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Which grants a submission of the site-access form actually changes.
+ *
+ * The old form was a `<select multiple>` posting the complete desired set, and
+ * the controller replaced the whole grant list with whatever arrived:
+ *
+ *     if ( $this->getParam('allowed_users') ) { updateAssignedUserIds( ... ); }
+ *     else                                    { updateAssignedUserIds( array() ); }
+ *
+ * A multi-select posts *nothing* when nothing is selected, so "deselect all", a
+ * stray plain click (which collapses a nine-user selection down to one), a
+ * truncated POST and a JavaScript error are indistinguishable at the server --
+ * and every one of them revoked access for every user of that site, silently.
+ *
+ * The replacement submits a delta: the ids the form *rendered* travel with the
+ * ids the operator *checked*, so absence stops meaning revocation. A user who
+ * was not on the page cannot be affected by it, which also makes the form safe
+ * to filter, paginate or render partially.
+ *
+ * These cases are all pure set arithmetic, so they need no database.
+ */
+final class SiteAccessGrantsTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function changes(array $current, array $rendered, array $checked): array
+    {
+        return \OWA\Module\Base\Entity\Site::computeGrantChanges($current, $rendered, $checked);
+    }
+
+    /**
+     * The defect this replaces: an empty submission must revoke only what the
+     * form actually offered, and when it offered nothing it must do nothing.
+     */
+    public function testAnEmptySubmissionWithNothingRenderedChangesNothing(): void
+    {
+        $changes = $this->changes([1, 2, 3], [], []);
+
+        $this->assertSame([], $changes['grant']);
+        $this->assertSame([], $changes['revoke'], 'an empty form must not revoke every user');
+    }
+
+    /**
+     * Unchecking everything the form showed does revoke those users -- the
+     * operator asked for it, and the rendered list is the evidence.
+     */
+    public function testUncheckingEverythingRenderedRevokesThoseUsers(): void
+    {
+        $changes = $this->changes([1, 2, 3], [1, 2, 3], []);
+
+        $this->assertSame([], $changes['grant']);
+        $this->assertEqualsCanonicalizing([1, 2, 3], $changes['revoke']);
+    }
+
+    /**
+     * The headline property: a user the form never rendered is untouched,
+     * whatever else the submission says.
+     */
+    public function testUsersNotRenderedAreNeverTouched(): void
+    {
+        // The form showed only user 2. User 3 keeps access; user 9 stays out.
+        $changes = $this->changes([2, 3], [2], []);
+
+        $this->assertSame([], $changes['grant']);
+        $this->assertSame([2], $changes['revoke'], 'only the rendered user may be revoked');
+
+        $changes = $this->changes([2, 3], [2], [2]);
+
+        $this->assertSame([], $changes['grant']);
+        $this->assertSame([], $changes['revoke']);
+    }
+
+    /**
+     * The common edit: one user added, one removed, everyone else left alone.
+     * The old code rewrote the entire set to achieve this.
+     */
+    public function testASingleChangeTouchesOnlyThatUser(): void
+    {
+        $changes = $this->changes([1, 2, 3], [1, 2, 3, 4], [1, 2, 4]);
+
+        $this->assertSame([4], $changes['grant']);
+        $this->assertSame([3], $changes['revoke']);
+    }
+
+    /**
+     * Re-submitting an unchanged form writes nothing at all.
+     */
+    public function testAnUnchangedSubmissionIsANoOp(): void
+    {
+        $changes = $this->changes([1, 2, 3], [1, 2, 3], [1, 2, 3]);
+
+        $this->assertSame([], $changes['grant']);
+        $this->assertSame([], $changes['revoke']);
+    }
+
+    /**
+     * A checked id the form never rendered is not a grant -- it did not come
+     * from the page, so it is either stale or forged.
+     */
+    public function testACheckedIdThatWasNotRenderedIsIgnored(): void
+    {
+        $changes = $this->changes([1], [1], [1, 99]);
+
+        $this->assertSame([], $changes['grant'], 'an unrendered id must not become a grant');
+        $this->assertSame([], $changes['revoke']);
+    }
+
+    /**
+     * Ids arrive from a form as strings; grants are stored as integers.
+     */
+    public function testIdsAreComparedAndReturnedAsIntegers(): void
+    {
+        $changes = $this->changes([1, 2], ['1', '2', '3'], ['1', '3']);
+
+        $this->assertSame([3], $changes['grant']);
+        $this->assertSame([2], $changes['revoke']);
+    }
+
+    /**
+     * Duplicates in the submission do not produce duplicate writes.
+     */
+    public function testDuplicateSubmittedIdsCollapse(): void
+    {
+        $changes = $this->changes([], [5, 5], [5, 5]);
+
+        $this->assertSame([5], $changes['grant']);
+        $this->assertSame([], $changes['revoke']);
+    }
+}

--- a/tests/e2e/admin-actions.spec.js
+++ b/tests/e2e/admin-actions.spec.js
@@ -233,48 +233,55 @@ test.describe('admin: user CRUD + site association', () => {
         ).toContainText('admin');
 
         // --- ASSOCIATE WITH SITE ----------------------------------------------
-        // The fixture site's edit page carries the "Allowed Users" multi-select
-        // (owa_allowed_users[] of INTERNAL user ids), and base.sitesEditAllowedUsers
-        // REPLACES the site's entire grant set with exactly what's submitted
-        // (site.updateAssignedUserIds deletes all owa_site_user rows for the site
-        // then re-inserts the posted ids). So we must submit the UNION of the
-        // already-assigned users (chiefly the reporter fixture user, whose grant
-        // the reporting specs depend on -- there is no reseed between specs in a
-        // full run) PLUS our newly-created user. Submitting only the new user
-        // would silently revoke the reporter and break every downstream report.
+        // The fixture site's edit page carries an "Allowed Users" checkbox per
+        // user. The form submits a DELTA -- the ids it rendered travel with the
+        // ids that were checked -- so ticking our new user grants only that
+        // user and leaves every other grant alone.
+        //
+        // This block used to submit the UNION of all existing grants plus the
+        // new one, because base.sitesEditAllowedUsers replaced the site's whole
+        // grant set with whatever arrived, and posting just the new user would
+        // silently revoke the reporter fixture and break every downstream
+        // report. That hazard is what the delta submission removes.
         await gotoAction(page, 'base.sitesProfile', `&owa_siteId=${FIXTURE.siteId}&owa_edit=1`);
-        const usersSelect = page.locator('select[name="owa_allowed_users[]"]');
-        await expect(usersSelect).toBeVisible();
-        // The <option> label is "<user_id> / <real_name> (<role>)" and its value
-        // is the INTERNAL user id. Resolve our new user's value + the currently
-        // selected values in the browser (selectOption's label match is exact).
-        const { newValue, currentValues } = await page.evaluate((userId) => {
-            const sel = document.querySelector('select[name="owa_allowed_users[]"]');
-            const opt = [...sel.options].find((o) => o.textContent.includes(userId));
-            return {
-                newValue: opt ? opt.value : null,
-                currentValues: [...sel.selectedOptions].map((o) => o.value),
-            };
-        }, FIXTURE.newUserId);
-        expect(newValue).not.toBeNull();
-        // Union: keep every pre-selected grant, add ours.
-        const unionValues = [...new Set([...currentValues, newValue])];
-        await usersSelect.selectOption(unionValues);
+
+        const userRow = page.locator('table.owa-allowed-users tr.owa-user-row', {
+            hasText: FIXTURE.newUserId,
+        });
+        await expect(userRow).toBeVisible();
+
+        const userCheckbox = userRow.locator('input[name="owa_allowed_users[]"]');
+        await expect(userCheckbox).toBeVisible();
+
+        // Record the other grants so we can prove the delta left them untouched.
+        const grantsBefore = await page.evaluate(() =>
+            [...document.querySelectorAll('input[name="owa_allowed_users[]"]:checked')]
+                .map((el) => el.value)
+        );
+
+        await userCheckbox.check();
         await Promise.all([
             page.waitForNavigation({ waitUntil: 'networkidle' }),
             page.locator('input[name="owa_submit_btn"][value="Save Users"]').click(),
         ]);
 
-        // Re-open the edit page: our user's option is now SELECTED (the grant
-        // round-tripped through base.sitesEditAllowedUsers -> site_user relation).
+        // Re-open: our user is ticked (the grant round-tripped through
+        // base.sitesEditAllowedUsers into an owa_site_user relation), and every
+        // grant that existed beforehand is still ticked.
         await gotoAction(page, 'base.sitesProfile', `&owa_siteId=${FIXTURE.siteId}&owa_edit=1`);
-        const selectedLabels = await page.evaluate(() => {
-            const sel = document.querySelector('select[name="owa_allowed_users[]"]');
-            return sel
-                ? [...sel.selectedOptions].map((o) => o.textContent.trim())
-                : [];
-        });
-        expect(selectedLabels.some((l) => l.includes(FIXTURE.newUserId))).toBe(true);
+
+        await expect(
+            page.locator('table.owa-allowed-users tr.owa-user-row', { hasText: FIXTURE.newUserId })
+                .locator('input[name="owa_allowed_users[]"]')
+        ).toBeChecked();
+
+        const grantsAfter = await page.evaluate(() =>
+            [...document.querySelectorAll('input[name="owa_allowed_users[]"]:checked')]
+                .map((el) => el.value)
+        );
+        for (const value of grantsBefore) {
+            expect(grantsAfter).toContain(value);
+        }
 
         // --- DELETE ------------------------------------------------------------
         await gotoAction(page, 'base.users');

--- a/tests/e2e/admin-actions.spec.js
+++ b/tests/e2e/admin-actions.spec.js
@@ -220,37 +220,27 @@ test.describe('admin: user CRUD + site association', () => {
         const rosterRow = page.locator('table.management tbody tr', { hasText: FIXTURE.newUserId });
         await expect(rosterRow).toContainText('analyst');
 
-        // --- EDIT (change role admin) -----------------------------------------
-        await gotoAction(page, 'base.usersProfile', `&owa_edit=1&owa_user_id=${encodeURIComponent(FIXTURE.newUserId)}`);
-        await page.selectOption('select[name="owa_role"]', 'admin');
-        await Promise.all([
-            page.waitForNavigation({ waitUntil: 'networkidle' }),
-            page.locator('input[name="owa_save_button"]').click(),
-        ]);
-        await gotoAction(page, 'base.users');
-        await expect(
-            page.locator('table.management tbody tr', { hasText: FIXTURE.newUserId })
-        ).toContainText('admin');
-
         // --- ASSOCIATE WITH SITE ----------------------------------------------
-        // The fixture site's edit page carries an "Allowed Users" checkbox per
-        // user. The form submits a DELTA -- the ids it rendered travel with the
-        // ids that were checked -- so ticking our new user grants only that
-        // user and leaves every other grant alone.
+        // Done while the user is still an analyst, deliberately. A grant only
+        // means anything for a non-admin: isSiteAccessible() returns true for
+        // role admin before it consults owa_site_user at all, so granting an
+        // admin writes a row that changes nothing. The old multi-select offered
+        // that choice anyway and this test took it -- the assertion round-tripped
+        // through the database and looked meaningful while testing nothing.
         //
-        // This block used to submit the UNION of all existing grants plus the
-        // new one, because base.sitesEditAllowedUsers replaced the site's whole
-        // grant set with whatever arrived, and posting just the new user would
-        // silently revoke the reporter fixture and break every downstream
-        // report. That hazard is what the delta submission removes.
+        // The form submits a DELTA: the ids it rendered travel with the ids that
+        // were checked, so ticking this user grants only this user. It used to
+        // submit the UNION of every existing grant plus the new one, because the
+        // controller replaced the whole set and posting just one user would
+        // silently revoke the reporter fixture and break every downstream report.
         await gotoAction(page, 'base.sitesProfile', `&owa_siteId=${FIXTURE.siteId}&owa_edit=1`);
 
-        const userRow = page.locator('table.owa-allowed-users tr.owa-user-row', {
+        const userRow = () => page.locator('table.owa-allowed-users tr.owa-user-row', {
             hasText: FIXTURE.newUserId,
         });
-        await expect(userRow).toBeVisible();
+        await expect(userRow()).toBeVisible();
 
-        const userCheckbox = userRow.locator('input[name="owa_allowed_users[]"]');
+        const userCheckbox = userRow().locator('input[name="owa_allowed_users[]"]');
         await expect(userCheckbox).toBeVisible();
 
         // Record the other grants so we can prove the delta left them untouched.
@@ -265,15 +255,12 @@ test.describe('admin: user CRUD + site association', () => {
             page.locator('input[name="owa_submit_btn"][value="Save Users"]').click(),
         ]);
 
-        // Re-open: our user is ticked (the grant round-tripped through
-        // base.sitesEditAllowedUsers into an owa_site_user relation), and every
-        // grant that existed beforehand is still ticked.
+        // Re-open: our user is ticked (the grant round-tripped into an
+        // owa_site_user relation), and every grant that existed beforehand
+        // survives -- the property that a user the form did not target is never
+        // affected, which the replace-everything version could not offer.
         await gotoAction(page, 'base.sitesProfile', `&owa_siteId=${FIXTURE.siteId}&owa_edit=1`);
-
-        await expect(
-            page.locator('table.owa-allowed-users tr.owa-user-row', { hasText: FIXTURE.newUserId })
-                .locator('input[name="owa_allowed_users[]"]')
-        ).toBeChecked();
+        await expect(userRow().locator('input[name="owa_allowed_users[]"]')).toBeChecked();
 
         const grantsAfter = await page.evaluate(() =>
             [...document.querySelectorAll('input[name="owa_allowed_users[]"]:checked')]
@@ -282,6 +269,27 @@ test.describe('admin: user CRUD + site association', () => {
         for (const value of grantsBefore) {
             expect(grantsAfter).toContain(value);
         }
+
+        // --- EDIT (change role admin) -----------------------------------------
+        await gotoAction(page, 'base.usersProfile', `&owa_edit=1&owa_user_id=${encodeURIComponent(FIXTURE.newUserId)}`);
+        await page.selectOption('select[name="owa_role"]', 'admin');
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'networkidle' }),
+            page.locator('input[name="owa_save_button"]').click(),
+        ]);
+
+        await gotoAction(page, 'base.users');
+        await expect(
+            page.locator('table.management tbody tr', { hasText: FIXTURE.newUserId })
+        ).toContainText('admin');
+
+        // Now that they are an admin, the site form stops offering a choice it
+        // would not honour: the row renders a disabled, ticked box and says so,
+        // with no submittable field to send.
+        await gotoAction(page, 'base.sitesProfile', `&owa_siteId=${FIXTURE.siteId}&owa_edit=1`);
+        await expect(userRow()).toContainText('always has access');
+        await expect(userRow().locator('input[type="checkbox"]')).toBeDisabled();
+        expect(await userRow().locator('input[name="owa_allowed_users[]"]').count()).toBe(0);
 
         // --- DELETE ------------------------------------------------------------
         await gotoAction(page, 'base.users');


### PR DESCRIPTION
### The defect

The form was a `<select multiple>` posting the complete desired set, and the controller replaced the whole grant list with whatever arrived:

```php
if ( $this->getParam('allowed_users') ) { $siteEntity->updateAssignedUserIds( ... ); }
else                                    { $siteEntity->updateAssignedUserIds( array() ); }
```

A multi-select posts **nothing** when nothing is selected. So "deselect all", a stray plain click (which collapses a nine-user selection down to one), a truncated POST and a JavaScript error are all indistinguishable at the server — and every one of them silently revoked access for **every user of that site**. No confirmation, no diff, no count.

Underneath, `updateAssignedUserIds()` deletes every grant for the site and reinserts the survivors, so even the intended path passes through a state where nobody has access — and `Db::query()` swallows errors, so a failure partway through leaves a partial grant set and reports success.

### The fix

**The submission is now a delta.** The form posts the ids it *rendered* alongside the ids that were *checked*; only users in the rendered list can be affected. Absence stops meaning revocation, a user who was not on the page cannot be touched by it, and the common edit writes one insert or one delete rather than rewriting the set. It also makes the form safe to filter or paginate, which the old semantics could not survive.

**The control is a row per user** — login, real name, role — so current state is unambiguous and a mis-click cannot discard a selection. The old form leaned on a lime-green `style` on selected `<option>`s to convey state, which most browsers ignore on a selected option anyway.

**Administrators render as a disabled ticked box** reading *always has access*, because `isSiteAccessible()` returns `true` for role `admin` before consulting grants — so the old form offered a choice it would never honour.

Plus a filter box for long lists, and a legend naming the three capabilities the grant actually gates (`view_reports`, `view_reports_ecommerce`, `edit_sites`), which the screen never said.

### Also: a latent precedence bug found alongside it

`Settings::addCapabilityToRole()` guarded with `! $role === 'everyone'`, which PHP parses as `(! $role) === 'everyone'` — a boolean compared identically against a string, so always false. The body never ran: no caller could add a capability to `capabilitiesThatRequireSiteAccess`. Nothing passes `true` today so it has never bitten, but it would have bitten the first caller that tried, silently leaving a capability ungated while the code plainly says otherwise.

### Tests

- `SiteAccessGrantsTest` (8) — pure set arithmetic, no DB: an empty submission with nothing rendered changes nothing; unchecking everything rendered revokes exactly those; unrendered users are never touched; a single change touches one user; an unchanged resubmission is a no-op; a checked-but-unrendered id is ignored; string/int coercion; duplicate collapse.
- `CapabilitySiteAccessTest` (4) — the gated capability lands in the list, ungated does not, `everyone` never requires site access, and the capability still reaches the role either way.

Both mutation-checked: reverting each fix reddens its tests. Full suite **651 green**; all three phpstan configs clean.