### PR TITLE
Decide CLI invocation from the environment rather than from argc

### DIFF
--- a/Core/CliInvocation.php
+++ b/Core/CliInvocation.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OWA\Core;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * Decides whether the process was started from a shell rather than by a web
+ * request.
+ *
+ * cli.php answers this before it loads anything, because a CLI front script
+ * reached over HTTP would run commands with the privileges of whoever asked.
+ * The SAPI name settles it in the ordinary case, but not in every case, which
+ * is why this is more than a one-line comparison:
+ *
+ * A host that ships no `php` binary runs scripts as `php-cgi script.php args`.
+ * The SAPI is then a CGI one even though the invocation is a genuine shell
+ * invocation, so a SAPI test alone would refuse to run at all there. The
+ * historical answer was to accept argc as a second signal -- if arguments were
+ * counted, something must have passed them on a command line.
+ *
+ * That inference does not hold. Whether argc is populated is governed by the
+ * `register_argc_argv` ini setting, and under a CGI SAPI it can be filled in
+ * from the request rather than from a command line. So argc says "arguments
+ * exist", never "a shell provided them", and on an installation whose ini
+ * differs from the one the author had in mind, the second signal answers yes
+ * for a request that is not a shell invocation at all.
+ *
+ * The fix is to stop asking argc to carry meaning it does not have, and to
+ * check for the request environment directly: REQUEST_METHOD is set for every
+ * request a web SAPI serves and by nothing a shell does. Ordering matters --
+ * the SAPI test comes first, so a real CLI run is never refused because the
+ * surrounding shell happened to export REQUEST_METHOD into its environment,
+ * which the CLI SAPI copies into $_SERVER.
+ *
+ * Deliberately dependency-free, so cli.php can require it before it has loaded
+ * anything else and still decide with the whole rule rather than a copy of it.
+ *
+ * @since owa 1.12.1
+ */
+final class CliInvocation {
+
+    /**
+     * @param string $sapi   php_sapi_name()
+     * @param array  $server $_SERVER
+     */
+    public static function detect( $sapi, array $server ) {
+
+        // The ordinary case, and the only signal that is unambiguous.
+        if ( $sapi === 'cli' ) {
+
+            return true;
+        }
+
+        // Something is serving a request, so whatever else is true, this
+        // process was not started by a person at a shell.
+        if ( isset( $server['REQUEST_METHOD'] ) ) {
+
+            return false;
+        }
+
+        // php-cgi used as an interpreter: no request in the environment, and
+        // arguments counted on the command line.
+        return isset( $server['argc'] )
+            && is_numeric( $server['argc'] )
+            && $server['argc'] > 0;
+    }
+}

--- a/cli.php
+++ b/cli.php
@@ -29,7 +29,12 @@
  */
 
 // Ensure we are being called as a CLI process before any other processing.
