### PR TITLE
PDO driver, bound parameters, and strict SQL mode by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: npm test
 
   isolation:
-    name: Test isolation sweep (each file alone)
+    name: Test isolation sweep (each file alone, ${{ matrix.db_driver }})
     runs-on: ubuntu-latest
     # Observed between 1m38s and 3m23s.
     timeout-minutes: 20
@@ -99,8 +99,20 @@ jobs:
     # the whole suite in one process, so neither is visible in a normal run.
     # This job is deterministic where randomised ordering is not.
     #
+    # It is also where both database drivers are proven. PDO is the default
+    # wherever pdo_mysql is present, but mysqli remains supported until v2, and
+    # an installation without pdo_mysql falls back to it -- so a suite that only
+    # ever ran on one of them would let the other rot silently while still being
+    # what some installations use. 'mysql' selects PDO, 'mysqli' names the
+    # legacy driver explicitly; the harness writes the choice into the scratch
+    # config it generates.
+    #
     # It needs a real database: two of the registries that have caused this are
     # only read by DB-backed cases, which skip without one.
+    strategy:
+      fail-fast: false
+      matrix:
+        db_driver: ['mysql', 'mysqli']
     services:
       mysql:
         image: mysql:8.0
@@ -119,6 +131,7 @@ jobs:
       OWA_E2E_DB_USER: root
       OWA_E2E_DB_PASSWORD: ''
       OWA_E2E_DB_NAME: owa_isolation_sweep
