### PR TITLE
Fetch overlay data over CORS instead of JSONP

### DIFF
--- a/Core/Template.php
+++ b/Core/Template.php
@@ -660,7 +660,16 @@ class Template extends TemplateEngine {
             $params[ $resourceKey ]
         );
 
-        return $this->makeLink( $params, false, $this->config['rest_api_url'] );
+        // add_state MUST be true. It is what carries siteId and the reporting
+        // period onto the link, and both overlay call sites used
+        // makeApiLink( $params, true, true ) before this method existed.
+        //
+        // Dropping it fails asymmetrically, which is why it is worth a comment:
+        // the player's controller declares siteId required and answers a clean
+        // 422, but the heatmap's reports route does not, so it returns 200 for a
+        // query with no site filter and a defaulted period -- the wrong clicks,
+        // reported as success. Only the cross-origin e2e caught that half.
+        return $this->makeLink( $params, true, $this->config['rest_api_url'] );
     }
 
     function makeApiLink($params = array(), $add_state = false, $add_apiKey = false) {

--- a/modules/Base/src/tracker/Heatmap.js
+++ b/modules/Base/src/tracker/Heatmap.js
@@ -214,8 +214,18 @@ class Heatmap {
         jQuery.ajax({
             url: url,
            
-            dataType: 'jsonp',
-            jsonp: 'owa_jsonpCallback',
+            // A plain cross-origin GET, not JSONP.
+            //
+            // JSONP returns the body as a <script> the browser executes, which
+            // makes the endpoint readable by any page on the internet. It was
+            // used here only because these run on the tracked site and call
+            // back to the OWA origin, and CORS did not work -- addCorsHeaders()
+            // never emitted a header, and isHttps() let a client's Origin flip
+            // the server's scheme and break the request signature. Both fixed.
+            //
+            // Credentials travel in the query string, so this stays a CORS
+            // "simple request" and costs no preflight round trip.
+            dataType: 'json',
             success: function(data) {
                 that.plotClickData(data);
             }

--- a/modules/Base/src/tracker/Player.js
+++ b/modules/Base/src/tracker/Player.js
@@ -64,8 +64,18 @@ class Player {
         jQuery.ajax({
             url:  url,
         
-            dataType: 'jsonp',
-            jsonp: 'owa_jsonpCallback',
+            // A plain cross-origin GET, not JSONP.
+            //
+            // JSONP returns the body as a <script> the browser executes, which
+            // makes the endpoint readable by any page on the internet. It was
+            // used here only because these run on the tracked site and call
+            // back to the OWA origin, and CORS did not work -- addCorsHeaders()
+            // never emitted a header, and isHttps() let a client's Origin flip
+            // the server's scheme and break the request signature. Both fixed.
+            //
+            // Credentials travel in the query string, so this stays a CORS
+            // "simple request" and costs no preflight round trip.
+            dataType: 'json',
             success: function(data) {
                 that.load(data);
             }

--- a/tests/OverlayApiLinkTest.php
+++ b/tests/OverlayApiLinkTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The overlay API link must carry the report's state, not just its token.
+ *
+ * Template::makeOverlayApiLink() replaced two makeApiLink( $params, true, true )
+ * calls -- in report_document.php (heatmap) and report_domstreams.php (player).
+ * The middle argument is add_state, and it is what merges caller_params
+ * ['link_state'] (siteId) and the time period onto the link. The replacement
+ * dropped it, and both overlays lost their siteId.
+ *
+ * That failed asymmetrically, which is why it needs pinning here rather than
+ * being left to the e2e:
+ *
+ *   - the player's controller declares siteId required, so it answered 422 and
+ *     the overlay was visibly broken;
+ *   - the heatmap's reports route does not, so it answered *200* for a query
+ *     with no site filter and a defaulted period. Wrong clicks, reported as
+ *     success -- no status code, no console error, and nothing in the DOM to
+ *     tell a passing overlay from one plotting another site's data.
+ *
+ * The cross-origin e2e cannot cover this: it builds its request URL directly,
+ * so it asserts what the API does with a siteId rather than whether the admin
+ * side puts one there. This is the seam where that decision is actually made.
+ */
+final class OverlayApiLinkTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /**
+     * A template positioned the way a report template is when it builds the
+     * link: a link_state carrying the site being reported on.
+     */
+    private function reportTemplate(string $siteId = 'site-under-report'): \OWA\Core\Template
+    {
+        $t = new \OWA\Core\Template();
+        $t->caller_params['link_state'] = ['siteId' => $siteId];
+        $t->config['rest_api_url']      = 'https://owa.example.com/api/index.php';
+
+        return $t;
+    }
+
+    private function heatmapLink(\OWA\Core\Template $t): string
+    {
+        return $t->makeOverlayApiLink([
+            'document_id' => 'doc-12345',
+            'module'      => 'base',
+            'version'     => 'v1',
+            'do'          => 'reports',
+            'report_name' => 'clicks',
+        ], 'document_id');
+    }
+
+    public function testTheHeatmapLinkCarriesTheSiteBeingReportedOn(): void
+    {
+        $link = $this->heatmapLink($this->reportTemplate());
+
+        // Without this the reports route still answers 200, for the wrong site.
+        $this->assertStringContainsString('siteId=site-under-report', $link);
+    }
+
+    public function testThePlayerLinkCarriesTheSiteBeingReportedOn(): void
+    {
+        $t = $this->reportTemplate();
+
+        $link = $t->makeOverlayApiLink([
+            'domstream_guid' => '4921417228',
+            'module'         => 'domstream',
+            'version'        => 'v1',
+            'do'             => 'domstreams',
+        ], 'domstream_guid');
+
+        // DomstreamsRestController::validate() declares siteId required.
+        $this->assertStringContainsString('siteId=', $link);
+        $this->assertStringContainsString('site-under-report', $link);
+    }
+
+    /**
+     * State is merged, never substituted for the caller's own parameters -- a
+     * link that carried siteId but lost the resource it names would satisfy the
+     * assertions above while being useless, and would not match its token.
+     */
+    public function testStateIsAddedWithoutDisplacingTheCallersParams(): void
+    {
+        $link = $this->heatmapLink($this->reportTemplate());
+
+        $this->assertStringContainsString('document_id=doc-12345', $link);
+        $this->assertStringContainsString('report_name=clicks', $link);
+        $this->assertStringContainsString('do=reports', $link);
+        $this->assertStringContainsString('overlayToken=', $link);
+    }
+
+    /**
+     * The token on the link must be valid for that same link: minted for the
+     * link's action, and for the resource the link actually names.
+     */
+    public function testTheTokenOnTheLinkMatchesTheLinkItIsOn(): void
+    {
+        $link = $this->heatmapLink($this->reportTemplate());
+
+        parse_str((string) parse_url($link, PHP_URL_QUERY), $q);
+
+        $token = $q['owa_overlayToken'] ?? ($q['overlayToken'] ?? '');
+        $this->assertNotSame('', $token, 'the link carried no overlay token');
+
+        $permitted = \OWA\Core\OverlayToken::permits(
+            $token,
+            'reports',
+            static fn($name) => $name === 'document_id' ? 'doc-12345' : ''
+        );
+
+        $this->assertTrue($permitted, 'the minted token does not permit its own link');
+    }
+}

--- a/tests/e2e/overlay-cross-origin.spec.js
+++ b/tests/e2e/overlay-cross-origin.spec.js
@@ -1,0 +1,208 @@
+// @ts-check
+/**
+ * The heatmap overlay and the domstream player fetch their data cross-origin.
+ *
+ * This is the property that JSONP existed to provide, and nothing tested it.
+ * Both overlays run on the *tracked* site and fetch from the OWA origin, so
+ * their request is genuinely cross-origin; JSONP got around the same-origin
+ * policy by returning the body as an executable script. Replacing it with CORS
+ * is only safe if CORS actually works from a browser, which curl cannot show
+ * and the existing overlay spec explicitly does not assert -- it says so in its
+ * own header: "the subsequent click-data fetch ... is not asserted (it simply
+ * never calls back in this harness)".
+ *
+ * That silence is the point. JSONP fails by never calling back, so an overlay
+ * whose fetch was broken looked exactly like one whose fetch was pending. The
+ * DOM assertions passed either way.
+ *
+ * HOW THIS IS CROSS-ORIGIN WITHOUT A SECOND HOST
+ * The self-host runner serves one php -S on 127.0.0.1:PORT, and
+ * http://localhost:PORT is a *different origin* from http://127.0.0.1:PORT --
+ * same server, different host string, so the browser sends a real Origin header
+ * and enforces the response's CORS headers for real. The fixture provisions a
+ * site at http://localhost so the request is allowed on the merits: the matcher
+ * compares the Origin's host against configured sites.
+ *
+ * WHAT WOULD HAVE CAUGHT WHAT
+ * Three separate defects had to be fixed before this could pass, and each was
+ * invisible to every other suite:
+ *   - addCorsHeaders() never emitted a header (row arrays vs a string)
+ *   - isHttps() let the Origin header flip the server's own scheme, breaking
+ *     the signature on every signed cross-origin request
+ *   - the overlay read its params from a cookie that had been removed
+ */
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { test, expect } = require('@playwright/test');
+
+const HELPER = path.join(__dirname, 'overlay_e2e_helper.php');
+const HARNESS_HTML = fs.readFileSync(path.join(__dirname, 'overlay_harness.html'), 'utf8');
+
+function helper(...args) {
+    return JSON.parse(execFileSync('php', [HELPER, ...args], { encoding: 'utf8' }));
+}
+
+function installRoot(baseURL) {
+    return baseURL.replace(/index\.php.*$/, '');
+}
+
+/** The same install, addressed by the other host name -- a different origin. */
+function crossOrigin(root) {
+    return root.replace('127.0.0.1', 'localhost');
+}
+
+const SELFHOST = process.env.OWA_E2E_SELFHOST === '1';
+
+/**
+ * Chrome's Local Network Access check has to be off for this spec, and that is
+ * not a way of dodging the thing being tested.
+ *
+ * LNA is a *separate* gate from CORS: a page may not reach the loopback or
+ * private address space without a user permission, and it is refused before the
+ * response's CORS headers are ever consulted -- headless Chrome auto-denies, so
+ * the fetch fails with status 0 and "Permission was denied for this request to
+ * access the `loopback` address space", which looks exactly like a missing
+ * Access-Control-Allow-Origin and is not one.
+ *
+ * It fires here only because the two origins are 127.0.0.1 and localhost, which
+ * is an artifact of getting two origins out of one php -S. A real overlay runs
+ * on a public tracked site fetching a public OWA host; neither is in the local
+ * address space, so LNA does not apply to the case this spec exists to cover.
+ * Leaving it on would test the harness rather than the product.
+ */
+test.use({
+    launchOptions: { args: ['--disable-features=LocalNetworkAccessChecks'] },
+});
+
+test.describe('overlays fetch cross-origin @selfhost-only', () => {
+
+    test.skip(!SELFHOST,
+        'Provisions a site, clicks and a domstream; runs only under the self-host e2e runner.');
+
+    /** @type {{site_id:string, document_id:string, domstream_guid:string, heatmap_token:string, player_token:string, clicks:number}} */
+    let fx;
+
+    test.beforeAll(() => {
+        fx = helper('provision');
+        expect(fx.clicks, 'no click rows were seeded for the heatmap to fetch').toBeGreaterThan(0);
+        expect(fx.heatmap_token, 'no heatmap token was minted').toBeTruthy();
+        expect(fx.player_token, 'no player token was minted').toBeTruthy();
+    });
+
+    test.afterAll(() => {
+        helper('cleanup');
+    });
+
+    /**
+     * Loads the tracked-page harness on the localhost origin, pointing the
+     * overlay at the API on the 127.0.0.1 origin.
+     */
+    async function runOverlay(page, testInfo, { action, apiQuery, extra = '' }) {
+        const apiRoot = installRoot(testInfo.project.use.baseURL);      // 127.0.0.1
+        const pageRoot = crossOrigin(apiRoot);                          // localhost
+
+        const apiUrl = apiRoot + 'api/index.php?' + apiQuery;
+
+        const harness = pageRoot + 'tests/e2e/overlay_harness.html'
+            + '?base=' + encodeURIComponent(pageRoot)
+            + '&action=' + encodeURIComponent(action)
+            + '&api=' + encodeURIComponent(apiUrl)
+            + extra;
+
+        // tests/ is 403'd by the deny-all .htaccess, so the document is served
+        // from disk at the right origin (see overlay-heatmap.spec.js).
+        await page.route('**/tests/e2e/overlay_harness.html*', (route) =>
+            route.fulfill({ status: 200, contentType: 'text/html', body: HARNESS_HTML })
+        );
+
+        const consoleErrors = [];
+        page.on('console', (m) => {
+            if (m.type() === 'error') consoleErrors.push(m.text());
+        });
+
+        await page.goto(harness, { waitUntil: 'load' });
+
+        // Wait for the overlay's own XHR to complete.
+        await page.waitForFunction(
+            () => (window.owaOverlayFetches || []).some((f) => f.url.indexOf('api/index.php') !== -1),
+            null,
+            { timeout: 15000 }
+        );
+
+        const fetches = await page.evaluate(() =>
+            (window.owaOverlayFetches || []).filter((f) => f.url.indexOf('api/index.php') !== -1)
+        );
+
+        return { fetches, consoleErrors, apiRoot, pageRoot };
+    }
+
+    test('the heatmap fetches its click data from another origin', async ({ page }, testInfo) => {
+        const { fetches, consoleErrors, apiRoot, pageRoot } = await runOverlay(page, testInfo, {
+            action: 'loadHeatmap',
+            apiQuery: 'owa_do=reports&owa_module=base&owa_version=v1'
+                + '&owa_report_name=clicks'
+                + '&owa_siteId=' + encodeURIComponent(fx.site_id)
+                + '&owa_document_id=' + encodeURIComponent(fx.document_id)
+                + '&owa_overlayToken=' + encodeURIComponent(fx.heatmap_token),
+            extra: '&document_id=' + encodeURIComponent(fx.document_id),
+        });
+
+        // The premise: the page and the API really are different origins.
+        expect(pageRoot).not.toBe(apiRoot);
+
+        const call = fetches[0];
+        expect(call, 'the overlay issued no API request').toBeDefined();
+
+        // 401 here means the credential or the signature failed; 0 means the
+        // browser blocked the response for want of CORS headers -- the exact
+        // failure JSONP was hiding.
+        expect(call.status,
+            `cross-origin overlay fetch failed (status ${call.status})\n`
+            + `  console: ${JSON.stringify(consoleErrors)}`
+        ).toBe(201);
+        expect(call.length, 'the response body was empty').toBeGreaterThan(0);
+
+        const corsBlocked = consoleErrors.filter((e) => /CORS|Access-Control/i.test(e));
+        expect(corsBlocked, 'the browser reported a CORS failure').toEqual([]);
+    });
+
+    test('the player fetches its recording from another origin', async ({ page }, testInfo) => {
+        const { fetches, consoleErrors } = await runOverlay(page, testInfo, {
+            action: 'loadPlayer',
+            apiQuery: 'owa_do=domstreams&owa_module=domstream&owa_version=v1'
+                // siteId is what makeOverlayApiLink's add_state contributes; the
+                // controller declares it required.
+                + '&owa_siteId=' + encodeURIComponent(fx.site_id)
+                + '&owa_domstream_guid=' + encodeURIComponent(fx.domstream_guid)
+                + '&owa_overlayToken=' + encodeURIComponent(fx.player_token),
+            extra: '&domstream_guid=' + encodeURIComponent(fx.domstream_guid),
+        });
+
+        const call = fetches[0];
+        expect(call, 'the player issued no API request').toBeDefined();
+        expect(call.status,
+            `cross-origin player fetch failed (status ${call.status})\n  body: ${call.body}`
+        ).toBe(201);
+
+        const corsBlocked = consoleErrors.filter((e) => /CORS|Access-Control/i.test(e));
+        expect(corsBlocked, 'the browser reported a CORS failure').toEqual([]);
+    });
+
+    test('an overlay token is refused for a resource it does not name', async ({ page }, testInfo) => {
+        // The scope check, exercised through a real browser fetch rather than a
+        // unit test: the heatmap token names one document.
+        const { fetches } = await runOverlay(page, testInfo, {
+            action: 'loadHeatmap',
+            apiQuery: 'owa_do=reports&owa_module=base&owa_version=v1'
+                + '&owa_report_name=clicks'
+                + '&owa_siteId=' + encodeURIComponent(fx.site_id)
+                + '&owa_document_id=some-other-document'
+                + '&owa_overlayToken=' + encodeURIComponent(fx.heatmap_token),
+        });
+
+        const call = fetches[0];
+        expect(call, 'no request was issued').toBeDefined();
+        expect(call.status, 'a token must not work for a document it does not name').toBe(401);
+    });
+});

--- a/tests/e2e/overlay_e2e_helper.php
+++ b/tests/e2e/overlay_e2e_helper.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Cross-origin overlay fixture provisioner for the self-host e2e runner.
+ *
+ * The heatmap overlay and the domstream player are the only genuinely
+ * cross-origin consumers of the API: they run on the *tracked* site and fetch
+ * from the OWA origin. That is why they used JSONP, and why replacing it with
+ * CORS needs proving in a browser rather than with curl.
+ *
+ * What a spec needs to do that:
+ *
+ *   provision   a site whose domain host is 'localhost', a document with click
+ *               data, a domstream recording, and a scoped overlay token for
+ *               each -- returned along with the ids the spec must assert on
+ *   cleanup     remove all of it
+ *
+ * The 'localhost' domain is the whole trick. The self-host runner serves one
+ * php -S on 127.0.0.1, and http://localhost:PORT is a *different origin* from
+ * http://127.0.0.1:PORT -- same server, different host string. So a harness
+ * page loaded from localhost fetching the API on 127.0.0.1 is a real
+ * cross-origin request, with a real Origin header, without needing a second
+ * host or a DNS entry. CORS then has to allow it on the merits: the matcher
+ * compares the Origin's host against configured sites, so a site at
+ * 'http://localhost' is what makes the request legitimate rather than a
+ * special case.
+ *
+ * This owns its own site and its own tag. provision() is destructive by design
+ * elsewhere in this suite -- rest_e2e_helper's calls cleanup() first, so two
+ * callers of one fixture delete each other's user mid-run -- so nothing here
+ * touches anything another helper created.
+ *
+ * Like the other e2e helpers this writes, so it HARD-REFUSES unless booted
+ * against the throwaway scratch DB the self-host harness provisions.
+ */
+
+if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+    $_SERVER['HTTP_USER_AGENT'] =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 '
+        . '(KHTML, like Gecko) Chrome/120.0 Safari/537.36';
+}
+$_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '203.0.113.11';
+
+const SCRATCH_DB_SENTINEL = 'owa_e2e_selfhost';
+const FIXTURE_TAG         = 'e2e-overlay';
+const OVERLAY_DOMAIN      = 'http://localhost';
+
+$owa_root = dirname(__DIR__, 2) . '/';
+require_once($owa_root . 'owa.php');
+new owa(['tracking_mode' => true, 'instance_role' => 'logger']);
+
+$connected_db = (string) owa_coreAPI::getSetting('base', 'db_name');
+$allowed_db   = getenv('OWA_E2E_DB_NAME') ?: SCRATCH_DB_SENTINEL;
+
+if ($connected_db !== $allowed_db) {
+    fwrite(STDERR, "[overlay_e2e_helper] REFUSING to run: connected DB '$connected_db' "
+        . "is not the scratch sentinel '$allowed_db'. This helper only runs under "
+        . "the self-host e2e runner.\n");
+    exit(3);
+}
+
+$cmd = $argv[1] ?? '';
+
+switch ($cmd) {
+    case 'provision': out(provision()); break;
+    case 'cleanup':   out(cleanup());   break;
+    default:
+        fwrite(STDERR, "Unknown command '$cmd'. Use: provision | cleanup\n");
+        exit(2);
+}
+
+function out(array $result): void
+{
+    echo json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+}
+
+function db()
+{
+    return owa_coreAPI::dbSingleton();
+}
+
+/**
+ * A site at localhost, a document with clicks, a domstream, and a scoped token
+ * for each overlay.
+ */
+function provision(): array
+{
+    cleanup();
+
+    $site_id = md5(OVERLAY_DOMAIN);
+
+    $s = owa_coreAPI::entityFactory('base.site');
+    $s->set('id', $s->generateId($site_id));
+    $s->set('site_id', $site_id);
+    $s->set('domain', OVERLAY_DOMAIN);
+    $s->set('name', 'OWA overlay cross-origin e2e site');
+    $s->set('description', FIXTURE_TAG);
+    $s->create();
+
+    // A user for the token to name. The token carries this user's privileges,
+    // scoped to one action and one resource.
+    $user_id = FIXTURE_TAG . '-admin@owatest.example.com';
+    $u = owa_coreAPI::entityFactory('base.user');
+    $u->createNewUser($user_id, 'admin', 'pw-' . FIXTURE_TAG, $user_id, 'OWA overlay e2e admin');
+    $u->load($u->generateId($user_id), 'user_id');
+
+    $document_id    = (string) sprintf('%d', crc32(FIXTURE_TAG . '-doc') + 4000000000);
+    $domstream_guid = (string) sprintf('%d', crc32(FIXTURE_TAG . '-ds') + 4000000000);
+
+    seedClicks($site_id, $document_id);
+    seedDomstream($site_id, $domstream_guid);
+
+    // The player's route is registered by the Domstream module, and a stock
+    // install activates 'base' only (Settings.php: 'modules' => array('base')).
+    // Without this the /domstreams route simply does not exist, and the request
+    // fails during authentication rather than at routing -- the API answers 401
+    // "Not authenticated", which reads as a broken credential and is not one.
+    // Worth stating because it cost a real debugging detour: the heatmap half of
+    // this spec passed throughout, since 'reports' is a Base route.
+    $domstream_was_active = (bool) owa_coreAPI::getSetting('domstream', 'is_active');
+
+    if (!$domstream_was_active) {
+        owa_coreAPI::activateModule('domstream');
+    }
+
+    return [
+        'site_id'        => $site_id,
+        'domain'         => OVERLAY_DOMAIN,
+        'user_id'        => $user_id,
+        'document_id'    => $document_id,
+        'domstream_guid' => $domstream_guid,
+        'clicks'         => countRows('owa_click', $site_id),
+        'domstream_module_activated' => !$domstream_was_active,
+        // Scoped tokens: one action, one resource, minutes. Minted here because
+        // only the server can sign them.
+        'heatmap_token'  => \OWA\Core\OverlayToken::mint(
+            $user_id, 'reports', 'document_id', $document_id, 600
+        ),
+        'player_token'   => \OWA\Core\OverlayToken::mint(
+            $user_id, 'domstreams', 'domstream_guid', $domstream_guid, 600
+        ),
+    ];
+}
+
+/**
+ * Click rows for the heatmap to plot. Written directly: the point of the spec
+ * is the fetch, not the ingestion path, which tracker-beacon.spec.js covers.
+ */
+function seedClicks(string $site_id, string $document_id): void
+{
+    $now = time();
+
+    for ($i = 0; $i < 5; $i++) {
+        $c = owa_coreAPI::entityFactory('base.click');
+        $c->set('id', $c->generateId(FIXTURE_TAG . '-click-' . $i));
+        $c->set('site_id', $site_id);
+        $c->set('document_id', $document_id);
+        $c->set('timestamp', $now - $i);
+        $c->set('yyyymmdd', (int) date('Ymd', $now));
+        $c->set('click_x', 100 + ($i * 10));
+        $c->set('click_y', 200 + ($i * 10));
+        $c->set('page_width', 1200);
+        $c->set('page_height', 800);
+        $c->create();
+    }
+}
+
+function seedDomstream(string $site_id, string $domstream_guid): void
+{
+    $now = time();
+
+    $d = owa_coreAPI::entityFactory('base.domstream');
+    $d->set('id', $d->generateId(FIXTURE_TAG . '-ds'));
+    $d->set('site_id', $site_id);
+    $d->set('domstream_guid', $domstream_guid);
+    $d->set('timestamp', $now);
+    $d->set('yyyymmdd', (int) date('Ymd', $now));
+    $d->set('duration', 12);
+    $d->set('stream', json_encode([
+        ['type' => 'mousemove', 'x' => 10, 'y' => 20, 'ts' => 0],
+        ['type' => 'mousemove', 'x' => 30, 'y' => 40, 'ts' => 1],
+    ]));
+    $d->create();
+}
+
+function countRows(string $table, string $site_id): int
+{
+    $db = db();
+    $db->selectFrom($table);
+    $db->selectColumn('COUNT(*) AS n');
+    $db->where('site_id', $site_id);
+    $row = $db->getOneRow();
+
+    return (int) ($row['n'] ?? 0);
+}
+
+function cleanup(): array
+{
+    $site_id = md5(OVERLAY_DOMAIN);
+    $removed = [];
+
+    foreach (['owa_click', 'owa_domstream'] as $table) {
+        $db = db();
+        $db->deleteFrom($table);
+        $db->where('site_id', $site_id);
+        $db->executeQuery();
+        $removed[$table] = 'cleared';
+    }
+
+    $db = db();
+    $db->deleteFrom('owa_site');
+    $db->where('site_id', $site_id);
+    $db->executeQuery();
+    $removed['owa_site'] = 'cleared';
+
+    $u = owa_coreAPI::entityFactory('base.user');
+    $u->delete(FIXTURE_TAG . '-admin@owatest.example.com', 'user_id');
+    $removed['owa_user'] = 'cleared';
+
+    // Put the install back to the base-only default this fixture found it in.
+    // persistSetting(..., false) removes the key from the settings blob rather
+    // than storing a false, which is exactly the state an unactivated module is
+    // in -- see the settings-blob falsy-write behaviour.
+    owa_coreAPI::deactivateModule('domstream');
+    $removed['domstream_module'] = 'deactivated';
+
+    return ['status' => 'cleaned', 'removed' => $removed];
+}

--- a/tests/e2e/overlay_harness.html
+++ b/tests/e2e/overlay_harness.html
@@ -66,15 +66,43 @@
             // containing "+" would be corrupted; percent-encoding the base64
             // (encodeURIComponent) is what survives that urldecode intact -- the
             // decode path is built to reverse a url-encoded base64.
+            // The overlay action and its API url may be supplied by the test.
+            //
+            // Without them this stays what it was: loadHeatmap against a
+            // well-formed but deliberately unreachable url, which is all the
+            // DOM-render assertions need.
+            //
+            // With them, the test can point the overlay at the REAL API on a
+            // DIFFERENT ORIGIN and assert the fetch itself. That is the case
+            // that matters now the transport is CORS rather than JSONP: JSONP
+            // failed silently by never calling back, so nothing here could tell
+            // a working fetch from a broken one.
             var overlayParams = {
-                action: 'loadHeatmap',
-                // A well-formed but deliberately unreachable API url. The heatmap
-                // builds its control panel + canvas BEFORE the first data fetch,
-                // and the fetch is JSONP (no CORS error, just never calls back),
-                // so an unresolved fetch does not affect what we assert.
-                api_url: base + 'api/?owa_do=base.reportHeatmap',
-                document_id: 'e2e-overlay-doc'
+                action: params.get('action') || 'loadHeatmap',
+                api_url: params.get('api') || (base + 'api/?owa_do=base.reportHeatmap'),
+                document_id: params.get('document_id') || 'e2e-overlay-doc'
             };
+
+            if (params.get('domstream_guid')) {
+                overlayParams.domstream_guid = params.get('domstream_guid');
+            }
+
+            // Record fetch outcomes so a test can assert the overlay actually
+            // received data, rather than inferring it from rendered DOM.
+            window.owaOverlayFetches = [];
+            (function (open) {
+                XMLHttpRequest.prototype.open = function (method, url) {
+                    this.addEventListener('loadend', function () {
+                        window.owaOverlayFetches.push({
+                            url: String(url),
+                            status: this.status,
+                            length: (this.responseText || '').length,
+                            body: (this.responseText || '').slice(0, 400)
+                        });
+                    });
+                    return open.apply(this, arguments);
+                };
+            })(XMLHttpRequest.prototype.open);
             var encoded = encodeURIComponent(btoa(JSON.stringify(overlayParams)));
             // Set the fragment BEFORE the tracker bundle loads so
             // checkForOverlaySession() (run from the Tracker constructor) sees it.

--- a/tests/js/OverlayFetchTransport.test.js
+++ b/tests/js/OverlayFetchTransport.test.js
@@ -1,0 +1,103 @@
+// Heatmap and Player call jQuery(...) and jQuery.ajax(...). Same interop fix as
+// DomStreamPlayback.test.js: babel-jest's wildcard namespace is not callable, so
+// mark the real jQuery as an ES module.
+jest.mock('jquery', () => {
+    const jq = jest.requireActual('jquery');
+    jq.__esModule = true;
+    return jq;
+});
+
+import * as jQuery from 'jquery';
+import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
+
+/**
+ * The overlay fetches its data over CORS, not JSONP.
+ *
+ * JSONP is not a transport, it is a way around the same-origin policy: the
+ * response comes back as a `<script>` the browser executes, so the endpoint is
+ * reachable by any page on the internet and its body runs with that page's
+ * privileges. OWA used it for the heatmap overlay and the domstream player
+ * because those run on the *tracked* site and call back to the OWA origin --
+ * genuinely cross-origin, and CORS did not work.
+ *
+ * CORS does work now: addCorsHeaders() had never emitted a header (it compared
+ * site row arrays against the Origin string), and isHttps() let a client's
+ * Origin header flip the server's own scheme, which broke the signature on
+ * every cross-origin signed request. With both fixed and covered end to end,
+ * the reason for JSONP is gone.
+ *
+ * These tests pin the transport rather than the plumbing, so they keep meaning
+ * something if the fetch is ever rewritten off jQuery: whatever issues the
+ * request must not ask for a JSONP response, and must not smuggle a callback
+ * name into the URL.
+ */
+describe('the overlay fetches over CORS, not JSONP', () => {
+
+    let calls;
+
+    beforeEach(() => {
+        calls = [];
+        jest.spyOn(jQuery, 'ajax').mockImplementation((opts) => {
+            calls.push(opts);
+            return { done: () => {}, fail: () => {} };
+        });
+
+        OWA.overlayParams = {
+            action: 'loadHeatmap',
+            api_url: 'https://reporting.example.com/owa/api/index.php'
+                + '?owa_do=reports&owa_document_id=doc-1&owa_overlayToken=tok',
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        OWA.overlayParams = null;
+    });
+
+    async function heatmapFetch() {
+        const { Heatmap } = await import('../../modules/Base/src/tracker/Heatmap.js');
+        const h = new Heatmap();
+        h.fetchData(1);
+        return calls[0];
+    }
+
+    async function playerFetch() {
+        const { Player } = await import('../../modules/Base/src/tracker/Player.js');
+        const p = new Player();
+        p.fetchData();
+        return calls[0];
+    }
+
+    test('the heatmap does not request a JSONP response', async () => {
+        const opts = await heatmapFetch();
+
+        expect(opts).toBeDefined();
+        // JSONP would make the response an executable script.
+        expect(opts.dataType).not.toBe('jsonp');
+        // and must not request a callback parameter.
+        expect(opts.jsonp).toBeUndefined();
+    });
+
+    test('the player does not request a JSONP response', async () => {
+        const opts = await playerFetch();
+
+        expect(opts).toBeDefined();
+        expect(opts.dataType).not.toBe('jsonp');
+        expect(opts.jsonp).toBeUndefined();
+    });
+
+    test('the request goes to the URL the admin interface supplied', async () => {
+        const opts = await heatmapFetch();
+
+        // Not derived client-side: the tracker's base URL is where it *logs*,
+        // which need not be where reporting lives.
+        expect(opts.url).toBe(OWA.overlayParams.api_url);
+    });
+
+    test('no callback name is smuggled into the URL', async () => {
+        const opts = await heatmapFetch();
+
+        expect(String(opts.url)).not.toMatch(/jsonpCallback/i);
+        expect(String(opts.url)).not.toMatch(/callback=/i);
+    });
+});


### PR DESCRIPTION
JSONP is not a transport, it is a way around the same-origin policy: the response returns as a `<script>` the browser executes, so the endpoint is readable by any page on the internet and its body runs with that page's privileges.

The heatmap overlay and domstream player used it for a real reason — they run on the *tracked* site and call back to the OWA origin, which is genuinely cross-origin, and CORS did not work. Getting there took three changes:

| | |
|---|---|
| **#1019** | `addCorsHeaders()` had never emitted a header — it compared `getSitesList()`'s **row arrays** against the `Origin` **string**, so `continue` always fired |
| **#1023** | `isHttps()` let a client's `Origin` header flip the server's own scheme, so every signed cross-origin request was verified against a URL the client had signed differently — and 401'd |
| **#1022** | an end-to-end test that actually sends an `Origin` header, which is what found #1023 |

With those in, the reason for JSONP is gone — and the server-side callback parameter now has **no consumer left in the tree**.

Credentials stay in the query string, so this remains a CORS **simple request**: no preflight round trip before every fetch.

### Verified against a live install

The exact request the overlay now makes:

```
HTTP/2 201
content-type: application/json
vary: Origin
access-control-allow-origin: https://test.openwebanalytics.com
rows=308
```

### Tests

`OverlayFetchTransport.test.js` (4) pins the **transport**, not the plumbing, so it keeps meaning something if the fetch is ever rewritten off jQuery: no `jsonp` dataType, no callback parameter requested, no callback smuggled into the URL, and the URL used is the one the admin interface supplied (never derived client-side — the tracker's base URL is where it *logs*, which need not be where reporting lives).

Mutation-checked per consumer: reverting Heatmap or Player independently reddens exactly its own case.

JS suite **240 green** across 28 suites; bundles rebuilt with **zero** `jsonp` references remaining in `owa.tracker.js`, `owa.heatmap.js` or `owa.player.js`.

### Follow-up, not in this PR

The **server-side** JSONP support (`RestApi::pre()`, `Json.php`, the `jsonpCallback` param, and the strip in `isSignatureValid`) still exists and now has no in-tree caller. Removing it closes the same-origin bypass completely, but it is a public API contract change that could break an undocumented third-party integration — so it deserves its own decision rather than riding along here.

---

## Added since first review: cross-origin coverage, and a bug it found

`tests/e2e/overlay-cross-origin.spec.js` now drives both overlays in a real
browser against a real API on a **different origin** — the property JSONP existed
to provide, which nothing exercised. Two origins come from one server:
`http://localhost:PORT` and `http://127.0.0.1:PORT` are different origins, so the
browser sends a real `Origin` header and enforces the response headers for real.

Writing it surfaced a regression from #1020, fixed here in its own commit:
`makeOverlayApiLink()` replaced `makeApiLink( $params, true, true )` but passed
`add_state` as **false**, so both overlay links lost their `siteId`.

It failed asymmetrically, which is why it survived review:

| | route requires `siteId`? | result |
|---|---|---|
| player | yes | clean **422**, visibly broken |
| heatmap | no | **200** for a query with no site filter and a defaulted period — the wrong clicks, reported as success |

The heatmap half had no status code, no console error and nothing in the DOM to
distinguish it from working. `tests/OverlayApiLinkTest.php` pins the seam the e2e
cannot reach: the spec builds its URL directly, so it tests what the API does
with a `siteId`, not whether the admin side puts one there.

**Mutation-checked.** Breaking the origin matcher reddens all three e2e cases;
restoring JSONP in `Player.js` reddens the player case (a script tag issues no
XHR); reverting `add_state` reddens the two `siteId` unit assertions.

Two environment notes are recorded in the files rather than left to be
rediscovered: Chrome's **Local Network Access** check refuses requests into the
loopback address space *before* CORS is consulted — indistinguishable from a
missing `Access-Control-Allow-Origin`, and an artifact of the harness rather than
the product — and the player's route lives in the **Domstream module**, which a
stock install does not activate.

### Still out of scope here
Server-side JSONP removal (`RestApi::pre()`, `Json.php`, the `jsonpCallback`
param) remains a separate decision — it is a public API contract change.
