### PR TITLE
Define getOverlayParams, which #1020 called but never added

### DIFF
--- a/modules/Base/src/common/owa.js
+++ b/modules/Base/src/common/owa.js
@@ -29,6 +29,7 @@ class OWA {
 	    
 	    this.state = {};
 	    this.overlayActive = false;
+	    this.overlayParams = null;
     }
     
     // depricated
@@ -225,15 +226,23 @@ class OWA {
         
         // set global is overlay actve flag
         this.overlayActive = true;
-        //alert(JSON.stringify(p));
+        
+        // Hold the overlay params for this page's lifetime.
+        //
+        // They used to be written to an owa_overlay cookie on the TRACKED
+        // site's own domain, so Heatmap.fetchData() and Player.fetchData()
+        // could read api_url back out -- which meant every other script on
+        // that page could read the credential in it, and the browser re-sent
+        // it to that site on every request. The params only ever need to
+        // survive from page load until the overlay fetches, so memory is the
+        // right lifetime and a cookie bought persistence nothing wanted.
+        this.overlayParams = p;
         
         if (p.hasOwnProperty('api_url')) {
                 
             this.setApiEndpoint(p.api_url);
         }
         
-        // get param from cookie    
-        //var params = Util.parseCookieStringToJson(p);
         var params = p;
         // evaluate the action param
         if (params.action === 'loadHeatmap') {
@@ -245,9 +254,25 @@ class OWA {
     }
     
     endOverlaySession() {
-                
+        
+        // Erase any owa_overlay cookie an older tracker left on this domain,
+        // then drop the in-memory copy.
         Util.eraseCookie(this.getSetting('ns') + 'overlay', document.domain);
+        this.overlayParams = null;
         this.overlayActive = false;
+    }
+    
+    /**
+     * The params for the overlay session running on this page, or null.
+     *
+     * Heatmap.fetchData() and Player.fetchData() read api_url from here. If
+     * this is missing they get undefined, jQuery.ajax is called with an
+     * undefined URL, and the overlay silently never draws -- so it is covered
+     * by tests/js/OverlayParamsInMemory.test.js rather than trusted.
+     */
+    getOverlayParams() {
+        
+        return this.overlayParams || null;
     }
     
     /**

--- a/tests/js/OverlayParamsInMemory.test.js
+++ b/tests/js/OverlayParamsInMemory.test.js
@@ -1,0 +1,101 @@
+// startOverlaySession() dispatches into Heatmap.js/Player.js, which call
+// jQuery(...). Same interop fix as DomStreamPlayback.test.js: babel-jest's
+// wildcard namespace is not callable, so mark the real jQuery as an ES module.
+jest.mock('jquery', () => {
+    const jq = jest.requireActual('jquery');
+    jq.__esModule = true;
+    return jq;
+});
+
+import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
+
+/**
+ * Overlay params are held in memory, not in a cookie -- and are actually
+ * readable by the code that needs them.
+ *
+ * They used to be written to an `owa_overlay` cookie on the *tracked* site's
+ * own domain, path `/`, so Heatmap.fetchData() and Player.fetchData() could
+ * read `api_url` back out. That put a credential somewhere every other script
+ * on the page could read and the browser re-sent to that site on every
+ * request.
+ *
+ * The cookie was never necessary: startOverlaySession() already receives the
+ * decoded params from the URL fragment. It now keeps them for the page's
+ * lifetime instead.
+ *
+ * These tests exist because the failure mode of getting this wrong is silent.
+ * If getOverlayParams() returned nothing, `var url = params.api_url` would be
+ * undefined, jQuery.ajax would be called with an undefined URL, and the overlay
+ * would simply never draw -- no error, no exception, nothing for a suite that
+ * only asserts DOM construction to catch. The existing overlay e2e explicitly
+ * does not assert the fetch ("it simply never calls back in this harness"), so
+ * nothing else covers this.
+ */
+describe('overlay params are kept in memory', () => {
+
+    const params = {
+        action: 'loadHeatmap',
+        api_url: 'https://reporting.example.com/owa/api/index.php?owa_do=reports&owa_overlayToken=abc',
+    };
+
+    beforeEach(() => {
+        OWA.overlayParams = null;
+        OWA.overlayActive = false;
+        document.cookie.split(';').forEach((c) => {
+            const name = c.split('=')[0].trim();
+            if (name) {
+                document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+            }
+        });
+    });
+
+    test('startOverlaySession keeps the params where the overlay can read them', () => {
+        OWA.startOverlaySession(params);
+
+        expect(OWA.getOverlayParams()).toEqual(params);
+        expect(OWA.getOverlayParams().api_url).toBe(params.api_url);
+    });
+
+    test('the api_url is never written to a cookie', () => {
+        OWA.startOverlaySession(params);
+
+        // The whole point: the credential in api_url must not be readable via
+        // document.cookie by anything else running on the tracked page.
+        expect(document.cookie).not.toContain('owa_overlay');
+        expect(document.cookie).not.toContain('overlayToken');
+        expect(document.cookie).not.toContain('api_url');
+    });
+
+    test('the session flag is set, so the tracker knows to stay paused', () => {
+        expect(OWA.overlayActive).toBe(false);
+
+        OWA.startOverlaySession(params);
+
+        expect(OWA.overlayActive).toBe(true);
+    });
+
+    test('ending the session drops the params', () => {
+        OWA.startOverlaySession(params);
+        expect(OWA.getOverlayParams()).not.toBeNull();
+
+        OWA.endOverlaySession();
+
+        expect(OWA.getOverlayParams()).toBeNull();
+        expect(OWA.overlayActive).toBe(false);
+    });
+
+    test('getOverlayParams returns null rather than undefined when no session is running', () => {
+        // fetchData() does `OWA_instance.getOverlayParams() || {}`, so a falsy
+        // return is required -- undefined would work by accident, null says so.
+        expect(OWA.getOverlayParams()).toBeNull();
+    });
+
+    test('a second overlay session replaces the first', () => {
+        OWA.startOverlaySession(params);
+
+        const second = { action: 'loadPlayer', api_url: 'https://reporting.example.com/other' };
+        OWA.startOverlaySession(second);
+
+        expect(OWA.getOverlayParams()).toEqual(second);
+    });
+});


### PR DESCRIPTION
### What broke

#1020 moved the overlay params off the `owa_overlay` cookie and pointed `Heatmap.js` and `Player.js` at `OWA_instance.getOverlayParams()`. The other half of that change — storing the params in `startOverlaySession()` and defining the accessor in `owa.js` — was written but **lost before the commit**, and I did not catch it: `git status` listed nine files and `owa.js` was not among them.

On master today, the overlay throws `TypeError: getOverlayParams is not a function` as soon as it fetches. **Heatmaps and domstream playback cannot load data.**

### Why nothing caught it

This is the part worth keeping. The full PHP suite passed, the JS suite passed, the bundle built, and the overlay e2e passed — because that e2e asserts only the synchronous jQuery-built DOM, and says so in its own header:

> the subsequent click-data fetch is an async JSONP call against live data; it is not part of the "does jQuery 3.x still build the overlay" contract and **is not asserted** (it simply never calls back in this harness)

So every green check stopped precisely where the change started. The failure mode is silent by construction too: `fetchData()` does `getOverlayParams() || {}`, then `var url = params.api_url` — an undefined URL handed to `jQuery.ajax`, no exception, no console error, an overlay that just never draws.

### The fix

`startOverlaySession()` stores the params, `getOverlayParams()` returns them, the constructor initialises the field, and `endOverlaySession()` clears it.

### Tests

New `OverlayParamsInMemory.test.js` (6 tests) covering the seam that had none:

- params survive `startOverlaySession` into `getOverlayParams`
- **`api_url` never reaches `document.cookie`** — the security property #1020 was for
- the overlay-active flag is set, so the tracker stays paused
- ending the session drops the params
- no session returns `null`, not `undefined` — `fetchData` relies on the falsy branch, so the wrong falsy value would fail silently
- a second session replaces the first

Also verified end-to-end against a live install, which is what surfaced this: a minted token fetches **308 click rows** for its document (matching the database), while the same token against a different document, a different endpoint, a tampered payload, or no credential each return **401**.

JS suite 236 green across 27 suites; bundle rebuilt and both definer and callers present in `owa.tracker.js`, `owa.heatmap.js` and `owa.player.js`.