### PR TITLE
Read Base's settings and error objects on first use

### DIFF
--- a/Core/Base.php
+++ b/Core/Base.php
@@ -75,9 +75,74 @@ class Base {
      */
     function __construct() {
         \OWA\Core\CoreAPI::profile($this, __FUNCTION__, __LINE__);
-        $this->e = \OWA\Core\CoreAPI::errorSingleton();
-        $this->c = \OWA\Core\CoreAPI::configSingleton();
-        $this->config = $this->c->fetch('base');
+
+        // Nothing is fetched here on purpose. Unsetting these declared
+        // properties is what routes the first read of each through __get below,
+        // which is where they are actually built. See that method for why.
+        unset( $this->e, $this->c, $this->config );
+    }
+
+    /**
+     * Builds $e, $c and $config on first read rather than at construction.
+     *
+     * WHY THIS IS NOT AN OPTIMISATION
+     * Constructing any object used to require a working settings system, and
+     * settings cannot be built without constructing objects. Settings::__construct
+     * loads the config file, then creates the base.configuration ENTITY, and only
+     * then applies the config constants as settings -- so the entity is built
+     * while the settings object that will hold its values is still half-built.
+     *
+     * That worked only because three classes -- Settings, Entity and Module --
+     * were kept outside this hierarchy, so nothing on that path ever ran this
+     * constructor. It was a real constraint enforced by nothing: giving entities
+     * a $this->c "like every other class" would have had configSingleton()
+     * re-entered before its own static was assigned, building a second Settings,
+     * a second entity, and so on until the stack ran out. On every request.
+     *
+     * Reading late instead of eagerly removes the cycle rather than dodging it.
+     * Construction touches nothing, so the first read happens when someone
+     * actually wants a value, by which time settings exist.
+     *
+     * $config is a snapshot of the base settings, and it is now taken at first
+     * read rather than at construction. Where that differs, later is the more
+     * correct of the two: an object built before a module applied its overrides
+     * used to keep the values from before them.
+     */
+    public function __get( $name ) {
+
+        switch ( $name ) {
+
+            case 'e':
+                return $this->e = \OWA\Core\CoreAPI::errorSingleton();
+
+            case 'c':
+                return $this->c = \OWA\Core\CoreAPI::configSingleton();
+
+            case 'config':
+                // $this->c, not the singleton directly: if a subclass has
+                // already been handed a different settings object, the snapshot
+                // must come from that one.
+                return $this->config = $this->c->fetch( 'base' );
+        }
+
+        // Anything else is an ordinary undefined property, and must still read
+        // like one rather than silently becoming null.
+        trigger_error(
+            sprintf( 'Undefined property: %s::$%s', get_class( $this ), $name ),
+            E_USER_WARNING
+        );
+
+        return null;
+    }
+
+    /**
+     * isset() and empty() have to agree with __get, or a lazy property reads as
+     * missing -- including isset($this->config['some_key']), which asks about
+     * the property first and only then about the offset.
+     */
+    public function __isset( $name ) {
+
+        return in_array( $name, [ 'e', 'c', 'config' ], true );
     }
 
     /**

--- a/tests/BaseLazyConfigTest.php
+++ b/tests/BaseLazyConfigTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Constructing an object must not require a working settings system.
+ *
+ * Settings::__construct loads the config file, creates the base.configuration
+ * ENTITY, and only afterwards applies the config constants as settings. So an
+ * entity gets built while the settings object that will hold its values is
+ * still half-constructed -- and Base::__construct used to ask for that settings
+ * object, via configSingleton(), whose static is assigned only AFTER the
+ * constructor it is calling returns.
+ *
+ * Nothing detected that. It stayed upright because Settings, Entity and Module
+ * were each kept outside the Base hierarchy, which is a real constraint that
+ * was written down nowhere: giving entities a $this->c "like every other class"
+ * would have re-entered configSingleton() with its static still unset, building
+ * a second Settings, a second entity, and so on until the stack ran out -- on
+ * every request, not in some corner case.
+ *
+ * Base now reads those properties on first access instead, so construction
+ * touches nothing. These tests pin both halves: that construction really is
+ * inert, and that every reader still gets what it got before.
+ */
+final class BaseLazyConfigTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function subject() {
+
+        return new class extends \OWA\Core\Base {};
+    }
+
+    /**
+     * The actual fix. Uninitialised, not merely null -- an eager constructor
+     * that assigned null would pass a null check and fail this.
+     */
+    public function testConstructionTouchesNeitherSettingsNorTheErrorLogger() {
+
+        $obj = $this->subject();
+
+        foreach ( [ 'e', 'c', 'config' ] as $property ) {
+
+            $ref = new ReflectionProperty( \OWA\Core\Base::class, $property );
+
+            $this->assertFalse(
+                $ref->isInitialized( $obj ),
+                sprintf(
+                    '$%s was populated during construction. Building any object then requires '
+                  . 'settings, which cannot be built without building objects.',
+                    $property
+                )
+            );
+        }
+    }
+
+    public function testEachPropertyIsBuiltOnFirstRead() {
+
+        $obj = $this->subject();
+
+        $this->assertSame(
+            \OWA\Core\CoreAPI::configSingleton(),
+            $obj->c,
+            'reading $c must yield the settings singleton'
+        );
+
+        $this->assertSame(
+            \OWA\Core\CoreAPI::errorSingleton(),
+            $obj->e,
+            'reading $e must yield the error singleton'
+        );
+
+        $this->assertIsArray( $obj->config, 'reading $config must yield the base settings array' );
+        $this->assertSame(
+            \OWA\Core\CoreAPI::configSingleton()->fetch( 'base' ),
+            $obj->config,
+            'the snapshot must match what the settings object holds'
+        );
+    }
+
+    /**
+     * Once read, the property is a real property again -- so the cost is paid
+     * once per object and __get is not on the hot path.
+     */
+    public function testTheValueIsRetainedAfterTheFirstRead() {
+
+        $obj = $this->subject();
+        $first = $obj->c;
+
+        $ref = new ReflectionProperty( \OWA\Core\Base::class, 'c' );
+
+        $this->assertTrue( $ref->isInitialized( $obj ), 'the first read must materialise the property' );
+        $this->assertSame( $first, $obj->c, 'a second read must return the same object' );
+    }
+
+    /**
+     * isset() has to agree with __get. A lazy property with no __isset reads as
+     * missing, and isset($this->config['key']) asks about the property before
+     * it ever asks about the offset -- so a real caller silently changes answer.
+     */
+    public function testIssetAgreesWithLazyReads() {
+
+        $obj = $this->subject();
+
+        $this->assertTrue( isset( $obj->c ), 'isset must not report a lazy property as missing' );
+        $this->assertTrue( isset( $obj->config ), 'isset must not report a lazy snapshot as missing' );
+
+        // The shape used in modules/Base/View/Updates.php.
+        $obj->config = [ 'is_embedded' => true ];
+        $this->assertTrue(
+            isset( $obj->config['is_embedded'] ),
+            'isset() on an offset of a lazy property must still see the offset'
+        );
+
+        $this->assertFalse( isset( $obj->no_such_property ), 'unrelated properties stay unset' );
+    }
+
+    /**
+     * __get must not turn every typo into a silent null.
+     */
+    public function testAnUnknownPropertyStillWarns() {
+
+        $obj = $this->subject();
+        $seen = null;
+
+        set_error_handler( function ( $errno, $errstr ) use ( &$seen ) {
+            $seen = $errstr;
+            return true;
+        } );
+
+        $value = $obj->definitely_not_a_property;
+
+        restore_error_handler();
+
+        $this->assertNull( $value );
+        $this->assertNotNull( $seen, 'an undefined property must still raise a warning' );
+        $this->assertStringContainsString( 'definitely_not_a_property', (string) $seen );
+    }
+
+    /**
+     * The constraint that used to hold the boot together on its own. It is no
+     * longer load-bearing, but these classes sit on the path that builds
+     * settings, so a future move into the hierarchy deserves to be a decision
+     * rather than an accident -- and this test is where that decision surfaces.
+     */
+    public function testTheClassesOnTheSettingsPathStayOutsideTheHierarchy() {
+
+        $roots = [
+            \OWA\Core\Entity::class                     => 'entities are created by Settings::__construct',
+            \OWA\Module\Base\Classes\Settings::class    => 'Settings is what configSingleton() builds',
+            \OWA\Core\Module::class                     => 'modules are loaded while settings are assembled',
+        ];
+
+        foreach ( $roots as $class => $why ) {
+
+            $this->assertFalse(
+                is_subclass_of( $class, \OWA\Core\Base::class ),
+                sprintf(
+                    '%s now extends Base -- %s, so this is the re-entrancy that lazy reads make '
+                  . 'survivable rather than safe. Check that construction is still inert before '
+                  . 'accepting it.',
+                    $class,
+                    $why
+                )
+            );
+        }
+    }
+}


