### PR TITLE
Make CORS work, so cross-origin REST calls stop needing JSONP

### DIFF
--- a/Core/View/RestApi.php
+++ b/Core/View/RestApi.php
@@ -154,33 +154,102 @@ class RestApi extends \OWA\Core\View {
 	    return $data;
     }
     
+    /**
+     * Decides whether an Origin belongs to one of this installation's sites.
+     *
+     * Matching is on **host**, not on the stored string. Sites are commonly
+     * stored with an `http://` scheme while being served over https -- both
+     * production installs are -- so a browser sends an `https://` Origin and
+     * comparing the stored value verbatim would refuse exactly the requests
+     * this is for. Hosts are compared in full and case-insensitively; a
+     * prefix or suffix match is what lets `evil-example.com` pass as
+     * `example.com`, and a subdomain is a separate origin, not a child.
+     *
+     * Pure: no request, no database, no headers. See tests/CorsOriginMatchTest.
+     *
+     * @param    string    $origin    the request's Origin header
+     * @param    array    $sites    site rows as getSitesList() returns them
+     * @return    string|null    the Origin to echo back, or null to refuse
+     */
+    public static function matchAllowedOrigin( $origin, array $sites ) {
+
+        if ( ! is_string( $origin ) || $origin === '' ) {
+
+            return null;
+        }
+
+        $originHost = parse_url( $origin, PHP_URL_HOST );
+        $scheme     = parse_url( $origin, PHP_URL_SCHEME );
+
+        // An Origin is a scheme and a host. Anything else -- 'null', a bare
+        // path, a javascript: URL -- is refused rather than coerced.
+        if ( ! $originHost || ! $scheme || ! in_array( strtolower( $scheme ), array( 'http', 'https' ), true ) ) {
+
+            return null;
+        }
+
+        foreach ( $sites as $site ) {
+
+            $domain = is_array( $site ) ? ( $site['domain'] ?? '' ) : '';
+
+            if ( ! is_string( $domain ) || $domain === '' ) {
+
+                continue;
+            }
+
+            // A stored domain may carry a scheme or not. Without one parse_url
+            // reads the whole value as a path, so give it something to parse --
+            // and a value with no host at all ('owa-test-site' exists on a real
+            // install) still yields nothing and is skipped.
+            $candidate = strpos( $domain, '//' ) === false ? 'http://' . $domain : $domain;
+            $siteHost  = parse_url( $candidate, PHP_URL_HOST );
+
+            if ( ! $siteHost ) {
+
+                continue;
+            }
+
+            if ( strcasecmp( $siteHost, $originHost ) === 0 ) {
+
+                // Echo what the browser actually sent, never the stored form.
+                return $origin;
+            }
+        }
+
+        return null;
+    }
+
     function addCorsHeaders() {
-	    
+
 	    $s = \OWA\Core\CoreAPI::serviceSingleton();
 	    $HTTP_ORIGIN = $s->request->getServerParam('HTTP_ORIGIN');
-	    
-	    // check for ORGIN header and bail if not found.
-        if ( ! isset( $HTTP_ORIGIN ) || $HTTP_ORIGIN == '') {
-	       
+
+        // Announce that the response body and its CORS headers depend on the
+        // Origin, so a shared cache cannot serve one site's allowed-origin
+        // header to a request from another. Sent whether or not the Origin is
+        // allowed, because the refusal is origin-dependent too. Varnish sits in
+        // front of this installation, which makes it a live concern rather than
+        // a formality.
+        header( 'Vary: Origin', false );
+
+	    // no Origin means this is not a cross-origin request.
+        if ( ! $HTTP_ORIGIN ) {
+
             return;
         }
 
-        // Loop through sites list and add cors headers if the ORGIN header is present on the request
-        foreach ( \OWA\Core\CoreAPI::getSitesList() as $allowedOrigin ) {
-        	
-        	if ( $allowedOrigin !== $HTTP_ORIGIN ) {
-	        	
-            	continue;
-            }
-			
-			// send back the allowed orgin
-            header( 'Access-Control-Allow-Origin: ' . $HTTP_ORIGIN );
-            
-            // needed to allow cookie content to become available to the DOM.
-            header( "Access-Control-Allow-Credentials: true" );
-            
-            // stop the loop
-            break;
+        $allowed = self::matchAllowedOrigin( $HTTP_ORIGIN, \OWA\Core\CoreAPI::getSitesList() );
+
+        if ( ! $allowed ) {
+
+            // Send nothing. The browser refuses the response, which is the
+            // correct outcome for an origin this installation does not serve.
+            return;
         }
+
+        header( 'Access-Control-Allow-Origin: ' . $allowed );
+
+        // needed to allow cookie content to become available to the DOM.
+        header( 'Access-Control-Allow-Credentials: true' );
     }
 }

--- a/tests/CorsOriginMatchTest.php
+++ b/tests/CorsOriginMatchTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Which Origins the REST API is willing to answer cross-origin.
+ *
+ * addCorsHeaders() has never emitted a header. It iterated getSitesList(),
+ * which returns `SELECT * FROM owa_site` -- an array of *row arrays* -- and
+ * compared each row against the Origin string:
+ *
+ *     foreach ( CoreAPI::getSitesList() as $allowedOrigin ) {
+ *         if ( $allowedOrigin !== $HTTP_ORIGIN ) { continue; }
+ *
+ * An array is never identical to a string, so `continue` always fired, the
+ * loop always fell through, and no Access-Control-Allow-Origin was ever sent.
+ * Cross-origin REST calls have therefore never worked, which is why playback
+ * still depends on JSONP -- a transport that exists precisely to evade the
+ * same-origin policy CORS is meant to satisfy properly.
+ *
+ * Matching is on HOST, not on the stored string. Real installs store
+ * `http://demo.openwebanalytics.com` while serving over https, so a browser
+ * sends `Origin: https://demo.openwebanalytics.com` and an exact-string match
+ * would leave CORS broken on exactly the installs that need it. Hosts are
+ * compared case-insensitively and in full -- never as a prefix or substring,
+ * which is how `evil-example.com` gets to impersonate `example.com`.
+ *
+ * The matcher is pure so these cases need no database and no request.
+ */
+final class CorsOriginMatchTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /** Site rows as getSitesList() returns them. */
+    private function sites(array $domains): array
+    {
+        return array_map(static fn($d) => ['domain' => $d], $domains);
+    }
+
+    private function match(string $origin, array $domains)
+    {
+        return \OWA\Core\View\RestApi::matchAllowedOrigin($origin, $this->sites($domains));
+    }
+
+    /**
+     * The defect, in the shape both production installs have: the site is
+     * stored with an http:// scheme and served over https.
+     */
+    public function testASiteStoredAsHttpMatchesAnHttpsOrigin(): void
+    {
+        $this->assertSame(
+            'https://demo.openwebanalytics.com',
+            $this->match('https://demo.openwebanalytics.com', ['http://demo.openwebanalytics.com'])
+        );
+    }
+
+    /**
+     * The Origin is echoed back exactly as sent, never the stored form.
+     */
+    public function testTheOriginIsEchoedBackVerbatim(): void
+    {
+        $this->assertSame(
+            'http://www.peteradamsphoto.com',
+            $this->match('http://www.peteradamsphoto.com', ['http://www.peteradamsphoto.com'])
+        );
+    }
+
+    /**
+     * Hosts match in full. A site named as a suffix of the Origin's host must
+     * not match -- this is the classic CORS allowlist bypass.
+     */
+    public function testASuffixHostDoesNotMatch(): void
+    {
+        $this->assertNull($this->match('https://evil-example.com', ['https://example.com']));
+        $this->assertNull($this->match('https://example.com.evil.net', ['https://example.com']));
+        $this->assertNull($this->match('https://notexample.com', ['https://example.com']));
+    }
+
+    /**
+     * A subdomain is a different origin and is not covered by its parent.
+     */
+    public function testASubdomainIsNotItsParent(): void
+    {
+        $this->assertNull($this->match('https://sub.example.com', ['https://example.com']));
+    }
+
+    public function testHostComparisonIsCaseInsensitive(): void
+    {
+        $this->assertSame(
+            'https://WWW.Example.COM',
+            $this->match('https://WWW.Example.COM', ['http://www.example.com'])
+        );
+    }
+
+    /**
+     * Sites whose domain carries no host at all -- `owa-test-site` exists on a
+     * real install -- must never match anything, least of all an empty Origin.
+     */
+    public function testASiteWithNoHostMatchesNothing(): void
+    {
+        $this->assertNull($this->match('https://example.com', ['owa-test-site']));
+        $this->assertNull($this->match('', ['owa-test-site']));
+        $this->assertNull($this->match('https://example.com', ['']));
+    }
+
+    /**
+     * A garbage or non-origin value is refused rather than coerced.
+     */
+    public function testMalformedOriginsAreRefused(): void
+    {
+        foreach (['null', 'not a url', 'javascript:alert(1)', '//example.com', 'https://'] as $origin) {
+            $this->assertNull($this->match($origin, ['https://example.com']), "matched: $origin");
+        }
+    }
+
+    /**
+     * With several sites configured, the right one matches.
+     */
+    public function testTheCorrectSiteMatchesAmongSeveral(): void
+    {
+        $domains = ['http://a.example.com', 'https://b.example.com', 'owa-test-site'];
+
+        $this->assertSame('https://b.example.com', $this->match('https://b.example.com', $domains));
+        $this->assertSame('https://a.example.com', $this->match('https://a.example.com', $domains));
+        $this->assertNull($this->match('https://c.example.com', $domains));
+    }
+
+    /**
+     * No sites configured means nothing is allowed.
+     */
+    public function testNoSitesMatchesNothing(): void
+    {
+        $this->assertNull($this->match('https://example.com', []));
+    }
+}


### PR DESCRIPTION
### The defect

`addCorsHeaders()` has never emitted a header. It iterates `getSitesList()`, which returns `SELECT * FROM owa_site` — an array of **row arrays** — and compares each row against the Origin string:

```php
foreach ( CoreAPI::getSitesList() as $allowedOrigin ) {
    if ( $allowedOrigin !== $HTTP_ORIGIN ) { continue; }
```

An array is never identical to a string, so `continue` always fires, the loop always falls through, and no `Access-Control-Allow-Origin` is ever sent. Cross-origin REST calls have never worked — which is why playback still rides JSONP, a transport whose whole purpose is evading the same-origin policy that CORS exists to satisfy properly.

### Matching on host, not on the stored string

Exact-string matching would have left this broken where it matters. Both production installs store their site as `http://…` while being served over **https**, so the browser sends an `https://` Origin that would never equal the stored value. And one real install has a site whose `domain` is `owa-test-site` — no scheme, no host.

So the matcher parses both sides and compares **hosts**, in full and case-insensitively:

- a suffix or prefix match is refused — `evil-example.com` must not pass as `example.com`
- a subdomain is a separate origin, not a child of its parent
- a stored domain yielding no host matches nothing
- `null`, bare paths and `javascript:` URLs are refused rather than coerced
- the Origin is echoed back **verbatim**, never the stored form

### Vary: Origin

Added, and sent whether or not the Origin is allowed — the refusal is origin-dependent too. **Varnish sits in front of this application**, so without it a shared cache could serve one site's allowed-origin header to a request from a different origin: a cross-origin leak introduced by *fixing* CORS rather than by leaving it broken. (`Cache-Control: max-age=0` is already set on REST responses, which limits but does not remove the exposure.)

### Tests

`CorsOriginMatchTest` (9 tests) against a pure static matcher — no request, no database: the http-stored/https-served case both installs actually have, verbatim echo, suffix and subdomain rejection, case-insensitivity, hostless domains, malformed origins, correct selection among several sites, and the empty-site-list case.

Mutation-checked in both directions: restoring the original array-vs-string comparison reddens **4** tests; loosening the host match to a substring reddens the **2** allowlist-bypass cases specifically.

Full suite **671 green**; all three phpstan configs clean.