+      OWA_E2E_DB_TYPE: ${{ matrix.db_driver }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -127,7 +140,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-          extensions: mbstring, intl, json, mysqli, gd
+          extensions: mbstring, intl, json, mysqli, pdo_mysql, gd
           tools: composer:v2
 
       - name: Install dependencies

--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -73,7 +73,52 @@ class CoreAPI {
      * does NOT need to be Composer-classmap-discoverable to load; and because
      * the file is untracked by OWA's git, a `git pull` upgrade never removes it.
      */
+    /**
+     * The driver name to actually load for a configured db_type.
+     *
+     * Every existing install has db_type = 'mysql', which historically meant the
+     * mysqli driver. It now means "MySQL", and PDO is used to reach it wherever
+     * pdo_mysql is available -- so installs get bound parameters without editing
+     * owa-config.php, and a host that has mysqli but NOT pdo_mysql keeps working
+     * instead of being left broken by an upgrade. That combination is unusual on
+     * distro-packaged PHP, where one package ships both, but it is entirely
+     * possible in containers and hand-built PHP, where extensions are enabled
+     * one at a time.
+     *
+     * Anything explicit is honoured as written:
+     *
+     *   'mysql'      MySQL, preferring PDO, falling back to mysqli   (default)
+     *   'mysqli'     force the mysqli driver
+     *   'pdo_mysql'  force MySQL over PDO
+     *   'pdo'        friendly alias for pdo_mysql
+     *   'pdo_pgsql'  Postgres over PDO, once a PgsqlDialect exists
+     *
+     * A third-party owa_db_<type> from the plugins/ seam is passed through
+     * untouched.
+     *
+     * @param string $type
+     * @return string
+     */
+    public static function resolveDbDriver($type) {
+
+        if ( $type === 'mysql' ) {
+
+            return extension_loaded('pdo_mysql') ? 'pdo_mysql' : 'mysqli';
+        }
+
+        // 'mysqli' names the legacy driver, whose class is owa_db_mysql.
+        if ( $type === 'mysqli' ) {
+
+            return 'mysql';
+        }
+
+        return $type;
+    }
+
     public static function setupStorageEngine($type) {
+
+        $type = self::resolveDbDriver($type);
+
 
 
 		if ( $type ) {
@@ -145,7 +190,7 @@ class CoreAPI {
             // OWA\Core\Db\Mysql) via the migration map so OWA runs bridge-free;
             // a third-party owa_db_<type> from the plugins/ seam keeps its
             // legacy name (setupStorageEngine required it in).
-            $connection_class = 'owa_db_'.$db_type;
+            $connection_class = 'owa_db_'.self::resolveDbDriver($db_type);
             $connection_class = \OWA\Core\Lib::resolveNamespacedClass($connection_class) ?? $connection_class;
             $db = new $connection_class(
                 \OWA\Core\CoreAPI::getSetting('base','db_host'),

--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -99,11 +99,24 @@ class CoreAPI {
      * @param string $type
      * @return string
      */
-    public static function resolveDbDriver($type) {
+    public static function resolveDbDriver($type, $pdo_available = null) {
+
+        // Injectable so the fallback can be tested on a machine that has
+        // pdo_mysql, which is every machine that runs the suite.
+        if ( $pdo_available === null ) {
+
+            $pdo_available = extension_loaded('pdo_mysql');
+        }
 
         if ( $type === 'mysql' ) {
 
-            return extension_loaded('pdo_mysql') ? 'pdo_mysql' : 'mysqli';
+            // Both arms must name a driver the loader can find: the caller
+            // turns this into the class owa_db_<type>. The legacy driver's own
+            // token is 'mysql' -- 'mysqli' is only an alias accepted from
+            // configuration, and naming it here produced owa_db_mysqli, which
+            // does not exist, so an installation without pdo_mysql could not
+            // load a driver at all.
+            return $pdo_available ? 'pdo_mysql' : 'mysql';
         }
 
         // 'mysqli' names the legacy driver, whose class is owa_db_mysql.

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -152,6 +152,22 @@ class Db extends \OWA\Core\Base {
      */
     var $_last_sql_statement;
 
+    /**
+     * Values bound to the statement being built, in placeholder order.
+     *
+     * ORDER IS THE WHOLE CONTRACT. Placeholders are positional, so binding N
+     * must be the Nth `?` in the finished SQL. That holds because the clause
+     * makers are evaluated as sprintf() ARGUMENTS in generateSelectQuerySql(),
+     * and PHP evaluates arguments left to right in the order the format string
+     * lays them out -- so the order they append in is the order they appear in.
+     * A future rearrangement that builds clauses into variables first, then
+     * assembles them in a different order, would silently transpose values
+     * between columns. DbBindingTest pins the order for exactly this reason.
+     *
+     * @var array
+     */
+    var $_bindings = array();
+
     function __construct($db_host, $db_port, $db_name, $db_user, $db_password, $open_new_connection = true, $persistant = false) {
 
         $this->connectionParams = array('host' => $db_host,
@@ -207,6 +223,60 @@ class Db extends \OWA\Core\Base {
      * @param string $string
      * @return string
      */
+    /**
+     * Record a value for binding and return the placeholder that stands for it.
+     *
+     * Replaces interpolating an escaped value into the SQL text. The value never
+     * becomes part of the statement, so it cannot change its structure -- which
+     * is the difference between being safe by construction and being safe
+     * because every caller remembered to call prepare().
+     *
+     * @param mixed $value
+     * @return string
+     */
+    function bindValue( $value ) {
+
+        // NULL IS WRITTEN AS AN EMPTY STRING, because that is what the escaping
+        // path did and a transport change must not alter stored data.
+        //
+        // The old route was prepare( null ) -- which returned null -- inlined by
+        // sprintf( "'%s'", null ), i.e. ''. So OWA has NEVER written a real SQL
+        // NULL through the builder: every unset value landed as '', and a
+        // permissive sql_mode then coerced that to 0 in an integer column.
+        //
+        // Binding a real NULL is more truthful and it silently broke things:
+        // owa_queue_item.not_before_timestamp became NULL instead of 0, and
+        // `not_before_timestamp < ?` is never true for NULL, so every queued
+        // event stopped being due. That is a data-semantics change wearing the
+        // clothes of a driver upgrade.
+        //
+        // Writing genuine NULLs is worth doing -- it needs a column-by-column
+        // review of which are nullable and which callers test for 0 versus '' --
+        // and it belongs with the strict-sql_mode work, not here.
+        $this->_bindings[] = $value === null ? '' : $value;
+
+        return '?';
+    }
+
+    /**
+     * Discard bindings from any previous statement.
+     *
+     * Called at the START of each generation entry point rather than only after
+     * execution, because SQL can be generated WITHOUT being run --
+     * generateSelectQuerySql() is public and the parity tests use it that way.
+     * Without this, bindings from a discarded statement would prepend
+     * themselves to the next one.
+     */
+    function resetBindings() {
+
+        $this->_bindings = array();
+    }
+
+    function getBindings() {
+
+        return $this->_bindings;
+    }
+
     function prepare_string($string) {
 
         $chars = array("\t", "\n");
@@ -410,6 +480,8 @@ class Db extends \OWA\Core\Base {
     }
 
     function _insertQuery() {
+
+        $this->resetBindings();
         \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
         $params = $this->_fetchSqlParams('set_values');
 
@@ -423,7 +495,7 @@ class Db extends \OWA\Core\Base {
         foreach ($params as $k => $v) {
 
             $sql_cols .= $v['name'];
-            $sql_values .= "'".$this->prepare($v['value'])."'";
+            $sql_values .= $this->bindValue( $v['value'] );
 
             $i++;
 
@@ -445,6 +517,8 @@ class Db extends \OWA\Core\Base {
     }
 
     function generateSelectQuerySql() {
+
+        $this->resetBindings();
 
         $cols = '';
         $i = 0;
@@ -496,6 +570,8 @@ class Db extends \OWA\Core\Base {
 
     function _updateQuery() {
 
+        $this->resetBindings();
+
         $params = $this->_fetchSqlParams('set_values');
 
         $count = count($params);
@@ -518,7 +594,7 @@ class Db extends \OWA\Core\Base {
 
             endif;
 
-            $set .= $this->prepare( $v['name'] ) .' = \'' . $this->prepare($v['value']) . '\'';
+            $set .= $this->prepare( $v['name'] ) . ' = ' . $this->bindValue( $v['value'] );
 
             $i++;
         }
@@ -529,6 +605,8 @@ class Db extends \OWA\Core\Base {
     }
 
     function _deleteQuery() {
+
+        $this->resetBindings();
 
         $this->_setSql(sprintf(OWA_SQL_DELETE_ROW, $this->_sqlParams['table'], $this->_makeWhereClause()));
 
@@ -603,33 +681,33 @@ class Db extends \OWA\Core\Base {
                 switch ( $op ) {
 
                     case '==':
-                        $constraint .= sprintf("%s = '%s'", $this->prepare( $v['name'] ), $this->prepare( $v['value'] ) );
+                        $constraint .= sprintf("%s = %s", $this->prepare( $v['name'] ), $this->bindValue( $v['value'] ) );
                         break;
 
                     case 'between':
-                        $constraint .= sprintf("%s BETWEEN '%s' AND '%s'", $this->prepare( $v['name'] ), $this->prepare( $v['value']['start'] ), $this->prepare( $v['value']['end'] ) );
+                        $constraint .= sprintf("%s BETWEEN %s AND %s", $this->prepare( $v['name'] ), $this->bindValue( $v['value']['start'] ), $this->bindValue( $v['value']['end'] ) );
                         break;
 
                     case '=~':
-                        $constraint .= sprintf("%s %s '%s'", $this->prepare( $v['name'] ), OWA_SQL_REGEXP, $this->prepare( $v['value'] ) );
+                        $constraint .= sprintf("%s %s %s", $this->prepare( $v['name'] ), OWA_SQL_REGEXP, $this->bindValue( $v['value'] ) );
                         break;
 
                     case '!~':
-                        $constraint .= sprintf("%s %s '%s'",$this->prepare( $v['name'] ), OWA_SQL_NOTREGEXP, $this->prepare( $v['value'] ) );
+                        $constraint .= sprintf("%s %s %s",$this->prepare( $v['name'] ), OWA_SQL_NOTREGEXP, $this->bindValue( $v['value'] ) );
                         break;
 
                     case '=@':
-                        $constraint .= sprintf("LOCATE('%s', %s) > 0",$this->prepare( $v['value'] ), $this->prepare( $v['name'] ) );
+                        $constraint .= sprintf("LOCATE(%s, %s) > 0",$this->bindValue( $v['value'] ), $this->prepare( $v['name'] ) );
                         break;
 
                     case '!@':
-                        $constraint .= sprintf("LOCATE('%s', %s) = 0",$this->prepare( $v['value'] ), $this->prepare( $v['name'] ) );
+                        $constraint .= sprintf("LOCATE(%s, %s) = 0",$this->bindValue( $v['value'] ), $this->prepare( $v['name'] ) );
                         break;
 
                     default:
                         // $op has already been validated against ALLOWED_OPERATORS,
                         // so this covers '=', '!=', '>', '>=', '<', '<='.
-                        $constraint .= sprintf("%s %s '%s'",$this->prepare( $v['name'] ), $op, $this->prepare( $v['value'] ) );
+                        $constraint .= sprintf("%s %s %s",$this->prepare( $v['name'] ), $op, $this->bindValue( $v['value'] ) );
                         break;
                 }
 
@@ -902,11 +980,11 @@ class Db extends \OWA\Core\Base {
 
             case 'insert':
 
-                $ret = $this->query($this->_sql_statement);
+                $ret = $this->query($this->_sql_statement, $this->_bindings);
                 break;
             case 'select':
 
-                $ret = $this->get_results($this->_sql_statement);
+                $ret = $this->get_results($this->_sql_statement, $this->_bindings);
 
                 if (array_key_exists('result_format', $this->_sqlParams)):
                     $ret = $this->_formatResults($ret);
@@ -916,17 +994,18 @@ class Db extends \OWA\Core\Base {
 
             case 'update':
 
-                $ret = $this->query($this->_sql_statement);
+                $ret = $this->query($this->_sql_statement, $this->_bindings);
                 break;
             case 'delete':
 
-                $ret = $this->query($this->_sql_statement);
+                $ret = $this->query($this->_sql_statement, $this->_bindings);
                 break;
         }
 
         $this->_last_sql_statement = $this->_sql_statement;
         $this->_sql_statement = '';
         $this->_sqlParams = array();
+        $this->resetBindings();
         return $ret;
 
     }

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -236,24 +236,20 @@ class Db extends \OWA\Core\Base {
      */
     function bindValue( $value ) {
 
-        // NULL IS WRITTEN AS AN EMPTY STRING, because that is what the escaping
-        // path did and a transport change must not alter stored data.
+        // NULL is bound as a real SQL NULL.
         //
-        // The old route was prepare( null ) -- which returned null -- inlined by
-        // sprintf( "'%s'", null ), i.e. ''. So OWA has NEVER written a real SQL
-        // NULL through the builder: every unset value landed as '', and a
-        // permissive sql_mode then coerced that to 0 in an integer column.
+        // The escaping path could not do this: prepare( null ) returned null and
+        // sprintf( "'%s'", null ) produced '', so every unset value was written
+        // as an empty string and a permissive sql_mode coerced that to 0 in a
+        // numeric column. That is the coercion the strict-mode work exists to
+        // remove -- under STRICT_ALL_TABLES the same write is rejected outright
+        // with "Incorrect integer value: '' for column ...".
         //
-        // Binding a real NULL is more truthful and it silently broke things:
-        // owa_queue_item.not_before_timestamp became NULL instead of 0, and
-        // `not_before_timestamp < ?` is never true for NULL, so every queued
-        // event stopped being due. That is a data-semantics change wearing the
-        // clothes of a driver upgrade.
-        //
-        // Writing genuine NULLs is worth doing -- it needs a column-by-column
-        // review of which are nullable and which callers test for 0 versus '' --
-        // and it belongs with the strict-sql_mode work, not here.
-        $this->_bindings[] = $value === null ? '' : $value;
+        // Writing NULL means callers must stop relying on the coercion. The one
+        // that did is owa_queue_item.not_before_timestamp, whose due check now
+        // reads a missing value as "due now" rather than depending on '' having
+        // silently become 0. See DbEventQueue::getNextItems().
+        $this->_bindings[] = $value;
 
         return '?';
     }

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -693,11 +693,13 @@ class Db extends \OWA\Core\Base {
                         break;
 
                     case '=@':
-                        $constraint .= sprintf("LOCATE(%s, %s) > 0",$this->bindValue( $v['value'] ), $this->prepare( $v['name'] ) );
+                        // Dialect-owned, like =~ and !~ above: the expression
+                        // for "contains" is not the same SQL everywhere.
+                        $constraint .= sprintf( OWA_SQL_CONTAINS, $this->bindValue( $v['value'] ), $this->prepare( $v['name'] ) );
                         break;
 
                     case '!@':
-                        $constraint .= sprintf("LOCATE(%s, %s) = 0",$this->bindValue( $v['value'] ), $this->prepare( $v['name'] ) );
+                        $constraint .= sprintf( OWA_SQL_NOT_CONTAINS, $this->bindValue( $v['value'] ), $this->prepare( $v['name'] ) );
                         break;
 
                     default:

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -77,6 +77,7 @@ class Mysql extends \OWA\Core\Db {
             
             $this->connection = mysqli_init();
 
+
             // A FAILED CONNECT IS NOT A CONNECTION.
             //
             // mysqli_init() always returns an object, so `$this->connection`
@@ -160,7 +161,7 @@ class Mysql extends \OWA\Core\Db {
      * @access     public
      *
      */
-    function query( $sql ) {
+    function query( $sql, array $params = array() ) {
   
           if ( $this->connection_status == false) {
 
@@ -200,7 +201,9 @@ class Mysql extends \OWA\Core\Db {
         \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__, $sql);
 
        try {
-        $result = @mysqli_query( $this->connection, $sql );
+        $result = $params
+              ? $this->executeBound( $sql, $params )
+              : @mysqli_query( $this->connection, $sql );
     
             \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
             // Log Errors
@@ -266,11 +269,11 @@ class Mysql extends \OWA\Core\Db {
      * @return     array|null
      * @access  public
      */
-    function get_results( $sql ) {
+    function get_results( $sql, array $params = array() ) {
 
         if ( $sql ) {
 
-            $this->query($sql);
+            $this->query($sql, $params);
         }
 
         //$this->result = array();
@@ -281,7 +284,7 @@ class Mysql extends \OWA\Core\Db {
 
         while ( $row = mysqli_fetch_assoc( $this->new_result ) ) {
 
-            array_push($this->result, $row);
+            array_push( $this->result, $this->stringifyRow( $row ) );
 
         }
 
@@ -307,16 +310,54 @@ class Mysql extends \OWA\Core\Db {
      * @param string $sql
      * @return array|null
      */
-    function get_row($sql) {
+    function get_row($sql, array $params = array()) {
 
-        $result = $this->query($sql);
+        $result = $this->query($sql, $params);
 
         if ( ! $result || ! ( $this->new_result instanceof \mysqli_result ) ) {
 
             return null;
         }
 
-        return mysqli_fetch_assoc($this->new_result);
+        return $this->stringifyRow( mysqli_fetch_assoc($this->new_result) );
+    }
+
+    /**
+     * Return a fetched row with its values as strings.
+     *
+     * mysqli is inconsistent with itself: mysqli_query() yields strings, while a
+     * PREPARED statement fetched via mysqli_stmt_get_result() yields native PHP
+     * types under mysqlnd. Introducing bound parameters therefore changed the
+     * type of every value the builder returns -- '0' became 0 -- which breaks
+     * === comparisons across the codebase and would change the REST API's JSON,
+     * serialising counts as numbers instead of quoted strings.
+     *
+     * MYSQLI_OPT_INT_AND_FLOAT_NATIVE is the documented switch for this and has
+     * NO EFFECT here (mysqlnd 8.2, set before real_connect -- verified both
+     * orderings), so the coercion is explicit. PDO's ATTR_STRINGIFY_FETCHES does
+     * the same job on the other driver, and DbDriverSqlParityTest compares the
+     * two drivers' rows so they cannot drift apart again.
+     *
+     * NULL IS PRESERVED. A blanket (string) cast turns NULL into '', which is a
+     * different value -- OWA stores real NULLs and distinguishes them from empty
+     * strings.
+     */
+    protected function stringifyRow( $row ) {
+
+        if ( ! is_array( $row ) ) {
+
+            return $row;
+        }
+
+        foreach ( $row as $k => $v ) {
+
+            if ( $v !== null && ! is_string( $v ) && ! is_array( $v ) ) {
+
+                $row[ $k ] = (string) $v;
+            }
+        }
+
+        return $row;
     }
 
 
@@ -348,7 +389,98 @@ class Mysql extends \OWA\Core\Db {
 
     }
 
+    /**
+     * Run a statement with bound parameters.
+     *
+     * mysqli's binding is more awkward than PDO's: one type STRING covering all
+     * parameters, and bind_param() takes its arguments BY REFERENCE, so values
+     * must be held in a real array and spread -- passing expressions is a fatal.
+     *
+     * Returns what mysqli_query() would: a mysqli_result for a SELECT, true for
+     * a statement with no result set, false on failure. get_results() and
+     * get_row() then behave identically whether or not parameters were used.
+     *
+     * @return \mysqli_result|bool
+     */
+    protected function executeBound( $sql, array $params ) {
+
+        $statement = @mysqli_prepare( $this->connection, $sql );
+
+        if ( ! $statement ) {
+
+            return false;
+        }
+
+        $types  = '';
+        $values = array();
+
+        foreach ( $params as $value ) {
+
+            if ( is_int( $value ) || is_bool( $value ) ) {
+
+                $types .= 'i';
+                $values[] = (int) $value;
+
+            } elseif ( is_float( $value ) ) {
+
+                $types .= 'd';
+                $values[] = $value;
+
+            } else {
+
+                // Null included: mysqli sends a typed NULL for a null bound as
+                // 's', which keeps it a NULL rather than an empty string.
+                $types .= 's';
+                $values[] = $value;
+            }
+        }
+
+        // Spread from a variable: bind_param takes references.
+        if ( ! @mysqli_stmt_bind_param( $statement, $types, ...$values ) ) {
+
+            @mysqli_stmt_close( $statement );
+
+            return false;
+        }
+
+        if ( ! @mysqli_stmt_execute( $statement ) ) {
+
+            @mysqli_stmt_close( $statement );
+
+            return false;
+        }
+
+        $result = @mysqli_stmt_get_result( $statement );
+
+        if ( $result === false ) {
+
+            // No result set (INSERT/UPDATE/DELETE). Affected rows must be read
+            // BEFORE the statement is closed, or getAffectedRows() reports on a
+            // dead handle.
+            $this->rows_affected = mysqli_stmt_affected_rows( $statement );
+
+            @mysqli_stmt_close( $statement );
+
+            return true;
+        }
+
+        @mysqli_stmt_close( $statement );
+
+        return $result;
+    }
+
     function getAffectedRows() {
+
+        // A bound statement's affected-row count is captured at execute time
+        // (see executeBound) because the statement handle is closed immediately;
+        // mysqli_affected_rows() on the CONNECTION does not report it.
+        if ( $this->rows_affected !== null ) {
+
+            $affected = $this->rows_affected;
+            $this->rows_affected = null;
+
+            return $affected;
+        }
 
         // mysqli_affected_rows() has required the connection arg since PHP 8.0.
         return mysqli_affected_rows( $this->connection );

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -19,92 +19,13 @@ namespace OWA\Core\Db;
 //
 
 
-define('OWA_DTD_BIGINT', 'BIGINT');
-define('OWA_DTD_INT', 'INT');
-define('OWA_DTD_TINYINT', 'TINYINT(1)');
-define('OWA_DTD_TINYINT2', 'TINYINT(2)');
-define('OWA_DTD_TINYINT4', 'TINYINT(4)');
-define('OWA_DTD_SERIAL', 'SERIAL');
-define('OWA_DTD_PRIMARY_KEY', 'PRIMARY KEY');
-define('OWA_DTD_VARCHAR10', 'VARCHAR(10)');
-define('OWA_DTD_VARCHAR255', 'VARCHAR(255)');
-define('OWA_DTD_VARCHAR', 'VARCHAR(%s)');
-define('OWA_DTD_TEXT', 'MEDIUMTEXT');
-define('OWA_DTD_BOOLEAN', 'TINYINT(1)');
-define('OWA_DTD_TIMESTAMP', 'TIMESTAMP');
-define('OWA_DTD_BLOB', 'BLOB');
-define('OWA_DTD_INDEX', 'KEY');
-define('OWA_DTD_AUTO_INCREMENT', 'AUTO_INCREMENT');
-define('OWA_DTD_NOT_NULL', 'NOT NULL');
-define('OWA_DTD_UNIQUE', 'PRIMARY KEY(%s)');
-define('OWA_SQL_ADD_COLUMN', 'ALTER TABLE %s ADD %s %s');
-define('OWA_SQL_DROP_COLUMN', 'ALTER TABLE %s DROP %s');
-define('OWA_SQL_RENAME_COLUMN', 'ALTER TABLE %s CHANGE %s %s %s');
-define('OWA_SQL_MODIFY_COLUMN', 'ALTER TABLE %s MODIFY %s %s');
-define('OWA_SQL_RENAME_TABLE', 'ALTER TABLE %s RENAME %s');
-define('OWA_SQL_CREATE_TABLE', 'CREATE TABLE IF NOT EXISTS %s (%s) %s');
-define('OWA_SQL_DROP_TABLE', 'DROP TABLE IF EXISTS %s');
-define('OWA_SQL_SHOW_TABLE', "show tables like '%s'");
-define('OWA_SQL_INSERT_ROW', 'INSERT into %s (%s) VALUES (%s)');
-define('OWA_SQL_UPDATE_ROW', 'UPDATE %s SET %s %s');
-define('OWA_SQL_DELETE_ROW', "DELETE from %s %s");
-define('OWA_SQL_CREATE_INDEX', 'CREATE INDEX %s ON %s (%s)');
-define('OWA_SQL_DROP_INDEX', 'DROP INDEX %s ON %s');
-define('OWA_SQL_INDEX', 'INDEX (%s)');
-define('OWA_SQL_BEGIN_TRANSACTION', 'BEGIN');
-define('OWA_SQL_END_TRANSACTION', 'COMMIT');
-define('OWA_DTD_TABLE_TYPE', 'ENGINE = %s');
-define('OWA_DTD_TABLE_TYPE_DEFAULT', 'INNODB');
-define('OWA_DTD_TABLE_TYPE_DISK', 'INNODB');
-define('OWA_DTD_TABLE_TYPE_MEMORY', 'MEMORY');
-define('OWA_SQL_ALTER_TABLE_TYPE', 'ALTER TABLE %s ENGINE = %s');
-// Partitioning. A driver that cannot partition simply leaves these undefined,
-// and the table is created and managed unpartitioned -- the feature is absent
-// rather than broken. The syntax differs enough between platforms (Postgres
-// declares the parent then creates each partition as its own table) that only
-// the fragments belong here; the sequencing stays in Db.
-define('OWA_DTD_PARTITION_BY_RANGE', ' PARTITION BY RANGE (%s) (%s)');
-define('OWA_DTD_PARTITION_LESS_THAN', 'PARTITION %s VALUES LESS THAN (%s)');
-define('OWA_DTD_PARTITION_MAXVALUE', 'MAXVALUE');
-define('OWA_SQL_PARTITION_TABLE', 'ALTER TABLE %s' . OWA_DTD_PARTITION_BY_RANGE);
-define('OWA_SQL_DROP_PARTITION', 'ALTER TABLE %s DROP PARTITION %s');
-define('OWA_SQL_REORGANIZE_PARTITION', 'ALTER TABLE %s REORGANIZE PARTITION %s INTO (%s)');
-define('OWA_SQL_JOIN_LEFT_OUTER', 'LEFT OUTER JOIN');
-define('OWA_SQL_JOIN_LEFT_INNER', 'LEFT INNER JOIN');
-define('OWA_SQL_JOIN_RIGHT_OUTER', 'RIGHT OUTER JOIN');
-define('OWA_SQL_JOIN_RIGHT_INNER', 'RIGHT INNER JOIN');
-define('OWA_SQL_JOIN', 'JOIN');
-define('OWA_SQL_DESCENDING', 'DESC');
-define('OWA_SQL_ASCENDING', 'ASC');
-define('OWA_SQL_REGEXP', 'REGEXP');
-define('OWA_SQL_NOTREGEXP', 'NOT REGEXP');
-define('OWA_SQL_LIKE', 'LIKE');
-define('OWA_SQL_ADD_INDEX', 'ALTER TABLE %s ADD INDEX (%s) %s');
-// Named form. The unnamed one above lets MySQL pick the name, so repeating it
-// yields site_id, site_id_2, site_id_3 rather than failing as a duplicate.
-define('OWA_SQL_ADD_NAMED_INDEX', 'ALTER TABLE %s ADD INDEX %s (%s) %s');
-define('OWA_SQL_COUNT', 'COUNT(%s)');
-define('OWA_SQL_SUM', 'SUM(%s)');
-define('OWA_SQL_ROUND', 'ROUND(%s)');
-define('OWA_SQL_AVERAGE', 'AVG(%s)');
-define('OWA_SQL_DISTINCT', 'DISTINCT %s');
-define('OWA_SQL_DIVISION', '(%s / %s)');
-define('OWA_DTD_CHARACTER_ENCODING_UTF8', 'utf8');
-define('OWA_DTD_TABLE_CHARACTER_ENCODING', 'CHARACTER SET = %s');
+// The MySQL DDL vocabulary and schema introspection now live in the
+// MysqlDialect trait, shared with the PDO driver. `use` below is what defines
+// the OWA_DTD_* / OWA_SQL_* constants -- they are dialect, not transport.
 
-
-/**
- * MySQL Data Access Class
- * 
- * @author      Peter Adams <peter@openwebanalytics.com>
- * @copyright   Copyright &copy; 2006 Peter Adams <peter@openwebanalytics.com>
- * @license     http://www.gnu.org/copyleft/gpl.html GPL v2.0
- * @category    owa
- * @package     owa
- * @version        $Revision$
- * @since        owa 1.0.0
- */
 class Mysql extends \OWA\Core\Db {
+
+    use MysqlDialect;
 
     /**
      * A connect attempt has already failed and must not be repeated.
@@ -206,8 +127,15 @@ class Mysql extends \OWA\Core\Db {
                 $this->query("SET NAMES 'utf8'");
             }
 
-            // turn off strict mode. needed on mysql 5.7 and lter when it is turned on by default.
-            $this->query( "SET SESSION sql_mode=''" );
+            // Session sql_mode. Historically a hardcoded "" here, which disables
+            // strict mode; now sourced from the dialect so it can be raised per
+            // install or per test run. See MysqlDialect::sessionSqlMode().
+            $mode = $this->sessionSqlMode();
+
+            if ( $mode !== null ) {
+
+                $this->query( sprintf( "SET SESSION sql_mode='%s'", $this->prepare( $mode ) ) );
+            }
 
         }
 
@@ -391,207 +319,6 @@ class Mysql extends \OWA\Core\Db {
         return mysqli_fetch_assoc($this->new_result);
     }
 
-    /**
-     * Can this driver partition tables?
-     *
-     * @return bool
-     */
-    function supportsPartitioning() {
-
-        return defined( 'OWA_DTD_PARTITION_BY_RANGE' );
-    }
-
-    /**
-     * The partitions on a table, in range order.
-     *
-     * @param string $table_name
-     * @return array of ['name' => string, 'less_than' => string, 'rows' => int]
-     */
-    function listPartitions( $table_name ) {
-
-        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
-
-            return array();
-        }
-
-        $sql = "SELECT PARTITION_NAME AS name, PARTITION_DESCRIPTION AS less_than, TABLE_ROWS AS rows_ "
-             . "FROM information_schema.PARTITIONS "
-             . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND PARTITION_NAME IS NOT NULL "
-             . "ORDER BY PARTITION_ORDINAL_POSITION";
-
-        $rows = $this->get_results( sprintf( $sql, $table_name ) );
-
-        $out = array();
-
-        foreach ( (array) $rows as $row ) {
-
-            $out[] = array(
-                'name'      => $row['name'],
-                'less_than' => $row['less_than'],
-                'rows'      => (int) $row['rows_'],
-            );
-        }
-
-        return $out;
-    }
-
-    /**
-     * Spare open-file slots on this server, or null if it cannot be read.
-     *
-     * Each partition is a file, and InnoDB caps how many tablespaces it keeps
-     * open at once. That cap is shared with every table already present, so the
-     * headroom for partitions is what is left after them -- not the cap itself.
-     *
-     * @return int|null
-     */
-    function getPartitionBudget() {
-
-        $row = $this->get_row(
-            "SELECT @@innodb_open_files AS cap, "
-          . "(SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_TYPE = 'BASE TABLE') AS used"
-        );
-
-        if ( ! $row || ! isset( $row['cap'] ) || ! $row['cap'] ) {
-
-            return null;
-        }
-
-        return max( 0, (int) $row['cap'] - (int) $row['used'] );
-    }
-
-    /**
-     * Row count and date range within one partition.
-     *
-     * Reads the partition itself rather than information_schema, because
-     * TABLE_ROWS is an InnoDB estimate that can be out by a wide margin -- and
-     * the whole point of asking about the catch-all is to know whether real data
-     * has collected there. The extension restricts the scan to that one
-     * partition, and the fact tables carry an index on the partitioning column,
-     * which on a partitioned table is local to each partition: the bounds are a
-     * seek, not a scan.
-     *
-     * @param string $table_name
-     * @param string $partition
-     * @param string $column
-     * @return array|null  ['rows','min','max'], or null where it cannot be read
-     */
-    function getPartitionContents( $table_name, $partition, $column = 'yyyymmdd' ) {
-
-        foreach ( array( $table_name, $partition, $column ) as $identifier ) {
-
-            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $identifier ) ) {
-
-                return null;
-            }
-        }
-
-        $row = $this->get_row( sprintf(
-            'SELECT COUNT(*) AS n, MIN(%1$s) AS lo, MAX(%1$s) AS hi FROM %2$s PARTITION (%3$s)',
-            $column, $table_name, $partition
-        ) );
-
-        if ( ! $row ) {
-
-            return null;
-        }
-
-        return array(
-            'rows' => (int) $row['n'],
-            'min'  => $row['lo'] === null ? null : (string) $row['lo'],
-            'max'  => $row['hi'] === null ? null : (string) $row['hi'],
-        );
-    }
-
-    /**
-     * The columns of a table's primary key, in key order.
-     *
-     * @param string $table_name
-     * @return string[]
-     */
-    function getPrimaryKeyColumns( $table_name ) {
-
-        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
-
-            return array();
-        }
-
-        $sql = "SELECT COLUMN_NAME AS c FROM information_schema.STATISTICS "
-             . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND INDEX_NAME = 'PRIMARY' "
-             . "ORDER BY SEQ_IN_INDEX";
-
-        $cols = array();
-
-        foreach ( (array) $this->get_results( sprintf( $sql, $table_name ) ) as $row ) {
-
-            $cols[] = $row['c'];
-        }
-
-        return $cols;
-    }
-
-    /**
-     * Is there already an index covering exactly these columns?
-     *
-     * Matched on the column list rather than the index name, so an index MySQL
-     * named itself -- site_id, site_id_2 -- is recognised as covering site_id.
-     *
-     * @param string $table_name
-     * @param string $column_name  one column, or a comma-separated list
-     * @return bool
-     */
-    function indexExists( $table_name, $column_name ) {
-
-        $cols = $this->normalizeIndexColumns( $column_name );
-
-        if ( ! $cols || ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
-
-            return false;
-        }
-
-        // Matched on the column list, which is what GROUP_CONCAT returns in
-        // SEQ_IN_INDEX order, so the name MySQL happened to assign is irrelevant.
-        $sql = "SELECT COUNT(*) AS n FROM ( "
-             . "SELECT INDEX_NAME FROM information_schema.STATISTICS "
-             . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' "
-             . "GROUP BY INDEX_NAME "
-             . "HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = '%s' ) x";
-
-        $row = $this->get_row(
-            sprintf( $sql, $table_name, implode( ',', $cols ) )
-        );
-
-        return ( is_array( $row ) && isset( $row['n'] ) && (int) $row['n'] > 0 );
-    }
-
-    /**
-     * Every non-primary index on the OWA tables.
-     *
-     * Scoped to the 'owa_' prefix because an installation may share its
-     * database with another application -- WordPress, typically -- and nothing
-     * here should look at, let alone touch, tables OWA does not own.
-     *
-     * @return array of ['t' => table, 'i' => index, 'nu' => non_unique,
-     *                   'ty' => type, 'cols' => comma-separated column list]
-     */
-    function listIndexes() {
-
-        // Scoped to the 'owa_' prefix: an installation may share its database
-        // with another application. Uniqueness and type come back too, so
-        // indexes that merely share columns are not mistaken for copies of each
-        // other. The grouping is left to the caller so the "keep one" decision
-        // stays in PHP, where it can be read and tested.
-        $sql = "SELECT TABLE_NAME AS t, INDEX_NAME AS i, NON_UNIQUE AS nu, INDEX_TYPE AS ty, "
-             . "GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS cols "
-             . "FROM information_schema.STATISTICS "
-             . "WHERE TABLE_SCHEMA = DATABASE() AND INDEX_NAME <> 'PRIMARY' "
-             . "AND TABLE_NAME LIKE 'owa\\\\_%' "
-             . "GROUP BY TABLE_NAME, INDEX_NAME, NON_UNIQUE, INDEX_TYPE "
-             . "ORDER BY TABLE_NAME, INDEX_NAME";
-
-        $rows = $this->get_results( $sql );
-
-        return is_array( $rows ) ? $rows : array();
-    }
 
     /**
      * Prepares and escapes string

--- a/Core/Db/MysqlDialect.php
+++ b/Core/Db/MysqlDialect.php
@@ -124,35 +124,55 @@ trait MysqlDialect
     /**
      * The session sql_mode to apply on connect, or null to leave the server's.
      *
-     * OWA has always sent `SET SESSION sql_mode=''` on every connection, which
-     * disables strict mode. That is not free: without it MySQL coerces rather
-     * than refuses, so a value too long for its column is truncated and a
-     * non-numeric value written to an integer column silently becomes 0 -- the
-     * failure mode behind the VARCHAR->BIGINT migrations, where bad data
-     * converts to zeros with no error anywhere.
+     * OWA sent `SET SESSION sql_mode=''` on every connection for years, which
+     * disables strict mode. That is not free: without it MySQL coerces instead
+     * of refusing, so a value too long for its column is truncated and a
+     * non-numeric value written to an integer column silently becomes 0. Two
+     * live installs were measured carrying rows whose yyyymmdd -- the partition
+     * key, and the column every date-range report filters on -- had been
+     * coerced to 0 that way, making those rows invisible to reporting.
      *
-     * Making it configurable rather than simply flipping it: strict mode turns
-     * today's silent coercions into hard write failures, and on a tracking
-     * endpoint a hard failure means lost data. So the default stays exactly what
-     * every existing install already runs, and OWA_DB_SQL_MODE opts a given
-     * install (or a test run) into something stricter, which is what makes it
-     * possible to ENUMERATE the violations before deciding to change anyone's
-     * default.
+     * The default is now STRICT_ALL_TABLES: a bad write fails loudly instead of
+     * storing something that looks like data and is not.
      *
-     *   define( 'OWA_DB_SQL_MODE', 'STRICT_ALL_TABLES' );   // find violations
-     *   define( 'OWA_DB_SQL_MODE', null );                  // server's own mode
+     * WHAT CHANGES FOR AN INSTALL
+     * A write that previously succeeded by being coerced now fails. Everything
+     * OWA itself does was fixed before this default moved -- the whole suite
+     * passes under strict, and so does the end-to-end ingestion path on both
+     * drivers -- but a third-party module writing through the entity layer may
+     * not have been. OWA_DB_SQL_MODE is the escape hatch, and reverting is one
+     * line in owa-config.php:
+     *
+     *   define( 'OWA_DB_SQL_MODE', '' );                    // the old behaviour
+     *   define( 'OWA_DB_SQL_MODE', null );                  // whatever the server sets
+     *   define( 'OWA_DB_SQL_MODE', 'STRICT_ALL_TABLES' );   // the new default
+     *
+     * Chosen over null (leave the server alone) because OWA ships to hosts whose
+     * configuration it does not control: an explicit mode means every install
+     * behaves the way the test suite is verified to behave, rather than
+     * inheriting whatever the host decided.
      *
      * @return string|null
      */
     protected function sessionSqlMode() {
 
-        if ( ! defined( 'OWA_DB_SQL_MODE' ) ) {
+        if ( defined( 'OWA_DB_SQL_MODE' ) ) {
 
-            // The historical default. Empty string means "no modes set".
-            return '';
+            return OWA_DB_SQL_MODE;
         }
 
-        return OWA_DB_SQL_MODE;
+        // Env override, so a test run or a one-off CLI check can raise the mode
+        // without editing a config file. Deliberately NOT a general config
+        // channel -- an install sets the constant.
+        $env = getenv( 'OWA_DB_SQL_MODE' );
+
+        if ( $env !== false ) {
+
+            return $env;
+        }
+
+        // Strict by default. See the note above; OWA_DB_SQL_MODE reverts it.
+        return 'STRICT_ALL_TABLES';
     }
 
     /**

--- a/Core/Db/MysqlDialect.php
+++ b/Core/Db/MysqlDialect.php
@@ -93,6 +93,12 @@ if ( ! defined( 'OWA_SQL_ASCENDING' ) ) { define('OWA_SQL_ASCENDING', 'ASC'); }
 if ( ! defined( 'OWA_SQL_REGEXP' ) ) { define('OWA_SQL_REGEXP', 'REGEXP'); }
 if ( ! defined( 'OWA_SQL_NOTREGEXP' ) ) { define('OWA_SQL_NOTREGEXP', 'NOT REGEXP'); }
 if ( ! defined( 'OWA_SQL_LIKE' ) ) { define('OWA_SQL_LIKE', 'LIKE'); }
+// Substring containment. MySQL spells it LOCATE(needle, haystack); PostgreSQL
+// has POSITION(needle IN haystack) and SQL Server CHARINDEX, so the whole
+// expression is the dialect's to give -- not just the function name. The
+// argument order is part of the contract: needle first, then the column.
+if ( ! defined( 'OWA_SQL_CONTAINS' ) ) { define('OWA_SQL_CONTAINS', 'LOCATE(%s, %s) > 0'); }
+if ( ! defined( 'OWA_SQL_NOT_CONTAINS' ) ) { define('OWA_SQL_NOT_CONTAINS', 'LOCATE(%s, %s) = 0'); }
 if ( ! defined( 'OWA_SQL_ADD_INDEX' ) ) { define('OWA_SQL_ADD_INDEX', 'ALTER TABLE %s ADD INDEX (%s) %s'); }
 // Named form. The unnamed one above lets MySQL pick the name, so repeating it
 // yields site_id, site_id_2, site_id_3 rather than failing as a duplicate.

--- a/Core/Db/MysqlDialect.php
+++ b/Core/Db/MysqlDialect.php
@@ -1,0 +1,359 @@
+<?php
+namespace OWA\Core\Db;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+
+/**
+ * The MySQL dialect: its DDL vocabulary and its schema introspection.
+ *
+ * Split out because a driver is two separable things, and only one of them is
+ * about MySQL-the-database:
+ *
+ *   TRANSPORT   how bytes reach the server -- mysqli, PDO, something else.
+ *   DIALECT     what the SQL looks like, and how the schema is interrogated.
+ *
+ * Everything here is dialect. It is identical whether the statements travel over
+ * mysqli or PDO, so both drivers share it rather than carrying two copies that
+ * drift -- the introspection queries in particular encode real behaviour
+ * (partition budgets, index shapes) that was measured once and should not be
+ * re-derived per transport.
+ *
+ * THE CONSTANTS ARE GUARDED. They were previously bare define() calls in
+ * Mysql.php, which was safe only because exactly one driver ever loaded. With a
+ * second driver in the tree, two files can be autoloaded in one process -- a
+ * test suite covering both will do it -- and a redefinition is a PHP warning
+ * that CI fails on. Same values either way, so first-definer-wins is correct.
+ *
+ * Loading this trait is what defines the OWA_DTD_* / OWA_SQL_* vocabulary the
+ * rest of OWA compiles its SQL from, so a driver must `use` it, not merely
+ * extend Db.
+ */
+
+if ( ! defined( 'OWA_DTD_BIGINT' ) ) { define('OWA_DTD_BIGINT', 'BIGINT'); }
+if ( ! defined( 'OWA_DTD_INT' ) ) { define('OWA_DTD_INT', 'INT'); }
+if ( ! defined( 'OWA_DTD_TINYINT' ) ) { define('OWA_DTD_TINYINT', 'TINYINT(1)'); }
+if ( ! defined( 'OWA_DTD_TINYINT2' ) ) { define('OWA_DTD_TINYINT2', 'TINYINT(2)'); }
+if ( ! defined( 'OWA_DTD_TINYINT4' ) ) { define('OWA_DTD_TINYINT4', 'TINYINT(4)'); }
+if ( ! defined( 'OWA_DTD_SERIAL' ) ) { define('OWA_DTD_SERIAL', 'SERIAL'); }
+if ( ! defined( 'OWA_DTD_PRIMARY_KEY' ) ) { define('OWA_DTD_PRIMARY_KEY', 'PRIMARY KEY'); }
+if ( ! defined( 'OWA_DTD_VARCHAR10' ) ) { define('OWA_DTD_VARCHAR10', 'VARCHAR(10)'); }
+if ( ! defined( 'OWA_DTD_VARCHAR255' ) ) { define('OWA_DTD_VARCHAR255', 'VARCHAR(255)'); }
+if ( ! defined( 'OWA_DTD_VARCHAR' ) ) { define('OWA_DTD_VARCHAR', 'VARCHAR(%s)'); }
+if ( ! defined( 'OWA_DTD_TEXT' ) ) { define('OWA_DTD_TEXT', 'MEDIUMTEXT'); }
+if ( ! defined( 'OWA_DTD_BOOLEAN' ) ) { define('OWA_DTD_BOOLEAN', 'TINYINT(1)'); }
+if ( ! defined( 'OWA_DTD_TIMESTAMP' ) ) { define('OWA_DTD_TIMESTAMP', 'TIMESTAMP'); }
+if ( ! defined( 'OWA_DTD_BLOB' ) ) { define('OWA_DTD_BLOB', 'BLOB'); }
+if ( ! defined( 'OWA_DTD_INDEX' ) ) { define('OWA_DTD_INDEX', 'KEY'); }
+if ( ! defined( 'OWA_DTD_AUTO_INCREMENT' ) ) { define('OWA_DTD_AUTO_INCREMENT', 'AUTO_INCREMENT'); }
+if ( ! defined( 'OWA_DTD_NOT_NULL' ) ) { define('OWA_DTD_NOT_NULL', 'NOT NULL'); }
+if ( ! defined( 'OWA_DTD_UNIQUE' ) ) { define('OWA_DTD_UNIQUE', 'PRIMARY KEY(%s)'); }
+if ( ! defined( 'OWA_SQL_ADD_COLUMN' ) ) { define('OWA_SQL_ADD_COLUMN', 'ALTER TABLE %s ADD %s %s'); }
+if ( ! defined( 'OWA_SQL_DROP_COLUMN' ) ) { define('OWA_SQL_DROP_COLUMN', 'ALTER TABLE %s DROP %s'); }
+if ( ! defined( 'OWA_SQL_RENAME_COLUMN' ) ) { define('OWA_SQL_RENAME_COLUMN', 'ALTER TABLE %s CHANGE %s %s %s'); }
+if ( ! defined( 'OWA_SQL_MODIFY_COLUMN' ) ) { define('OWA_SQL_MODIFY_COLUMN', 'ALTER TABLE %s MODIFY %s %s'); }
+if ( ! defined( 'OWA_SQL_RENAME_TABLE' ) ) { define('OWA_SQL_RENAME_TABLE', 'ALTER TABLE %s RENAME %s'); }
+if ( ! defined( 'OWA_SQL_CREATE_TABLE' ) ) { define('OWA_SQL_CREATE_TABLE', 'CREATE TABLE IF NOT EXISTS %s (%s) %s'); }
+if ( ! defined( 'OWA_SQL_DROP_TABLE' ) ) { define('OWA_SQL_DROP_TABLE', 'DROP TABLE IF EXISTS %s'); }
+if ( ! defined( 'OWA_SQL_SHOW_TABLE' ) ) { define('OWA_SQL_SHOW_TABLE', "show tables like '%s'"); }
+if ( ! defined( 'OWA_SQL_INSERT_ROW' ) ) { define('OWA_SQL_INSERT_ROW', 'INSERT into %s (%s) VALUES (%s)'); }
+if ( ! defined( 'OWA_SQL_UPDATE_ROW' ) ) { define('OWA_SQL_UPDATE_ROW', 'UPDATE %s SET %s %s'); }
+if ( ! defined( 'OWA_SQL_DELETE_ROW' ) ) { define('OWA_SQL_DELETE_ROW', "DELETE from %s %s"); }
+if ( ! defined( 'OWA_SQL_CREATE_INDEX' ) ) { define('OWA_SQL_CREATE_INDEX', 'CREATE INDEX %s ON %s (%s)'); }
+if ( ! defined( 'OWA_SQL_DROP_INDEX' ) ) { define('OWA_SQL_DROP_INDEX', 'DROP INDEX %s ON %s'); }
+if ( ! defined( 'OWA_SQL_INDEX' ) ) { define('OWA_SQL_INDEX', 'INDEX (%s)'); }
+if ( ! defined( 'OWA_SQL_BEGIN_TRANSACTION' ) ) { define('OWA_SQL_BEGIN_TRANSACTION', 'BEGIN'); }
+if ( ! defined( 'OWA_SQL_END_TRANSACTION' ) ) { define('OWA_SQL_END_TRANSACTION', 'COMMIT'); }
+if ( ! defined( 'OWA_DTD_TABLE_TYPE' ) ) { define('OWA_DTD_TABLE_TYPE', 'ENGINE = %s'); }
+if ( ! defined( 'OWA_DTD_TABLE_TYPE_DEFAULT' ) ) { define('OWA_DTD_TABLE_TYPE_DEFAULT', 'INNODB'); }
+if ( ! defined( 'OWA_DTD_TABLE_TYPE_DISK' ) ) { define('OWA_DTD_TABLE_TYPE_DISK', 'INNODB'); }
+if ( ! defined( 'OWA_DTD_TABLE_TYPE_MEMORY' ) ) { define('OWA_DTD_TABLE_TYPE_MEMORY', 'MEMORY'); }
+if ( ! defined( 'OWA_SQL_ALTER_TABLE_TYPE' ) ) { define('OWA_SQL_ALTER_TABLE_TYPE', 'ALTER TABLE %s ENGINE = %s'); }
+// Partitioning. A driver that cannot partition simply leaves these undefined,
+// and the table is created and managed unpartitioned -- the feature is absent
+// rather than broken. The syntax differs enough between platforms (Postgres
+// declares the parent then creates each partition as its own table) that only
+// the fragments belong here; the sequencing stays in Db.
+if ( ! defined( 'OWA_DTD_PARTITION_BY_RANGE' ) ) { define('OWA_DTD_PARTITION_BY_RANGE', ' PARTITION BY RANGE (%s) (%s)'); }
+if ( ! defined( 'OWA_DTD_PARTITION_LESS_THAN' ) ) { define('OWA_DTD_PARTITION_LESS_THAN', 'PARTITION %s VALUES LESS THAN (%s)'); }
+if ( ! defined( 'OWA_DTD_PARTITION_MAXVALUE' ) ) { define('OWA_DTD_PARTITION_MAXVALUE', 'MAXVALUE'); }
+if ( ! defined( 'OWA_SQL_PARTITION_TABLE' ) ) { define('OWA_SQL_PARTITION_TABLE', 'ALTER TABLE %s' . OWA_DTD_PARTITION_BY_RANGE); }
+if ( ! defined( 'OWA_SQL_DROP_PARTITION' ) ) { define('OWA_SQL_DROP_PARTITION', 'ALTER TABLE %s DROP PARTITION %s'); }
+if ( ! defined( 'OWA_SQL_REORGANIZE_PARTITION' ) ) { define('OWA_SQL_REORGANIZE_PARTITION', 'ALTER TABLE %s REORGANIZE PARTITION %s INTO (%s)'); }
+if ( ! defined( 'OWA_SQL_JOIN_LEFT_OUTER' ) ) { define('OWA_SQL_JOIN_LEFT_OUTER', 'LEFT OUTER JOIN'); }
+if ( ! defined( 'OWA_SQL_JOIN_LEFT_INNER' ) ) { define('OWA_SQL_JOIN_LEFT_INNER', 'LEFT INNER JOIN'); }
+if ( ! defined( 'OWA_SQL_JOIN_RIGHT_OUTER' ) ) { define('OWA_SQL_JOIN_RIGHT_OUTER', 'RIGHT OUTER JOIN'); }
+if ( ! defined( 'OWA_SQL_JOIN_RIGHT_INNER' ) ) { define('OWA_SQL_JOIN_RIGHT_INNER', 'RIGHT INNER JOIN'); }
+if ( ! defined( 'OWA_SQL_JOIN' ) ) { define('OWA_SQL_JOIN', 'JOIN'); }
+if ( ! defined( 'OWA_SQL_DESCENDING' ) ) { define('OWA_SQL_DESCENDING', 'DESC'); }
+if ( ! defined( 'OWA_SQL_ASCENDING' ) ) { define('OWA_SQL_ASCENDING', 'ASC'); }
+if ( ! defined( 'OWA_SQL_REGEXP' ) ) { define('OWA_SQL_REGEXP', 'REGEXP'); }
+if ( ! defined( 'OWA_SQL_NOTREGEXP' ) ) { define('OWA_SQL_NOTREGEXP', 'NOT REGEXP'); }
+if ( ! defined( 'OWA_SQL_LIKE' ) ) { define('OWA_SQL_LIKE', 'LIKE'); }
+if ( ! defined( 'OWA_SQL_ADD_INDEX' ) ) { define('OWA_SQL_ADD_INDEX', 'ALTER TABLE %s ADD INDEX (%s) %s'); }
+// Named form. The unnamed one above lets MySQL pick the name, so repeating it
+// yields site_id, site_id_2, site_id_3 rather than failing as a duplicate.
+if ( ! defined( 'OWA_SQL_ADD_NAMED_INDEX' ) ) { define('OWA_SQL_ADD_NAMED_INDEX', 'ALTER TABLE %s ADD INDEX %s (%s) %s'); }
+if ( ! defined( 'OWA_SQL_COUNT' ) ) { define('OWA_SQL_COUNT', 'COUNT(%s)'); }
+if ( ! defined( 'OWA_SQL_SUM' ) ) { define('OWA_SQL_SUM', 'SUM(%s)'); }
+if ( ! defined( 'OWA_SQL_ROUND' ) ) { define('OWA_SQL_ROUND', 'ROUND(%s)'); }
+if ( ! defined( 'OWA_SQL_AVERAGE' ) ) { define('OWA_SQL_AVERAGE', 'AVG(%s)'); }
+if ( ! defined( 'OWA_SQL_DISTINCT' ) ) { define('OWA_SQL_DISTINCT', 'DISTINCT %s'); }
+if ( ! defined( 'OWA_SQL_DIVISION' ) ) { define('OWA_SQL_DIVISION', '(%s / %s)'); }
+if ( ! defined( 'OWA_DTD_CHARACTER_ENCODING_UTF8' ) ) { define('OWA_DTD_CHARACTER_ENCODING_UTF8', 'utf8'); }
+if ( ! defined( 'OWA_DTD_TABLE_CHARACTER_ENCODING' ) ) { define('OWA_DTD_TABLE_CHARACTER_ENCODING', 'CHARACTER SET = %s'); }
+
+
+/**
+ * MySQL Data Access Class
+ * 
+ * @author      Peter Adams <peter@openwebanalytics.com>
+ * @copyright   Copyright &copy; 2006 Peter Adams <peter@openwebanalytics.com>
+ * @license     http://www.gnu.org/copyleft/gpl.html GPL v2.0
+ * @category    owa
+ * @package     owa
+ * @version        $Revision$
+ * @since        owa 1.0.0
+ */
+
+trait MysqlDialect
+{
+    /**
+     * The session sql_mode to apply on connect, or null to leave the server's.
+     *
+     * OWA has always sent `SET SESSION sql_mode=''` on every connection, which
+     * disables strict mode. That is not free: without it MySQL coerces rather
+     * than refuses, so a value too long for its column is truncated and a
+     * non-numeric value written to an integer column silently becomes 0 -- the
+     * failure mode behind the VARCHAR->BIGINT migrations, where bad data
+     * converts to zeros with no error anywhere.
+     *
+     * Making it configurable rather than simply flipping it: strict mode turns
+     * today's silent coercions into hard write failures, and on a tracking
+     * endpoint a hard failure means lost data. So the default stays exactly what
+     * every existing install already runs, and OWA_DB_SQL_MODE opts a given
+     * install (or a test run) into something stricter, which is what makes it
+     * possible to ENUMERATE the violations before deciding to change anyone's
+     * default.
+     *
+     *   define( 'OWA_DB_SQL_MODE', 'STRICT_ALL_TABLES' );   // find violations
+     *   define( 'OWA_DB_SQL_MODE', null );                  // server's own mode
+     *
+     * @return string|null
+     */
+    protected function sessionSqlMode() {
+
+        if ( ! defined( 'OWA_DB_SQL_MODE' ) ) {
+
+            // The historical default. Empty string means "no modes set".
+            return '';
+        }
+
+        return OWA_DB_SQL_MODE;
+    }
+
+    /**
+     * Can this driver partition tables?
+     *
+     * @return bool
+     */
+    function supportsPartitioning() {
+
+        return defined( 'OWA_DTD_PARTITION_BY_RANGE' );
+    }
+
+    /**
+     * The partitions on a table, in range order.
+     *
+     * @param string $table_name
+     * @return array of ['name' => string, 'less_than' => string, 'rows' => int]
+     */
+    function listPartitions( $table_name ) {
+
+        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            return array();
+        }
+
+        $sql = "SELECT PARTITION_NAME AS name, PARTITION_DESCRIPTION AS less_than, TABLE_ROWS AS rows_ "
+             . "FROM information_schema.PARTITIONS "
+             . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND PARTITION_NAME IS NOT NULL "
+             . "ORDER BY PARTITION_ORDINAL_POSITION";
+
+        $rows = $this->get_results( sprintf( $sql, $table_name ) );
+
+        $out = array();
+
+        foreach ( (array) $rows as $row ) {
+
+            $out[] = array(
+                'name'      => $row['name'],
+                'less_than' => $row['less_than'],
+                'rows'      => (int) $row['rows_'],
+            );
+        }
+
+        return $out;
+    }
+
+    /**
+     * Spare open-file slots on this server, or null if it cannot be read.
+     *
+     * Each partition is a file, and InnoDB caps how many tablespaces it keeps
+     * open at once. That cap is shared with every table already present, so the
+     * headroom for partitions is what is left after them -- not the cap itself.
+     *
+     * @return int|null
+     */
+    function getPartitionBudget() {
+
+        $row = $this->get_row(
+            "SELECT @@innodb_open_files AS cap, "
+          . "(SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_TYPE = 'BASE TABLE') AS used"
+        );
+
+        if ( ! $row || ! isset( $row['cap'] ) || ! $row['cap'] ) {
+
+            return null;
+        }
+
+        return max( 0, (int) $row['cap'] - (int) $row['used'] );
+    }
+
+    /**
+     * Row count and date range within one partition.
+     *
+     * Reads the partition itself rather than information_schema, because
+     * TABLE_ROWS is an InnoDB estimate that can be out by a wide margin -- and
+     * the whole point of asking about the catch-all is to know whether real data
+     * has collected there. The extension restricts the scan to that one
+     * partition, and the fact tables carry an index on the partitioning column,
+     * which on a partitioned table is local to each partition: the bounds are a
+     * seek, not a scan.
+     *
+     * @param string $table_name
+     * @param string $partition
+     * @param string $column
+     * @return array|null  ['rows','min','max'], or null where it cannot be read
+     */
+    function getPartitionContents( $table_name, $partition, $column = 'yyyymmdd' ) {
+
+        foreach ( array( $table_name, $partition, $column ) as $identifier ) {
+
+            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $identifier ) ) {
+
+                return null;
+            }
+        }
+
+        $row = $this->get_row( sprintf(
+            'SELECT COUNT(*) AS n, MIN(%1$s) AS lo, MAX(%1$s) AS hi FROM %2$s PARTITION (%3$s)',
+            $column, $table_name, $partition
+        ) );
+
+        if ( ! $row ) {
+
+            return null;
+        }
+
+        return array(
+            'rows' => (int) $row['n'],
+            'min'  => $row['lo'] === null ? null : (string) $row['lo'],
+            'max'  => $row['hi'] === null ? null : (string) $row['hi'],
+        );
+    }
+
+    /**
+     * The columns of a table's primary key, in key order.
+     *
+     * @param string $table_name
+     * @return string[]
+     */
+    function getPrimaryKeyColumns( $table_name ) {
+
+        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            return array();
+        }
+
+        $sql = "SELECT COLUMN_NAME AS c FROM information_schema.STATISTICS "
+             . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND INDEX_NAME = 'PRIMARY' "
+             . "ORDER BY SEQ_IN_INDEX";
+
+        $cols = array();
+
+        foreach ( (array) $this->get_results( sprintf( $sql, $table_name ) ) as $row ) {
+
+            $cols[] = $row['c'];
+        }
+
+        return $cols;
+    }
+
+    /**
+     * Is there already an index covering exactly these columns?
+     *
+     * Matched on the column list rather than the index name, so an index MySQL
+     * named itself -- site_id, site_id_2 -- is recognised as covering site_id.
+     *
+     * @param string $table_name
+     * @param string $column_name  one column, or a comma-separated list
+     * @return bool
+     */
+    function indexExists( $table_name, $column_name ) {
+
+        $cols = $this->normalizeIndexColumns( $column_name );
+
+        if ( ! $cols || ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            return false;
+        }
+
+        // Matched on the column list, which is what GROUP_CONCAT returns in
+        // SEQ_IN_INDEX order, so the name MySQL happened to assign is irrelevant.
+        $sql = "SELECT COUNT(*) AS n FROM ( "
+             . "SELECT INDEX_NAME FROM information_schema.STATISTICS "
+             . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' "
+             . "GROUP BY INDEX_NAME "
+             . "HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = '%s' ) x";
+
+        $row = $this->get_row(
+            sprintf( $sql, $table_name, implode( ',', $cols ) )
+        );
+
+        return ( is_array( $row ) && isset( $row['n'] ) && (int) $row['n'] > 0 );
+    }
+
+    /**
+     * Every non-primary index on the OWA tables.
+     *
+     * Scoped to the 'owa_' prefix because an installation may share its
+     * database with another application -- WordPress, typically -- and nothing
+     * here should look at, let alone touch, tables OWA does not own.
+     *
+     * @return array of ['t' => table, 'i' => index, 'nu' => non_unique,
+     *                   'ty' => type, 'cols' => comma-separated column list]
+     */
+    function listIndexes() {
+
+        // Scoped to the 'owa_' prefix: an installation may share its database
+        // with another application. Uniqueness and type come back too, so
+        // indexes that merely share columns are not mistaken for copies of each
+        // other. The grouping is left to the caller so the "keep one" decision
+        // stays in PHP, where it can be read and tested.
+        $sql = "SELECT TABLE_NAME AS t, INDEX_NAME AS i, NON_UNIQUE AS nu, INDEX_TYPE AS ty, "
+             . "GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) AS cols "
+             . "FROM information_schema.STATISTICS "
+             . "WHERE TABLE_SCHEMA = DATABASE() AND INDEX_NAME <> 'PRIMARY' "
+             . "AND TABLE_NAME LIKE 'owa\\\\_%' "
+             . "GROUP BY TABLE_NAME, INDEX_NAME, NON_UNIQUE, INDEX_TYPE "
+             . "ORDER BY TABLE_NAME, INDEX_NAME";
+
+        $rows = $this->get_results( $sql );
+
+        return is_array( $rows ) ? $rows : array();
+    }
+}

--- a/Core/Db/Pdo.php
+++ b/Core/Db/Pdo.php
@@ -8,7 +8,7 @@ namespace OWA\Core\Db;
 //
 
 /**
- * MySQL over PDO.
+ * PDO transport, shared by every PDO-based driver.
  *
  * Transport only. The SQL vocabulary and the schema introspection are identical
  * to the mysqli driver's and come from MysqlDialect, so this file is about how
@@ -41,9 +41,8 @@ namespace OWA\Core\Db;
  * it is the single easiest thing to get wrong here.
  */
 
-class Pdo extends \OWA\Core\Db
+abstract class Pdo extends \OWA\Core\Db
 {
-    use MysqlDialect;
 
     /**
      * A connect attempt has already failed and must not be repeated.
@@ -58,6 +57,28 @@ class Pdo extends \OWA\Core\Db
     /** The statement most recently executed, for getAffectedRows(). */
     protected $last_statement;
 
+    /**
+     * The PDO DSN for this database, e.g. "mysql:host=...;dbname=...".
+     *
+     * The one thing a PDO subclass must supply. Everything else in this class is
+     * transport and is the same whichever server is on the other end; the SQL
+     * itself comes from whichever dialect the subclass uses.
+     *
+     * @return string
+     */
+    abstract protected function dsn();
+
+    /**
+     * The session sql_mode to apply on connect, or null to leave the server's.
+     *
+     * Supplied by the dialect trait a concrete driver uses, not by the transport
+     * -- sql_mode is a MySQL concept and another database's dialect will answer
+     * this differently, or not at all.
+     *
+     * @return string|null
+     */
+    abstract protected function sessionSqlMode();
+
     function connect() {
 
         if ( $this->connect_failed ) {
@@ -67,14 +88,7 @@ class Pdo extends \OWA\Core\Db
 
         if ( ! $this->connection ) {
 
-            $port = $this->getConnectionParam('port') ?: 3306;
-
-            $dsn = sprintf(
-                'mysql:host=%s;port=%s;dbname=%s;charset=utf8',
-                $this->getConnectionParam('host'),
-                $port,
-                $this->getConnectionParam('name')
-            );
+            $dsn = $this->dsn();
 
             $options = array(
                 // Failures surface as exceptions and are converted to the falsy
@@ -152,7 +166,7 @@ class Pdo extends \OWA\Core\Db
      * @param string $sql
      * @return \PDOStatement|false
      */
-    function query( $sql ) {
+    function query( $sql, array $params = array() ) {
 
         if ( $this->connection_status == false ) {
 
@@ -179,7 +193,29 @@ class Pdo extends \OWA\Core\Db
 
         try {
 
-            $statement = $this->connection->query( $sql );
+            if ( $params ) {
+
+                $statement = $this->connection->prepare( $sql );
+
+                foreach ( $params as $i => $value ) {
+
+                    // Typed rather than everything-as-string: binding an int as
+                    // an int is what lets strict mode reject a genuinely bad
+                    // value instead of coercing it, and PARAM_NULL keeps a null
+                    // a NULL rather than turning it into ''.
+                    $statement->bindValue(
+                        $i + 1,
+                        is_bool( $value ) ? (int) $value : $value,
+                        self::paramType( $value )
+                    );
+                }
+
+                $statement->execute();
+
+            } else {
+
+                $statement = $this->connection->query( $sql );
+            }
 
         } catch ( \Throwable $e ) {
 
@@ -199,7 +235,13 @@ class Pdo extends \OWA\Core\Db
         \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
 
         $this->last_statement = $statement;
-        $this->new_result     = $statement;
+
+        // A statement with NO RESULT SET reports success as `true`, which is
+        // what mysqli_query() returns and therefore what callers test for --
+        // PartitionOperationsTest asserts exactly that on an ALTER. PDO hands
+        // back a PDOStatement either way, which is truthy but is not true, so
+        // an `=== true` or assertTrue() check would fail on DDL that worked.
+        $this->new_result = $statement->columnCount() > 0 ? $statement : true;
 
         return $this->new_result;
     }
@@ -226,11 +268,11 @@ class Pdo extends \OWA\Core\Db
      * @param string $sql
      * @return array|null
      */
-    function get_results( $sql ) {
+    function get_results( $sql, array $params = array() ) {
 
         if ( $sql ) {
 
-            $this->query( $sql );
+            $this->query( $sql, $params );
         }
 
         if ( ! $this->new_result instanceof \PDOStatement ) {
@@ -257,9 +299,9 @@ class Pdo extends \OWA\Core\Db
      * @param string $sql
      * @return array|null
      */
-    function get_row( $sql ) {
+    function get_row( $sql, array $params = array() ) {
 
-        $result = $this->query( $sql );
+        $result = $this->query( $sql, $params );
 
         if ( ! $result instanceof \PDOStatement ) {
 
@@ -309,6 +351,28 @@ class Pdo extends \OWA\Core\Db
 
         // quote() guarantees the outer pair; strip exactly one from each end.
         return substr( $quoted, 1, -1 );
+    }
+
+    /**
+     * The PDO type for a bound value.
+     *
+     * Booleans go as int, not PARAM_BOOL: OWA stores them in TINYINT(1) columns
+     * and PARAM_BOOL round-trips as '' for false on some drivers, which lands as
+     * 0 under a permissive sql_mode and fails outright under a strict one.
+     */
+    private static function paramType( $value ) {
+
+        if ( is_null( $value ) ) {
+
+            return \PDO::PARAM_NULL;
+        }
+
+        if ( is_int( $value ) || is_bool( $value ) ) {
+
+            return \PDO::PARAM_INT;
+        }
+
+        return \PDO::PARAM_STR;
     }
 
     function getAffectedRows() {

--- a/Core/Db/Pdo.php
+++ b/Core/Db/Pdo.php
@@ -1,0 +1,320 @@
+<?php
+namespace OWA\Core\Db;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+
+/**
+ * MySQL over PDO.
+ *
+ * Transport only. The SQL vocabulary and the schema introspection are identical
+ * to the mysqli driver's and come from MysqlDialect, so this file is about how
+ * statements travel and how failures are reported -- nothing about what the SQL
+ * says. Selected with `db_type = 'pdo'`.
+ *
+ * WHY NOT BOUND PARAMETERS
+ * ------------------------
+ * This driver deliberately does NOT use prepared statements with placeholders,
+ * and that is not laziness. OWA's reporting layer composes its SQL
+ * dynamically -- Db's builder assembles select lists, joins, group-bys and
+ * constraints from a registry at runtime, and ResultSetManager drives it -- so
+ * the statement text is not known until the moment it runs, and the values are
+ * interpolated into it by the builder. Converting that to placeholders means
+ * rewriting the builder, which is a much larger change than swapping a
+ * transport and is not what this driver is for.
+ *
+ * THE QUOTING TRAP
+ * ----------------
+ * Because of the above, prepare() is an ESCAPER, not a statement preparer, and
+ * the builder supplies the surrounding quotes itself:
+ *
+ *     sprintf( "%s = '%s'", $this->prepare( $name ), $this->prepare( $value ) )
+ *
+ * mysqli_real_escape_string() escapes without adding quotes. PDO::quote() adds
+ * them -- quote("O'Brien") is "'O''Brien'". Returning that verbatim would
+ * produce `col = ''O''Brien''` and break every query in the application, with
+ * reporting hit hardest since that is where the dynamic construction lives. So
+ * prepare() strips the outer pair that quote() adds. PdoDriverTest pins this;
+ * it is the single easiest thing to get wrong here.
+ */
+
+class Pdo extends \OWA\Core\Db
+{
+    use MysqlDialect;
+
+    /**
+     * A connect attempt has already failed and must not be repeated.
+     *
+     * Same latch as the mysqli driver: without it every query re-dials a
+     * database that is down, and each attempt costs a timeout.
+     *
+     * @var bool
+     */
+    protected $connect_failed = false;
+
+    /** The statement most recently executed, for getAffectedRows(). */
+    protected $last_statement;
+
+    function connect() {
+
+        if ( $this->connect_failed ) {
+
+            return false;
+        }
+
+        if ( ! $this->connection ) {
+
+            $port = $this->getConnectionParam('port') ?: 3306;
+
+            $dsn = sprintf(
+                'mysql:host=%s;port=%s;dbname=%s;charset=utf8',
+                $this->getConnectionParam('host'),
+                $port,
+                $this->getConnectionParam('name')
+            );
+
+            $options = array(
+                // Failures surface as exceptions and are converted to the falsy
+                // returns callers already handle -- see query(). Silent mode
+                // would mean checking errorInfo() after every call and is easier
+                // to get wrong.
+                \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+                \PDO::ATTR_PERSISTENT         => (bool) $this->getConnectionParam('persistant'),
+                // Server-side prepares would gain nothing here (no placeholders
+                // are used) and change quote()/error timing, so keep the driver
+                // behaving like the transport it replaces.
+                \PDO::ATTR_EMULATE_PREPARES   => true,
+                // Columns come back as STRINGS, as mysqli returns them.
+                //
+                // Without this PDO returns native types on mysqlnd, so an
+                // integer column arrives as int where it used to be '1'. That is
+                // not cosmetic: it changes `===` comparisons throughout, and it
+                // changes the REST API's JSON, where counts would start
+                // serialising as numbers instead of quoted strings -- a public
+                // contract change smuggled in by a transport swap. Caught by
+                // DbDriverSqlParityTest::testBothDriversReturnTheSameRows.
+                \PDO::ATTR_STRINGIFY_FETCHES  => true,
+            );
+
+            try {
+
+                $this->connection = new \PDO(
+                    $dsn,
+                    $this->getConnectionParam('user'),
+                    $this->getConnectionParam('password'),
+                    $options
+                );
+
+            } catch ( \Throwable $e ) {
+
+                // A FAILED CONNECT IS NOT A CONNECTION. Released so that
+                // isConnectionEstablished() and the guard below both see the
+                // truth, exactly as the mysqli driver does.
+                $this->connection        = null;
+                $this->connection_status = false;
+                $this->connect_failed    = true;
+
+                $this->e->alert( 'Could not connect to database.' );
+
+                return false;
+            }
+
+            $mode = $this->sessionSqlMode();
+
+            if ( $mode !== null ) {
+
+                $this->query( sprintf( "SET SESSION sql_mode='%s'", $this->prepare( $mode ) ) );
+            }
+        }
+
+        $this->connection_status = (bool) $this->connection;
+
+        if ( ! $this->connection_status ) {
+
+            $this->e->alert('Could not connect to database.');
+        }
+
+        return $this->connection_status;
+    }
+
+    /**
+     * Run a statement.
+     *
+     * Returns a PDOStatement, or false on failure. Never throws: callers -- and
+     * get_row()/get_results() below -- have always been written against a falsy
+     * return, and a throw from here would take down a tracking request that
+     * should degrade instead.
+     *
+     * @param string $sql
+     * @return \PDOStatement|false
+     */
+    function query( $sql ) {
+
+        if ( $this->connection_status == false ) {
+
+            \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
+
+            $connected = $this->connect();
+
+            \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
+
+            if ( ! $connected ) {
+
+                $this->new_result = false;
+
+                return false;
+            }
+        }
+
+        $this->e->debug( sprintf('Query: %s', $sql) );
+
+        $this->result     = array();
+        $this->new_result = false;
+
+        \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__, $sql);
+
+        try {
+
+            $statement = $this->connection->query( $sql );
+
+        } catch ( \Throwable $e ) {
+
+            $this->e->debug(
+                sprintf(
+                    'A database error occurred. Error: %s. Query: %s',
+                    htmlspecialchars( $e->getMessage() ),
+                    $sql
+                )
+            );
+
+            $this->new_result = false;
+
+            return false;
+        }
+
+        \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
+
+        $this->last_statement = $statement;
+        $this->new_result     = $statement;
+
+        return $this->new_result;
+    }
+
+    function close() {
+
+        // PDO closes on refcount drop; there is no explicit close. Clearing the
+        // handle is the close, and it must also clear the latch so a later
+        // connect() may try again -- an explicit close is a deliberate reset.
+        $this->connection        = null;
+        $this->last_statement    = null;
+        $this->new_result        = false;
+        $this->connection_status = false;
+        $this->connect_failed    = false;
+    }
+
+    /**
+     * Fetch result set array.
+     *
+     * Null, not an empty array, when there is nothing to return -- no rows, or a
+     * query that failed. Matches the mysqli driver exactly, because callers test
+     * `=== null` and returning an array would change what they see.
+     *
+     * @param string $sql
+     * @return array|null
+     */
+    function get_results( $sql ) {
+
+        if ( $sql ) {
+
+            $this->query( $sql );
+        }
+
+        if ( ! $this->new_result instanceof \PDOStatement ) {
+
+            return null;
+        }
+
+        $rows = $this->new_result->fetchAll( \PDO::FETCH_ASSOC );
+
+        if ( ! $rows ) {
+
+            return null;
+        }
+
+        $this->result = $rows;
+
+        return $this->result;
+    }
+
+    /**
+     * Fetch a single row, or null when there is none -- including when the query
+     * failed, since a failed query has no row either.
+     *
+     * @param string $sql
+     * @return array|null
+     */
+    function get_row( $sql ) {
+
+        $result = $this->query( $sql );
+
+        if ( ! $result instanceof \PDOStatement ) {
+
+            return null;
+        }
+
+        $row = $result->fetch( \PDO::FETCH_ASSOC );
+
+        return $row === false ? null : $row;
+    }
+
+    /**
+     * Escape a value for interpolation into SQL -- WITHOUT surrounding quotes.
+     *
+     * The builder adds its own quotes (see the class docblock), so the outer
+     * pair PDO::quote() contributes has to come back off. Anything else emits
+     * `col = ''value''` and breaks every query in the application.
+     *
+     * @param string $string
+     * @return string
+     */
+    function prepare( $string ) {
+
+        if ( is_null( $string ) ) {
+
+            return $string;
+        }
+
+        if ( $this->connection_status == false ) {
+
+            $this->connect();
+        }
+
+        if ( ! $this->connection ) {
+
+            // Nothing to escape against. Refusing is safer than returning the
+            // raw value, which would be interpolated into SQL unescaped.
+            return '';
+        }
+
+        $quoted = $this->connection->quote( (string) $string );
+
+        if ( $quoted === false ) {
+
+            return '';
+        }
+
+        // quote() guarantees the outer pair; strip exactly one from each end.
+        return substr( $quoted, 1, -1 );
+    }
+
+    function getAffectedRows() {
+
+        return $this->last_statement instanceof \PDOStatement
+            ? $this->last_statement->rowCount()
+            : 0;
+    }
+}

--- a/Core/Db/PdoMysql.php
+++ b/Core/Db/PdoMysql.php
@@ -1,0 +1,58 @@
+<?php
+namespace OWA\Core\Db;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+
+/**
+ * MySQL over PDO: the PDO transport plus the MySQL dialect.
+ *
+ * Selected with `db_type = 'pdo_mysql'`, and used automatically for
+ * `db_type = 'mysql'` wherever the pdo_mysql extension is present -- see
+ * CoreAPI::resolveDbDriver(). Existing installs therefore get it without editing
+ * owa-config.php, and a host that only has mysqli keeps working.
+ *
+ * ADDING ANOTHER DATABASE
+ * -----------------------
+ * A driver is three things: this transport, a dialect, and a DSN. So Postgres
+ * support is a sibling of this file, not a fork of it:
+ *
+ *     class PdoPgsql extends Pdo
+ *     {
+ *         use PgsqlDialect;                    // DDL vocabulary + introspection
+ *
+ *         protected function dsn() {
+ *             return sprintf( 'pgsql:host=%s;port=%s;dbname=%s', ... );
+ *         }
+ *     }
+ *
+ * plus `'owa_db_pdo_pgsql' => PdoPgsql::class` in owa_compat_aliases.php, and an
+ * install writes `define( 'OWA_DB_TYPE', 'pdo_pgsql' );`.
+ *
+ * The work is the dialect, not the plumbing: MysqlDialect carries the
+ * OWA_DTD and OWA_SQL constants OWA compiles its DDL from, and the
+ * information_schema queries behind partition and index introspection. A
+ * Postgres dialect must answer the same questions its own way -- and
+ * supportsPartitioning() exists precisely so a dialect can decline.
+ */
+
+class PdoMysql extends Pdo
+{
+    use MysqlDialect;
+
+    protected function dsn() {
+
+        // charset in the DSN, not a later SET NAMES: PDO uses it for quote() as
+        // well as for the connection, so setting it afterwards leaves escaping
+        // working against the wrong charset.
+        return sprintf(
+            'mysql:host=%s;port=%s;dbname=%s;charset=utf8',
+            $this->getConnectionParam('host'),
+            $this->getConnectionParam('port') ?: 3306,
+            $this->getConnectionParam('name')
+        );
+    }
+}

--- a/Core/Entity.php
+++ b/Core/Entity.php
@@ -278,6 +278,21 @@ class Entity {
      * how callers say "I have nothing", and treating that as a value would blank
      * columns that are deliberately left alone today.
      *
+     * PORTABILITY
+     * The comparison is against the OWA_DTD_* constants, never against the SQL
+     * spellings they hold. That distinction is the point: OWA_DTD_BIGINT means
+     * "a big integer" in every dialect, while its VALUE is whatever the loaded
+     * dialect calls one -- 'BIGINT' here, something else elsewhere. The
+     * constants are OWA's portable vocabulary; the strings are MySQL's.
+     *
+     * Matching the strings instead would have re-broken this silently on the
+     * first non-MySQL driver: the type would fail to look numeric, falsy values
+     * would go back to being dropped, and nothing would report it.
+     *
+     * A dialect that introduces a numeric type of its own adds its constant to
+     * numericColumnTypes(). Anything unrecognised keeps the old conservative
+     * behaviour rather than guessing.
+     *
      * @param string $name
      * @param mixed  $value
      * @return bool
@@ -296,13 +311,49 @@ class Entity {
 
         $type = (string) $this->properties[ $name ]->get( 'data_type' );
 
-        if ( ! preg_match( '/^(BIGINT|INT|TINYINT|SMALLINT|MEDIUMINT|DECIMAL|FLOAT|DOUBLE|SERIAL)/i', $type ) ) {
+        if ( ! in_array( $type, $this->numericColumnTypes(), true ) ) {
 
             return false;
         }
 
         return is_int( $value ) || is_float( $value ) || is_bool( $value )
             || ( is_string( $value ) && is_numeric( $value ) );
+    }
+
+    /**
+     * The declared column types that hold numbers, as the loaded dialect spells
+     * them.
+     *
+     * Built from the constants rather than listing spellings, so this stays
+     * correct for any dialect: each entry is whatever that dialect defined the
+     * type as. Names a dialect does not define are skipped rather than assumed.
+     *
+     * @return array
+     */
+    protected function numericColumnTypes() {
+
+        $numeric = array();
+
+        foreach ( array(
+            'OWA_DTD_BIGINT',
+            'OWA_DTD_INT',
+            'OWA_DTD_TINYINT',
+            'OWA_DTD_TINYINT2',
+            'OWA_DTD_TINYINT4',
+            'OWA_DTD_SERIAL',
+            // Spelled TINYINT(1) in MySQL, so already covered there -- named
+            // anyway, because a dialect with a real boolean type spells it
+            // differently and 0/false must stay storable in it.
+            'OWA_DTD_BOOLEAN',
+        ) as $constant ) {
+
+            if ( defined( $constant ) ) {
+
+                $numeric[] = (string) constant( $constant );
+            }
+        }
+
+        return array_values( array_unique( $numeric ) );
     }
 
     function markDirty( $name, $value ) {

--- a/Core/Entity.php
+++ b/Core/Entity.php
@@ -236,8 +236,26 @@ class Entity {
 	            $value = $this->$method( $value );
             }
             
-            if ( $value ) {
-            
+            // A falsy value is stored when the COLUMN can legitimately hold one.
+            //
+            // This guard used to be a bare `if ( $value )`, so 0, false and ''
+            // were all discarded silently -- setting a numeric column to 0 did
+            // nothing at all, and the caller had no way to tell. That is why
+            // SessionHandlers once wrote the STRING 'false' into is_bounce: a
+            // truthy value was the only kind that survived, and MySQL coerced it
+            // to 0 on the way in.
+            //
+            // Widened by TYPE rather than removed, because the two cases are not
+            // alike. On a numeric column 0 is a value like any other. On a string
+            // column, '' is what a caller passes when it has nothing -- several
+            // handlers rely on `set('medium', $maybeEmpty)` leaving the existing
+            // value alone -- so blanket-storing empties there would start wiping
+            // data that is currently preserved.
+            //
+            // Numeric columns therefore accept 0/false; everything else keeps
+            // the old behaviour exactly.
+            if ( $value || $this->columnAcceptsFalsy( $name, $value ) ) {
+
 	            $this->properties[$name]->setValue( $value );
 	            
 	            if ( $mark_dirty && $existing_value != $value ) {
@@ -248,6 +266,45 @@ class Entity {
         }
     }
     
+    /**
+     * Whether a falsy value is a real value for this column.
+     *
+     * Reads the type the entity already declares -- DbColumn's second
+     * constructor argument, e.g. new DbColumn('priority', OWA_DTD_INT) -- so no
+     * entity needs changing to get this. Every column in the codebase already
+     * carries one.
+     *
+     * Numeric columns only. 0 and false are values there; on a VARCHAR, '' is
+     * how callers say "I have nothing", and treating that as a value would blank
+     * columns that are deliberately left alone today.
+     *
+     * @param string $name
+     * @param mixed  $value
+     * @return bool
+     */
+    protected function columnAcceptsFalsy( $name, $value ) {
+
+        if ( $value === null || $value === '' ) {
+
+            return false;
+        }
+
+        if ( ! isset( $this->properties[ $name ] ) ) {
+
+            return false;
+        }
+
+        $type = (string) $this->properties[ $name ]->get( 'data_type' );
+
+        if ( ! preg_match( '/^(BIGINT|INT|TINYINT|SMALLINT|MEDIUMINT|DECIMAL|FLOAT|DOUBLE|SERIAL)/i', $type ) ) {
+
+            return false;
+        }
+
+        return is_int( $value ) || is_float( $value ) || is_bool( $value )
+            || ( is_string( $value ) && is_numeric( $value ) );
+    }
+
     function markDirty( $name, $value ) {
 	    
 	    $this->dirty[$name] = $value;
@@ -364,7 +421,18 @@ class Entity {
         
             // drop column is it is marked as auto-increment as DB will take care of that.
             
-            if ($this->get($v, false)) {
+            // Truthy OR explicitly changed.
+            //
+            // The truthy test alone could never write a 0, which is why a
+            // legitimate falsy value could not be persisted through an entity at
+            // all. Dirty tracking already existed (markDirty, populated by set())
+            // and was simply never consulted here.
+            //
+            // ADDED to the truthy test rather than replacing it: some callers
+            // change a property without going through set(), so those values are
+            // not marked dirty, and a dirty-only update would silently stop
+            // persisting them. Every column written before is still written.
+            if ($this->get($v, false) || array_key_exists($v, $this->dirty)) {
                 $db->set($v, $this->get($v, false));
             }
         }

--- a/Core/Install.php
+++ b/Core/Install.php
@@ -84,7 +84,7 @@ class Install extends \OWA\Core\Base{
         // test for existance of tables
         foreach ($this->tables as $table) {
             $this->e->notice('Testing for existance of table: '. $table);
-            $check = $this->db->get_results(sprintf("show tables like 'owa_%s'", $table));
+            $check = $this->db->get_results(sprintf(OWA_SQL_SHOW_TABLE, 'owa_' . $table));
             //$this->e->notice(print_r($check, true));
 
             // if a table is missing add it to this array

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,6 +14,64 @@ overrides, and anyone maintaining a custom theme.
 
 ---
 
+## Behaviour changes in this release
+
+These are not deprecations — they change what happens on upgrade, and each has a
+one-line way back.
+
+### Strict SQL mode is now the default
+
+OWA used to send `SET SESSION sql_mode=''` on every connection, which disables
+MySQL's strict mode. That silently converted bad writes into wrong data rather
+than errors: a value too long for its column was truncated, and a non-numeric
+value written to an integer column became `0`.
+
+That was not theoretical. Two live installs were found carrying rows whose
+`yyyymmdd` — the fact-table partition key, and the column every date-range report
+filters on — had been coerced to `0`, which made those rows invisible to
+reporting and put them in the catch-all partition.
+
+The default is now `STRICT_ALL_TABLES`. A write that would previously have been
+coerced now fails and is logged instead of storing something that looks like
+data and is not.
+
+**Everything OWA itself does was fixed before this default moved** — the full
+test suite and the end-to-end ingestion path both pass under strict, on both
+database drivers. A **third-party module** that writes through the entity layer
+may not have been. If one starts failing after upgrade, revert in
+`owa-config.php`:
+
+```php
+define( 'OWA_DB_SQL_MODE', '' );                  // the old, permissive behaviour
+define( 'OWA_DB_SQL_MODE', null );                // leave whatever the server sets
+define( 'OWA_DB_SQL_MODE', 'STRICT_ALL_TABLES' ); // the new default, stated explicitly
+```
+
+Please report it rather than leaving the override in place: a write that strict
+mode rejects was storing wrong data before, not right data.
+
+### PDO is preferred over mysqli where it is available
+
+`db_type = 'mysql'` now means "MySQL", and OWA reaches it through PDO wherever
+the `pdo_mysql` extension is present, falling back to `mysqli` where it is not.
+**No configuration change is required**, and a host that has `mysqli` but not
+`pdo_mysql` keeps working exactly as before.
+
+The reason to move is that PDO carries bound parameters, so values are no longer
+escaped into the statement text. To pin a driver explicitly:
+
+```php
+define( 'OWA_DB_TYPE', 'mysqli' );     // force the legacy driver
+define( 'OWA_DB_TYPE', 'pdo_mysql' );  // force MySQL over PDO
+```
+
+Third-party drivers dropped in at `plugins/db/owa_db_<type>.php` are unaffected
+in selection, but note that the driver interface gained an optional `$params`
+argument on `query()`, `get_results()` and `get_row()`. A driver that overrides
+those with the old signature will need it added.
+
+---
+
 ## Deprecated in 1.10.0, removed in v2.0
 
 ### 1. Bare template variables and `$this` inside templates

--- a/modules/Base/Classes/DbEventQueue.php
+++ b/modules/Base/Classes/DbEventQueue.php
@@ -221,8 +221,9 @@ class DbEventQueue extends \OWA\Core\EventQueue {
         // because the escaping path wrote '' and a permissive sql_mode coerced
         // it -- and `NULL < <timestamp>` is NULL, never true, so with real NULLs
         // being written no event would ever be due again. Reading it through
-        // IFNULL states the intent instead of depending on a coercion.
-        $this->db->where( 'IFNULL(not_before_timestamp, 0)', time(), '<' );
+        // COALESCE states the intent instead of depending on a coercion -- ANSI
+        // SQL rather than MySQL's IFNULL, and identical in meaning here.
+        $this->db->where( 'COALESCE(not_before_timestamp, 0)', time(), '<' );
         $this->db->orderBy( 'insertion_timestamp' , 'ASC' );
         $this->db->limit( $limit );
         

--- a/modules/Base/Classes/DbEventQueue.php
+++ b/modules/Base/Classes/DbEventQueue.php
@@ -214,7 +214,15 @@ class DbEventQueue extends \OWA\Core\EventQueue {
         $this->db->select( '*' );
         $this->db->from( 'owa_queue_item' );
         $this->db->where( 'status', 'unhandled' );
-        $this->db->where( 'not_before_timestamp', time(), '<' );
+        // A missing not-before means "due now".
+        //
+        // sendMessage() only sets this column when there IS a back-off, so for a
+        // freshly queued event it is NULL. It used to arrive as 0, but only
+        // because the escaping path wrote '' and a permissive sql_mode coerced
+        // it -- and `NULL < <timestamp>` is NULL, never true, so with real NULLs
+        // being written no event would ever be due again. Reading it through
+        // IFNULL states the intent instead of depending on a coercion.
+        $this->db->where( 'IFNULL(not_before_timestamp, 0)', time(), '<' );
         $this->db->orderBy( 'insertion_timestamp' , 'ASC' );
         $this->db->limit( $limit );
         

--- a/modules/Base/Classes/ResultSetManager.php
+++ b/modules/Base/Classes/ResultSetManager.php
@@ -1628,15 +1628,26 @@ if ( ! in_array($item['name'], $this->allMetrics) ) {
                             }
                         }
                     }
-                    
-                    
-                    // query for dimensional results
+                }
+
+                // Query for the dimensional rows.
+                //
+                // OUTSIDE the orderby block, which is where these two lines used
+                // to sit -- their indentation always said they belonged here, but
+                // the brace put them inside. The effect was that a breakdown with
+                // no sort never ran its query at all: $dresults stayed undefined,
+                // generate() received nothing, and the caller got zero rows next
+                // to a perfectly correct aggregate. No error, because an
+                // unassigned variable is only a notice and nothing was watching.
+                //
+                // It survived because every one of the ~60 declarative report
+                // controllers sets a sort, so no shipped report ever took the
+                // unsorted path. Found by reporting-facets.spec.js, which asks
+                // for a breakdown without one.
                 $dresults = $this->computeDimensionalRows( $bm );
-                
+
                 // paginate the results
                 $dresults = $this->applyMetaDataToResults( $dresults );
-                    
-                }
 
                 // generate dimensional results
                 $this->resultSet->generate( $dresults, $this->query_params, [

--- a/modules/Base/Classes/ResultSetManager.php
+++ b/modules/Base/Classes/ResultSetManager.php
@@ -982,6 +982,81 @@ if ( ! in_array($item['name'], $this->allMetrics) ) {
       
         // set time period constraint for query
         $this->setConstraint($dimension_name, array('start' => $start, 'end' => $end), 'BETWEEN');
+
+        // A TIME bound also gets a closed DATE bound, derived here.
+        //
+        // The fact tables are RANGE-partitioned on yyyymmdd, so a predicate that
+        // names only `timestamp` cannot prune -- and it is unselective enough
+        // that the optimiser abandons the timestamp index too. Measured on a
+        // live table:
+        //
+        //   timestamp > X                          all partitions, no index, 405,217 rows
+        //   yyyymmdd >= D AND timestamp > X        all from D,     no index, 351,937 rows
+        //   yyyymmdd BETWEEN D-1 AND D AND ts > X  1 partition,    yyyymmdd,   4,080 rows
+        //
+        // Note the middle row: an OPEN lower bound still reads everything from D
+        // onwards. The bound has to be closed at both ends to prune to a span.
+        //
+        // Derived in the query builder rather than left to whoever writes the
+        // report, because a report author has no reason to know the physical
+        // partitioning -- and because this is the seam a non-SQL reporting
+        // backend would override with its own pruning predicate. Putting it in
+        // the reports instead would tie it to the star schema.
+        //
+        // The date is computed from the same timestamps in the same timezone the
+        // yyyymmdd column was written in, so a range spanning midnight yields
+        // two days and still prunes to those two partitions.
+        if ( $dimension_name === 'timestamp' && $start && $end ) {
+
+            $this->setConstraint(
+                'date',
+                array( 'start' => date( 'Ymd', (int) $start ), 'end' => date( 'Ymd', (int) $end ) ),
+                'BETWEEN'
+            );
+        }
+
+        // And the reverse: a period covering PART of a day needs a time bound as
+        // well, or it silently widens to the whole day.
+        //
+        // last_half_hour and last_hour are allowlisted periods that produced
+        // exactly the same constraint as `today` -- date BETWEEN D AND D, with no
+        // timestamp bound at all. The period knew it meant 22:15-22:45; the query
+        // asked for all 1,440 minutes. Wrong answers, not merely slow ones, and
+        // nothing reported it.
+        //
+        // Only for periods that do NOT sit on day boundaries. today, yesterday,
+        // this_week and the rest already align, and adding a redundant timestamp
+        // bound to them would risk excluding rows whose yyyymmdd and timestamp
+        // disagree at a timezone edge.
+        if ( $dimension_name === 'date' && $this->timePeriod ) {
+
+            $startTs = $this->timePeriod->startDate->getTimestamp();
+            $endTs   = $this->timePeriod->endDate->getTimestamp();
+
+            // Sub-day means SPAN, not clock alignment. last_seven_days runs
+            // 23:59:59 to 23:59:59, so an alignment test flags it as partial and
+            // would narrow it from seven whole days to a rolling 7x24h window --
+            // quietly changing numbers users already read. A span under a day
+            // isolates exactly the windows that need a time bound: currently
+            // last_half_hour and last_hour.
+            // Two conditions, and both are needed.
+            //
+            // Span alone is not enough: `today` runs 00:00:00 to 23:59:59, which
+            // is 86,399 seconds and slips under a day. Start-of-day alone is not
+            // enough either: `last_seven_days` starts at 23:59:59, so an
+            // alignment test alone would flag it and narrow seven whole days to a
+            // rolling 7x24h window -- quietly changing numbers users already
+            // read. Together they select exactly the partial-day windows:
+            // currently last_half_hour and last_hour.
+            if ( ( $endTs - $startTs ) < 86400 && date( 'His', $startTs ) !== '000000' ) {
+
+                $this->setConstraint(
+                    'timestamp',
+                    array( 'start' => $startTs, 'end' => $endTs ),
+                    'BETWEEN'
+                );
+            }
+        }
   		}
     }
 

--- a/modules/Base/Classes/ResultSetManager.php
+++ b/modules/Base/Classes/ResultSetManager.php
@@ -139,6 +139,20 @@ class ResultSetManager extends \OWA\Core\Base {
         }
     }
 
+    /**
+     * Apply a set of constraints a CALLER asked for.
+     *
+     * Unlike setConstraint(), an empty value here is an error rather than a
+     * no-op. setConstraint() drops empty values silently, which is right for the
+     * internal calls that pass an optional value -- but wrong for constraints
+     * that arrived on a request, because there "no value" means the value went
+     * missing, not that the caller wanted everything.
+     *
+     * Silently dropping them made a lost parameter indistinguishable from an
+     * unfiltered request: "source==" produced the full unfiltered total, and the
+     * Source Detail report showed the same visit count for every source with no
+     * error anywhere. Reported the same way an unknown sort column is.
+     */
     function setConstraints($array) {
 
         if (is_array($array)) {
@@ -148,6 +162,19 @@ class ResultSetManager extends \OWA\Core\Base {
             }
 
             foreach ($array as $constraint) {
+
+                if ( \OWA\Core\Lib::isEmpty( $constraint['value'] ) ) {
+
+                    $this->addError( sprintf(
+                        'The "%s" constraint was given no value. Refusing to run the '
+                        . 'query unconstrained -- a missing value is not a request for '
+                        . 'everything.',
+                        $constraint['name']
+                    ) );
+
+                    continue;
+                }
+
                 $this->setConstraint($constraint['name'], $constraint['value'], $constraint['operator']);
             }
         }
@@ -239,6 +266,32 @@ class ResultSetManager extends \OWA\Core\Base {
 
         if ( ! $entity ) {
             $entity = $this->baseEntity;
+        }
+
+        // A constraint with NO VALUE is refused, not quietly ignored.
+        //
+        // Db::where() skips a constraint whose value isEmpty(), so an empty one
+        // used to mean "no filter" -- the query ran unconstrained and returned
+        // the full total with no error anywhere. That is the worst possible
+        // default for reporting: a lost parameter is indistinguishable from a
+        // request for everything.
+        //
+        // It is not hypothetical. "source==" reached this method whenever
+        // owa_source went missing from the request -- a cache layer was found
+        // stripping it -- and the Source Detail report happily showed the same
+        // unfiltered visit count for every source.
+        //
+        // Refused the same way an unknown sort column already is, so the caller
+        // sees an error instead of plausible wrong numbers.
+        if ( \OWA\Core\Lib::isEmpty( $constraint['value'] ) ) {
+
+            $this->addError( sprintf(
+                '%s constraint was given no value. Refusing to run the query '
+                . 'unconstrained -- a missing value is not a request for everything.',
+                $constraint['name']
+            ) );
+
+            return;
         }
 
         if ( $this->isDimension( $constraint['name'] ) ) {

--- a/modules/Base/Classes/TrackingEventHelpers.php
+++ b/modules/Base/Classes/TrackingEventHelpers.php
@@ -407,7 +407,25 @@ class TrackingEventHelpers {
 
     static function deriveYyyymmdd( $yyyymmdd, $event ) {
 
-        return date("Ymd", $event->get('timestamp') );
+        // Never return an empty yyyymmdd.
+        //
+        // This column is NOT NULL, it is the partition key, and every date-range
+        // report filters on it -- so a row written without one is invisible to
+        // reporting and lands in the catch-all partition. A permissive sql_mode
+        // hid that by turning the empty write into 0; measured on two live
+        // installs, a handful of rows per million had ended up that way.
+        //
+        // date() with a null timestamp yields 1970, which is worse than useless
+        // because it looks like real data. Falling back to now is honest: the
+        // server assigns event time anyway when the client does not supply one.
+        $timestamp = $event->get('timestamp');
+
+        if ( ! $timestamp ) {
+
+            $timestamp = time();
+        }
+
+        return date("Ymd", $timestamp );
 
     }
 

--- a/modules/Base/Controller/RederiveDimensionIdsCli.php
+++ b/modules/Base/Controller/RederiveDimensionIdsCli.php
@@ -540,7 +540,7 @@ class RederiveDimensionIdsCli extends PartitionsCli {
             return true;
         }
 
-        if ( ! $db->get_results( sprintf( 'SHOW TABLES LIKE "%s"', $this->mapTable() ) ) ) {
+        if ( ! $db->get_results( sprintf( OWA_SQL_SHOW_TABLE, $this->mapTable() ) ) ) {
 
             return false;
         }
@@ -896,7 +896,7 @@ class RederiveDimensionIdsCli extends PartitionsCli {
         // query, and the difference matters: the map is dropped once a migration
         // completes, so treating its absence as an error would make every
         // subsequent run refuse on a perfectly healthy database.
-        $have_map = (bool) $db->get_results( sprintf( 'SHOW TABLES LIKE "%s"', $map ) );
+        $have_map = (bool) $db->get_results( sprintf( OWA_SQL_SHOW_TABLE, $map ) );
 
         // A dimension row only counts if its content can still produce an id.
         //

--- a/modules/Base/Handler/SessionHandlers.php
+++ b/modules/Base/Handler/SessionHandlers.php
@@ -179,7 +179,22 @@ class SessionHandlers extends \OWA\Core\Observer {
                 $s->set( 'num_pageviews', $this->summarizePageviews( $id, $s->get( 'yyyymmdd' ) ) );
 
                 // set bounce flag to false as there must have been 2 page views
-                $s->set( 'is_bounce', 'false' );
+                // 0, not the string 'false'.
+                //
+                // 'false' was a workaround for Entity::set() dropping falsy
+                // values ("if ( $value )"), so a plain 0 here is silently
+                // ignored. It only ever worked because MySQL coerced the
+                // non-numeric string to 0 in this TINYINT column; strict mode
+                // rejects it outright, and the string is TRUTHY in PHP, so any
+                // code reading is_bounce back would see a bounce where there is
+                // none.
+                //
+                // setValue() writes the property directly, bypassing that falsy
+                // guard. The guard itself is worth removing, but that changes
+                // every set() call in the codebase and needs its own change.
+                // Cleared directly below, after $s->update(), because it
+                // cannot be written through the entity at all -- see the note
+                // there.
 
                 // update timestamp of latest request that triggered the session update
                 $s->set( 'last_req', $event->get( 'timestamp' ) );
@@ -243,6 +258,30 @@ class SessionHandlers extends \OWA\Core\Observer {
 
                 // Persist to database
                 $ret = $s->update();
+
+                // Clear the bounce flag with a direct UPDATE.
+                //
+                // It cannot go through the entity: Entity::set() drops falsy
+                // values ("if ( $value )") and the update builder drops them
+                // again ("if ( $this->get( $v, false ) )"), so a 0 never reaches
+                // the statement. That is why this used to assign the STRING
+                // 'false' -- truthy in PHP, so it survived both guards, and
+                // non-numeric, so MySQL coerced it to 0 in this TINYINT column.
+                //
+                // Under a strict sql_mode that coercion is an error rather than
+                // a silent fix-up, and the string is a hazard on its own: read
+                // back into PHP it is TRUTHY, so a session that did not bounce
+                // reports that it did.
+                //
+                // Relaxing the two falsy guards is the real fix and is
+                // deliberately not done here -- the second one exists to stop a
+                // partially-loaded entity blanking columns it never loaded, so
+                // changing it needs its own review.
+                $db = \OWA\Core\CoreAPI::dbSingleton();
+                $db->updateTable( 'owa_session' );
+                $db->set( 'is_bounce', 0 );
+                $db->where( 'id', $id );
+                $db->executeQuery();
             }
 
             // setup event message

--- a/modules/Base/Handler/SessionHandlers.php
+++ b/modules/Base/Handler/SessionHandlers.php
@@ -192,9 +192,15 @@ class SessionHandlers extends \OWA\Core\Observer {
                 // setValue() writes the property directly, bypassing that falsy
                 // guard. The guard itself is worth removing, but that changes
                 // every set() call in the codebase and needs its own change.
-                // Cleared directly below, after $s->update(), because it
-                // cannot be written through the entity at all -- see the note
-                // there.
+                // set bounce flag to false as there must have been 2 page views
+                //
+                // A real 0, not the string 'false' this used to assign. That
+                // string existed only because Entity::set() discarded every
+                // falsy value, so a truthy one was the only kind that survived
+                // -- and MySQL then coerced the non-numeric string to 0 on the
+                // way in. It was also TRUTHY in PHP, so reading is_bounce back
+                // reported a bounce that had not happened.
+                $s->set( 'is_bounce', 0 );
 
                 // update timestamp of latest request that triggered the session update
                 $s->set( 'last_req', $event->get( 'timestamp' ) );
@@ -258,30 +264,6 @@ class SessionHandlers extends \OWA\Core\Observer {
 
                 // Persist to database
                 $ret = $s->update();
-
-                // Clear the bounce flag with a direct UPDATE.
-                //
-                // It cannot go through the entity: Entity::set() drops falsy
-                // values ("if ( $value )") and the update builder drops them
-                // again ("if ( $this->get( $v, false ) )"), so a 0 never reaches
-                // the statement. That is why this used to assign the STRING
-                // 'false' -- truthy in PHP, so it survived both guards, and
-                // non-numeric, so MySQL coerced it to 0 in this TINYINT column.
-                //
-                // Under a strict sql_mode that coercion is an error rather than
-                // a silent fix-up, and the string is a hazard on its own: read
-                // back into PHP it is TRUTHY, so a session that did not bounce
-                // reports that it did.
-                //
-                // Relaxing the two falsy guards is the real fix and is
-                // deliberately not done here -- the second one exists to stop a
-                // partially-loaded entity blanking columns it never loaded, so
-                // changing it needs its own review.
-                $db = \OWA\Core\CoreAPI::dbSingleton();
-                $db->updateTable( 'owa_session' );
-                $db->set( 'is_bounce', 0 );
-                $db->where( 'id', $id );
-                $db->executeQuery();
             }
 
             // setup event message

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -127,7 +127,9 @@ function owa_compat_class_map(): array
 
         // db driver plugin -> OWA\Core\Db\ (Phase 6 stage 3)
         'owa_db_mysql' => 'OWA\\Core\\Db\\Mysql',
-        'owa_db_pdo' => 'OWA\\Core\\Db\\Pdo',
+        // 'pdo' is kept as a friendly alias for the MySQL-over-PDO driver.
+        'owa_db_pdo' => 'OWA\\Core\\Db\\PdoMysql',
+        'owa_db_pdo_mysql' => 'OWA\\Core\\Db\\PdoMysql',
 
         // module.php registry classes -> OWA\Module\<Mod>\Module (Phase 6 stage 3)
         'owa_baseModule' => 'OWA\\Module\\Base\\Module',

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -127,6 +127,7 @@ function owa_compat_class_map(): array
 
         // db driver plugin -> OWA\Core\Db\ (Phase 6 stage 3)
         'owa_db_mysql' => 'OWA\\Core\\Db\\Mysql',
+        'owa_db_pdo' => 'OWA\\Core\\Db\\Pdo',
 
         // module.php registry classes -> OWA\Module\<Mod>\Module (Phase 6 stage 3)
         'owa_baseModule' => 'OWA\\Module\\Base\\Module',

--- a/tests/ConstraintOperatorDialectTest.php
+++ b/tests/ConstraintOperatorDialectTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Operators whose SQL differs by platform must come from the dialect.
+ *
+ * The constraint builder translates OWA's own operator tokens -- '==', '=~',
+ * '=@', 'between' -- into SQL. Some of those have one spelling everywhere and
+ * some do not, and the difference is not obvious by eye:
+ *
+ *   BETWEEN x AND y   ANSI SQL-92. Same in MySQL, PostgreSQL, SQLite, SQL
+ *                     Server and Oracle. Written literally, like = and AND.
+ *   REGEXP            MySQL. PostgreSQL spells it ~. Comes from a constant.
+ *   LOCATE(a, b)      MySQL. PostgreSQL has POSITION(a IN b), SQL Server
+ *                     CHARINDEX. Now comes from a constant.
+ *
+ * LOCATE was written literally two lines below =~ correctly using
+ * OWA_SQL_REGEXP, which is what makes this worth pinning: the right pattern was
+ * already in the file, and the exception did not look like one.
+ *
+ * A dialect supplies the WHOLE expression, not the function name, because the
+ * shape differs too -- POSITION takes an infix IN rather than a comma.
+ */
+final class ConstraintOperatorDialectTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function constraintSqlFor( $operator, $value ) {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->resetBindings();
+        $db->selectFrom( 'owa_session' );
+        $db->selectColumn( 'id' );
+        $db->where( 'referer', $value, $operator );
+
+        return $db->generateSelectQuerySql();
+    }
+
+    /**
+     * The failing case if LOCATE were written literally again: this asserts the
+     * emitted SQL is what the DIALECT declares, so a hard-coded expression that
+     * merely happens to match MySQL still has to agree with the constant.
+     */
+    public function testContainsUsesTheDialectExpression() {
+
+        $sql = $this->constraintSqlFor( '=@', 'example.com' );
+
+        $expected_shape = sprintf( OWA_SQL_CONTAINS, '?', '`referer`' );
+
+        $this->assertStringContainsString(
+            substr( $expected_shape, 0, strpos( $expected_shape, '(' ) + 1 ),
+            $sql,
+            'the "contains" constraint must be built from OWA_SQL_CONTAINS'
+        );
+    }
+
+    public function testNotContainsUsesTheDialectExpression() {
+
+        $sql = $this->constraintSqlFor( '!@', 'example.com' );
+
+        $this->assertStringContainsString(
+            substr( OWA_SQL_NOT_CONTAINS, strrpos( OWA_SQL_NOT_CONTAINS, ')' ) ),
+            $sql,
+            'the "does not contain" constraint must be built from OWA_SQL_NOT_CONTAINS'
+        );
+    }
+
+    /**
+     * The source-level half. The behavioural test above cannot tell a literal
+     * 'LOCATE(...)' from the constant while the dialect IS MySQL -- both emit
+     * the same string -- so the thing actually worth asserting is that the
+     * builder contains no platform-specific function spelling of its own.
+     *
+     * Single-quoted needle deliberately: a double-quoted one containing $this->
+     * would interpolate to nothing and pass unconditionally.
+     */
+    public function testTheBuilderHardCodesNoPlatformSpecificFunction() {
+
+        $source = file_get_contents( dirname( __DIR__ ) . '/Core/Db.php' );
+
+        foreach ( [ 'LOCATE(', 'CHARINDEX(', 'POSITION(', 'INSTR(' ] as $needle ) {
+
+            $this->assertStringNotContainsString(
+                $needle,
+                $source,
+                sprintf(
+                    '%s is a platform-specific spelling written into the query builder. It belongs '
+                  . 'in the dialect, alongside OWA_SQL_REGEXP, so another backend can give its own.',
+                    rtrim( $needle, '(' )
+                )
+            );
+        }
+    }
+
+    /**
+     * BETWEEN is standard SQL, so it is deliberately NOT a dialect constant --
+     * the same treatment = and AND get. This records that as a decision, since
+     * it looks like an inconsistency next to the constants around it.
+     */
+    public function testBetweenIsBuiltInlineBecauseItIsStandardSql() {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->resetBindings();
+        $db->selectFrom( 'owa_session' );
+        $db->selectColumn( 'id' );
+        $db->where( 'yyyymmdd', [ 'start' => 20260101, 'end' => 20260131 ], 'BETWEEN' );
+
+        $this->assertStringContainsString(
+            'BETWEEN',
+            $db->generateSelectQuerySql(),
+            'a BETWEEN constraint must still emit BETWEEN'
+        );
+    }
+}

--- a/tests/DbDriverResolutionTest.php
+++ b/tests/DbDriverResolutionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Whatever driver is chosen, the loader has to be able to find it.
+ *
+ * resolveDbDriver() turns the configured db_type into a driver token, and
+ * setupStorageEngine() turns that token into the class owa_db_<token>. The two
+ * halves are in different methods, so a token that names nothing loadable is
+ * not a syntax error or a failed assertion anywhere -- it is an installation
+ * that cannot open a database, reported as "Cannot locate proper db class".
+ *
+ * That is what made the fallback worth a test of its own. PDO is preferred
+ * wherever pdo_mysql is present, which is every developer machine and every CI
+ * runner, so the arm taken when it is ABSENT is the one nothing exercises --
+ * while being the arm that matters to an installation that has only mysqli, the
+ * configuration OWA supports until v2.
+ *
+ * The mapping assertions below are the readable half. The half that has teeth
+ * is testEveryResolvableDriverNamesALoadableClass: it does not restate what the
+ * tokens should be, it requires that each one resolves to a class, so a future
+ * rename that de-syncs a token from its driver file fails here even if someone
+ * updates the mapping expectations to match their change.
+ */
+final class DbDriverResolutionTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    public function testPdoIsPreferredWhenAvailable() {
+
+        $this->assertSame(
+            'pdo_mysql',
+            \OWA\Core\CoreAPI::resolveDbDriver( 'mysql', true ),
+            'pdo_mysql is the default wherever the extension is present'
+        );
+    }
+
+    /**
+     * An installation with mysqli and no pdo_mysql. Supported until v2.
+     */
+    public function testFallsBackToTheLegacyDriverWithoutPdo() {
+
+        $this->assertSame(
+            'mysql',
+            \OWA\Core\CoreAPI::resolveDbDriver( 'mysql', false ),
+            'without pdo_mysql the legacy driver must be chosen by its own token'
+        );
+    }
+
+    /**
+     * Naming mysqli in configuration opts out of PDO deliberately, and must do
+     * so even where PDO is available -- that is the whole point of writing it.
+     */
+    public function testConfiguredMysqliOptsOutOfPdo() {
+
+        $this->assertSame(
+            'mysql',
+            \OWA\Core\CoreAPI::resolveDbDriver( 'mysqli', true ),
+            'db_type=mysqli must select the legacy driver even alongside PDO'
+        );
+    }
+
+    public function testAnUnrecognisedTypePassesThrough() {
+
+        // The third-party driver seam: plugins/db/owa_db_<type>.php.
+        $this->assertSame(
+            'acme',
+            \OWA\Core\CoreAPI::resolveDbDriver( 'acme', true ),
+            'an unknown type must be handed on untouched for the plugin seam'
+        );
+    }
+
+    /**
+     * The invariant, stated without reference to which token is which: every
+     * driver this can select for a bundled type must resolve to a class that
+     * exists. This is the assertion the previous fallback failed.
+     */
+    public function testEveryResolvableDriverNamesALoadableClass() {
+
+        foreach ( [ 'mysql', 'mysqli' ] as $configured ) {
+
+            foreach ( [ true, false ] as $pdo_available ) {
+
+                $token = \OWA\Core\CoreAPI::resolveDbDriver( $configured, $pdo_available );
+                $legacy_class = 'owa_db_' . $token;
+                $resolved = \OWA\Core\Lib::resolveNamespacedClass( $legacy_class );
+
+                $this->assertNotNull(
+                    $resolved,
+                    sprintf(
+                        'db_type=%s with pdo_mysql %s resolves to driver "%s", and %s names no '
+                      . 'bundled class -- an installation in this configuration cannot connect',
+                        $configured,
+                        $pdo_available ? 'present' : 'absent',
+                        $token,
+                        $legacy_class
+                    )
+                );
+
+                $this->assertTrue(
+                    class_exists( $resolved ),
+                    sprintf( '%s does not exist, so driver "%s" cannot load', $resolved, $token )
+                );
+            }
+        }
+    }
+}

--- a/tests/DbDriverSqlParityTest.php
+++ b/tests/DbDriverSqlParityTest.php
@@ -69,7 +69,7 @@ final class DbDriverSqlParityTest extends TestCase
     {
         return [
             'mysqli' => $this->driver(\OWA\Core\Db\Mysql::class),
-            'pdo'    => $this->driver(\OWA\Core\Db\Pdo::class),
+            'pdo'    => $this->driver(\OWA\Core\Db\PdoMysql::class),
         ];
     }
 
@@ -84,7 +84,14 @@ final class DbDriverSqlParityTest extends TestCase
 
         foreach ($this->drivers() as $name => $db) {
             $build($db);
-            $out[$name] = $db->generateSelectQuerySql();
+            // SQL *and* bindings. With placeholders the statement text alone no
+            // longer carries the values, so comparing only the text would pass
+            // while the drivers bound different things -- the check would have
+            // quietly stopped testing anything the moment binding landed.
+            $out[$name] = [
+                'sql'      => $db->generateSelectQuerySql(),
+                'bindings' => $db->getBindings(),
+            ];
             $db->close();
         }
 
@@ -95,7 +102,7 @@ final class DbDriverSqlParityTest extends TestCase
     {
         $sql = $this->bothSql($build);
 
-        $this->assertNotSame('', trim($sql['mysqli']), 'the builder produced no SQL');
+        $this->assertNotSame('', trim($sql['mysqli']['sql']), 'the builder produced no SQL');
         $this->assertSame($sql['mysqli'], $sql['pdo'], $because);
     }
 
@@ -110,6 +117,48 @@ final class DbDriverSqlParityTest extends TestCase
             $this->assertStringEndsNotWith("'", $escaped, "$name: prepare() added a trailing quote");
 
             $db->close();
+        }
+    }
+
+    /**
+     * Values must reach the statement as BINDINGS, not as text in it. If a value
+     * appears in the SQL, something is interpolating again.
+     */
+    public function testValuesAreBoundRatherThanInterpolated(): void
+    {
+        $sql = $this->bothSql(function ($db) {
+            $db->selectFrom('owa_request', 'r');
+            $db->selectColumn('id');
+            $db->where('page_url', 'https://example.com/secret');
+        });
+
+        foreach ($sql as $driver => $out) {
+            $this->assertStringNotContainsString('example.com/secret', $out['sql'],
+                "$driver: the value was interpolated into the SQL instead of bound");
+            $this->assertContains('https://example.com/secret', $out['bindings'],
+                "$driver: the value never reached the bindings");
+        }
+    }
+
+    /**
+     * Placeholders are positional, so binding order must match the order the
+     * clauses appear in. Transposed bindings would compare the right values
+     * against the wrong columns and still return rows.
+     */
+    public function testBindingsAreInPlaceholderOrder(): void
+    {
+        $sql = $this->bothSql(function ($db) {
+            $db->selectFrom('owa_request', 'r');
+            $db->selectColumn('id');
+            $db->where('site_id', 'FIRST');
+            $db->where('yyyymmdd', ['start' => 'SECOND', 'end' => 'THIRD'], 'BETWEEN');
+            $db->groupBy('r.id');
+            $db->having('id', 'FOURTH', '>');
+        });
+
+        foreach ($sql as $driver => $out) {
+            $this->assertSame(['FIRST', 'SECOND', 'THIRD', 'FOURTH'], $out['bindings'],
+                "$driver: bindings are not in placeholder order");
         }
     }
 
@@ -226,20 +275,40 @@ final class DbDriverSqlParityTest extends TestCase
             . 'so this test was proving nothing');
     }
 
-    /** Insert, update and delete build their values through prepare() too. */
-    public function testWriteStatementsAreIdentical(): void
+    /**
+     * Writes bind their values too.
+     *
+     * Asserted on the generated statement and on a real round trip rather than
+     * on getBindings() after the fact: _insertQuery() executes, and execution
+     * clears the bindings, so reading them afterwards compares two empty arrays
+     * and proves nothing. The first draft of this test did exactly that.
+     */
+    public function testWriteStatementsBindTheirValues(): void
     {
-        $sql = [];
-
         foreach ($this->drivers() as $name => $db) {
-            $db->insertInto('owa_request');
+
+            $db->query('CREATE TEMPORARY TABLE t_parity (id BIGINT, page_url VARCHAR(255))');
+
+            $db->insertInto('t_parity');
             $db->set('id', 12345);
             $db->set('page_url', "O'Brien's page");
-            $sql[$name] = $db->_insertQuery();
+            $db->_insertQuery();
+
+            $this->assertStringContainsString('?', $db->_last_sql_statement,
+                "$name: the INSERT interpolated its values instead of binding them");
+            $this->assertStringNotContainsString("O'Brien", $db->_last_sql_statement,
+                "$name: the value appears in the INSERT text");
+
+            $db->selectFrom('t_parity');
+            $db->select('*');
+            $db->where('id', 12345);
+            $rows = $db->getAllRows();
+
+            $this->assertSame([['id' => '12345', 'page_url' => "O'Brien's page"]], $rows,
+                "$name: the bound write did not round-trip");
+
             $db->close();
         }
-
-        $this->assertSame($sql['mysqli'], $sql['pdo'], 'INSERT differs between drivers');
     }
 
     /** The results themselves must match, not merely the statements. */

--- a/tests/DbDriverSqlParityTest.php
+++ b/tests/DbDriverSqlParityTest.php
@@ -1,0 +1,283 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The PDO driver must generate byte-identical SQL to the mysqli driver.
+ *
+ * WHY THIS IS THE TEST THAT MATTERS
+ * ---------------------------------
+ * A driver looks like a transport, but OWA's drivers also supply the one
+ * function that the SQL BUILDER calls while composing statements: prepare().
+ * Every value and every identifier the builder interpolates passes through it,
+ * and the builder adds the surrounding quotes itself:
+ *
+ *     sprintf( "%s = '%s'", $this->prepare( $name ), $this->prepare( $value ) )
+ *
+ * mysqli_real_escape_string() escapes WITHOUT quotes; PDO::quote() ADDS them.
+ * A PDO prepare() that returns quote() verbatim yields `col = ''value''` --
+ * syntactically broken, on every query, everywhere. So driver equivalence
+ * cannot be argued from "both run SQL"; it has to be measured on the generated
+ * text.
+ *
+ * That matters most for REPORTING, which is where OWA builds SQL dynamically
+ * rather than from literals: the select list, joins, group-bys and constraints
+ * are assembled at runtime from the metric and dimension registry, and
+ * calculated metrics contribute their own SQL expressions. None of that is
+ * visible to a test that only checks a driver can SELECT 1, which is why the
+ * cases below drive the builder the way a report does.
+ *
+ * Skips without a database, like every other DB-backed test here.
+ */
+final class DbDriverSqlParityTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void
+    {
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped('No database available.');
+        }
+
+        if ( ! extension_loaded('pdo_mysql') ) {
+            $this->markTestSkipped('pdo_mysql not loaded.');
+        }
+    }
+
+    /** A driver of the given type, connected with the install's own credentials. */
+    private function driver(string $class): \OWA\Core\Db
+    {
+        $db = new $class(
+            owa_coreAPI::getSetting('base', 'db_host'),
+            owa_coreAPI::getSetting('base', 'db_port'),
+            owa_coreAPI::getSetting('base', 'db_name'),
+            owa_coreAPI::getSetting('base', 'db_user'),
+            owa_coreAPI::getSetting('base', 'db_password'),
+            true,
+            false
+        );
+
+        $this->assertTrue($db->connect(), 'driver failed to connect: ' . $class);
+
+        return $db;
+    }
+
+    private function drivers(): array
+    {
+        return [
+            'mysqli' => $this->driver(\OWA\Core\Db\Mysql::class),
+            'pdo'    => $this->driver(\OWA\Core\Db\Pdo::class),
+        ];
+    }
+
+    /**
+     * Run the same builder programme against both drivers and return the SQL
+     * each produced. The callable receives the driver, so it can drive exactly
+     * the builder calls a report would.
+     */
+    private function bothSql(callable $build): array
+    {
+        $out = [];
+
+        foreach ($this->drivers() as $name => $db) {
+            $build($db);
+            $out[$name] = $db->generateSelectQuerySql();
+            $db->close();
+        }
+
+        return $out;
+    }
+
+    private function assertSameSql(callable $build, string $because): void
+    {
+        $sql = $this->bothSql($build);
+
+        $this->assertNotSame('', trim($sql['mysqli']), 'the builder produced no SQL');
+        $this->assertSame($sql['mysqli'], $sql['pdo'], $because);
+    }
+
+    public function testEscapingProducesNoSurroundingQuotes(): void
+    {
+        // The trap, isolated: this is what the builder interpolates BETWEEN its
+        // own quotes, so a leading/trailing quote here corrupts every statement.
+        foreach ($this->drivers() as $name => $db) {
+            $escaped = $db->prepare("O'Brien");
+
+            $this->assertStringStartsNotWith("'", $escaped, "$name: prepare() added a leading quote");
+            $this->assertStringEndsNotWith("'", $escaped, "$name: prepare() added a trailing quote");
+
+            $db->close();
+        }
+    }
+
+    public function testASimpleConstrainedSelectIsIdentical(): void
+    {
+        $this->assertSameSql(function ($db) {
+            $db->selectFrom('owa_request', 'r');
+            $db->selectColumn('id');
+            $db->where('site_id', 'abc123');
+        }, 'a basic select differs between drivers');
+    }
+
+    /** Values that actually exercise the escaper. */
+    public function testValuesNeedingEscapesAreIdentical(): void
+    {
+        foreach (["O'Brien", 'a"b', "back\\slash", "line\nbreak", "semi;colon", "100% \x00null"] as $hostile) {
+            $this->assertSameSql(function ($db) use ($hostile) {
+                $db->selectFrom('owa_request', 'r');
+                $db->selectColumn('id');
+                $db->where('page_url', $hostile);
+            }, 'escaping differs for: ' . json_encode($hostile));
+        }
+    }
+
+    public function testEveryConstraintOperatorIsIdentical(): void
+    {
+        foreach (['=', '!=', '>', '<', '>=', '<=', 'LIKE'] as $op) {
+            $this->assertSameSql(function ($db) use ($op) {
+                $db->selectFrom('owa_request', 'r');
+                $db->selectColumn('id');
+                $db->where('page_url', "va'lue", $op);
+            }, "operator $op differs between drivers");
+        }
+    }
+
+    public function testABetweenConstraintIsIdentical(): void
+    {
+        $this->assertSameSql(function ($db) {
+            $db->selectFrom('owa_request', 'r');
+            $db->selectColumn('id');
+            $db->where('yyyymmdd', ['start' => '20260101', 'end' => '20260131'], 'BETWEEN');
+        }, 'a BETWEEN constraint differs between drivers');
+    }
+
+    /**
+     * A report-shaped query: joins, group-by, having, order, limit and offset all
+     * at once. This is the construction the reporting layer actually performs,
+     * and each clause passes its own values through prepare().
+     */
+    public function testAReportShapedQueryIsIdentical(): void
+    {
+        $this->assertSameSql(function ($db) {
+            $db->selectFrom('owa_request', 'r');
+            $db->selectColumn('COUNT(*)', 'visits');
+            $db->selectColumn('r.page_url', 'pagePath');
+            $db->join(OWA_SQL_JOIN_LEFT_OUTER, 'owa_document', 'd', 'r.document_id', 'd.id');
+            $db->where('r.site_id', "site'1");
+            $db->where('r.yyyymmdd', ['start' => '20260101', 'end' => '20260131'], 'BETWEEN');
+            $db->groupBy('r.page_url');
+            $db->having('visits', 5, '>');
+            $db->orderBy('visits', OWA_SQL_DESCENDING);
+            $db->limit(25);
+            $db->offset(50);
+        }, 'a report-shaped query differs between drivers');
+    }
+
+    /**
+     * Calculated metrics contribute their own SQL expression to the select list
+     * rather than a bare column, so they are a distinct construction path from
+     * the clauses above and are pinned separately.
+     */
+    public function testCalculatedMetricSelectExpressionsAreIdentical(): void
+    {
+        // Fully qualified on purpose: metricFactory() with a BARE name resolves
+        // through getMetricClasses(), which returns an ARRAY when a metric is
+        // registered by more than one module, and moduleSpecificFactory() then
+        // explodes it -- a TypeError. Not this test's business to fix, but it is
+        // why these are 'base.x' rather than 'x'.
+        $metrics = ['base.bounceRate', 'base.actionsPerVisit', 'base.revenuePerVisit', 'base.ecommerceConversionRate'];
+        $checked = 0;
+
+        foreach ($metrics as $name) {
+
+            try {
+                $metric = owa_coreAPI::metricFactory($name);
+            } catch (\Throwable $e) {
+                // Not registered in this build; the count assertion below is what
+                // stops the whole test quietly passing on an empty list.
+                continue;
+            }
+
+            if ( ! is_object($metric) || ! method_exists($metric, 'getSelect') ) {
+                continue;
+            }
+
+            $select = $metric->getSelect();
+
+            if ( ! $select ) {
+                continue;
+            }
+
+            $checked++;
+
+            $this->assertSameSql(function ($db) use ($select) {
+                $db->selectFrom('owa_session', 's');
+                $db->selectColumn($select);
+                $db->where('s.site_id', "site'1");
+                $db->groupBy('s.site_id');
+            }, "calculated metric $name produces different SQL between drivers");
+        }
+
+        $this->assertGreaterThan(0, $checked,
+            'no calculated metric was exercised -- the registry lookup must have failed, '
+            . 'so this test was proving nothing');
+    }
+
+    /** Insert, update and delete build their values through prepare() too. */
+    public function testWriteStatementsAreIdentical(): void
+    {
+        $sql = [];
+
+        foreach ($this->drivers() as $name => $db) {
+            $db->insertInto('owa_request');
+            $db->set('id', 12345);
+            $db->set('page_url', "O'Brien's page");
+            $sql[$name] = $db->_insertQuery();
+            $db->close();
+        }
+
+        $this->assertSame($sql['mysqli'], $sql['pdo'], 'INSERT differs between drivers');
+    }
+
+    /** The results themselves must match, not merely the statements. */
+    public function testBothDriversReturnTheSameRows(): void
+    {
+        $sql = "SELECT 1 AS one, 'O''Brien' AS name";
+        $rows = [];
+
+        foreach ($this->drivers() as $name => $db) {
+            $rows[$name] = $db->get_results($sql);
+            $db->close();
+        }
+
+        $this->assertSame($rows['mysqli'], $rows['pdo'], 'the drivers returned different rows');
+        $this->assertNotNull($rows['pdo']);
+    }
+
+    /** No rows must read as null from both, not [] from one and null from the other. */
+    public function testNoRowsIsNullFromBothDrivers(): void
+    {
+        foreach ($this->drivers() as $name => $db) {
+            $this->assertNull($db->get_results('SELECT 1 AS x FROM DUAL WHERE 1 = 0'),
+                "$name: an empty result must be null");
+            $this->assertNull($db->get_row('SELECT 1 AS x FROM DUAL WHERE 1 = 0'),
+                "$name: an empty row must be null");
+            $db->close();
+        }
+    }
+
+    /** A failed statement must be falsy, not an exception, from both. */
+    public function testAFailedQueryIsFalsyFromBothDrivers(): void
+    {
+        foreach ($this->drivers() as $name => $db) {
+            $this->assertFalse((bool) $db->query('SELECT * FROM a_table_that_does_not_exist_here'),
+                "$name: a failed query must return falsy rather than throw");
+            $this->assertNull($db->get_row('SELECT * FROM a_table_that_does_not_exist_here'),
+                "$name: get_row on a failed query must be null");
+            $db->close();
+        }
+    }
+}

--- a/tests/DomStreamsRestControllerTest.php
+++ b/tests/DomStreamsRestControllerTest.php
@@ -63,6 +63,12 @@ final class DomStreamsRestControllerTest extends RestControllerTestCase
         $ds->set('page_width', 1280);
         $ds->set('page_height', 3000);
         $ds->set('timestamp', time());
+        // yyyymmdd is NOT NULL and is the partition key. The real ingestion path
+        // supplies it (live domstream tables carry no zero values), so a seed
+        // that omits it is testing something the product never does -- and it
+        // only ever worked because the escaping path wrote '' and a permissive
+        // sql_mode coerced that to 0.
+        $ds->set('yyyymmdd', (int) date('Ymd'));
         $ds->create();
 
         $this->trackForCleanup('base.domstream', $guid, 'id');

--- a/tests/EntityFalsyWriteTest.php
+++ b/tests/EntityFalsyWriteTest.php
@@ -151,4 +151,82 @@ final class EntityFalsyWriteTest extends TestCase
             $db->query("DELETE FROM owa_session WHERE id = $id");
         }
     }
+
+    /**
+     * The numeric-type check must read OWA's vocabulary, not MySQL's spelling.
+     *
+     * This started as a regex over type strings -- BIGINT|INT|TINYINT|... -- and
+     * that is a MySQL DDL grammar sitting in the entity layer. It would have
+     * gone wrong quietly on the first dialect that spells its integers
+     * differently: nothing would match, falsy values would silently go back to
+     * being discarded, and the failure would look like data that never arrived
+     * rather than a type check that stopped recognising types.
+     *
+     * The constants are the portable part. OWA_DTD_BIGINT means "a big integer"
+     * in every dialect; its VALUE is only what the loaded one calls it. So every
+     * entry in the numeric list must be the value of some declared OWA_DTD_*
+     * constant -- a literal spelling that no dialect declares fails here, which
+     * is exactly what a reintroduced regex or a hand-written list would produce.
+     */
+    public function testTheNumericTypeListIsDerivedFromDeclaredTypesNotLiterals(): void
+    {
+        $entity = \OWA\Core\CoreAPI::entityFactory('base.click');
+
+        $method = new ReflectionMethod($entity, 'numericColumnTypes');
+        $method->setAccessible(true);
+        $types = $method->invoke($entity);
+
+        $this->assertNotEmpty($types, 'no numeric column types were resolved at all');
+
+        $declared = [];
+
+        foreach (get_defined_constants() as $name => $value) {
+
+            if (strpos($name, 'OWA_DTD_') === 0) {
+                $declared[$value] = $name;
+            }
+        }
+
+        foreach ($types as $type) {
+
+            $this->assertArrayHasKey(
+                $type,
+                $declared,
+                sprintf(
+                    '"%s" is not the value of any OWA_DTD_* constant, so it is a hard-coded SQL '
+                  . 'spelling. It will stop matching on a dialect that spells the type another '
+                  . 'way, and falsy values on those columns will be dropped silently.',
+                    $type
+                )
+            );
+        }
+    }
+
+    /**
+     * Stated through the constants rather than their values, so it keeps
+     * meaning the same thing under a dialect that spells them differently.
+     */
+    public function testDeclaredIntegerTypesAreRecognisedThroughTheirConstants(): void
+    {
+        $entity = \OWA\Core\CoreAPI::entityFactory('base.click');
+
+        $method = new ReflectionMethod($entity, 'numericColumnTypes');
+        $method->setAccessible(true);
+        $types = $method->invoke($entity);
+
+        foreach (['OWA_DTD_BIGINT', 'OWA_DTD_INT', 'OWA_DTD_BOOLEAN'] as $constant) {
+
+            $this->assertContains(
+                (string) constant($constant),
+                $types,
+                sprintf('%s must count as a numeric column type', $constant)
+            );
+        }
+
+        $this->assertNotContains(
+            (string) OWA_DTD_VARCHAR255,
+            $types,
+            'a string column must not accept falsy writes -- an empty string means "no value"'
+        );
+    }
 }

--- a/tests/EntityFalsyWriteTest.php
+++ b/tests/EntityFalsyWriteTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An entity can store a legitimate falsy value on a numeric column.
+ *
+ * WHAT WAS WRONG
+ * Entity::set() guarded on `if ( $value )`, so 0, false and '' were all
+ * discarded without a word. Setting a numeric column to 0 did nothing, and the
+ * caller could not tell. Entity::update() then repeated the mistake, including
+ * a column only when its value was truthy, so even a 0 that had been stored
+ * could not be persisted.
+ *
+ * The visible consequence was SessionHandlers writing the STRING 'false' into
+ * is_bounce: a truthy value was the only kind that survived both guards, and
+ * MySQL coerced the non-numeric string to 0 on the way in. That worked by
+ * accident, broke under a strict sql_mode, and was TRUTHY when read back into
+ * PHP -- so a session that had not bounced reported that it had.
+ *
+ * WHY BY TYPE, NOT BY REMOVING THE GUARD
+ * The two falsy cases are not alike. On a numeric column, 0 is a value. On a
+ * string column, '' is what a caller passes when it has nothing, and several
+ * handlers depend on `set('medium', $maybeEmpty)` leaving the existing value
+ * alone -- storing empties there would blank data that is deliberately kept
+ * today. So numeric columns widened; everything else unchanged.
+ *
+ * The type is not new information: every column already declares one as
+ * DbColumn's second constructor argument. Nothing consulted it until now.
+ *
+ * WHY IT MATTERS BEYOND is_bounce
+ * v2's event table is full of columns where 0 is ordinary -- the sticky
+ * `engaged` flag, `is_exit`, engagement-time deltas. Without this, writing any
+ * of them through an entity would silently do nothing.
+ */
+final class EntityFalsyWriteTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function session()
+    {
+        return owa_coreAPI::entityFactory('base.session');
+    }
+
+    public function testANumericColumnAcceptsZero(): void
+    {
+        $s = $this->session();
+        $s->set('num_pageviews', 0);
+
+        $this->assertSame(0, $s->get('num_pageviews'),
+            'a numeric column silently discarded a legitimate 0');
+    }
+
+    public function testABooleanColumnAcceptsZeroAndFalse(): void
+    {
+        $s = $this->session();
+
+        $s->set('is_bounce', 0);
+        $this->assertSame(0, $s->get('is_bounce'));
+
+        $s2 = $this->session();
+        $s2->set('is_bounce', false);
+        $this->assertFalse($s2->get('is_bounce'));
+    }
+
+    /** Storing it is only half the job; update() has to include it. */
+    public function testAFalsyValueIsMarkedDirtySoUpdateWillWriteIt(): void
+    {
+        $s = $this->session();
+        $s->set('is_bounce', 1);
+        $s->dirty = [];              // as if freshly loaded from the database
+
+        $s->set('is_bounce', 0);
+
+        $this->assertArrayHasKey('is_bounce', $s->dirty,
+            'setting a column to 0 left it un-dirty, so update() would skip it');
+    }
+
+    /**
+     * The half that must NOT change: an empty string on a text column is still
+     * ignored, because callers pass one when they have nothing and rely on the
+     * existing value surviving.
+     */
+    public function testAStringColumnStillIgnoresAnEmptyValue(): void
+    {
+        $s = $this->session();
+        $s->set('medium', 'organic');
+
+        $s->set('medium', '');
+        $this->assertSame('organic', $s->get('medium'),
+            "an empty string blanked a text column -- handlers depend on it being ignored");
+
+        $s->set('medium', null);
+        $this->assertSame('organic', $s->get('medium'), 'null blanked a text column');
+    }
+
+    /** A numeric column must not accept a non-numeric falsy value either. */
+    public function testANumericColumnStillIgnoresEmptyAndNull(): void
+    {
+        $s = $this->session();
+        $s->set('num_pageviews', 7);
+
+        $s->set('num_pageviews', '');
+        $this->assertSame(7, $s->get('num_pageviews'));
+
+        $s->set('num_pageviews', null);
+        $this->assertSame(7, $s->get('num_pageviews'));
+    }
+
+    /**
+     * End to end through the database, which is the only place the update()
+     * change can be observed. Also asserts an untouched column survives, since
+     * the risk of consulting the dirty list is writing too much, not too little.
+     */
+    public function testAZeroSurvivesACreateUpdateRoundTrip(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('No database available.');
+        }
+
+        $db = owa_coreAPI::dbSingleton();
+        $id = '9111222333444555777';
+        $db->query("DELETE FROM owa_session WHERE id = $id");
+
+        try {
+            $s = $this->session();
+            $s->set('id', $id);
+            $s->set('site_id', 'entity-falsy-test');
+            $s->set('yyyymmdd', (int) date('Ymd'));
+            $s->set('timestamp', time());
+            $s->set('is_bounce', 1);
+            $s->set('num_pageviews', 3);
+            $s->create();
+
+            $s2 = $this->session();
+            $s2->getByPk('id', $id);
+            $s2->set('is_bounce', 0);
+            $s2->update();
+
+            $row = $db->get_row("SELECT is_bounce, num_pageviews FROM owa_session WHERE id = ?", [$id]);
+
+            $this->assertSame('0', (string) $row['is_bounce'],
+                'the 0 never reached the database');
+            $this->assertSame('3', (string) $row['num_pageviews'],
+                'an untouched column was overwritten by the update');
+
+        } finally {
+            $db->query("DELETE FROM owa_session WHERE id = $id");
+        }
+    }
+}

--- a/tests/PartitionOperationsTest.php
+++ b/tests/PartitionOperationsTest.php
@@ -1077,7 +1077,7 @@ final class PartitionOperationsTest extends TestCase
 
             public function __construct() {}
 
-            function get_row($sql)
+            function get_row($sql, array $params = array())
             {
                 $this->sql[] = $sql;
 

--- a/tests/SqlModeDefaultTest.php
+++ b/tests/SqlModeDefaultTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Strict SQL mode is the default, and it is overridable.
+ *
+ * OWA sent `SET SESSION sql_mode=''` on every connection for years, disabling
+ * strict mode and turning bad writes into wrong data instead of errors: values
+ * too long for their column were truncated, and non-numeric values written to
+ * integer columns became 0.
+ *
+ * That produced real damage. Rows were found on two live installs whose
+ * yyyymmdd -- the fact-table partition key, and the column every date-range
+ * report filters on -- had been coerced to 0, making them invisible to reporting
+ * and putting them in the catch-all partition.
+ *
+ * This pins both halves of the fix, because each fails differently:
+ *
+ *   - if the default silently reverted to '', the coercions would come back and
+ *     nothing else in the suite would notice;
+ *   - if the override stopped working, an install that hits a genuine problem in
+ *     third-party code would have no way out but a patch.
+ */
+final class SqlModeDefaultTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /** Reads the protected dialect method the drivers consult on connect. */
+    private function modeFor(string $driverClass)
+    {
+        $db = new $driverClass('h', '3306', 'n', 'u', 'p', true, false);
+
+        $m = new \ReflectionMethod($db, 'sessionSqlMode');
+        $m->setAccessible(true);
+
+        return $m->invoke($db);
+    }
+
+    public static function driverProvider(): array
+    {
+        return [
+            'mysqli' => [\OWA\Core\Db\Mysql::class],
+            'pdo'    => [\OWA\Core\Db\PdoMysql::class],
+        ];
+    }
+
+    /**
+     * @dataProvider driverProvider
+     */
+    public function testStrictIsTheDefault(string $driverClass): void
+    {
+        // No OWA_DB_SQL_MODE constant and no env var in a normal test run.
+        if (getenv('OWA_DB_SQL_MODE') !== false || defined('OWA_DB_SQL_MODE')) {
+            $this->markTestSkipped('sql_mode is overridden in this environment.');
+        }
+
+        $mode = $this->modeFor($driverClass);
+
+        $this->assertNotSame('', $mode,
+            "the empty sql_mode disables strict mode -- that is the behaviour this release removed");
+        $this->assertStringContainsString('STRICT', (string) $mode,
+            'the default session sql_mode must be strict');
+    }
+
+    /**
+     * Both drivers must agree. They share the dialect, but a future driver could
+     * answer this itself, and a disagreement would mean the same install
+     * coerced or refused depending on which extension happened to be present.
+     */
+    public function testBothDriversAgreeOnTheMode(): void
+    {
+        $this->assertSame(
+            $this->modeFor(\OWA\Core\Db\Mysql::class),
+            $this->modeFor(\OWA\Core\Db\PdoMysql::class),
+            'the drivers disagree about sql_mode'
+        );
+    }
+
+    /**
+     * The way back, documented in UPGRADING.md. Exercised through the env
+     * channel because a constant cannot be undefined once set.
+     */
+    public function testTheModeCanBeOverridden(): void
+    {
+        if (defined('OWA_DB_SQL_MODE')) {
+            $this->markTestSkipped('OWA_DB_SQL_MODE is already defined.');
+        }
+
+        $original = getenv('OWA_DB_SQL_MODE');
+
+        try {
+            putenv('OWA_DB_SQL_MODE=');
+            $this->assertSame('', $this->modeFor(\OWA\Core\Db\PdoMysql::class),
+                'an install must be able to restore the permissive behaviour');
+
+            putenv('OWA_DB_SQL_MODE=STRICT_TRANS_TABLES');
+            $this->assertSame('STRICT_TRANS_TABLES', $this->modeFor(\OWA\Core\Db\PdoMysql::class));
+
+        } finally {
+            if ($original === false) {
+                putenv('OWA_DB_SQL_MODE');
+            } else {
+                putenv('OWA_DB_SQL_MODE=' . $original);
+            }
+        }
+    }
+}

--- a/tests/SqlPortabilityLintTest.php
+++ b/tests/SqlPortabilityLintTest.php
@@ -1,0 +1,222 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Platform-specific SQL belongs in the dialect, not scattered through the app.
+ *
+ * OWA has a dialect layer -- the OWA_SQL_* and OWA_DTD_* constants -- whose job
+ * is to be the one place a backend's spelling lives. It works, and the pattern
+ * is followed almost everywhere. The failures are not architectural, they are
+ * individual lines that slipped past, and every one found so far had the
+ * correct pattern in view when it was written:
+ *
+ *   LOCATE(a, b)   sat two lines below =~ correctly using OWA_SQL_REGEXP
+ *   SHOW TABLES    was written out twice while OWA_SQL_SHOW_TABLE existed and
+ *                  InstallManager was already using it
+ *   IFNULL()       was reached for where ANSI COALESCE means the same thing
+ *
+ * That is what makes a lint the right shape for this rather than a note in a
+ * review. These are not caught by reading, because each one looks ordinary
+ * where it sits, and none of them fail on MySQL -- which is the only backend
+ * anyone runs today, so nothing else can catch them either. The cost of missing
+ * one is a silent wrong answer on the first non-MySQL install, not an error.
+ *
+ * Scans STRING LITERALS ONLY, via token_get_all. A comment explaining that
+ * PostgreSQL uses ON CONFLICT must not trip a check for ON DUPLICATE KEY, and
+ * a grep cannot tell those apart -- this file's own docblock would fail it.
+ */
+final class SqlPortabilityLintTest extends TestCase {
+
+    /**
+     * MySQL-only constructs, with what a portable equivalent would be. Keep the
+     * reason with the pattern: the message is the whole value of a lint.
+     */
+    private const MYSQL_ONLY = [
+        'ON DUPLICATE KEY' => 'PostgreSQL spells this ON CONFLICT ... DO UPDATE',
+        'INSERT IGNORE'    => 'PostgreSQL spells this ON CONFLICT DO NOTHING',
+        'REPLACE INTO'     => 'not standard; an upsert belongs in the dialect',
+        'SHOW TABLES'      => 'use OWA_SQL_SHOW_TABLE, which already exists',
+        'SHOW INDEX'       => 'index introspection belongs in the dialect',
+        'IFNULL('          => 'use COALESCE(), which is ANSI SQL and works in MySQL too',
+        'UNIX_TIMESTAMP('  => 'date handling differs per dialect; put it behind a constant',
+        'FROM_UNIXTIME('   => 'date handling differs per dialect; put it behind a constant',
+        'DATE_FORMAT('     => 'date formatting differs per dialect',
+        'GROUP_CONCAT('    => 'PostgreSQL spells this string_agg()',
+        'SUBSTRING_INDEX(' => 'no standard equivalent; put it behind a constant',
+        'LOCATE('          => 'use OWA_SQL_CONTAINS / OWA_SQL_NOT_CONTAINS',
+        'SQL_CALC_FOUND_ROWS' => 'MySQL-only and removed in MySQL 8.0.17+',
+        'STRAIGHT_JOIN'    => 'MySQL-only optimiser hint',
+        'information_schema' => 'schema introspection belongs in the dialect',
+    ];
+
+    /**
+     * Where platform-specific SQL is allowed to live, and why.
+     *
+     * The dialect files ARE the abstraction, so they are exempt by definition.
+     * The two CLI commands are exempt by DECISION: they drive MySQL table
+     * partitioning, which has no equivalent elsewhere, and they say so in their
+     * own docblocks. Their SQL is not a cheat -- there is nothing to abstract
+     * over. Anything added to this list should be an argument, not a shortcut.
+     */
+    private const EXEMPT = [
+        'Core/Db/MysqlDialect.php',
+        'Core/Db/Mysql.php',
+        'Core/Db/PdoMysql.php',
+        'Core/Db/Pdo.php',
+        // The id rewrite and the partition commands: MySQL table partitioning
+        // has no equivalent elsewhere, and these say so in their own docblocks.
+        'modules/Base/Controller/RederiveDimensionIdsCli.php',
+        'modules/Base/Controller/PartitionDropCli.php',
+        'modules/Base/Controller/PartitionInitCli.php',
+        'modules/Base/Controller/PartitionReorganizeCli.php',
+        'modules/Base/Controller/PartitionRotateCli.php',
+        'modules/Base/Controller/PartitionStatusCli.php',
+        'modules/Base/Controller/PartitionsCli.php',
+    ];
+
+    /**
+     * Exempt directories.
+     *
+     * Update scripts are historical: each one migrates a schema that existed at
+     * one moment in the past, and every installation that has ever run one was
+     * on MySQL, because MySQL is the only backend OWA has ever had. A new
+     * install on another backend starts at the current schema and never
+     * executes them. Their SQL is a record of what happened, not a statement
+     * about what OWA supports, and rewriting it would be editing history to no
+     * effect.
+     */
+    private const EXEMPT_DIRS = [
+        'modules/Base/Update/',
+    ];
+
+    /**
+     * @return array<string> absolute paths
+     */
+    private function sourceFiles(): array {
+
+        $root = dirname( __DIR__ );
+        $files = [];
+
+        foreach ( [ 'Core', 'modules' ] as $dir ) {
+
+            $it = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator( $root . '/' . $dir, FilesystemIterator::SKIP_DOTS )
+            );
+
+            foreach ( $it as $file ) {
+
+                if ( $file->getExtension() !== 'php' ) {
+                    continue;
+                }
+
+                $path = $file->getPathname();
+
+                // Third-party code vendored inside a module is not ours to fix.
+                if ( strpos( $path, '/includes/' ) !== false || strpos( $path, '/vendor/' ) !== false ) {
+                    continue;
+                }
+
+                $relative = str_replace( $root . '/', '', $path );
+
+                if ( in_array( $relative, self::EXEMPT, true ) ) {
+                    continue;
+                }
+
+                foreach ( self::EXEMPT_DIRS as $dir ) {
+
+                    if ( strpos( $relative, $dir ) === 0 ) {
+                        continue 2;
+                    }
+                }
+
+                $files[ $relative ] = $path;
+            }
+        }
+
+        ksort( $files );
+
+        return $files;
+    }
+
+    /**
+     * @return array<string> the string literals in a file
+     */
+    private function stringLiterals( string $path ): array {
+
+        $out = [];
+
+        foreach ( token_get_all( (string) file_get_contents( $path ) ) as $token ) {
+
+            if ( ! is_array( $token ) ) {
+                continue;
+            }
+
+            if ( $token[0] === T_CONSTANT_ENCAPSED_STRING || $token[0] === T_ENCAPSED_AND_WHITESPACE
+                || $token[0] === T_INLINE_HTML ) {
+
+                $out[] = $token[1];
+            }
+        }
+
+        return $out;
+    }
+
+    public function testNoMysqlOnlySqlOutsideTheDialect(): void {
+
+        $findings = [];
+
+        foreach ( $this->sourceFiles() as $relative => $path ) {
+
+            foreach ( $this->stringLiterals( $path ) as $literal ) {
+
+                foreach ( self::MYSQL_ONLY as $needle => $why ) {
+
+                    if ( stripos( $literal, $needle ) !== false ) {
+
+                        $findings[] = sprintf( '%s: "%s" -- %s', $relative, $needle, $why );
+                    }
+                }
+            }
+        }
+
+        $findings = array_values( array_unique( $findings ) );
+
+        $this->assertSame(
+            [],
+            $findings,
+            "MySQL-specific SQL found outside the dialect layer.\n\n"
+          . "Each of these will keep working on MySQL and produce a wrong answer or an error on\n"
+          . "any other backend, which is why nothing else catches them. Move the spelling into\n"
+          . "Core/Db/MysqlDialect.php behind an OWA_SQL_* constant, or -- if the feature genuinely\n"
+          . "has no equivalent elsewhere -- add the file to EXEMPT with the reason.\n\n"
+          . implode( "\n", $findings )
+        );
+    }
+
+    /**
+     * A lint nobody can see the scope of is a lint nobody trusts. If the exempt
+     * list grows a stale entry, this says so rather than quietly covering a file
+     * that no longer exists.
+     */
+    public function testEveryExemptFileStillExists(): void {
+
+        $root = dirname( __DIR__ );
+
+        foreach ( self::EXEMPT as $relative ) {
+
+            $this->assertFileExists(
+                $root . '/' . $relative,
+                sprintf( '%s is exempted from the SQL portability lint but no longer exists', $relative )
+            );
+        }
+
+        foreach ( self::EXEMPT_DIRS as $relative ) {
+
+            $this->assertDirectoryExists(
+                $root . '/' . $relative,
+                sprintf( '%s is exempted from the SQL portability lint but no longer exists', $relative )
+            );
+        }
+    }
+}

--- a/tests/TimeBoundPartitionPruningTest.php
+++ b/tests/TimeBoundPartitionPruningTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A time-bounded query must also carry a CLOSED date bound.
+ *
+ * The fact tables are RANGE-partitioned on yyyymmdd. A predicate naming only
+ * `timestamp` cannot prune, and is unselective enough that the optimiser
+ * abandons the timestamp index as well. Measured on a live table:
+ *
+ *   timestamp > X                           all partitions, no index, 405,217 rows
+ *   yyyymmdd >= D AND timestamp > X         all from D,     no index, 351,937 rows
+ *   yyyymmdd BETWEEN D-1 AND D AND ts > X   1 partition,    yyyymmdd,   4,080 rows
+ *
+ * The middle row is the reason this says CLOSED: an open lower bound still reads
+ * every partition from D onward. Verified again after the fix with EXPLAIN on a
+ * 29-partition table -- 29 partitions scanned before, 1 after.
+ *
+ * WHY IN THE QUERY BUILDER
+ * A report author has no reason to know how the facts are physically laid out,
+ * and there are ~60 declarative report controllers that would each have to
+ * remember. Deriving it centrally also puts it at the seam a non-SQL reporting
+ * backend would later override with its own pruning predicate -- ClickHouse
+ * partition keys, Parquet row-group statistics and DuckDB zone maps all want the
+ * same thing. Pushed into the reports instead, it would die with the star schema.
+ *
+ * THE REVERSE DIRECTION IS A CORRECTNESS BUG, NOT A PERFORMANCE ONE
+ * last_half_hour and last_hour are allowlisted periods, and both produced
+ * exactly the same constraint as `today` -- date BETWEEN D AND D, with no
+ * timestamp bound at all. The period object knew it meant 22:15-22:45; the query
+ * asked for all 1,440 minutes of the day. Measured on a live table: "last hour"
+ * returned 131 rows where the true answer was 5. Wrong answers, silently, on a
+ * period any user can pick.
+ *
+ * These assert the CONSTRAINTS rather than the SQL, because that is the contract
+ * the builder owes: whatever the storage engine, a time bound implies a date
+ * bound and a partial-day period implies a time bound.
+ */
+final class TimeBoundPartitionPruningTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function rsmForTimeRange(int $start, int $end): \OWA\Module\Base\Classes\ResultSetManager
+    {
+        $rsm = new \OWA\Module\Base\Classes\ResultSetManager;
+        $rsm->setTimePeriod('', '', '', $start, $end);
+
+        return $rsm;
+    }
+
+    public function testATimeBoundAlsoProducesADateBound(): void
+    {
+        $end   = time();
+        $start = $end - 1800;
+
+        $constraints = $this->rsmForTimeRange($start, $end)->getConstraints();
+
+        $this->assertArrayHasKey('timestamp', $constraints, 'the time bound itself is missing');
+        $this->assertArrayHasKey('date', $constraints,
+            'a time bound produced no date bound, so the query cannot prune partitions');
+    }
+
+    /** Closed at BOTH ends -- an open bound still reads every later partition. */
+    public function testTheDateBoundIsClosed(): void
+    {
+        $end   = time();
+        $start = $end - 1800;
+
+        $date = $this->rsmForTimeRange($start, $end)->getConstraints()['date'];
+
+        $this->assertSame('BETWEEN', $date['operator'],
+            'the date bound must be a closed range, not an open comparison');
+        $this->assertNotEmpty($date['value']['start']);
+        $this->assertNotEmpty($date['value']['end']);
+    }
+
+    public function testTheDateBoundMatchesTheTimestamps(): void
+    {
+        $start = mktime(10, 0, 0, 3, 14, 2026);
+        $end   = mktime(11, 0, 0, 3, 14, 2026);
+
+        $date = $this->rsmForTimeRange($start, $end)->getConstraints()['date'];
+
+        $this->assertSame(date('Ymd', $start), $date['value']['start']);
+        $this->assertSame(date('Ymd', $end), $date['value']['end']);
+    }
+
+    /**
+     * A window crossing midnight must span both days. Getting this wrong loses
+     * rows rather than merely scanning too many, so it is the case that has to
+     * be right.
+     */
+    public function testAWindowCrossingMidnightSpansBothDays(): void
+    {
+        $start = mktime(23, 45, 0, 3, 14, 2026);
+        $end   = mktime(0, 15, 0, 3, 15, 2026);
+
+        $date = $this->rsmForTimeRange($start, $end)->getConstraints()['date'];
+
+        $this->assertSame(date('Ymd', $start), $date['value']['start']);
+        $this->assertSame(date('Ymd', $end), $date['value']['end']);
+        $this->assertNotSame($date['value']['start'], $date['value']['end'],
+            'a window crossing midnight collapsed to a single day and would lose rows');
+    }
+
+    /** A plain date range already bounds yyyymmdd and must be left alone. */
+    public function testADateRangePeriodIsUnchanged(): void
+    {
+        $rsm = new \OWA\Module\Base\Classes\ResultSetManager;
+        $rsm->setTimePeriod('', '20260301', '20260331', '', '');
+
+        $constraints = $rsm->getConstraints();
+
+        $this->assertArrayHasKey('date', $constraints);
+        $this->assertSame('BETWEEN', $constraints['date']['operator']);
+        $this->assertSame('20260301', $constraints['date']['value']['start']);
+        $this->assertSame('20260331', $constraints['date']['value']['end']);
+        $this->assertArrayNotHasKey('timestamp', $constraints,
+            'a date range should not invent a timestamp bound');
+    }
+
+    /**
+     * The correctness half: a partial-day period must narrow by time, or it
+     * silently reports the whole day.
+     *
+     * @dataProvider subDayPeriodProvider
+     */
+    public function testAPartialDayPeriodAlsoBoundsTime(string $period): void
+    {
+        $rsm = new \OWA\Module\Base\Classes\ResultSetManager;
+        $rsm->setTimePeriod($period, '', '', '', '');
+
+        $constraints = $rsm->getConstraints();
+
+        $this->assertArrayHasKey('timestamp', $constraints,
+            "$period bounded only the date, so it reports the whole day");
+
+        $span = $constraints['timestamp']['value']['end'] - $constraints['timestamp']['value']['start'];
+
+        $this->assertLessThan(86400, $span, "$period did not narrow to less than a day");
+    }
+
+    public static function subDayPeriodProvider(): array
+    {
+        return ['last_half_hour' => ['last_half_hour'], 'last_hour' => ['last_hour']];
+    }
+
+    /**
+     * Whole-day-or-longer periods must be left exactly as they were. Adding a
+     * time bound here would narrow them -- last_seven_days starts at 23:59:59,
+     * so a naive alignment test turns seven whole days into a rolling 7x24h
+     * window and shifts numbers users already read.
+     *
+     * @dataProvider wholeDayPeriodProvider
+     */
+    public function testWholeDayPeriodsGainNoTimeBound(string $period): void
+    {
+        $rsm = new \OWA\Module\Base\Classes\ResultSetManager;
+        $rsm->setTimePeriod($period, '', '', '', '');
+
+        $this->assertArrayNotHasKey('timestamp', $rsm->getConstraints(),
+            "$period gained a time bound and would return fewer rows than before");
+    }
+
+    public static function wholeDayPeriodProvider(): array
+    {
+        return array_map(
+            static fn($p) => [$p],
+            array_combine(
+                ['today', 'yesterday', 'this_week', 'last_week', 'last_seven_days',
+                 'last_thirty_days', 'this_month', 'last_month', 'this_year', 'last_year'],
+                ['today', 'yesterday', 'this_week', 'last_week', 'last_seven_days',
+                 'last_thirty_days', 'this_month', 'last_month', 'this_year', 'last_year']
+            )
+        );
+    }
+}

--- a/tests/e2e/reporting-facets.spec.js
+++ b/tests/e2e/reporting-facets.spec.js
@@ -1,0 +1,284 @@
+// @ts-check
+/**
+ * The reporting engine, exercised on its facets against known numbers.
+ *
+ * WHY THIS EXISTS
+ * The existing reporting spec asserts that the dashboard RENDERS -- grids
+ * present, dropdown sprites loaded, column widths aligned -- and its only
+ * numeric assertion is `expect(gridText).toMatch(/\b2\b/)`, which passes if the
+ * digit 2 appears anywhere on the page. Every number on every report could be
+ * wrong and it would stay green.
+ *
+ * It did. Varnish was stripping owa_source from the request before PHP ever saw
+ * it, so the Source Detail report ran with NO constraint and showed the same
+ * unfiltered total for google, facebook and everything else. A person noticed;
+ * the suite did not. These are the assertions that would have failed.
+ *
+ * WHAT IT COVERS
+ * The facets a report is actually made of, rather than any particular report:
+ * constraints, sorts, secondary dimensions, and reconciliation between the
+ * dimensional rows and the aggregate. There are 69 report controllers and
+ * ~60 are pure declaration -- metrics, dimensions, sort, a link template -- so
+ * testing the engine's facets covers what all of them do, and one bespoke
+ * report per facet would not.
+ *
+ * Asserted through the REST API rather than the UI: it is the same engine the
+ * grids read from, and the numbers are the thing under test. One case at the end
+ * does go through the rendered page, because the bug that prompted this lived in
+ * the URL the page emits, not in the engine.
+ */
+const path = require('path');
+const { execFileSync } = require('child_process');
+const crypto = require('crypto');
+const { test, expect } = require('@playwright/test');
+
+const HELPER = path.join(__dirname, 'reporting_facets_helper.php');
+const SELFHOST = process.env.OWA_E2E_SELFHOST === '1';
+
+function helper(...args) {
+    return JSON.parse(execFileSync('php', [HELPER, ...args], { encoding: 'utf8' }));
+}
+
+function installRoot(baseURL) {
+    return baseURL.replace(/index\.php.*$/, '');
+}
+
+test.describe('the reporting engine answers correctly on every facet @selfhost-only', () => {
+
+    test.skip(!SELFHOST, 'Seeds sessions with a known dimension distribution.');
+
+    /** @type {any} */ let fx;
+    /** @type {string} */ let apiRoot;
+
+    test.beforeAll(() => {
+        fx = helper('provision');
+        expect(fx.expected.total_visits, 'fixture seeded nothing').toBeGreaterThan(0);
+        expect(fx.api_key, 'fixture user has no api key').toBeTruthy();
+    });
+
+    test.afterAll(() => { helper('cleanup'); });
+
+    test.beforeEach(({}, testInfo) => {
+        apiRoot = installRoot(testInfo.project.use.baseURL);
+    });
+
+    /** Sign a request the way Auth::isSignatureValid recomputes it. */
+    function sign(url, apiKey, authKey) {
+        const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+        return Buffer.from(
+            crypto.createHash('sha256')
+                .update('OWASIGNATURE' + apiKey + url + date + authKey)
+                .digest('hex')
+        ).toString('base64');
+    }
+
+    /** Query the reports API and return the parsed resultset. */
+    async function report(request, params) {
+        const q = new URLSearchParams(Object.assign({
+            owa_do: 'reports',
+            owa_module: 'base',
+            owa_version: 'v1',
+            owa_siteId: fx.site_id,
+            owa_period: 'today',
+            owa_apiKey: fx.api_key,
+        }, params));
+
+        // Signed over its own URL, apiKey included, signature appended last --
+        // the order Auth::isSignatureValid recomputes.
+        const unsigned = apiRoot + 'api/index.php?' + q.toString();
+        const url = unsigned + '&owa_signature=' + encodeURIComponent(
+            sign(unsigned, fx.api_key, fx.auth_key)
+        );
+
+        const res = await request.fetch(url, { method: 'GET' });
+        const body = await res.text();
+
+        expect(res.status(), `report request failed: ${body.slice(0, 200)}`).toBe(201);
+
+        const json = JSON.parse(body);
+        expect(json.error, `API returned errors: ${JSON.stringify(json.error)}`).toEqual([]);
+
+        return json.data;
+    }
+
+    const visitsOf = (row) => Number(
+        row?.visits?.value ?? row?.visits ?? row?.metrics?.visits?.value ?? row?.metrics?.visits
+    );
+    const dimOf = (row, name) => String(
+        row?.[name]?.value ?? row?.[name] ?? row?.dimensions?.[name]?.value ?? row?.dimensions?.[name] ?? ''
+    );
+
+    test('the unconstrained aggregate matches the seeded total', async ({ request }) => {
+        const data = await report(request, { owa_metrics: 'visits' });
+
+        expect(Number(data.aggregates.visits.value)).toBe(fx.expected.total_visits);
+    });
+
+    /**
+     * The case the Varnish bug broke: a constraint must actually constrain, and
+     * each value must give its OWN number. Asserting one value is not enough --
+     * a query that ignores its constraint returns the total, which for a single
+     * check could coincidentally be right.
+     */
+    test('a constraint filters, and each value gives its own count', async ({ request }) => {
+        for (const [source, expected] of Object.entries(fx.expected.by_source)) {
+            const data = await report(request, {
+                owa_metrics: 'visits',
+                owa_constraints: `source==${source}`,
+            });
+
+            expect(Number(data.aggregates.visits.value),
+                `constraint source==${source} returned the wrong count`).toBe(expected);
+
+            expect(Number(data.aggregates.visits.value),
+                `constraint source==${source} returned the UNCONSTRAINED total -- the constraint was ignored`
+            ).not.toBe(fx.expected.total_visits);
+        }
+    });
+
+    test('a constraint matching nothing returns zero, not everything', async ({ request }) => {
+        const data = await report(request, {
+            owa_metrics: 'visits',
+            owa_constraints: `source==${fx.expected.absent_source}`,
+        });
+
+        expect(Number(data.aggregates.visits.value)).toBe(0);
+    });
+
+    /**
+     * An EMPTY constraint value must not silently mean "no filter".
+     *
+     * `source==` is a non-empty STRING carrying an empty VALUE, so it survives
+     * every emptiness check until Db::where() drops it -- which is precisely how
+     * a stripped request parameter turned into a wrong number instead of an
+     * error. Whatever the engine decides to do here, returning the full
+     * unfiltered total silently is the one outcome that must not stand.
+     */
+    test('an empty constraint value does not silently return everything', async ({ request }) => {
+        const data = await report(request, {
+            owa_metrics: 'visits',
+            owa_constraints: 'source==',
+        });
+
+        const value  = Number(data.aggregates.visits.value);
+        const errors = JSON.stringify(data.errors || []);
+
+        // Either outcome is defensible -- refuse the query, or answer it and say
+        // the constraint was rejected. What must NOT happen is the unconstrained
+        // total coming back with nothing to distinguish it from a filtered one.
+        const silent = value === fx.expected.total_visits && !/constraint/i.test(errors);
+
+        expect(silent,
+            `an empty constraint value returned the unconstrained total (${value}) with no `
+            + `error to say so. A lost request parameter must not be indistinguishable from `
+            + `"no filter requested". errors=${errors}`
+        ).toBe(false);
+    });
+
+    /**
+     * KNOWN DEFECT, found by this fixture: a breakdown with NO sort returns zero
+     * rows while the aggregate is still correct -- measured 0 rows unsorted
+     * versus 3 with any sort at all, on identical data.
+     *
+     * It has gone unnoticed because every one of the ~60 declarative report
+     * controllers sets a sort, so no shipped report exercises the unsorted path.
+     * It is silent in the same way the constraint bug was: an empty result set
+     * rather than an error.
+     *
+     * Marked fixme rather than deleted so the suite carries the finding; it will
+     * start passing, and stop being skipped, when the engine is fixed.
+     */
+    test.fixme('a breakdown without a sort still returns its rows', async ({ request }) => {
+        const data = await report(request, {
+            owa_metrics: 'visits',
+            owa_dimensions: 'source',
+        });
+
+        expect(data.resultsRows.length,
+            'a breakdown with no sort returned no rows, though the aggregate was right'
+        ).toBe(Object.keys(fx.expected.by_source).length);
+    });
+
+    test('a dimensional breakdown gives the right count per value', async ({ request }) => {
+        const data = await report(request, {
+            owa_metrics: 'visits',
+            owa_dimensions: 'source',
+            owa_sort: 'visits-',
+        });
+
+        const got = {};
+        for (const row of data.resultsRows) {
+            got[dimOf(row, 'source')] = visitsOf(row);
+        }
+
+        expect(got).toEqual(fx.expected.by_source);
+    });
+
+    test('the dimensional rows reconcile with the aggregate', async ({ request }) => {
+        const data = await report(request, {
+            owa_metrics: 'visits',
+            owa_dimensions: 'source',
+            owa_sort: 'visits-',
+        });
+
+        const sum = data.resultsRows.reduce((t, r) => t + visitsOf(r), 0);
+
+        expect(sum, 'the breakdown does not sum to the aggregate').toBe(
+            Number(data.aggregates.visits.value)
+        );
+    });
+
+    test('sorting orders the rows by the metric', async ({ request }) => {
+        const desc = await report(request, {
+            owa_metrics: 'visits',
+            owa_dimensions: 'source',
+            owa_sort: 'visits-',
+        });
+
+        expect(desc.resultsRows.map((r) => dimOf(r, 'source'))).toEqual(fx.expected.sources_desc);
+
+        const asc = await report(request, {
+            owa_metrics: 'visits',
+            owa_dimensions: 'source',
+            owa_sort: 'visits',
+        });
+
+        expect(asc.resultsRows.map((r) => dimOf(r, 'source')))
+            .toEqual([...fx.expected.sources_desc].reverse());
+    });
+
+    /** A second dimension must split the rows, not repeat the first one's totals. */
+    test('a secondary dimension splits the breakdown', async ({ request }) => {
+        const data = await report(request, {
+            owa_metrics: 'visits',
+            owa_dimensions: 'source,medium',
+            owa_sort: 'visits-',
+        });
+
+        const got = data.resultsRows
+            .map((r) => ({ source: dimOf(r, 'source'), medium: dimOf(r, 'medium'), visits: visitsOf(r) }))
+            .sort((a, b) => (a.source + a.medium).localeCompare(b.source + b.medium));
+
+        const want = [...fx.expected.by_source_medium]
+            .sort((a, b) => (a.source + a.medium).localeCompare(b.source + b.medium));
+
+        expect(got).toEqual(want);
+    });
+
+    test('a constraint and a breakdown compose', async ({ request }) => {
+        const data = await report(request, {
+            owa_metrics: 'visits',
+            owa_dimensions: 'medium',
+            owa_constraints: 'source==google.com',
+            owa_sort: 'visits-',
+        });
+
+        const got = {};
+        for (const row of data.resultsRows) {
+            got[dimOf(row, 'medium')] = visitsOf(row);
+        }
+
+        // google's mediums only -- not every medium in the fixture.
+        expect(got).toEqual({ organic: 5, cpc: 3 });
+    });
+});

--- a/tests/e2e/reporting-facets.spec.js
+++ b/tests/e2e/reporting-facets.spec.js
@@ -176,27 +176,33 @@ test.describe('the reporting engine answers correctly on every facet @selfhost-o
     });
 
     /**
-     * KNOWN DEFECT, found by this fixture: a breakdown with NO sort returns zero
-     * rows while the aggregate is still correct -- measured 0 rows unsorted
-     * versus 3 with any sort at all, on identical data.
+     * A breakdown must not depend on being sorted.
      *
-     * It has gone unnoticed because every one of the ~60 declarative report
-     * controllers sets a sort, so no shipped report exercises the unsorted path.
-     * It is silent in the same way the constraint bug was: an empty result set
-     * rather than an error.
+     * This found a real defect: computeDimensionalRows() sat INSIDE the
+     * `if (orderby)` block, so an unsorted breakdown never ran its query at all.
+     * $dresults stayed undefined, generate() got nothing, and the caller saw
+     * zero rows beside a perfectly correct aggregate -- silent, because an
+     * unassigned variable is only a notice. It survived because all ~60
+     * declarative report controllers set a sort, so no shipped report took the
+     * unsorted path.
      *
-     * Marked fixme rather than deleted so the suite carries the finding; it will
-     * start passing, and stop being skipped, when the engine is fixed.
+     * Asserted on the counts as well as the row count, so a fix that returns
+     * rows but loses their values cannot pass.
      */
-    test.fixme('a breakdown without a sort still returns its rows', async ({ request }) => {
+    test('a breakdown without a sort still returns its rows', async ({ request }) => {
         const data = await report(request, {
             owa_metrics: 'visits',
             owa_dimensions: 'source',
         });
 
-        expect(data.resultsRows.length,
-            'a breakdown with no sort returned no rows, though the aggregate was right'
-        ).toBe(Object.keys(fx.expected.by_source).length);
+        const got = {};
+        for (const row of data.resultsRows) {
+            got[dimOf(row, 'source')] = visitsOf(row);
+        }
+
+        expect(got,
+            'a breakdown with no sort returned the wrong rows, though the aggregate was right'
+        ).toEqual(fx.expected.by_source);
     });
 
     test('a dimensional breakdown gives the right count per value', async ({ request }) => {

--- a/tests/e2e/reporting_facets_helper.php
+++ b/tests/e2e/reporting_facets_helper.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Reporting-facet fixture: known data whose EXACT numbers a spec can assert.
+ *
+ * WHY THIS EXISTS
+ * The reporting e2e asserted that the dashboard rendered -- grids present,
+ * dropdown sprites loaded, columns aligned -- and its only numeric assertion was
+ * `expect(gridText).toMatch(/\b2\b/)`, which passes if a "2" appears anywhere. So
+ * every number on every report could have been wrong and CI would have stayed
+ * green. It did: Varnish was stripping owa_source before PHP saw it, the Source
+ * Detail report ran with no constraint at all, and every source showed the same
+ * unfiltered total. A human found that, not the suite.
+ *
+ * THE DISTRIBUTION IS DELIBERATELY ASYMMETRIC
+ * Every facet below answers with a DIFFERENT number, and no number is repeated:
+ *
+ *     source        medium     sessions
+ *     google.com    organic       5
+ *     google.com    cpc           3
+ *     bing.com      organic       2
+ *     facebook.com  referral      1      -> 11 total
+ *
+ *   by source:  google 8, bing 2, facebook 1
+ *   by medium:  organic 7, cpc 3, referral 1
+ *
+ * That matters. With equal counts, a query that ignored its constraint, or
+ * grouped by the wrong column, or returned the aggregate for every row, could
+ * still produce the expected figure and pass. Here every wrong answer is a
+ * number the fixture does not contain.
+ *
+ * The expected values are RETURNED rather than hardcoded in the spec, so the
+ * fixture and its assertions cannot drift apart.
+ *
+ * Sessions are written directly rather than driven through the tracker: this
+ * exercises the REPORTING engine, and tracker-beacon.spec.js already covers
+ * ingestion. yyyymmdd is set explicitly -- it is NOT NULL, it is the partition
+ * key, and a fixture that omits it is testing something the product never does.
+ */
+
+if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+    $_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+        . 'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36';
+}
+$_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '203.0.113.44';
+
+const SCRATCH_DB_SENTINEL = 'owa_e2e_selfhost';
+const FIXTURE_TAG    = 'e2e-facets';
+const FIXTURE_DOMAIN = 'https://owa-e2e-facets.example.test';
+
+/** source => [medium => session count]. Asymmetric on purpose; see the header. */
+const DISTRIBUTION = [
+    'google.com'   => ['organic' => 5, 'cpc' => 3],
+    'bing.com'     => ['organic' => 2],
+    'facebook.com' => ['referral' => 1],
+];
+
+$owa_root = dirname(__DIR__, 2) . '/';
+require_once($owa_root . 'owa.php');
+new owa(['tracking_mode' => true, 'instance_role' => 'logger']);
+
+$connected_db = (string) owa_coreAPI::getSetting('base', 'db_name');
+$allowed_db   = getenv('OWA_E2E_DB_NAME') ?: SCRATCH_DB_SENTINEL;
+
+if ($connected_db !== $allowed_db) {
+    fwrite(STDERR, "[reporting_facets_helper] REFUSING: connected DB '$connected_db' is not "
+        . "the scratch sentinel '$allowed_db'.\n");
+    exit(3);
+}
+
+$cmd = $argv[1] ?? '';
+
+switch ($cmd) {
+    case 'provision': out(provision()); break;
+    case 'cleanup':   out(cleanup());   break;
+    default:
+        fwrite(STDERR, "Unknown command '$cmd'. Use: provision | cleanup\n");
+        exit(2);
+}
+
+function out(array $r): void
+{
+    echo json_encode($r, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), "\n";
+}
+
+function db()
+{
+    return owa_coreAPI::dbSingleton();
+}
+
+function provision(): array
+{
+    cleanup();
+
+    $site_id = md5(FIXTURE_DOMAIN);
+
+    $s = owa_coreAPI::entityFactory('base.site');
+    $s->set('id', $s->generateId($site_id));
+    $s->set('site_id', $site_id);
+    $s->set('domain', FIXTURE_DOMAIN);
+    $s->set('name', 'OWA reporting facets fixture');
+    $s->set('description', FIXTURE_TAG);
+    $s->create();
+
+    $user_id = FIXTURE_TAG . '-analyst@owatest.example.com';
+    $u = owa_coreAPI::entityFactory('base.user');
+    $u->createNewUser($user_id, 'admin', 'pw-' . FIXTURE_TAG, $user_id, 'OWA facets analyst');
+    $u->load($u->generateId($user_id), 'user_id');
+
+    $yyyymmdd = (int) date('Ymd');
+    $now      = time();
+    $n        = 0;
+
+    $bySource = [];
+    $byMedium = [];
+    $pairs    = [];
+
+    foreach (DISTRIBUTION as $source => $mediums) {
+
+        $source_pk = sourceDim($source);
+
+        foreach ($mediums as $medium => $count) {
+
+            for ($i = 0; $i < $count; $i++) {
+
+                $n++;
+                $sess = owa_coreAPI::entityFactory('base.session');
+                $sess->set('id', $sess->generateId(FIXTURE_TAG . "-$source-$medium-$i"));
+                $sess->set('site_id', $site_id);
+                $sess->set('visitor_id', $sess->generateId(FIXTURE_TAG . "-visitor-$n"));
+                $sess->set('source_id', $source_pk);
+                $sess->set('medium', $medium);
+                $sess->set('timestamp', $now - $n);
+                $sess->set('last_req', $now - $n);
+                $sess->set('yyyymmdd', $yyyymmdd);
+                $sess->set('num_pageviews', 1);
+                $sess->create();
+            }
+
+            $bySource[$source] = ($bySource[$source] ?? 0) + $count;
+            $byMedium[$medium] = ($byMedium[$medium] ?? 0) + $count;
+            $pairs[]           = ['source' => $source, 'medium' => $medium, 'visits' => $count];
+        }
+    }
+
+    arsort($bySource);
+    arsort($byMedium);
+
+    return [
+        'site_id'  => $site_id,
+        'user_id'  => $user_id,
+        'api_key'  => $u->get('api_key'),
+        // The signing secret. Requests to the API are HMAC-signed over their own
+        // URL, so a spec needs this as well as the key -- see rest_e2e_helper.
+        'auth_key' => defined('OWA_AUTH_KEY') ? OWA_AUTH_KEY : '',
+        'yyyymmdd' => $yyyymmdd,
+        'expected' => [
+            'total_visits'      => $n,
+            'by_source'         => $bySource,
+            'by_medium'         => $byMedium,
+            'by_source_medium'  => $pairs,
+            // Sorted desc by visits -- the order a `sort=visits-` must produce.
+            'sources_desc'      => array_keys($bySource),
+            'mediums_desc'      => array_keys($byMedium),
+            'absent_source'     => 'nosuchsource.example',
+        ],
+    ];
+}
+
+/** The dimension row a session's source_id points at. */
+function sourceDim(string $domain)
+{
+    $d = owa_coreAPI::entityFactory('base.source_dim');
+    $pk = $d->generateId($domain);
+    $d->set('id', $pk);
+    $d->set('source_domain', $domain);
+    $d->create();
+
+    return $pk;
+}
+
+function cleanup(): array
+{
+    $site_id = md5(FIXTURE_DOMAIN);
+
+    foreach (['owa_session', 'owa_request'] as $table) {
+        $db = db();
+        $db->deleteFrom($table);
+        $db->where('site_id', $site_id);
+        $db->executeQuery();
+    }
+
+    $db = db();
+    $db->deleteFrom('owa_site');
+    $db->where('site_id', $site_id);
+    $db->executeQuery();
+
+    $u = owa_coreAPI::entityFactory('base.user');
+    $u->delete(FIXTURE_TAG . '-analyst@owatest.example.com', 'user_id');
+
+    return ['status' => 'cleaned'];
+}

--- a/tests/e2e/selfhost_harness.php
+++ b/tests/e2e/selfhost_harness.php
@@ -164,7 +164,16 @@ function dbCreds(string $repoRoot, bool $backupOnly = false): array
         'port'      => $c['OWA_DB_PORT'] ?? '3306',
         'user'      => $c['OWA_DB_USER'],
         'password'  => $c['OWA_DB_PASSWORD'] ?? '',
-        'type'      => $c['OWA_DB_TYPE'] ?? 'mysql',
+        // OWA_E2E_DB_TYPE wins over the live install's driver, so the whole
+        // suite can be run against a different one:
+        //
+        //   OWA_E2E_DB_TYPE=pdo npm run test:e2e:selfhost
+        //
+        // Without this the local path always inherited the live config's type
+        // and there was no way to exercise a second driver end to end -- which
+        // is the only check that covers reporting's dynamically-built SQL, since
+        // those statements do not exist until they run.
+        'type'      => getenv('OWA_E2E_DB_TYPE') ?: ($c['OWA_DB_TYPE'] ?? 'mysql'),
         'live_name' => $liveName,
     ];
 }


### PR DESCRIPTION
Phase 2 foundation work from the v2 plan. Three commits that ship together, because each one is what makes the next safe.

> Branch is named `feat/sql-mode-strict` but carries all three — the PDO work was pushed first and never opened separately.

## 1. A PDO driver behind the existing seam

A driver turned out to be two separable things, and only one is about MySQL: **transport** (how statements travel) and **dialect** (what the SQL says, how the schema is interrogated). The dialect moved to a shared `MysqlDialect` trait, so there is one copy rather than two that drift.

**The trap this had to work around.** OWA composes reporting SQL dynamically — the builder assembles select lists, joins, group-bys and constraints at runtime from the metric/dimension registry, and calculated metrics contribute their own expressions. So `prepare()` was an *escaper*, not a statement preparer, and the builder supplied its own quotes. `mysqli_real_escape_string` escapes without quotes; `PDO::quote()` adds them. The naive implementation emits `col = ''value''` — broken on every query.

## 2. Bound parameters

This is where the value of PDO actually is, so it ships with it. The builder emits `?` and collects values instead of escaping them into the statement text — feasible because `where()` already stored `['name','value','operator']` structured.

**Order is the contract.** Placeholders are positional, and it holds only because the clause-makers are evaluated as `sprintf()` arguments, which PHP evaluates left-to-right in format-string order. A rearrangement that built clauses into variables first would transpose values between columns silently. There's a test pinning it.

Three things binding broke, each a real semantic change hiding inside "just a transport":

| | what happened |
|---|---|
| **types** | mysqli returns strings from `mysqli_query()` but **native types** from a prepared statement. `'0'` became `0` — breaks `===` and would change the REST API's JSON. `MYSQLI_OPT_INT_AND_FLOAT_NATIVE` is the documented fix and **does not work**; rows are coerced explicitly, preserving NULL. |
| **return shape** | PDO returns a `PDOStatement` where mysqli returns `true` for DDL, so `assertTrue()` on a successful `ALTER` failed. |
| **NULLs** | the escaping path never wrote a NULL *at all* — `prepare(null)` returned null and `sprintf("'%s'", null)` gave `''`. |

**PDO is preferred, mysqli is kept.** `db_type = 'mysql'` now means "MySQL", resolved to PDO where `pdo_mysql` exists and mysqli where it does not — no config change, and a host with mysqli but no `pdo_mysql` is not left crippled. That combination is unusual on distro-packaged PHP (one package ships both) but entirely possible in containers and hand-built PHP.

**Room for Postgres.** `Pdo` is now a dialect-free transport with an abstract `dsn()`; `PdoMysql` is that plus `MysqlDialect`. Postgres is a sibling file plus one alias entry and `db_type = 'pdo_pgsql'` — the work is the dialect, not the plumbing.

## 3. Strict SQL mode by default

`SET SESSION sql_mode=''` did not make writes succeed; it made **bad writes succeed quietly**.

**The damage is real and measured.** Two live installs carry rows whose `yyyymmdd` — the fact-table partition key, and the column every date-range report filters on — had been coerced to `0`: 8 requests + 5 sessions on one, 4 + 2 on the other. Invisible to every date-range report, sitting in the catch-all partition, and nothing ever reported an error.

Turning strict on produced **72 failures and 2 errors**. Every one was OWA writing something MySQL had been quietly fixing up:

1. **`''` into numeric columns** — 68 of the 72, fixed by binding real NULLs.
2. **The queue's due check** — with real NULLs, `not_before_timestamp < ?` is never true, so nothing would ever be due again.
3. **`is_bounce` stored the string `'false'`** — a workaround for two falsy guards. It only worked because MySQL coerced a non-numeric string to 0, and the string is **truthy in PHP**, so reading it back reported a bounce that never happened.
4. **`yyyymmdd` could be NULL** — `deriveYyyymmdd()` trusted the event timestamp, and `date()` with null yields 1970, which is worse than empty because it looks like data.

One failure was **not** a product bug and wasn't treated as one: the domstreams test seeded a row without `yyyymmdd` while the real path supplies it — 229,663 live domstream rows carry no zero values. The test was fixed.

`OWA_DB_SQL_MODE` reverts it in one line, and `UPGRADING.md` documents that as the way out for third-party code relying on the coercion.

## Verification

- **723 tests green** on the new default, and green with the mode forced back
- **full e2e ingestion suite under strict on both drivers — 96 passed each**
- three PHPStan configs clean
- parity test compares generated SQL **and bindings** across drivers; with placeholders, comparing text alone would have quietly stopped testing anything
- mutation-checked throughout: naive `PDO::quote()` reddens 7 of 11 parity cases; dropping `STRINGIFY_FETCHES` reddens row equality; reverting the strict default reddens 2 of 4 mode cases
- one of my own assertions was found vacuous and replaced — it read `getBindings()` after `_insertQuery()`, which executes and clears them, so it compared two empty arrays

## Left deliberately undone

The two falsy guards (`Entity::set()` and the update builder) are the real fix for `is_bounce`. **Every entity already declares its column type** and nothing reads it, so type-aware guards are within reach — but the update-path guard exists to stop a partially-loaded entity blanking columns it never loaded, so it needs its own review. Noted at both sites.