### PR DESCRIPTION
`Base::__construct` fetched the settings singleton, the error singleton, and a snapshot of the base settings. Most of the system descends from `Base`, so that made *construct an object* depend on *settings exist* — while settings are themselves assembled by constructing objects.

`Settings::__construct` shows the cycle plainly:

```
74:  loadConfigFile();                      → defines OWA_DB_TYPE
77:  entityFactory('base.configuration');   → creates the entity
85:  applyConfigConstants();                → db_type becomes a setting
```

The entity at line 77 is built while the settings object that will hold its values is still half-constructed.

**Why it never fell over:** `Settings`, `Entity` and `Module` are each kept outside the `Base` hierarchy, so nothing on that path ever ran the constructor. That was a real constraint enforced by nothing. Giving entities a `$this->c` *"like every other class"* would have re-entered `configSingleton()` with its own static still unassigned — building a second `Settings`, a second entity, and so on until the stack ran out, on every request. The storage engine is reachable at line 77 for a related reason: `setupStorageEngine` reads the `OWA_DB_TYPE` **constant**, not the `db_type` setting, because the setting does not exist yet.

**The change:** the properties are unset in the constructor and built by `__get` on first read. Construction touches nothing, so the cycle is removed rather than dodged, and those three classes are free to join the hierarchy on their merits.

Every existing reader is unchanged — there are ~220 direct uses of `$this->e`, `$this->c` and `$this->config`, and they all still read as before. Deleting the properties was not an option; reading them late was.

`__isset` is defined alongside `__get` because `isset($this->config['is_embedded'])` — a real caller in `Base/View/Updates.php` — asks about the property before the offset, and a lazy property with no `__isset` answers no. An unknown property still warns rather than becoming a silent null.

**One deliberate behaviour change:** `$config` is a snapshot, now taken at first read rather than at construction. Where those differ, later is the more correct of the two — an object built before a module applied its overrides used to keep the values from before them.

**Tests** — `tests/BaseLazyConfigTest.php`. The load-bearing one asserts the properties are *uninitialised* after construction, not merely null, so an eager constructor assigning null still fails it. Also pins `isset` agreement, the warning on unknown properties, retention after first read, and that the three classes on the settings path are still outside the hierarchy — now a decision to revisit rather than an invariant nobody recorded.

Full suite 712 · e2e 96 passed · install-flow e2e 2 passed · PHPStan clean (Core and whole-tree).