### PR TITLE
Let the config file set the paths reserved to it, and isolate the e2e queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ public/
 /.phpunit.cache/
 /test-results/
 /playwright-report/
+owa-data/e2e-selfhost-logs/

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -1181,8 +1181,31 @@ namespace OWA\Module\Base\Classes;
         $this->set('base','log_url',$public_url.'log.php');
         $this->set('base','rest_api_url',$public_url.'api/index.php');
 
-        $this->set('base', 'error_log_file', OWA_DATA_DIR . 'logs/errors_'. \OWA\Core\CoreAPI::generateInstanceSpecificHash() .'.txt');
-        $this->set('base', 'async_log_dir', OWA_DATA_DIR . 'logs/');
+        // Fill these only when nothing has already named a path.
+        //
+        // Both are declared config-file-only (configFileOnlySettings), which is
+        // what a stored value from a previous server would otherwise poison --
+        // so the config file is the ONE place they may be set. loadConfigFile()
+        // runs before this method, so setting them unconditionally here silently
+        // discarded whatever the file said, and the config-file-only contract
+        // could not be honoured by the config file.
+        //
+        // Their declared default is '' (see the defaults array), so "empty means
+        // nobody set it" is exactly the existing convention, and every install
+        // that does not set them is unaffected.
+        if ( ! $this->get( 'base', 'error_log_file' ) ) {
+
+            $this->set(
+                'base',
+                'error_log_file',
+                OWA_DATA_DIR . 'logs/errors_' . \OWA\Core\CoreAPI::generateInstanceSpecificHash() . '.txt'
+            );
+        }
+
+        if ( ! $this->get( 'base', 'async_log_dir' ) ) {
+
+            $this->set( 'base', 'async_log_dir', OWA_DATA_DIR . 'logs/' );
+        }
 
         \OWA\Core\CoreAPI::debug('check for http host');
         // Set cookie domain

