### PR TITLE
Remove JSONP from the server

### DIFF
--- a/Core/Auth.php
+++ b/Core/Auth.php
@@ -597,7 +597,10 @@ class Auth extends \OWA\Core\Base {
     
     function isSignatureValid( $signature, $apiKey, $requestUrl ) {
 	    
-	    $requestUrl = \OWA\Core\Lib::removeQueryParamFromUrl( $requestUrl, 'owa_jsonpCallback' );
+		// '_' is jQuery's cache-buster, appended after the URL is signed, so it
+		// must stay excluded. owa_jsonpCallback was excluded for the same reason
+		// and is gone with JSONP -- keeping the carve-out would leave a param
+		// that could be set to anything without invalidating the signature.
 		$requestUrl = \OWA\Core\Lib::removeQueryParamFromUrl( $requestUrl, '_' );
 		
 	    

--- a/Core/Lib.php
+++ b/Core/Lib.php
@@ -1235,7 +1235,6 @@ class Lib {
         $content_types = array('html' => 'text/html',
                                'xml' => 'text/xml',
                                'json' => 'application/json',
-                               'jsonp' => 'application/json',
                                'csv' => 'text/csv');
 
         if (array_key_exists($type, $content_types)) {

--- a/Core/View/Json.php
+++ b/Core/View/Json.php
@@ -30,24 +30,11 @@ class Json extends \OWA\Core\View {
         $this->t->set_template('wrapper_blank.php');
         $this->body->set_template('json.php');
 
-        // look for jsonp callback
-        $callback = $this->get('jsonpCallback');
+        // JSON only. The JSONP variant interpolated a caller-supplied callback
+        // name straight into a script body -- reflected XSS on top of being a
+        // same-origin-policy bypass.
+        $this->body->set('json', json_encode( $this->get( 'json' ) ) );
 
-        // if not found look on the request scope.
-        if ( ! $callback ) {
-            $callback = \OWA\Core\CoreAPI::getRequestParam('jsonpCallback');
-        }
-
-        if ( $callback ) {
-            $body = sprintf("%s(%s);", $callback, json_encode( $this->get( 'json' ) ) );
-            $type = 'jsonp';
-        } else {
-            $body = json_encode( $this->get( 'json' ) );
-            $type = 'json';
-        }
-
-        $this->body->set('json', $body);
-
-        \OWA\Core\Lib::setContentTypeHeader( $type );
+        \OWA\Core\Lib::setContentTypeHeader( 'json' );
     }
 }

--- a/Core/View/Json.php
+++ b/Core/View/Json.php
@@ -30,9 +30,9 @@ class Json extends \OWA\Core\View {
         $this->t->set_template('wrapper_blank.php');
         $this->body->set_template('json.php');
 
-        // JSON only. The JSONP variant interpolated a caller-supplied callback
-        // name straight into a script body -- reflected XSS on top of being a
-        // same-origin-policy bypass.
+        // JSON only. JSONP wrapped this same body in a caller-named function so
+        // it could be loaded with a <script> tag -- a same-origin-policy bypass,
+        // and unnecessary now the overlays fetch over CORS.
         $this->body->set('json', json_encode( $this->get( 'json' ) ) );
 
         \OWA\Core\Lib::setContentTypeHeader( 'json' );

--- a/Core/View/RestApi.php
+++ b/Core/View/RestApi.php
@@ -40,22 +40,13 @@ class RestApi extends \OWA\Core\View {
 	 *
 	 */
     function pre() {
-	   
-	   // look for jsonp callback
-        $callback = $this->get('jsonpCallback');
 
-        // if not found look on the request scope.
-        if ( ! $callback ) {
-            $callback = \OWA\Core\CoreAPI::getRequestParam('jsonpCallback');
-        }
-
-        if ( $callback ) {
-            $this->body->set('callback', $callback);
-            $type = 'jsonp';
-        } else {
-            
-            $type = 'json';
-        }
+        // The response is JSON. It was optionally JSONP -- the same body wrapped
+        // in a caller-named function so it could be loaded as a <script> and
+        // execute on any page on the internet. The two overlays that needed it
+        // now fetch over CORS, so the wrapper only widened who could read the
+        // response, and the callback name went into the body unescaped.
+        $type = 'json';
 
 	   // set header if the request is from the API endpoint. Could be an internal request.
 	   

--- a/Core/View/RestApi.php
+++ b/Core/View/RestApi.php
@@ -42,10 +42,10 @@ class RestApi extends \OWA\Core\View {
     function pre() {
 
         // The response is JSON. It was optionally JSONP -- the same body wrapped
-        // in a caller-named function so it could be loaded as a <script> and
-        // execute on any page on the internet. The two overlays that needed it
+        // in a caller-named function so it could be loaded with a <script> tag,
+        // which is a same-origin-policy bypass. The two overlays that needed it
         // now fetch over CORS, so the wrapper only widened who could read the
-        // response, and the callback name went into the body unescaped.
+        // response.
         $type = 'json';
 
 	   // set header if the request is from the API endpoint. Could be an internal request.

--- a/modules/Base/Classes/PaginatedResultSet.php
+++ b/modules/Base/Classes/PaginatedResultSet.php
@@ -396,7 +396,6 @@ class PaginatedResultSet {
 
         $formats = array('html' => 'resultSetToHtml',
                          'json'    =>    'resultSetToJson',
-                         'jsonp' => 'resultSetToJsonp',
                          'xml'    =>    'resultSetToXml',
                          'php'    =>    'resultSetToSerializedPhp',
                          'csv'    =>    'resultSetToCsv',
@@ -428,12 +427,6 @@ class PaginatedResultSet {
 
     //json formatting has been moved to owa_jsonView
     function resultSetToJson() {
-
-        return $this;
-    }
-
-    //json formatting has been moved to owa_jsonView
-    function resultSetToJsonp($callback = '') {
 
         return $this;
     }

--- a/modules/Base/Controller/ApiRequest.php
+++ b/modules/Base/Controller/ApiRequest.php
@@ -86,16 +86,11 @@ class ApiRequest extends \OWA\Core\Controller {
         $output = \OWA\Core\CoreAPI::executeApiCommand($map);
 
         // assign to a view for output
-        if ( $format === 'json' || $format === 'jsonp') {
+        if ( $format === 'json' ) {
 
             $this->setView( 'base.json' );
             $this->set( 'json', $output );
             $this->set( 'format', $format );
-
-            if ( $format ==='jsonp' ) {
-
-                $this->set('jsonpCallback', $this->getParam('jsonpCallback') );
-            }
 
         } else {
             //@todo move this to a generic raw output view.

--- a/modules/Base/templates/restApiResponse.php
+++ b/modules/Base/templates/restApiResponse.php
@@ -16,11 +16,5 @@ if ( isset( $view->response_data ) ) {
 	$_response['data'] = $view->response_data;
 }
 
-if ( isset( $view->callback ) && ! empty( $view->callback) ) {
-	
-	echo sprintf("%s(%s);", $view->callback, json_encode( $_response ) );	
-} else {
-
-	echo json_encode( $_response );
-}
+echo json_encode( $_response );
 ?>

--- a/tests/CorsOriginMatchTest.php
+++ b/tests/CorsOriginMatchTest.php
@@ -14,9 +14,11 @@ use PHPUnit\Framework\TestCase;
  *
  * An array is never identical to a string, so `continue` always fired, the
  * loop always fell through, and no Access-Control-Allow-Origin was ever sent.
- * Cross-origin REST calls have therefore never worked, which is why playback
- * still depends on JSONP -- a transport that exists precisely to evade the
- * same-origin policy CORS is meant to satisfy properly.
+ * Cross-origin REST calls had therefore never worked, which is why playback
+ * depended on JSONP -- a transport that exists precisely to evade the
+ * same-origin policy CORS is meant to satisfy properly. With this fixed and
+ * covered end to end, JSONP has been removed from both the overlays and the
+ * server.
  *
  * Matching is on HOST, not on the stored string. Real installs store
  * `http://demo.openwebanalytics.com` while serving over https, so a browser

--- a/tests/RequestSignatureTest.php
+++ b/tests/RequestSignatureTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * What the request signature covers -- and what used to be carved out of it.
+ *
+ * isSignatureValid() strips certain parameters before recomputing the HMAC,
+ * because they are appended by the client *after* the URL is signed. Each strip
+ * is a hole by construction: a stripped parameter can be set to anything without
+ * invalidating the signature.
+ *
+ *   '_'                  jQuery's cache-buster. Still needed, still stripped.
+ *   'owa_signature'      cannot be part of what it signs.
+ *   'owa_jsonpCallback'  REMOVED with JSONP. It existed because jQuery appended
+ *                        the callback name after signing.
+ *
+ * That last one is why this file exists. The callback name was interpolated
+ * straight into a script body, so an exempt-from-signature parameter that lands
+ * unescaped in executable output is the worst combination available -- and it
+ * would have outlived the feature that needed it, since nothing else referenced
+ * it once the overlays moved to CORS.
+ *
+ * This is a unit test rather than an e2e case on purpose: over HTTP an appended
+ * parameter answers 401 whether or not the exemption is present (the exemption
+ * only decides *why*), so an end-to-end assertion would pass either way. The
+ * signature function is where the difference is observable.
+ */
+final class RequestSignatureTest extends TestCase
+{
+    private const KEY = 'deadbeefdeadbeefdeadbeefdeadbeef';
+
+    private \OWA\Core\Auth $auth;
+    private string $signed;
+    private string $signature;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        $this->auth = new \OWA\Core\Auth();
+
+        $base = 'http://owa.example.com/api/index.php'
+            . '?owa_rest_params=base/v1/sites&owa_apiKey=' . self::KEY;
+
+        $this->signature = $this->auth->generateSignature($base, self::KEY);
+        $this->signed    = $base . '&owa_signature=' . urlencode($this->signature);
+    }
+
+    private function valid(string $url): bool
+    {
+        return (bool) $this->auth->isSignatureValid($this->signature, self::KEY, $url);
+    }
+
+    public function testASignedUrlValidates(): void
+    {
+        $this->assertTrue($this->valid($this->signed));
+    }
+
+    /**
+     * The property the removal buys: no parameter may be bolted on afterwards.
+     */
+    public function testAParameterAppendedAfterSigningInvalidatesTheSignature(): void
+    {
+        $this->assertFalse(
+            $this->valid($this->signed . '&owa_jsonpCallback=owaEvil'),
+            'owa_jsonpCallback must no longer be exempt from the signature'
+        );
+    }
+
+    /**
+     * Not special to that one name -- the point is that nothing is exempt, so an
+     * arbitrary added parameter must fail the same way.
+     */
+    public function testAnArbitraryAppendedParameterAlsoInvalidatesIt(): void
+    {
+        $this->assertFalse($this->valid($this->signed . '&owa_anything=1'));
+        $this->assertFalse($this->valid($this->signed . '&owa_siteId=someone-elses-site'));
+    }
+
+    /**
+     * The cache-buster must stay exempt. jQuery appends `_` after signing, so
+     * removing this strip would break every signed request it makes -- the
+     * mirror image of the mistake above, and the reason the strips cannot simply
+     * all be deleted.
+     */
+    public function testTheCacheBusterRemainsExempt(): void
+    {
+        $this->assertTrue(
+            $this->valid($this->signed . '&_=1699999999999'),
+            "jQuery's cache-buster is appended after signing and must stay exempt"
+        );
+    }
+
+    public function testATamperedSignatureIsRefused(): void
+    {
+        $this->assertFalse(
+            (bool) $this->auth->isSignatureValid('not-the-signature', self::KEY, $this->signed)
+        );
+    }
+}

--- a/tests/RequestSignatureTest.php
+++ b/tests/RequestSignatureTest.php
@@ -15,11 +15,10 @@ use PHPUnit\Framework\TestCase;
  *   'owa_jsonpCallback'  REMOVED with JSONP. It existed because jQuery appended
  *                        the callback name after signing.
  *
- * That last one is why this file exists. The callback name was interpolated
- * straight into a script body, so an exempt-from-signature parameter that lands
- * unescaped in executable output is the worst combination available -- and it
- * would have outlived the feature that needed it, since nothing else referenced
- * it once the overlays moved to CORS.
+ * That last one is why this file exists. The exemption would have outlived the
+ * feature that needed it -- nothing referenced owa_jsonpCallback once the
+ * overlays moved to CORS -- leaving a parameter permanently outside the
+ * signature for no reason at all.
  *
  * This is a unit test rather than an e2e case on purpose: over HTTP an appended
  * parameter answers 401 whether or not the exemption is present (the exemption

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -76,6 +76,7 @@ anchor, so the tracker's `checkForOverlaySession()` → `startOverlaySession()` 
 dynamic-import of `Heatmap.js` runs exactly as in production.
 
 This test needs **no DB seeding** — it drives the client-side render only (the
-subsequent click-data JSONP fetch is not asserted). It shares the same
+subsequent click-data fetch is asserted separately, cross-origin, by
+`overlay-cross-origin.spec.js`). It shares the same
 `OWA_E2E_BASE_URL` / public-URL target as the dashboard tests because the
 harness must be served from under that install's webroot.

--- a/tests/e2e/overlay-heatmap.spec.js
+++ b/tests/e2e/overlay-heatmap.spec.js
@@ -20,9 +20,10 @@
  * WHAT IT ASSERTS (and what it deliberately does not)
  * Only the synchronous, deterministic jQuery-built DOM: the control panel, its
  * three controls, the toggled "active" class, and the canvas element. The
- * subsequent click-data fetch is an async JSONP call against live data; it is
- * not part of the "does jQuery 3.x still build the overlay" contract and is not
- * asserted (it simply never calls back in this harness).
+ * subsequent click-data fetch is an async call against live data; it is not
+ * part of the "does jQuery 3.x still build the overlay" contract and is not
+ * asserted here. It is covered on its own, cross-origin and against a real API,
+ * by overlay-cross-origin.spec.js.
  */
 
 const fs = require('fs');

--- a/tests/e2e/rest-routes.spec.js
+++ b/tests/e2e/rest-routes.spec.js
@@ -304,4 +304,50 @@ test.describe('every registered REST route answers over HTTP @selfhost-only', ()
             expect(res.status(), `same-origin request failed: ${await res.text()}`).not.toBe(401);
         });
     });
+
+    /**
+     * JSONP is gone from the server, not just from the two overlays.
+     *
+     * It was never a documented part of the API. What it did was wrap the same
+     * JSON body in a caller-named function so the response could be loaded with
+     * a <script> tag -- which made every endpoint readable by any page on the
+     * internet, with the response executing in that page's context. CORS is the
+     * mechanism that grants the same access deliberately, to named origins, and
+     * it works now.
+     *
+     * Asserted over real HTTP rather than as a unit test because a callback
+     * wrapper is a property of the response body and its Content-Type, and both
+     * are produced by the view layer that only runs on a real request.
+     *
+     * The other half of the removal -- that owa_jsonpCallback is no longer
+     * exempt from the request signature -- is covered by
+     * tests/RequestSignatureTest.php. It cannot be asserted here: an appended
+     * parameter yields 401 whether or not the exemption exists, so an e2e case
+     * for it would pass either way.
+     */
+    test.describe('JSONP is not served', () => {
+
+        test('a jsonpCallback parameter does not produce executable script', async ({ request }) => {
+            const root = installRoot(test.info().project.use.baseURL);
+
+            // Signed WITH the parameter, so this reaches the view rather than
+            // being turned away for a bad signature.
+            const url = routeUrl(root, 'base/v1/sites', 'owa_jsonpCallback=owaEvil', creds);
+
+            const res = await request.fetch(url, { method: 'GET' });
+            const body = await res.text();
+
+            expect(res.status(), `request failed: ${body}`).not.toBe(401);
+
+            // The whole risk in one assertion: the body must not be a call.
+            expect(body.trimStart().startsWith('owaEvil('),
+                `the response was wrapped in a JSONP callback: ${body.slice(0, 120)}`).toBe(false);
+            expect(body).not.toContain('owaEvil');
+
+            // and it must still be JSON, both in fact and in what it claims.
+            expect(String(res.headers()['content-type'] || '')).toContain('application/json');
+            expect(() => JSON.parse(body), 'the response did not parse as JSON').not.toThrow();
+        });
+
+    });
 });


### PR DESCRIPTION
Follow-up to #1024, which stopped the two overlays *asking* for JSONP. This removes the server's ability to *serve* it. It was never a documented part of the API.

## Why

JSONP wraps the same JSON body in a caller-named function so the response can be loaded with a `<script>` tag. That is a same-origin-policy bypass by design: every endpoint becomes readable by any page on the internet, with the response executing in that page's context. CORS grants the same access deliberately, to named origins, and it works now (#1019, #1023, #1024).

One removal stands on its own merits. **`isSignatureValid()` exempted `owa_jsonpCallback` from the request signature**, stripping it before recomputing the HMAC, because jQuery appended the callback name *after* the URL was signed. Every strip narrows what the signature covers, so an exemption that outlives the feature needing it leaves a parameter permanently outside the signature for no reason. `_` stays stripped: it is jQuery's cache-buster and is still appended after signing.

## What was removed

| file | what |
|---|---|
| `Core/View/RestApi.php` | callback lookup in `pre()`; response is always JSON |
| `Core/View/Json.php` | the callback branch |
| `modules/Base/templates/restApiResponse.php` | the callback output path |
| `modules/Base/Controller/ApiRequest.php` | the `jsonp` format and `jsonpCallback` param |
| `modules/Base/Classes/PaginatedResultSet.php` | `jsonp` format + `resultSetToJsonp()` |
| `Core/Lib.php` | the `jsonp` content type |
| `Core/Auth.php` | the signature exemption |

`resultSetToJsonp()` was a no-op returning `$this`, and its only caller `formatResults()` is called from nowhere. No module registers a legacy API method, so `base.apiRequest`'s `format` branch has nothing to dispatch to in practice.

## Tests

- `rest-routes.spec.js` — over real HTTP, `owa_jsonpCallback=owaEvil` must produce neither a callback wrapper nor a non-JSON content type. Asserted end to end because a wrapper is a property of the body *and* its `Content-Type`, both produced by the view layer.
- `tests/RequestSignatureTest.php` — the signature half, deliberately a **unit** test: over HTTP an appended parameter answers 401 whether or not the exemption is present, so an e2e case would pass either way. My first draft *was* that vacuous e2e case — it passed against the restored exemption, so it was replaced.

**Mutation-checked, one mutation at a time** (applying both at once misattributed the failures — the restored exemption broke the signature in the wrapper test, masking what was actually being measured):

| mutation | expected | observed |
|---|---|---|
| restore the callback wrapper | e2e reddens on the wrapper assertion | ✅ fails on that assertion, at status 200 |
| restore the signature exemption | exactly one `RequestSignatureTest` assertion reddens | ✅ 1 of 5 fails |

Full local run: PHPUnit 696 green, Jest 240 green, all three PHPStan configs clean, self-host e2e 94 passed. The one e2e failure is `event-queue-processing` (file queue not draining), which reproduces with all these changes stashed and passes in CI — pre-existing and unrelated.

## Compatibility

Any caller passing `owa_jsonpCallback` now receives plain JSON with `Content-Type: application/json` rather than executable script. Undocumented, and the only in-tree consumers were the two overlays, already migrated.