-define('OWA_CLI', (php_sapi_name() == 'cli' || (is_numeric($_SERVER['argc']) && $_SERVER['argc'] > 0)));
+// CliInvocation has no dependencies of its own, so requiring it here does not
+// start OWA for a caller that is about to be turned away. See that class for
+// why argc alone is not enough to tell a shell invocation from a request.
+require_once(__DIR__ . '/Core/CliInvocation.php');
+
+define('OWA_CLI', \OWA\Core\CliInvocation::detect(php_sapi_name(), $_SERVER));
 
 if (!OWA_CLI)
 {

--- a/tests/CliInvocationTest.php
+++ b/tests/CliInvocationTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * cli.php must run from a shell and refuse a web request.
+ *
+ * It is a front script that executes whatever command it is given, so the
+ * question "was this started by a person at a shell" is the only thing standing
+ * between the command set and whoever can reach the file. A deployment is
+ * expected to keep it out of the docroot as well, but that is a second line and
+ * this is the first.
+ *
+ * The detection cannot simply be the SAPI name: a host with no `php` binary
+ * runs scripts as `php-cgi script.php args`, and refusing every CGI SAPI would
+ * refuse those installations outright. The fallback signal for that case used
+ * to be argc, which does not mean what it appears to -- see CliInvocation.
+ *
+ * WHAT MAKES THESE TESTS DISCRIMINATING
+ * The interesting case is a CGI SAPI with argc populated, which is both what a
+ * legitimate php-cgi invocation looks like and what a served request can look
+ * like. Every test below therefore holds argc populated and varies only whether
+ * a request environment is present. A rule that ignored that distinction would
+ * fail here rather than passing on the easy cases.
+ */
+final class CliInvocationTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once( dirname( __DIR__ ) . '/Core/CliInvocation.php' );
+    }
+
+    public function testShellRunIsAccepted() {
+
+        $this->assertTrue(
+            \OWA\Core\CliInvocation::detect( 'cli', [ 'argc' => 2 ] ),
+            'an ordinary command line run must be allowed'
+        );
+    }
+
+    /**
+     * The php-cgi-as-interpreter case the argc fallback exists to serve. If
+     * this breaks, installations without a php binary lose the CLI entirely.
+     */
+    public function testCgiInterpreterRunFromAShellIsAccepted() {
+
+        $this->assertTrue(
+            \OWA\Core\CliInvocation::detect( 'cgi-fcgi', [ 'argc' => 3 ] ),
+            'php-cgi used as a shell interpreter must still be allowed'
+        );
+    }
+
+    /**
+     * The case the SAPI test alone does not catch and argc alone gets wrong:
+     * a request being served, with argc populated anyway.
+     */
+    public function testServedRequestIsRefusedEvenWithArgcPopulated() {
+
+        $refused = [
+            'cgi-fcgi'  => [ 'argc' => 1, 'REQUEST_METHOD' => 'GET' ],
+            'fpm-fcgi'  => [ 'argc' => 2, 'REQUEST_METHOD' => 'POST' ],
+            'apache2handler' => [ 'argc' => 9, 'REQUEST_METHOD' => 'HEAD' ],
+        ];
+
+        foreach ( $refused as $sapi => $server ) {
+
+            $this->assertFalse(
+                \OWA\Core\CliInvocation::detect( $sapi, $server ),
+                sprintf( 'a request served by %s must not count as a CLI run', $sapi )
+            );
+        }
+    }
+
+    /**
+     * The CLI SAPI copies the surrounding environment into $_SERVER, so a shell
+     * that exports REQUEST_METHOD would otherwise lock the operator out of
+     * their own command line. The SAPI test is checked first for this reason.
+     */
+    public function testRealCliIsNotRefusedByAnInheritedRequestMethod() {
+
+        $this->assertTrue(
+            \OWA\Core\CliInvocation::detect( 'cli', [ 'argc' => 2, 'REQUEST_METHOD' => 'GET' ] ),
+            'an exported REQUEST_METHOD must not disable the command line'
+        );
+    }
+
+    public function testMissingOrUnusableArgcIsRefused() {
+
+        $this->assertFalse(
+            \OWA\Core\CliInvocation::detect( 'cgi-fcgi', [] ),
+            'no argc and no shell SAPI is not a CLI run'
+        );
+
+        $this->assertFalse(
+            \OWA\Core\CliInvocation::detect( 'cgi-fcgi', [ 'argc' => 0 ] ),
+            'a zero argument count is not a CLI run'
+        );
+
+        $this->assertFalse(
+            \OWA\Core\CliInvocation::detect( 'cgi-fcgi', [ 'argc' => 'not-a-number' ] ),
+            'a non-numeric argc is not a CLI run'
+        );
+    }
+
+    /**
+     * The rule above, exercised through the real front script under a real
+     * non-CLI SAPI rather than by calling the predicate directly.
+     *
+     * This is the test that would have caught the original: it needs no
+     * agreement about what the rule should be, only php-cgi and a request
+     * environment. Skips where php-cgi is not installed -- it is a separate
+     * package from the CLI binary and CI does not install it -- which is why
+     * the cases above exist as well rather than instead.
+     */
+    public function testFrontScriptRefusesARequestUnderACgiSapi() {
+
+        $php_cgi = trim( (string) @shell_exec( 'command -v php-cgi 2>/dev/null' ) );
+
+        if ( ! $php_cgi ) {
+
+            $this->markTestSkipped( 'php-cgi is not installed' );
+        }
+
+        $cli = dirname( __DIR__ ) . '/cli.php';
+
+        // register_argc_argv is what fills argc in for a served request, so it
+        // is turned on deliberately: this reproduces the installation whose ini
+        // makes argc an unreliable signal, not a hypothetical one.
+        $cmd = sprintf(
+            'REQUEST_METHOD=GET SERVER_PROTOCOL=HTTP/1.1 QUERY_STRING=%s REDIRECT_STATUS=1 SCRIPT_FILENAME=%s '
+          . '%s -d register_argc_argv=On %s 2>&1',
+            escapeshellarg( 'cmd=flush-cache' ),
+            escapeshellarg( $cli ),
+            escapeshellarg( $php_cgi ),
+            escapeshellarg( $cli )
+        );
+
+        $output = (string) shell_exec( $cmd );
+
+        $this->assertStringContainsString(
+            '404',
+            $output,
+            'a request under a CGI SAPI must be turned away as a missing file'
+        );
+
+        // The failure this replaces did not stop here: it reached argument
+        // parsing, which means the front script had already loaded OWA for a
+        // caller arriving over HTTP. Naming the symptom keeps the test honest
+        // if the 404 above is ever produced for some other reason.
+        $this->assertStringNotContainsString(
+            'parseCliArgs',
+            $output,
+            'the request must be refused before the script parses arguments'
+        );
+
+        $this->assertStringNotContainsString(
+            'Arguments required',
+            $output,
+            'the request must be refused before the script looks for a command'
+        );
+    }
+}


### PR DESCRIPTION
`cli.php` establishes that a shell started it before loading anything, since it executes whatever command it is handed.

It did that with the SAPI name, falling back to a populated `argc`. That fallback exists for a real case — hosts with no `php` binary run scripts as `php-cgi script.php args`, where the SAPI is a CGI one but the invocation is genuine, so a SAPI test alone would refuse those installations outright.

The problem is that `argc` does not carry that meaning. Whether it is populated is governed by an ini setting, and under a CGI SAPI it can be filled in from the request rather than from a command line. It says *arguments exist*, never *a shell provided them*.

This asks about the request environment directly: `REQUEST_METHOD` is set by every web SAPI serving a request and by nothing a shell does. The SAPI test stays first so an exported `REQUEST_METHOD` cannot disable a real command line, and the php-cgi case keeps working.

The rule moves to `Core/CliInvocation` so it can be tested rather than restated — dependency-free, so `cli.php` still consults it before loading anything.

**Tests** — `tests/CliInvocationTest.php` covers the rule (every case holds `argc` populated and varies only whether a request environment is present, so a rule that ignored the distinction fails rather than passing on easy cases) and drives the real front script under php-cgi. That last one skips where the binary is absent, which includes CI, so the rule-level cases are what carry there. Both mutants — dropping the environment check, and the previous inline expression — fail the suite.

Full suite green: 712 tests, 44,525 assertions.