### PR TITLE
Stop putting a full-privilege API key in a cookie on the tracked site

### DIFF
--- a/Core/Auth.php
+++ b/Core/Auth.php
@@ -136,6 +136,17 @@ class Auth extends \OWA\Core\Base {
             $ret = $this->authByInput(\OWA\Core\CoreAPI::getRequestParam('user_id'), \OWA\Core\CoreAPI::getRequestParam('password'));
              \OWA\Core\CoreAPI::debug('User authenticated via form input.');
     
+        } elseif ( \OWA\Core\CoreAPI::getRequestParam('overlayToken') ) {
+            // auth by a scoped, short-lived overlay token.
+            //
+            // Checked BEFORE the apiKey branch so that a request carrying both
+            // is held to the narrower credential, and scope is enforced here
+            // rather than later: a request outside the token's scope does not
+            // authenticate at all, so there is no window in which a caller is
+            // authenticated but not yet constrained.
+            $this->setAuthMethod( 'overlay_token');
+            $ret = $this->authByOverlayToken( \OWA\Core\CoreAPI::getRequestParam('overlayToken') );
+            \OWA\Core\CoreAPI::debug('User authenticated via overlay token.');
         } elseif ( $apiKey ) {
             // auth user by api key
             $this->setAuthMethod( 'api_key');
@@ -158,6 +169,67 @@ class Auth extends \OWA\Core\Base {
 
         return array('auth_status' => $ret);
 
+    }
+
+    /**
+     * Authenticates a heatmap-overlay or domstream-player request.
+     *
+     * These run on the *tracked* site and call back to the OWA origin, so they
+     * are cross-origin: a session cookie would be a third-party cookie, and an
+     * Authorization header would turn a simple GET into a preflighted one. The
+     * credential has to sit in the URL, so what matters is that it is worth as
+     * little as possible to anyone who reads it there.
+     *
+     * It replaces the user's apiKey, which was long-lived and carried the whole
+     * account. This carries one user, one endpoint, one resource, and expires
+     * in minutes.
+     *
+     * **Scope is checked here, before the user is loaded**, so a request outside
+     * the token's scope never authenticates. Deferring the check to an
+     * authorisation layer would leave a window in which the caller is
+     * authenticated but unconstrained, and the constraint is the entire point.
+     *
+     * @param    string    $token
+     * @return    boolean
+     */
+    function authByOverlayToken( $token ) {
+
+        $action = \OWA\Core\CoreAPI::getRequestParam('do');
+
+        $permitted = \OWA\Core\OverlayToken::permits(
+            $token,
+            $action,
+            function( $name ) {
+
+                return \OWA\Core\CoreAPI::getRequestParam( $name );
+            }
+        );
+
+        if ( ! $permitted ) {
+
+            \OWA\Core\CoreAPI::debug('Overlay token missing, expired, or out of scope for this request.');
+
+            return false;
+        }
+
+        $claims = \OWA\Core\OverlayToken::verify( $token );
+
+        $this->u = \OWA\Core\CoreAPI::entityFactory( 'base.user' );
+        $this->u->load( $claims['user_id'], 'user_id' );
+
+        if ( ! $this->u->get( 'user_id' ) ) {
+
+            \OWA\Core\CoreAPI::debug('Overlay token names a user that no longer exists.');
+
+            return false;
+        }
+
+        $cu = \OWA\Core\CoreAPI::getCurrentUser();
+        $cu->loadNewUserByObject( $this->u );
+        $cu->setAuthStatus( true );
+        $this->_is_user = true;
+
+        return true;
     }
 
     function authByApiKey( $key ) {

--- a/Core/OverlayToken.php
+++ b/Core/OverlayToken.php
@@ -35,6 +35,15 @@ namespace OWA\Core;
  * looking the token up, so there is no table, no schema version to bump and no
  * cleanup job. The usual objection to stateless tokens -- that they cannot be
  * revoked before they expire -- is answered by the expiry being minutes.
+ *
+ * **This token does not replace the API URL the admin interface sends with it.**
+ * The token names an action and a resource, so it looks as though the overlay
+ * could build its own request URL and the fragment could carry the token alone.
+ * It cannot: the tracker's base URL is where it *logs*, and OWA supports split
+ * deployment on purpose (independent logger/API endpoints, RemoteQueue,
+ * OWA_USE_STATIC_CONFIG_ONLY for a logging-only node). The reporting origin is
+ * the only party that knows where reporting lives. See the note on
+ * Template::makeOverlayApiLink().
  */
 class OverlayToken {
 

--- a/Core/OverlayToken.php
+++ b/Core/OverlayToken.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace OWA\Core;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * A short-lived, scoped credential for the heatmap overlay and domstream
+ * player.
+ *
+ * Those two run on the *tracked* site and fetch from the OWA origin, so they
+ * cannot use a session cookie -- it would be a third-party cookie, which
+ * browsers increasingly refuse -- and they cannot send an Authorization header
+ * without turning a simple cross-origin GET into a preflighted one. The
+ * credential therefore has to travel in the URL, and the question is only what
+ * it is worth to whoever reads it there.
+ *
+ * Previously it was the signed-in user's **apiKey**, which is long-lived and
+ * carries that user's whole account. This carries one user, one endpoint, one
+ * resource, and expires in minutes.
+ *
+ * Stateless by design: verification recomputes the signature rather than
+ * looking the token up, so there is no table, no schema version to bump and no
+ * cleanup job. The usual objection to stateless tokens -- that they cannot be
+ * revoked before they expire -- is answered by the expiry being minutes.
+ */
+class OverlayToken {
+
+    /**
+     * How long a freshly minted token is good for, in seconds.
+     *
+     * Long enough to open a page and let the overlay fetch, short enough that a
+     * leaked token is worth little. Overridable per install, but not upward
+     * without thought: the token's safety is its brevity.
+     */
+    const DEFAULT_TTL = 300;
+
+    /**
+     * Mints a token authorising exactly one action on one resource.
+     *
+     * The resource is named by the request parameter that carries it, so the
+     * token is self-describing and verification needs no table mapping actions
+     * to parameter names -- one that would have to be remembered the next time
+     * an overlay is added.
+     *
+     * @param    string    $userId        the user whose privileges this carries
+     * @param    string    $action        the REST 'do' this permits, e.g. 'reports'
+     * @param    string    $resourceKey    the request param naming the resource
+     * @param    string    $resource    the one value of that param this permits
+     * @param    int        $ttl        lifetime in seconds
+     * @return    string    a URL-safe token
+     */
+    public static function mint( $userId, $action, $resourceKey, $resource, $ttl = self::DEFAULT_TTL ) {
+
+        $claims = array(
+            'user_id'      => (string) $userId,
+            'action'       => (string) $action,
+            'resource_key' => (string) $resourceKey,
+            'resource'     => (string) $resource,
+            'exp'          => time() + (int) $ttl,
+        );
+
+        $payload = self::encode( $claims );
+
+        return $payload . '.' . self::sign( $payload );
+    }
+
+    /**
+     * Returns the token's claims, or null if it is not a token this
+     * installation minted, or has expired.
+     *
+     * @param    string    $token
+     * @return    array|null
+     */
+    public static function verify( $token ) {
+
+        if ( ! is_string( $token ) || $token === '' || strlen( $token ) > 4096 ) {
+
+            return null;
+        }
+
+        $parts = explode( '.', $token );
+
+        if ( count( $parts ) !== 2 ) {
+
+            return null;
+        }
+
+        list( $payload, $signature ) = $parts;
+
+        if ( $payload === '' || $signature === '' ) {
+
+            return null;
+        }
+
+        // Constant-time: a timing-variable compare here leaks the signature a
+        // byte at a time to anyone willing to make enough requests.
+        if ( ! hash_equals( self::sign( $payload ), $signature ) ) {
+
+            return null;
+        }
+
+        $claims = json_decode( self::decode( $payload ), true );
+
+        if ( ! is_array( $claims ) ) {
+
+            return null;
+        }
+
+        foreach ( array( 'user_id', 'action', 'resource_key', 'resource', 'exp' ) as $required ) {
+
+            if ( ! array_key_exists( $required, $claims ) ) {
+
+                return null;
+            }
+        }
+
+        if ( (int) $claims['exp'] <= time() ) {
+
+            return null;
+        }
+
+        return $claims;
+    }
+
+    /**
+     * Whether this token permits this exact action on this exact resource.
+     *
+     * The scope check is the security-critical half of the design: a token that
+     * authenticates a user without constraining what they may reach is no
+     * better than the apiKey it replaces.
+     *
+     * @param    string    $token
+     * @param    string    $action        the 'do' the request is asking for
+     * @param    callable    $paramReader    given a param name, returns its request value
+     * @return    boolean
+     */
+    public static function permits( $token, $action, $paramReader ) {
+
+        $claims = self::verify( $token );
+
+        if ( ! $claims ) {
+
+            return false;
+        }
+
+        if ( ! hash_equals( (string) $claims['action'], (string) $action ) ) {
+
+            return false;
+        }
+
+        $submitted = (string) call_user_func( $paramReader, $claims['resource_key'] );
+
+        // An empty resource on the request must never satisfy a token, or a
+        // request that simply omits the parameter would pass unchecked.
+        if ( $submitted === '' ) {
+
+            return false;
+        }
+
+        return hash_equals( (string) $claims['resource'], $submitted );
+    }
+
+    /**
+     * The signature covers the whole payload, so every claim in it -- the user,
+     * the action, the resource and the expiry alike -- is uneditable in a URL.
+     */
+    private static function sign( $payload ) {
+
+        return rtrim( strtr( base64_encode(
+            hash_hmac( 'sha256', 'owa_overlay_token' . $payload, self::key(), true )
+        ), '+/', '-_' ), '=' );
+    }
+
+    private static function key() {
+
+        // The install's nonce secret, reused rather than adding another
+        // constant to owa-config.php. Rotating it invalidates outstanding
+        // tokens, which at a five-minute lifetime costs nothing.
+        return (string) \OWA\Core\CoreAPI::getSalt( 'nonce' );
+    }
+
+    private static function encode( array $claims ) {
+
+        return rtrim( strtr( base64_encode( json_encode( $claims ) ), '+/', '-_' ), '=' );
+    }
+
+    private static function decode( $payload ) {
+
+        return (string) base64_decode( strtr( $payload, '-_', '+/' ), true );
+    }
+}

--- a/Core/Template.php
+++ b/Core/Template.php
@@ -611,6 +611,39 @@ class Template extends TemplateEngine {
 		return \OWA\Core\CoreAPI::getCurrentUserApiKey();
     }
 
+    /**
+     * An API link for the heatmap overlay or the domstream player.
+     *
+     * These two are the only cross-origin API consumers: they run on the
+     * *tracked* site and call back to the OWA origin. They used to be built
+     * with makeApiLink( ..., $add_apiKey = true ), which put the signed-in
+     * user's long-lived apiKey into a URL that the tracker then wrote to a
+     * cookie on the tracked site's own domain -- readable by every other script
+     * on that page, and re-sent to that site on every subsequent request.
+     *
+     * They now carry a token scoped to one endpoint and one resource that
+     * expires in minutes, so what leaks is worth almost nothing. No signature:
+     * request signing exists to make a long-lived key survivable in a URL, and
+     * there is no longer a long-lived key here.
+     *
+     * @param    array    $params        the API request params
+     * @param    string    $resourceKey    which param names the resource
+     * @return    string
+     */
+    function makeOverlayApiLink( $params, $resourceKey ) {
+
+        $cu = \OWA\Core\CoreAPI::getCurrentUser();
+
+        $params['overlayToken'] = \OWA\Core\OverlayToken::mint(
+            $cu->getUserData('user_id'),
+            $params['do'],
+            $resourceKey,
+            $params[ $resourceKey ]
+        );
+
+        return $this->makeLink( $params, false, $this->config['rest_api_url'] );
+    }
+
     function makeApiLink($params = array(), $add_state = false, $add_apiKey = false) {
 
         $url = $this->config['rest_api_url'];

--- a/Core/Template.php
+++ b/Core/Template.php
@@ -626,6 +626,25 @@ class Template extends TemplateEngine {
      * request signing exists to make a long-lived key survivable in a URL, and
      * there is no longer a long-lived key here.
      *
+     * **The full API URL must be built here and handed to the overlay. Do not
+     * be tempted to send only the token and let the tracker derive the URL.**
+     *
+     * It looks redundant -- the token already names its action and resource,
+     * and the tracker has a base URL -- but the tracker's base URL is where it
+     * *logs*, which need not be where reporting lives. OWA supports split
+     * deployment deliberately: setEndpoint(), setLoggerEndpoint() and
+     * setApiEndpoint() are independently settable, the RemoteQueue module
+     * exists so a node can receive events somewhere other than the reporting
+     * install, and OWA_USE_STATIC_CONFIG_ONLY exists for a logging-only node
+     * that never touches the reporting database. The admin interface can be on
+     * an entirely different domain from the collector.
+     *
+     * The reporting origin is the only party that knows where reporting lives,
+     * and it is already the party minting this link, so the API URL and the
+     * token both travel from here. Deriving it client-side works on a
+     * single-box install and fails silently on exactly the deployments that
+     * most need it right, by fetching from a host that never answers.
+     *
      * @param    array    $params        the API request params
      * @param    string    $resourceKey    which param names the resource
      * @return    string

--- a/modules/Base/src/common/owa.js
+++ b/modules/Base/src/common/owa.js
@@ -165,6 +165,23 @@ class OWA {
         this.config['rest_api_endpoint'] = endpoint;
     }
     
+    /**
+     * The REST API endpoint.
+     *
+     * The fallback below is a trap and has never executed: on a tracked page
+     * `baseUrl` is where the tracker *logs*, which need not be where reporting
+     * lives. OWA supports split deployment on purpose -- separate logger and
+     * API endpoints, the RemoteQueue module, and OWA_USE_STATIC_CONFIG_ONLY for
+     * a logging-only node that never touches the reporting database -- so the
+     * admin interface can be on a different domain entirely.
+     *
+     * In practice startOverlaySession() always calls setApiEndpoint() with the
+     * URL the *admin interface* minted, because that origin is the only one
+     * that knows where reporting lives. Guessing here would work on a
+     * single-box install and fail silently everywhere else, by fetching from a
+     * host that never answers. Do not build on this fallback; prefer deleting
+     * it over making it clever.
+     */
     getApiEndpoint() {
 	    
         return this.config['rest_api_endpoint'] || this.getSetting('baseUrl') + 'api/';

--- a/modules/Base/src/tracker/Heatmap.js
+++ b/modules/Base/src/tracker/Heatmap.js
@@ -200,9 +200,9 @@ class Heatmap {
 	        var url = this.clicks.next;
 	        
         } else {
-	        // get data urlr from overlay cookie
-	        var p = unescape( OWA_instance.state.getStateFromCookie('overlay') );
-			var params = JSON.parse( p );
+	        // Overlay params live in memory for this page's lifetime;
+	        // they are never written to a cookie on the tracked site.
+	        var params = OWA_instance.getOverlayParams() || {};
 	        var url = params.api_url;
         }
         

--- a/modules/Base/src/tracker/Player.js
+++ b/modules/Base/src/tracker/Player.js
@@ -53,8 +53,9 @@ class Player {
      */
     fetchData() {
 
-        var p = unescape(OWA_instance.state.getStateFromCookie('overlay'));
-        var params = JSON.parse(p);
+        // Overlay params live in memory for this page's lifetime;
+        // they are never written to a cookie on the tracked site.
+        var params = OWA_instance.getOverlayParams() || {};
         var url = params.api_url;
         
         //closure

--- a/modules/Base/src/tracker/Tracker.js
+++ b/modules/Base/src/tracker/Tracker.js
@@ -358,9 +358,11 @@ class OWATracker  {
             OWA.debug('overlay anchor value: ' + a);
             //var domain = this.getCookieDomain();
 
-            // set the overlay cookie
-            Util.setCookie( OWA.getSetting('ns') + 'overlay',a, '','/', document.domain );
-            //alert(Util.readCookie('owa_overlay') );
+            // Deliberately NOT written to a cookie. The payload carries a
+            // credential, and a cookie on the tracked site's own domain is
+            // readable by every other script there and re-sent to that site
+            // on every request. startOverlaySession() holds it in memory
+            // instead, which is all its lifetime requires.
             // pause tracker so we dont log anything during an overlay session
             this.pause();
             // start overlay session

--- a/modules/Base/src/tracker/Tracker.js
+++ b/modules/Base/src/tracker/Tracker.js
@@ -495,6 +495,13 @@ class OWATracker  {
         OWA.setApiEndpoint(url);
     }
 
+    /**
+     * See the note on OWA.getApiEndpoint(): this fallback has never executed
+     * and must not be relied upon. It also disagrees with that one about what
+     * an API URL looks like ('api.php' here, 'api/' there), which is what dead
+     * code does. The overlay's API URL comes from the admin interface, the only
+     * origin that knows where reporting lives.
+     */
     getApiEndpoint() {
 
         return this.getOption('api_endpoint') || this.getEndpoint() + 'api.php';

--- a/modules/Base/templates/report_document.php
+++ b/modules/Base/templates/report_document.php
@@ -45,7 +45,7 @@
 							                    
 								                [
 								                    'action' 		=> 'loadHeatmap', 
-									                'api_url' 		=> $view->makeApiLink(
+									                'api_url' 		=> $view->makeOverlayApiLink(
 									                	
 										                [
 										                	'document_id' 	=> $view->document->get('id'),
@@ -54,8 +54,7 @@
 														    'do'			=> 'reports',
 														    'report_name'	=> 'clicks'    	
 									                	], 
-										                true, 
-											            true
+										                'document_id'
 									                ), 
 										            
 											        'document_id' 	=> $view->document->get('id')

--- a/modules/Base/templates/report_domstreams.php
+++ b/modules/Base/templates/report_domstreams.php
@@ -35,7 +35,7 @@
                                     [
                                         'action' => 'loadPlayer',
                                         'domstream_guid' => $ds['domstream_guid'],
-	                                    'api_url' 		=> $view->makeApiLink(
+	                                    'api_url' 		=> $view->makeOverlayApiLink(
 									                	
 										                [
 										                	'domstream_guid' => $ds['domstream_guid'],
@@ -43,8 +43,7 @@
 														    'version'		=> 'v1',
 														    'do'			=> 'domstreams'	
 									                	], 
-										                true, 
-											            true
+										                'domstream_guid'
 									                ), 
                                     ],
                                     true,

--- a/tests/OverlayTokenTest.php
+++ b/tests/OverlayTokenTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The credential the heatmap overlay and domstream player carry.
+ *
+ * What this replaces: the report templates built their API URL with
+ * makeApiLink( ..., $add_apiKey = true ), which embeds the signed-in user's
+ * **apiKey** in the URL and HMAC-signs it. The tracker then wrote that URL to
+ * an `owa_overlay` cookie on the *tracked site's* own domain, path `/`
+ * (Tracker.js:362), where the overlay's JS could read it back.
+ *
+ * So a long-lived credential carrying a user's full privileges sat in a
+ * JS-readable cookie on a domain OWA does not control -- readable by any other
+ * script on that page, and re-sent by the browser on every subsequent request
+ * to that site, landing in its access logs and its CDN's. It could not be
+ * HttpOnly, because the overlay itself has to read it.
+ *
+ * The replacement is a token that is worth almost nothing if it leaks: it names
+ * one user, one action, one resource, and expires in minutes. Verification is
+ * stateless -- the signature is recomputed, not looked up -- so this needs no
+ * table, no schema version and no cleanup job. Early revocation is moot at this
+ * lifetime.
+ */
+final class OverlayTokenTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function mint(array $overrides = []): string
+    {
+        $a = array_merge([
+            'user_id'      => 'reporter',
+            'action'       => 'reports',
+            'resource_key' => 'document_id',
+            'resource'     => 'doc-12345',
+            'ttl'          => 300,
+        ], $overrides);
+
+        return \OWA\Core\OverlayToken::mint(
+            $a['user_id'], $a['action'], $a['resource_key'], $a['resource'], $a['ttl']
+        );
+    }
+
+    /** A stand-in for the request: given a param name, return its value. */
+    private function request(array $params): callable
+    {
+        return static fn($name) => $params[$name] ?? '';
+    }
+
+    public function testAMintedTokenVerifiesAndReportsItsScope(): void
+    {
+        $claims = \OWA\Core\OverlayToken::verify($this->mint());
+
+        $this->assertIsArray($claims);
+        $this->assertSame('reporter', $claims['user_id']);
+        $this->assertSame('reports', $claims['action']);
+        $this->assertSame('doc-12345', $claims['resource']);
+    }
+
+    /**
+     * The point of the whole change: a token is useless for anything but the
+     * one thing it was minted for.
+     */
+    public function testScopeIsEnforcedOnActionAndResource(): void
+    {
+        $token = $this->mint(['action' => 'reports', 'resource' => 'doc-12345']);
+
+        $this->assertTrue(\OWA\Core\OverlayToken::permits(
+            $token, 'reports', $this->request(['document_id' => 'doc-12345'])
+        ));
+
+        // Right user, right action, someone else's document.
+        $this->assertFalse(\OWA\Core\OverlayToken::permits(
+            $token, 'reports', $this->request(['document_id' => 'doc-99999'])
+        ));
+
+        // Right resource, different endpoint.
+        $this->assertFalse(\OWA\Core\OverlayToken::permits(
+            $token, 'domstreams', $this->request(['document_id' => 'doc-12345'])
+        ));
+
+        // The resource arriving under a different parameter than the token
+        // names does not satisfy it.
+        $this->assertFalse(\OWA\Core\OverlayToken::permits(
+            $token, 'reports', $this->request(['domstream_guid' => 'doc-12345'])
+        ));
+
+        // Omitting the parameter entirely must not pass unchecked.
+        $this->assertFalse(\OWA\Core\OverlayToken::permits(
+            $token, 'reports', $this->request([])
+        ));
+    }
+
+    public function testAnExpiredTokenIsRefused(): void
+    {
+        $expired = $this->mint(['ttl' => -1]);
+
+        $this->assertNull(\OWA\Core\OverlayToken::verify($expired));
+        $this->assertFalse(\OWA\Core\OverlayToken::permits(
+            $expired, 'reports', $this->request(['document_id' => 'doc-12345'])
+        ));
+    }
+
+    /**
+     * Every field is covered by the signature, so none can be edited in the
+     * URL -- which is the whole difference between this and a bare identifier.
+     */
+    public function testTamperingWithAnyClaimInvalidatesTheToken(): void
+    {
+        $token = $this->mint();
+        [$payload, $sig] = explode('.', $token, 2);
+
+        $claims = json_decode(base64_decode(strtr($payload, '-_', '+/')), true);
+        $this->assertIsArray($claims, 'payload should decode; the signature is what protects it');
+
+        foreach ([
+            ['user_id' => 'admin'],
+            ['action' => 'sites'],
+            ['resource' => 'doc-99999'],
+            ['resource_key' => 'domstream_guid'],
+            ['exp' => time() + 999999],
+        ] as $edit) {
+            $edited  = array_merge($claims, $edit);
+            $forged  = rtrim(strtr(base64_encode(json_encode($edited)), '+/', '-_'), '=') . '.' . $sig;
+
+            $this->assertNull(
+                \OWA\Core\OverlayToken::verify($forged),
+                'edited claim was accepted: ' . key($edit)
+            );
+        }
+    }
+
+    public function testAGarbageTokenIsRefusedRatherThanFatal(): void
+    {
+        foreach (['', 'nonsense', 'a.b', '.', 'YWJj', str_repeat('x', 5000)] as $bad) {
+            $this->assertNull(\OWA\Core\OverlayToken::verify($bad), "accepted: $bad");
+            $this->assertFalse(\OWA\Core\OverlayToken::permits(
+                $bad, 'reports', $this->request(['document_id' => 'doc-12345'])
+            ));
+        }
+    }
+
+    /**
+     * Two tokens for the same scope differ, so one cannot be recognised as a
+     * stable identifier for a user or a page.
+     */
+    public function testTokensAreNotAStableIdentifier(): void
+    {
+        $this->assertNotSame(
+            $this->mint(['resource' => 'doc-1']),
+            $this->mint(['resource' => 'doc-2'])
+        );
+    }
+
+    /**
+     * The token is URL-safe: it travels in a query string and in a fragment,
+     * so it must survive both without escaping.
+     */
+    public function testTheTokenIsUrlSafe(): void
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $token = $this->mint(['resource' => 'doc-' . $i]);
+            $this->assertSame($token, urlencode($token), 'token needs escaping: ' . $token);
+        }
+    }
+
+    /**
+     * A token minted for one resource cannot be replayed against another by
+     * swapping only the signature from a second token.
+     */
+    public function testSignaturesAreNotInterchangeable(): void
+    {
+        [$payloadA, ]        = explode('.', $this->mint(['resource' => 'doc-A']), 2);
+        [, $sigB]            = explode('.', $this->mint(['resource' => 'doc-B']), 2);
+
+        $this->assertNull(\OWA\Core\OverlayToken::verify($payloadA . '.' . $sigB));
+    }
+}


### PR DESCRIPTION
### The problem

The heatmap overlay and domstream player run on the **tracked** site and call back to the OWA origin. That is genuinely cross-origin, so the credential has to travel in the URL — a session cookie would be a third-party cookie, and an `Authorization` header would turn a simple GET into a preflighted one.

The credential was the signed-in user's **`apiKey`**, HMAC-signed. And the tracker wrote that URL into an `owa_overlay` **cookie on the tracked site's own domain**, path `/` (`Tracker.js:362`), so the overlay's JS could read it back.

So a long-lived credential carrying a user's entire account sat in a cookie on a domain OWA does not control:

- readable by **every other script on that page** — ad tags, other analytics, a compromised plugin — via `document.cookie`
- as a cookie, **re-sent on every subsequent request to that site**, landing in its access logs, its CDN's, and any proxy in between
- it could not be `HttpOnly`, because the overlay itself has to read it
- a *user* key, not a scoped one, so a leak is account compromise rather than the loss of one page's heatmap

The one mitigation was that it was a session cookie, which bounds the cookie's life — not the key's.

### The credential is now scoped and short-lived

One user, one endpoint, one resource, five minutes. What leaks is worth almost nothing.

Verification recomputes the signature rather than looking it up, so this is **stateless**: no table, no schema version bump, no reaper job. The usual objection — no early revocation — is answered by the expiry being minutes.

Two design points worth review:

- **The token names the request parameter that carries its resource** (`document_id` for heatmaps, `domstream_guid` for playback), so verification needs no table mapping actions to parameter names — one the next overlay would have to remember to update.
- **Scope is enforced during authentication, not after it.** A request outside the token's scope never authenticates, so there is no window in which a caller is authenticated but not yet constrained. The token branch is checked *before* the apiKey branch, so a request carrying both is held to the narrower credential.

Request signing goes away with it: signing exists to make a long-lived key survivable in a URL, and there is no longer a long-lived key.

### The cookie is gone, and was never necessary

`startOverlaySession()` already **receives** the decoded params from the fragment. The cookie existed solely so `Heatmap.fetchData()` and `Player.fetchData()` could re-read `api_url` later. They now read it from memory, which is all a page-lifetime value needs — a cookie bought persistence and automatic transmission that nothing wanted.

The `#owa_overlay.<base64>` **fragment is unchanged** and still signals overlay mode, so the tracker still calls `pause()` and logs no pageview. Nothing ever read the cookie to *detect* overlay mode. The `eraseCookie` calls stay, to clear cookies an older tracker left behind on that domain during rollout.

**One behavioural change**: an overlay session no longer survives navigation. A heatmap is scoped to one document — `document_id` is baked into the token — so ending at the page boundary is correct, but it is a change.

### Tests

`OverlayTokenTest` (8 tests, 51 assertions): scope enforced on action *and* resource; the resource arriving under a different parameter than the token names does not satisfy it; an omitted parameter does not pass unchecked; expiry; every claim covered by the signature (user, action, resource, resource key, expiry each rejected when edited); signatures not interchangeable between tokens; garbage refused rather than fatal; URL-safety; tokens not a stable identifier.

Mutation-checked on each security property independently — removing the scope check, the expiry check, or the payload from the signature each reddens the suite.

Full suite **679 green**; all three phpstan configs clean; JS suite 230 green; bundle builds and no longer contains an overlay cookie write.