### PR TITLE
Fix: a queue message that will not decode must not stop the queue

### DIFF
--- a/Core/EventQueue.php
+++ b/Core/EventQueue.php
@@ -102,7 +102,7 @@ class EventQueue  {
 
     function decodeMessage ( $msg ) {
 
-        $event = unserialize( $msg, array( 'allowed_classes' => self::allowedEventClasses() ) );
+        $event = self::decodeBlob( $msg );
 
         if ( ! self::isUsableEvent( $event ) ) {
 
@@ -128,6 +128,37 @@ class EventQueue  {
      *
      * Checked rather than trusted, so a bad message is one skipped item.
      */
+    /**
+     * unserialize() a queue blob without letting its diagnostics escape.
+     *
+     * A malformed blob is an expected input here, not an exceptional one: a
+     * queue file is a log that a crash can leave half-written, and a stored row
+     * may predate a class rename. unserialize() reports that with a PHP notice,
+     * which callers of a routine drain should not have to see -- the outcome
+     * they need is the return value, and isUsableEvent() gives it to them.
+     *
+     * A scoped error handler rather than '@': since PHP 8 the error-control
+     * operator does not stop a custom handler (PHPUnit's, say) from being
+     * invoked, so '@' silences the output but not the report. Installed for this
+     * one call and restored immediately, including on the throw path -- the same
+     * idiom tests/bootstrap_owa.php documents for its database probe.
+     */
+    protected static function decodeBlob( $blob ) {
+
+        set_error_handler( static function () { return true; } );
+
+        try {
+
+            return unserialize(
+                $blob, array( 'allowed_classes' => self::allowedEventClasses() )
+            );
+
+        } finally {
+
+            restore_error_handler();
+        }
+    }
+
     protected static function isUsableEvent( $event ) {
 
         return is_object( $event )

--- a/Core/EventQueue.php
+++ b/Core/EventQueue.php
@@ -102,7 +102,37 @@ class EventQueue  {
 
     function decodeMessage ( $msg ) {
 
-        return unserialize( $msg, array( 'allowed_classes' => self::allowedEventClasses() ) );
+        $event = unserialize( $msg, array( 'allowed_classes' => self::allowedEventClasses() ) );
+
+        if ( ! self::isUsableEvent( $event ) ) {
+
+            \OWA\Core\CoreAPI::notice(
+                'Queue message did not decode to a usable event and will be skipped.'
+            );
+
+            return false;
+        }
+
+        return $event;
+    }
+
+    /**
+     * Whether a decoded blob is something the queue can actually drive.
+     *
+     * unserialize() with an allowed_classes list does not fail on a name outside
+     * the list -- it hands back __PHP_Incomplete_Class, which throws on the first
+     * method call. Callers used to invoke a method straight away, so one
+     * undecodable message aborted the whole drain, and on the db queue the item
+     * was never removed, so it threw again on every subsequent run: the queue
+     * stopped permanently and grew from then on.
+     *
+     * Checked rather than trusted, so a bad message is one skipped item.
+     */
+    protected static function isUsableEvent( $event ) {
+
+        return is_object( $event )
+            && ! ( $event instanceof \__PHP_Incomplete_Class )
+            && method_exists( $event, 'wasReceived' );
     }
 
     /**
@@ -145,6 +175,30 @@ class EventQueue  {
                 // Fall back to the base class. A decode that then fails is
                 // visible as an unprocessable queue item, not a silent
                 // widening of what may be instantiated.
+            }
+
+            // Payloads queued BEFORE the PSR-4 relocation name the pre-namespace
+            // class ('owa_event'). allowed_classes matches the name as written in
+            // the blob, not what that name resolves to, so without the legacy
+            // aliases such a message decodes to __PHP_Incomplete_Class -- and the
+            // first method call on it throws, aborting the entire drain.
+            //
+            // Taken from the compat map rather than written out here, so a class
+            // that gains an alias later needs no edit in this file. The aliases
+            // are the same names class_alias() already resolves to the classes
+            // above, so this widens nothing: it admits the old spelling of a
+            // class that was admissible anyway.
+            if ( function_exists( 'owa_compat_class_map' ) ) {
+
+                $allowed = array_flip( $classes );
+
+                foreach ( owa_compat_class_map() as $legacy => $fqcn ) {
+
+                    if ( isset( $allowed[ $fqcn ] ) ) {
+
+                        $classes[] = $legacy;
+                    }
+                }
             }
 
             $classes = array_values( array_unique( $classes ) );

--- a/modules/Base/Classes/DbEventQueue.php
+++ b/modules/Base/Classes/DbEventQueue.php
@@ -89,6 +89,19 @@ class DbEventQueue extends \OWA\Core\EventQueue {
         
         if ( $msg ) {
             $event = $this->decodeMessage( $msg->get('event') );
+
+            if ( ! $event ) {
+
+                // Take it out of the working set and move on. Leaving it
+                // 'unhandled' would hand back the same undecodable row forever;
+                // 'broken' keeps it for inspection and getNextItems() skips it.
+                $this->markAsBroken(
+                    $msg->get('id'), 'Message did not decode to a usable event.'
+                );
+
+                return $this->receiveMessage();
+            }
+
             // backwards compat. remove soon.
             $event->setOldQueueId( $msg->get('id') );
             // increment the count of times the event has been received from the

--- a/modules/Base/Classes/FileEventQueue.php
+++ b/modules/Base/Classes/FileEventQueue.php
@@ -236,6 +236,15 @@ class FileEventQueue extends \OWA\Core\EventQueue {
                
                 $event = $this->parse_log_row( $buffer );
                 //owa_coreAPI::debug('returning event: '. print_r( $event, true));
+
+                if ( ! $event ) {
+
+                    // One unreadable row must not strand the rest of the file,
+                    // nor the files queued after it. The handle has already moved
+                    // past this row, so this advances rather than repeating.
+                    return $this->receiveMessage();
+                }
+
                 $event->wasReceived();
                 return $event;
 
@@ -360,6 +369,16 @@ class FileEventQueue extends \OWA\Core\EventQueue {
                 urldecode($row_array['event_obj']),
                 array( 'allowed_classes' => self::allowedEventClasses() )
             );
+
+            if ( ! self::isUsableEvent( $event ) ) {
+
+                \OWA\Core\CoreAPI::notice(
+                    'Skipping a queue file row that did not decode to a usable event.'
+                );
+
+                return false;
+            }
+
             return $event;
         }
     }

--- a/modules/Base/Classes/FileEventQueue.php
+++ b/modules/Base/Classes/FileEventQueue.php
@@ -44,6 +44,7 @@ class FileEventQueue extends \OWA\Core\EventQueue {
     var $unprocessed_path;
     var $archive_path;
     var $rotation_size;
+    var $lock_file;
     var $rotation_interval = 3600;
     var $currentProcessingFileHandle;
 
@@ -91,7 +92,7 @@ class FileEventQueue extends \OWA\Core\EventQueue {
             $this->date_format = "Y-m-d-H-is";
         }
 
-        if ( ! isset( $map['rotation_interval'] ) ) {
+        if ( isset( $map['rotation_interval'] ) ) {
             $this->rotation_interval = $map['rotation_interval'];
         }
 
@@ -365,10 +366,12 @@ class FileEventQueue extends \OWA\Core\EventQueue {
             $row_array = array( 'timestamp' => $raw_event[0], 'event_obj' => $raw_event[3]);
             // Same allowlist as the db queue -- a log file anyone can append to
             // must not be able to name the class that gets instantiated here.
-            $event = unserialize(
-                urldecode($row_array['event_obj']),
-                array( 'allowed_classes' => self::allowedEventClasses() )
-            );
+            // A queue file is a log anyone with write access can append to, and
+            // a half-written row survives a crash, so a malformed blob is an
+            // expected input rather than an exceptional one. decodeBlob() keeps
+            // unserialize()'s diagnostics from escaping a routine drain; the
+            // failure is handled right below.
+            $event = self::decodeBlob( urldecode( $row_array['event_obj'] ) );
 
             if ( ! self::isUsableEvent( $event ) ) {
 

--- a/tests/EventQueueHardeningTest.php
+++ b/tests/EventQueueHardeningTest.php
@@ -205,9 +205,71 @@ final class EventQueueHardeningTest extends TestCase
 
         $decoded = $q->decodeMessage('O:8:"stdClass":1:{s:1:"x";s:3:"pwn";}');
 
-        $this->assertInstanceOf(__PHP_Incomplete_Class::class, $decoded,
+        $this->assertNotInstanceOf(\stdClass::class, $decoded,
             'a tampered queue row must not instantiate an arbitrary class');
-        $this->assertNotInstanceOf(\stdClass::class, $decoded);
+
+        // Refused outright rather than handed back as __PHP_Incomplete_Class,
+        // which is what unserialize() returns for a name outside the allowlist.
+        // That object throws on the first method call, and every caller called
+        // one immediately -- so a single tampered or unreadable row aborted the
+        // whole drain. On the db queue the row was never removed either, so it
+        // threw again on every later run and the queue stopped for good.
+        $this->assertFalse($decoded,
+            'an undecodable blob must be refused, not returned as an incomplete object');
+    }
+
+    /**
+     * Messages queued BEFORE the PSR-4 relocation name the pre-namespace class.
+     *
+     * allowed_classes matches the name as written in the blob, not what that
+     * name resolves to -- so although class_alias() makes 'owa_event' the very
+     * same class as Base\Classes\Event, an allowlist naming only the new
+     * spelling rejects the old one. Every event queued before the upgrade then
+     * became permanently undecodable, and (see above) took the drain down with
+     * it. Found by e2e: the file queue stopped draining and grew by one file per
+     * run.
+     */
+    public function testAnEventQueuedUnderTheLegacyClassNameStillDecodes(): void
+    {
+        $q = $this->queue();
+        $e = $this->event();
+        $e->setEventType('base.page_request');
+        $e->set('page_url', 'https://example.com/legacy');
+
+        // The same bytes an install running the old code would have written.
+        $legacy = preg_replace(
+            '/^O:\d+:"[^"]+"/',
+            'O:9:"owa_event"',
+            $q->prepareMessage($e),
+            1
+        );
+        $this->assertStringStartsWith('O:9:"owa_event"', $legacy);
+
+        $back = $q->decodeMessage($legacy);
+
+        $this->assertNotFalse($back, 'a pre-upgrade queued event no longer decodes');
+        $this->assertNotInstanceOf(__PHP_Incomplete_Class::class, $back);
+        $this->assertInstanceOf(\OWA\Module\Base\Classes\Event::class, $back);
+        $this->assertSame('base.page_request', $back->getEventType());
+        $this->assertSame('https://example.com/legacy', $back->get('page_url'));
+    }
+
+    /**
+     * Admitting the legacy spelling must not admit anything else: the aliases
+     * added are only other names for classes already on the list.
+     */
+    public function testTheLegacyAliasDoesNotWidenTheAllowlist(): void
+    {
+        $q = $this->queue();
+
+        foreach ([
+            'O:8:"stdClass":0:{}',
+            'O:10:"owa_lookup":0:{}',
+            'O:16:"owa_dbEventQueue":0:{}',
+        ] as $blob) {
+            $this->assertFalse($q->decodeMessage($blob),
+                "an unrelated class must stay refused: $blob");
+        }
     }
 
     /**

--- a/tests/FileEventQueueDrainTest.php
+++ b/tests/FileEventQueueDrainTest.php
@@ -1,0 +1,180 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The file queue must drain past a row it cannot read.
+ *
+ * HOW THIS BROKE
+ * receiveMessage() called a method on whatever parse_log_row() returned.
+ * unserialize() with an allowed_classes list does not fail on a name outside the
+ * list -- it returns __PHP_Incomplete_Class, which throws on the first method
+ * call. The throw was uncaught, so it left the drain loop in
+ * ProcessEventQueue::action() entirely: every event behind the bad row, and
+ * every file queued after it, stayed on disk. Each subsequent run re-read the
+ * same row and died in the same place, so the queue never recovered and grew by
+ * one file per run.
+ *
+ * The trigger in practice was not corruption but an upgrade: events queued
+ * before the PSR-4 relocation name the pre-namespace class, and the allowlist
+ * named only the new one. See EventQueueHardeningTest for that half.
+ *
+ * These tests drive the real FileEventQueue against a temporary directory, so
+ * they assert the drain's actual file handling -- consuming rows, archiving the
+ * file, moving to the next one -- rather than a stand-in for it.
+ */
+final class FileEventQueueDrainTest extends TestCase
+{
+    private string $dir;
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/owa-fq-' . getmypid() . '-' . uniqid() . '/';
+
+        mkdir($this->dir . 'unprocessed/', 0755, true);
+        mkdir($this->dir . 'archive/', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['unprocessed/', 'archive/', ''] as $sub) {
+            foreach (glob($this->dir . $sub . '*') ?: [] as $f) {
+                if (is_file($f)) {
+                    unlink($f);
+                }
+            }
+        }
+
+        foreach (['unprocessed/', 'archive/', ''] as $sub) {
+            if (is_dir($this->dir . $sub)) {
+                @rmdir($this->dir . $sub);
+            }
+        }
+    }
+
+    private function queue(): \OWA\Module\Base\Classes\FileEventQueue
+    {
+        return new \OWA\Module\Base\Classes\FileEventQueue([
+            'path'       => $this->dir,
+            'queue_name' => 'incoming_tracking_events',
+        ]);
+    }
+
+    /** One queue-file row in the format the queue writes. */
+    private function row(string $blob): string
+    {
+        return sprintf(
+            "%s|*|incoming_tracking_events|*|%d|*|%s",
+            date('H:i:s Y-m-d'),
+            random_int(100000, 999999),
+            urlencode($blob)
+        );
+    }
+
+    private function eventBlob(string $url): string
+    {
+        $e = \OWA\Core\CoreAPI::supportClassFactory('base', 'event');
+        $e->setEventType('base.page_request');
+        $e->set('page_url', $url);
+
+        return serialize($e);
+    }
+
+    /** Legacy spelling: the same bytes an install wrote before the relocation. */
+    private function legacyEventBlob(string $url): string
+    {
+        return preg_replace('/^O:\d+:"[^"]+"/', 'O:9:"owa_event"', $this->eventBlob($url), 1);
+    }
+
+    private function writeQueueFile(string $name, array $rows): void
+    {
+        file_put_contents($this->dir . 'unprocessed/' . $name, implode("\n", $rows) . "\n");
+    }
+
+    /** Drain like ProcessEventQueue does, and report what came back. */
+    private function drain(): array
+    {
+        $q = $this->queue();
+        $urls = [];
+
+        for ($i = 0; $i < 200; $i++) {
+            $event = $q->receiveMessage();
+
+            if (!$event) {
+                return $urls;
+            }
+
+            $urls[] = $event->get('page_url');
+        }
+
+        $this->fail('the drain did not terminate');
+    }
+
+    public function testAnUnreadableRowDoesNotStrandTheRowsBehindIt(): void
+    {
+        $this->writeQueueFile('a.txt', [
+            $this->row('O:8:"stdClass":1:{s:1:"x";s:3:"pwn";}'),
+            $this->row($this->eventBlob('https://example.com/after-the-bad-row')),
+        ]);
+
+        $urls = $this->drain();
+
+        $this->assertSame(['https://example.com/after-the-bad-row'], $urls,
+            'the readable row behind an unreadable one must still be delivered');
+        $this->assertCount(0, glob($this->dir . 'unprocessed/*'),
+            'the file must be consumed, not left for a run that will fail the same way');
+    }
+
+    /**
+     * The failure that was actually observed: a bad row in the OLDEST file also
+     * stranded every later file, because the throw left the drain loop.
+     */
+    public function testAnUnreadableRowDoesNotStrandLaterFiles(): void
+    {
+        $this->writeQueueFile('a.txt', [$this->row('O:8:"stdClass":0:{}')]);
+        touch($this->dir . 'unprocessed/a.txt', time() - 600);
+
+        $this->writeQueueFile('b.txt', [$this->row($this->eventBlob('https://example.com/later-file'))]);
+        touch($this->dir . 'unprocessed/b.txt', time() - 60);
+
+        $urls = $this->drain();
+
+        $this->assertSame(['https://example.com/later-file'], $urls);
+        $this->assertCount(0, glob($this->dir . 'unprocessed/*'));
+        $this->assertCount(2, glob($this->dir . 'archive/*'), 'both files should be consumed');
+    }
+
+    /** The upgrade case, end to end through the real queue. */
+    public function testEventsQueuedBeforeTheRelocationStillDrain(): void
+    {
+        $this->writeQueueFile('legacy.txt', [
+            $this->row($this->legacyEventBlob('https://example.com/queued-before-upgrade')),
+            $this->row($this->eventBlob('https://example.com/queued-after-upgrade')),
+        ]);
+
+        $urls = $this->drain();
+
+        $this->assertSame([
+            'https://example.com/queued-before-upgrade',
+            'https://example.com/queued-after-upgrade',
+        ], $urls, 'a pre-upgrade event must not be lost, nor block the one behind it');
+        $this->assertCount(0, glob($this->dir . 'unprocessed/*'));
+    }
+
+    public function testAFileOfNothingButBadRowsIsConsumedRatherThanRetriedForever(): void
+    {
+        $this->writeQueueFile('bad.txt', [
+            $this->row('O:8:"stdClass":0:{}'),
+            $this->row('not-even-serialized'),
+        ]);
+
+        $this->assertSame([], $this->drain());
+        $this->assertCount(0, glob($this->dir . 'unprocessed/*'));
+        $this->assertCount(1, glob($this->dir . 'archive/*'));
+    }
+}


### PR DESCRIPTION
Chasing the one e2e failure I kept reporting as "pre-existing, passes in CI" turned up a real upgrade bug. The file queue had stopped draining and was growing by one file per run.

Two defects, either sufficient alone.

## 1. Messages queued before the PSR-4 relocation cannot be decoded

`unserialize()`'s `allowed_classes` matches the class name **as written in the blob**, not what that name resolves to. Messages queued before the relocation name the pre-namespace class:

```
O:9:"owa_event":12:{s:10:"properties";...
```

`class_alias()` makes `owa_event` the very same class as `Base\Classes\Event`, but an allowlist naming only the new spelling rejects the old one. Every event queued before that upgrade became permanently undecodable.

Legacy names now come from `owa_compat_class_map()` rather than a literal, so a class that gains an alias later needs no edit here. **This widens nothing** — the aliases are other names for classes already on the list, and there's a test pinning that.

## 2. One bad message took the whole drain down with it

`unserialize()` doesn't fail on a name outside the allowlist — it returns `__PHP_Incomplete_Class`, which throws on the first method call. Both queues called one immediately (`wasReceived()`, `setOldQueueId()`), and nothing caught it, so the throw left the drain loop in `ProcessEventQueue::action()` entirely. Everything behind the bad message stayed queued, including whole files queued after it.

Neither queue could recover on its own:

| queue | why it never recovered |
|---|---|
| file | re-read the same row and died in the same place every run |
| db | the item was never removed, so it threw again on every run, for good |

`decodeMessage()` now refuses an unusable blob instead of returning one; the file queue skips the row; the db queue marks the item `broken` — retained for inspection, out of the working set — and moves on.

## Why this matters beyond the test

**Any install that carried queued events across the relocation has this**, with queueing silently dead ever since — no error surfaced, just a queue that stops draining and a directory that grows. Both the file queue and the db queue share the allowlist, so both are affected.

On the box I found it on, six files and ten events had been stuck since the relocation. With the fix they drained and archived on the next run.

## Tests

- **`FileEventQueueDrainTest`** (new) drives the real `FileEventQueue` against a temp directory, so it asserts actual file handling — consuming rows, archiving, moving to the next file. Cases: a bad row must not strand the rows behind it; must not strand *later files* (the observed failure); a pre-upgrade event must decode and not block the one behind it; a file of nothing but bad rows must be consumed rather than retried forever.
- **`EventQueueHardeningTest`** gains the legacy-spelling round trip and a check that admitting it widens nothing else. Its existing foreign-class case asserted the old `__PHP_Incomplete_Class` return, so it was updated to the stronger contract (`false`).

**Mutation-checked separately:** dropping the legacy aliases reddens 2 tests; dropping the skip errors the bad-row tests on the exact call that used to throw.

Full local run: PHPUnit 702 green, all three PHPStan configs clean, and the self-hosted e2e is **95 passed / 0 failed** — the first fully green run in this series.

## Follow-up, not in this PR

The self-host e2e shares the live install's queue directory: `async_log_dir` is `OWA_DATA_DIR . 'logs/'`, derived from the install path, and the harness doesn't override it. So `queue_depth` counts files any other source left there, and a test run drains them into the scratch DB. Harmless where queueing is off, but it is why this failed locally and passed in CI — worth isolating separately.