--- a/tests/ConfigFileLogPathsTest.php
+++ b/tests/ConfigFileLogPathsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The config file must actually be able to set the paths reserved to it.
+ *
+ * error_log_file and async_log_dir are declared config-file-only
+ * (Settings::configFileOnlySettings): a value stored in the database is stripped
+ * on load, deliberately, so that a path naming a previous server cannot follow a
+ * database to a new one. The config file is therefore the ONE place they may be
+ * set.
+ *
+ * It could not set them. loadConfigFile() runs before setupPaths(), and
+ * setupPaths() assigned both unconditionally -- so whatever the file said was
+ * overwritten moments later, silently. A setting reserved to a channel that
+ * cannot write it is unsettable everywhere.
+ *
+ * WHY IT MATTERS BEYOND TIDINESS
+ * async_log_dir is where the event queue lives, and it is derived from the
+ * install directory rather than the database. Two installs sharing a directory
+ * therefore share a queue no matter how separate their databases are. The
+ * self-host e2e runner is exactly that case: it provisions a scratch database
+ * but wrote its queue into the live install's owa-data/logs/, so a spec's
+ * measurements counted other people's files and its drain consumed their events.
+ * That is now fixed by having the harness set async_log_dir -- which requires
+ * this.
+ *
+ * setupPaths() is private and runs during construction, so these drive it by
+ * reflection. That is the real method, not a restatement of it: a change that
+ * reintroduced the unconditional assignment would fail here.
+ */
+final class ConfigFileLogPathsTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function settings(): \OWA\Module\Base\Classes\Settings
+    {
+        // A fresh instance, so nothing here disturbs the booted one.
+        return new \OWA\Module\Base\Classes\Settings();
+    }
+
+    private function runSetupPaths(\OWA\Module\Base\Classes\Settings $s): void
+    {
+        $m = new \ReflectionMethod($s, 'setupPaths');
+        $m->setAccessible(true);
+        $m->invoke($s);
+    }
+
+    public function testAConfigFileValueForTheQueueDirectorySurvives(): void
+    {
+        $s = $this->settings();
+        $s->set('base', 'async_log_dir', '/tmp/owa-config-chosen-queue/');
+
+        $this->runSetupPaths($s);
+
+        $this->assertSame('/tmp/owa-config-chosen-queue/', $s->get('base', 'async_log_dir'),
+            'setupPaths() overwrote a path the config file had already set');
+    }
+
+    public function testAConfigFileValueForTheErrorLogSurvives(): void
+    {
+        $s = $this->settings();
+        $s->set('base', 'error_log_file', '/tmp/owa-config-chosen-errors.txt');
+
+        $this->runSetupPaths($s);
+
+        $this->assertSame('/tmp/owa-config-chosen-errors.txt', $s->get('base', 'error_log_file'));
+    }
+
+    /**
+     * The other half of the contract: an install that sets nothing still gets a
+     * working default. Their declared default is '', which is what "nobody set
+     * this" means here.
+     */
+    public function testTheDefaultStillAppliesWhenTheConfigFileSaysNothing(): void
+    {
+        $s = $this->settings();
+        $s->set('base', 'async_log_dir', '');
+        $s->set('base', 'error_log_file', '');
+
+        $this->runSetupPaths($s);
+
+        $this->assertSame(OWA_DATA_DIR . 'logs/', $s->get('base', 'async_log_dir'),
+            'an install that sets nothing must still get the default queue directory');
+        $this->assertStringStartsWith(OWA_DATA_DIR . 'logs/errors_', $s->get('base', 'error_log_file'));
+        $this->assertStringEndsWith('.txt', $s->get('base', 'error_log_file'));
+    }
+
+    /**
+     * Pins why the config file is the only channel: a stored value is dropped on
+     * load. If these ever stopped being config-file-only, a stale path could
+     * arrive from the database and the tests above would be guarding nothing.
+     */
+    public function testBothPathsRemainConfigFileOnly(): void
+    {
+        $only = \OWA\Module\Base\Classes\Settings::configFileOnlySettings();
+
+        $this->assertArrayHasKey('async_log_dir', $only['base']);
+        $this->assertArrayHasKey('error_log_file', $only['base']);
+
+        $stripped = \OWA\Module\Base\Classes\Settings::stripConfigFileOnlySettings([
+            'base' => [
+                'async_log_dir'  => '/some/previous/server/logs/',
+                'error_log_file' => '/some/previous/server/errors.txt',
+                'site_id'        => 'kept',
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('async_log_dir', $stripped['base']);
+        $this->assertArrayNotHasKey('error_log_file', $stripped['base']);
+        $this->assertSame('kept', $stripped['base']['site_id']);
+    }
+}

--- a/tests/e2e/event-queue-processing.spec.js
+++ b/tests/e2e/event-queue-processing.spec.js
@@ -88,9 +88,37 @@ test.describe('tracking events queue to a file and ingest on drain @selfhost-onl
         helper('disable-queue');
     });
 
+    /**
+     * The queue this spec measures must be this run's own.
+     *
+     * async_log_dir is a filesystem path derived from the install directory, NOT
+     * from the database, so pointing the run at a scratch DB does not move the
+     * file queue. Sharing it with the live install means queue_depth counts files
+     * anyone else left there and the drain consumes their events.
+     *
+     * That is why this spec failed locally and passed in CI for weeks -- a fresh
+     * checkout has an empty directory -- and it masked a real queue bug the whole
+     * time. Asserting the location makes a regression say so, instead of
+     * reappearing as an unexplained local-only failure.
+     */
+    test('the queue under test is this run\'s own, not the install default', () => {
+        const state = helper('state', `site=${HARNESS_SITE_ID}`);
+
+        expect(state.queue_dir, 'the helper reported no queue directory').toBeTruthy();
+        expect(state.queue_dir, 'the e2e queue must not be the install default owa-data/logs/')
+            .not.toMatch(/owa-data\/logs\/$/);
+        expect(state.queue_dir, 'the e2e queue must be the harness scratch directory')
+            .toContain('e2e-selfhost-logs');
+    });
+
     test('a beacon queues to the file queue, stays out of the facts, then ingests on drain', async ({ page }) => {
         // --- baseline -------------------------------------------------------
         const before = helper('state', `site=${HARNESS_SITE_ID}`);
+
+        // An isolated queue starts empty. Asserted rather than merely used as a
+        // baseline: a non-zero start means something else is writing here, which
+        // is the condition this isolation exists to rule out.
+        expect(before.queue_depth, `the run's own queue should start empty (${before.queue_dir})`).toBe(0);
 
         // --- fire the real built tracker beacon -----------------------------
         const beacons = [];

--- a/tests/e2e/queue_e2e_helper.php
+++ b/tests/e2e/queue_e2e_helper.php
@@ -123,6 +123,11 @@ function state(string $site_id): array
 {
     return [
         'site_id'     => $site_id,
+        // Reported so a spec can assert WHICH queue it just measured. async_log_dir
+        // is a filesystem path derived from the install directory, not from the
+        // database, so a scratch DB alone does not isolate the queue -- without
+        // this the depth silently counts whatever else shares the directory.
+        'queue_dir'   => (string) owa_coreAPI::getSetting('base', 'async_log_dir'),
         'queue_depth' => fileQueueDepth(),
         'fact_rows'   => countSiteRequests($site_id),
     ];

--- a/tests/e2e/selfhost_harness.php
+++ b/tests/e2e/selfhost_harness.php
@@ -64,6 +64,20 @@ const DEFAULT_PORT = '8964';
 const INSTALL_ADMIN_ID = 'owa-e2e-selfhost-admin@example.test';
 const INSTALL_DOMAIN    = 'owa-e2e-selfhost.example.test';
 
+// The file queue and error log this run may write to.
+//
+// WHY THIS IS NOT owa-data/logs/: async_log_dir is a filesystem path derived
+// from the install directory, not from the database, so a scratch DB alone does
+// NOT isolate the queue. Sharing it with the live install means the queue depth
+// a spec measures counts whatever anyone else left there, and a drain the spec
+// runs consumes the live install's queued events into the scratch DB.
+//
+// That is not hypothetical: it hid a real queue bug for weeks. The queue spec
+// failed here and passed in CI -- a fresh checkout has an empty directory, this
+// box did not -- so the failure read as local mess and was repeatedly dismissed
+// as environmental.
+const SCRATCH_LOG_DIR = 'owa-data/e2e-selfhost-logs/';
+
 $repoRoot = dirname(__DIR__, 2) . '/';
 $cmd = $argv[1] ?? 'info';
 
@@ -233,6 +247,14 @@ function up(string $repoRoot): array
     $backup = $repoRoot . BACKUP_FILE;
     $db     = scratchDb();
 
+    // Made here rather than left to FileEventQueue, whose mkdir() is not
+    // recursive and would fail on the missing parent.
+    $logDir = $repoRoot . SCRATCH_LOG_DIR;
+
+    if (!is_dir($logDir) && !mkdir($logDir, 0755, true) && !is_dir($logDir)) {
+        fail('Could not create the scratch log directory: ' . $logDir);
+    }
+
     if (file_exists($backup)) {
         fail('Stale backup ' . BACKUP_FILE . ' present -- a prior run did not tear down. Run `doctor` first.');
     }
@@ -373,10 +395,72 @@ function writeConfig(string $repoRoot, array $creds, string $db): void
         }
         $out .= $line;
     }
+    // Point the file queue and error log at this run's own directory.
+    //
+    // Set through the config file because both are config-file-only settings
+    // (Settings::configFileOnlySettings) -- a stored value is stripped on load,
+    // deliberately, so a path from a previous server cannot follow a database
+    // around. setupPaths() fills them only when unset, which is what lets this
+    // land.
+    //
+    // Spliced in BEFORE the template's closing tag, not appended: the template
+    // ends by closing PHP mode, so anything after that point is not code -- it
+    // is output, printed on every request and every CLI call, which corrupts the
+    // JSON these helpers return.
+    //
+    // (The closing tag is written only as a string literal below, never in a
+    // comment: a close-tag sequence ends PHP mode even inside a // comment, so
+    // spelling it out here would do to this file what it warns about.)
+    $override = "\n"
+        . "// Added by tests/e2e/selfhost_harness.php -- keeps this run's queue and\n"
+        . "// error log out of the live install's owa-data/logs/.\n"
+        . "\$this->set('base', 'async_log_dir', OWA_DIR . " . var_export(SCRATCH_LOG_DIR, true) . ");\n"
+        . "\$this->set('base', 'error_log_file', OWA_DIR . " . var_export(SCRATCH_LOG_DIR . 'errors.txt', true) . ");\n";
+
+    $close = strrpos($out, '?>');
+    $out = $close === false ? $out . $override : substr($out, 0, $close) . $override . substr($out, $close);
+
     if (file_put_contents($config, $out) === false) {
         fail('Failed to write ' . CONFIG_FILE);
     }
     @chmod($config, 0640);
+}
+
+/**
+ * Delete this run's log directory.
+ *
+ * Scoped to SCRATCH_LOG_DIR and refuses anything else, because a wrong path here
+ * would delete the live install's queue -- the very thing this exists to protect.
+ */
+function removeScratchLogs(string $repoRoot)
+{
+    $dir = $repoRoot . SCRATCH_LOG_DIR;
+
+    if (substr(SCRATCH_LOG_DIR, 0, 9) !== 'owa-data/' || strpos(SCRATCH_LOG_DIR, 'e2e') === false) {
+        return 'refused: SCRATCH_LOG_DIR is not a recognisable scratch path';
+    }
+
+    if (!is_dir($dir)) {
+        return 'absent';
+    }
+
+    $removed = 0;
+
+    foreach (['unprocessed/', 'archive/', ''] as $sub) {
+        foreach (glob($dir . $sub . '*') ?: [] as $f) {
+            if (is_file($f) && @unlink($f)) {
+                $removed++;
+            }
+        }
+    }
+
+    foreach (['unprocessed/', 'archive/', ''] as $sub) {
+        if (is_dir($dir . $sub)) {
+            @rmdir($dir . $sub);
+        }
+    }
+
+    return $removed . ' file(s)';
 }
 
 /** Shell out to the real CLI installer; return its combined output + exit code. */
@@ -439,6 +523,8 @@ function down(string $repoRoot): array
     } catch (\Throwable $e) {
         $done['dropped_db'] = 'skip: ' . $e->getMessage();
     }
+
+    $done['scratch_logs_removed'] = removeScratchLogs($repoRoot);
 
     if (file_exists($backup)) {
         if (file_exists($config)) { @unlink($config); }        // remove our scratch config


### PR DESCRIPTION
Task follow-up from #1026. `async_log_dir` is a **filesystem** path derived from the install directory, not from the database — so pointing the self-host e2e runner at a scratch DB never moved its event queue. It shared `owa-data/logs/` with the live install:

- the queue depth a spec measured counted files anyone else had left there;
- the drain it ran consumed the live install's queued events into the scratch database.

**This is why the queue bug in #1026 hid for weeks.** The spec failed locally and passed in CI — a fresh checkout has an empty directory, this box did not — so the failure read as local mess and I dismissed it as environmental three times before chasing it.

## The product change this needed first

`error_log_file` and `async_log_dir` are declared config-file-only (`configFileOnlySettings`): a value stored in the database is stripped on load, deliberately, so a path naming a previous server cannot follow a database to a new one. The config file is therefore the **only** place they may be set.

It could not set them. `loadConfigFile()` runs before `setupPaths()`, and `setupPaths()` assigned both unconditionally — so whatever the file said was overwritten moments later, silently. A setting reserved to a channel that cannot write it is unsettable everywhere.

`setupPaths()` now fills them only when nothing has already named a path. Their declared default is `''`, so "empty means nobody set it" is the existing convention and **no install that leaves them alone is affected**.

## The harness change

Writes both settings into the config it generates, creates the directory (`FileEventQueue`'s `mkdir` is not recursive and would fail on a missing parent), and removes it on teardown — refusing any path that is not a recognisable scratch one, since a wrong path there would delete the very queue this protects.

Made **assertable** rather than assumed: the queue helper reports the directory it measured, and the spec asserts it is this run's own *and that it starts empty*. A non-zero start means something else is writing there — exactly the condition being ruled out.

## Tests

- **`ConfigFileLogPathsTest`** (new) drives the real, private `setupPaths()` by reflection: a config-file value survives, an unset one still gets the default, and both settings remain config-file-only — if they stopped being, a stale path could arrive from the database and the rest would be guarding nothing.
- The spec's new case fails with *"must not be the install default"* when the harness override is removed.

**Mutation-checked:** restoring the unconditional assignment reddens 2 unit tests; dropping the harness override reddens the e2e guard with the right message.

## One thing worth knowing

My first attempt appended the override after the template's content and broke every helper's JSON output — the dist template ends by closing PHP mode, so the lines became literal output. The fix splices before it. Then the *comment explaining that* contained a literal close-tag sequence, which ends PHP mode **even inside a `//` comment**, and broke the file the same way it was warning about. The comment now spells it out only as a string literal.

Full local run: PHPUnit 706 green, three PHPStan configs clean, self-hosted e2e **96 passed / 0 failed**, live `owa-data/logs/` untouched, scratch directory removed, live config unmodified.