### PR TITLE
Heal values that cannot be stored, on set

### DIFF
--- a/modules/Base/Classes/DbColumn.php
+++ b/modules/Base/Classes/DbColumn.php
@@ -38,6 +38,27 @@ class DbColumn {
 
      var $data_type;
 
+     /**
+      * Whether an over-long value may be trimmed to fit this column.
+      *
+      * True by default because that is what the database was already doing.
+      * Set it false on a column whose value is IDENTITY-BEARING -- one that
+      * something derives a key from -- where a trimmed value and the full one
+      * are not the same thing. Those need a real answer (normalise before
+      * hashing, hash the full value, or widen the column), and a flag here is
+      * how they stay visible instead of being silently trimmed like the rest.
+      *
+      * Nothing sets it false yet. owa_document.url is the known candidate: the
+      * document id is derived from the event's full page_url while the column
+      * stores a trimmed copy, so ~15% of rows already hold a url that does not
+      * derive to the id naming them. That divergence predates this flag -- the
+      * database was trimming them regardless -- but it is the case the flag
+      * exists to make addressable.
+      *
+      * @var bool
+      */
+     var $truncatable = true;
+
      var $foreign_key;
 
      var $is_primary_key = false;
@@ -85,10 +106,88 @@ class DbColumn {
 
      function setValue($value) {
 
-         $this->value = $value;
+         $this->value = $this->fitToColumn( $value );
 
          return;
      }
+
+    /**
+     * Cut an over-long string down to what the column can actually hold.
+     *
+     * MySQL used to do this silently, and OWA depended on it without saying so.
+     * It is not a rare path: on a live install ~15% of document urls and ~9% of
+     * referer urls sit at exactly the column limit, which is the fingerprint of
+     * a value that arrived longer and got trimmed on the way in.
+     *
+     * Under a permissive sql_mode that trim is a warning nobody reads. Under
+     * STRICT_ALL_TABLES it is an ERROR, and the whole INSERT is refused -- so
+     * the page view is not truncated, it is LOST, and silently, because the
+     * write path does not surface the failure. Healing the value here is what
+     * makes strict mode safe to turn on: the row still lands, holding what it
+     * always held.
+     *
+     * Measured in CHARACTERS, not bytes, because the column is declared that
+     * way -- and cutting a UTF-8 sequence in half would produce a value that
+     * strict mode rejects for a different reason, turning one silent loss into
+     * another.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    protected function fitToColumn( $value ) {
+
+        if ( ! $this->truncatable || ! is_string( $value ) || $value === '' ) {
+
+            return $value;
+        }
+
+        $max = $this->maxLength();
+
+        if ( ! $max || mb_strlen( $value, 'UTF-8' ) <= $max ) {
+
+            return $value;
+        }
+
+        return mb_substr( $value, 0, $max, 'UTF-8' );
+    }
+
+    /**
+     * Mark whether this column's value may be trimmed to fit.
+     *
+     * @param bool $truncatable
+     * @return void
+     */
+    function setTruncatable( $truncatable ) {
+
+        $this->truncatable = (bool) $truncatable;
+    }
+
+    /**
+     * The declared length of this column, or 0 if it does not have one.
+     *
+     * Resolved through the OWA_DTD_* constants rather than by reading a number
+     * out of the type string. The constant NAMES are OWA's vocabulary and the
+     * VALUES are one dialect's spelling, so comparing against the constants
+     * keeps this working wherever a dialect spells its types differently.
+     *
+     * @return int
+     */
+    protected function maxLength() {
+
+        $lengths = array();
+
+        foreach ( array( 'OWA_DTD_VARCHAR255' => 255, 'OWA_DTD_VARCHAR10' => 10 ) as $constant => $length ) {
+
+            if ( defined( $constant ) ) {
+
+                $lengths[ (string) constant( $constant ) ] = $length;
+            }
+        }
+
+        $type = (string) $this->get( 'data_type' );
+
+        return isset( $lengths[ $type ] ) ? $lengths[ $type ] : 0;
+    }
 
      /**
       * @param bool $omit_primary_key  leave the inline PRIMARY KEY off, for a

--- a/modules/Base/Classes/DbColumn.php
+++ b/modules/Base/Classes/DbColumn.php
@@ -141,6 +141,11 @@ class DbColumn {
             return $value;
         }
 
+        // Before the length check, not after: what gets stored is what is left
+        // once characters the encoding cannot hold are gone, so that is what
+        // the length has to be measured against.
+        $value = $this->dropUnstorableCharacters( $value );
+
         $max = $this->maxLength();
 
         if ( ! $max || mb_strlen( $value, 'UTF-8' ) <= $max ) {
@@ -149,6 +154,73 @@ class DbColumn {
         }
 
         return mb_substr( $value, 0, $max, 'UTF-8' );
+    }
+
+    /**
+     * Remove characters the declared encoding cannot store.
+     *
+     * OWA declares utf8, which in MySQL is utf8mb3 and holds no character above
+     * U+FFFF. An emoji in a page title is therefore unstorable -- and what
+     * MySQL does with it is not drop the character, it drops THE REST OF THE
+     * STRING. Measured: a 35-character title containing one emoji stores as 13
+     * characters. Everything from the emoji onward is gone, silently, under the
+     * permissive mode. Under a strict mode the whole row is refused instead.
+     *
+     * Dropping the offending character costs one character rather than the
+     * remainder, and leaves something storable either way. It is a floor, not a
+     * fix -- the fix is migrating the schema to utf8mb4, which needs the tables
+     * still on ROW_FORMAT=Compact converted first, since a varchar(255) utf8mb4
+     * index key is 1020 bytes against Compact's 767-byte limit.
+     *
+     * Conditional on the DECLARED encoding, so it stops doing anything once
+     * that migration lands, and does nothing on a dialect whose UTF-8 is not
+     * width-limited.
+     *
+     * @param string $value
+     * @return string
+     */
+    protected function dropUnstorableCharacters( $value ) {
+
+        // Every 4-byte UTF-8 sequence starts F0-F4. No such byte, nothing to
+        // do -- which is the overwhelming majority of values, so the regex
+        // below is never reached for them.
+        if ( strpbrk( $value, "\xF0\xF1\xF2\xF3\xF4" ) === false ) {
+
+            return $value;
+        }
+
+        if ( ! $this->encodingIsWidthLimited() ) {
+
+            return $value;
+        }
+
+        $stripped = preg_replace( '/[\x{10000}-\x{10FFFF}]/u', '', $value );
+
+        // preg_replace returns null on malformed UTF-8. Keeping the original is
+        // the safer of the two: it is what is stored today.
+        return $stripped === null ? $value : $stripped;
+    }
+
+    /**
+     * Whether the declared encoding tops out below U+10000.
+     *
+     * Named encodings rather than a pattern: 'utf8' and 'utf8mb3' are MySQL's
+     * three-byte encoding, while PostgreSQL's 'UTF8' is the full range and must
+     * not match. There is no way to tell those apart except by knowing them, so
+     * the list is explicit and the default is to leave values alone.
+     *
+     * @return bool
+     */
+    protected function encodingIsWidthLimited() {
+
+        if ( ! defined( 'OWA_DTD_CHARACTER_ENCODING_UTF8' ) ) {
+
+            return false;
+        }
+
+        $declared = strtolower( (string) constant( 'OWA_DTD_CHARACTER_ENCODING_UTF8' ) );
+
+        return in_array( $declared, array( 'utf8', 'utf8mb3' ), true );
     }
 
     /**

--- a/tests/ColumnLengthHealTest.php
+++ b/tests/ColumnLengthHealTest.php
@@ -181,4 +181,92 @@ final class ColumnLengthHealTest extends TestCase {
         $this->assertTrue( $c->get( 'truncatable' ),
             'the default must match what the database was already doing' );
     }
+
+    /**
+     * The emoji case, which is not exotic -- emoji in page titles is ordinary.
+     *
+     * OWA declares utf8, which in MySQL holds nothing above U+FFFF. What MySQL
+     * does with an unstorable character is not drop it, it drops THE REST OF
+     * THE VALUE: a 35-character title with one emoji in the middle stores as 13
+     * characters, silently, under the permissive mode. Dropping the character
+     * costs one character instead of the remainder.
+     */
+    public function testAnUnstorableCharacterCostsOneCharacterNotTheRest(): void
+    {
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setValue( "Sales report \xF0\x9F\x93\x8A Q3 summary and notes" );
+
+        $this->assertStringContainsString( 'Q3 summary and notes', $c->getValue(),
+            'everything after the unstorable character must survive' );
+        $this->assertStringNotContainsString( "\xF0\x9F\x93\x8A", $c->getValue() );
+    }
+
+    public function testThreeByteCharactersAreNotDisturbed(): void
+    {
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setValue( '日本語のページタイトル' );
+
+        $this->assertSame( '日本語のページタイトル', $c->getValue(),
+            'characters the encoding CAN hold must be left alone' );
+    }
+
+    /**
+     * Order matters: the length is what will be stored, so it has to be
+     * measured after the unstorable characters are gone, not before.
+     */
+    public function testLengthIsMeasuredAfterUnstorableCharactersAreRemoved(): void
+    {
+        $c = $this->column( OWA_DTD_VARCHAR10 );
+        // 4 emoji then 10 ascii: 14 characters, 10 of them storable.
+        $c->setValue( str_repeat( "\xF0\x9F\x93\x8A", 4 ) . 'abcdefghij' );
+
+        $this->assertSame( 'abcdefghij', $c->getValue(),
+            'stripping first is what leaves a full ten storable characters' );
+    }
+
+    /**
+     * A dialect whose UTF-8 is not width-limited -- PostgreSQL's, for one --
+     * must keep the character. The check is on the DECLARED encoding, so this
+     * stops doing anything once the schema moves to utf8mb4.
+     */
+    public function testNothingIsStrippedWhenTheEncodingIsNotWidthLimited(): void
+    {
+        $c = new class( 'probe', OWA_DTD_VARCHAR255 ) extends \OWA\Module\Base\Classes\DbColumn {
+            protected function encodingIsWidthLimited() { return false; }
+        };
+
+        $value = "keeps \xF0\x9F\x93\x8A the emoji";
+        $c->setValue( $value );
+
+        $this->assertSame( $value, $c->getValue() );
+    }
+
+    /**
+     * End to end: the row that strict mode would refuse now lands, holding
+     * everything except the one character that could never have been stored.
+     */
+    public function testAnEmojiValueSurvivesAWriteUnderStrictMode(): void
+    {
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->query( 'CREATE TEMPORARY TABLE mb4_heal_probe (id BIGINT, page_title VARCHAR(255))' );
+        $db->query( "SET SESSION sql_mode = 'STRICT_ALL_TABLES'" );
+
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setValue( "Sales report \xF0\x9F\x93\x8A Q3 summary and notes" );
+
+        $db->query( sprintf(
+            "INSERT INTO mb4_heal_probe (id, page_title) VALUES (1, '%s')", $c->getValue() ) );
+
+        $row = $db->get_row( 'SELECT COUNT(*) AS n, page_title AS t FROM mb4_heal_probe' );
+        $db->query( "SET SESSION sql_mode = ''" );
+
+        $this->assertSame( 1, (int) $row['n'],
+            'strict mode refused the row -- the unstorable character was not removed first' );
+        $this->assertStringContainsString( 'Q3 summary and notes', (string) $row['t'],
+            'the text after the emoji must be in the stored row' );
+    }
 }

--- a/tests/ColumnLengthHealTest.php
+++ b/tests/ColumnLengthHealTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A value longer than its column is trimmed on the way in, not on the way out.
+ *
+ * MySQL used to do this, silently, and OWA depended on it without saying so.
+ * Measured on a live install, the dependency is heavy rather than incidental:
+ *
+ *   owa_document.url    135 / 874     15.4% sitting at exactly the limit
+ *   owa_referer.url   2,429 / 25,454   9.5%
+ *   owa_document.uri     52 / 874      5.9%
+ *   owa_ua.ua           180 / 39,953   0.45%
+ *
+ * A row at exactly the limit is the fingerprint of a value that arrived longer.
+ *
+ * Under a permissive sql_mode that trim is a warning nobody reads. Under
+ * STRICT_ALL_TABLES it is an error and the INSERT is refused outright -- so the
+ * page view is not truncated, it is lost, and the write path does not surface
+ * the failure, so it is lost quietly. That is why this is a correctness fix and
+ * not tidying: it is the thing standing between OWA and a strict sql_mode.
+ */
+final class ColumnLengthHealTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function column( $type ) {
+
+        return new \OWA\Module\Base\Classes\DbColumn( 'probe', $type );
+    }
+
+    public function testAnOverLongValueIsTrimmedToTheColumnLength(): void {
+
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setValue( str_repeat( 'x', 300 ) );
+
+        $this->assertSame( 255, mb_strlen( $c->getValue(), 'UTF-8' ) );
+    }
+
+    public function testAShorterColumnUsesItsOwnLength(): void {
+
+        $c = $this->column( OWA_DTD_VARCHAR10 );
+        $c->setValue( str_repeat( 'x', 40 ) );
+
+        $this->assertSame( 10, mb_strlen( $c->getValue(), 'UTF-8' ),
+            'the length must come from the column, not from a single global maximum' );
+    }
+
+    public function testAValueThatFitsIsUntouched(): void {
+
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setValue( 'https://example.com/a-normal-url' );
+
+        $this->assertSame( 'https://example.com/a-normal-url', $c->getValue() );
+    }
+
+    /**
+     * Trimming by bytes would cut a UTF-8 sequence in half. Strict mode rejects
+     * the result of THAT too, so a byte-wise fix would trade one silent loss
+     * for another -- and this test is the only thing that tells them apart,
+     * since both produce a value of roughly the right size.
+     */
+    public function testMultibyteValuesAreCutOnCharacterBoundaries(): void {
+
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setValue( str_repeat( '日', 300 ) );
+
+        $value = $c->getValue();
+
+        $this->assertSame( 255, mb_strlen( $value, 'UTF-8' ), 'the column counts characters' );
+        $this->assertSame( $value, mb_convert_encoding( $value, 'UTF-8', 'UTF-8' ),
+            'trimming must not leave a partial character behind' );
+    }
+
+    public function testNonStringsAndUnboundedTypesPassThrough(): void {
+
+        foreach ( [ 0, 1, false, true, null, 12345 ] as $value ) {
+
+            $c = $this->column( OWA_DTD_VARCHAR255 );
+            $c->setValue( $value );
+
+            $this->assertSame( $value, $c->getValue(), 'non-strings must not be touched' );
+        }
+
+        $text = $this->column( OWA_DTD_TEXT );
+        $long = str_repeat( 'x', 5000 );
+        $text->setValue( $long );
+
+        $this->assertSame( $long, $text->getValue(),
+            'a text column has no declared limit here and must not be trimmed' );
+    }
+
+    /**
+     * Same portability property as the numeric-type check: the lengths are keyed
+     * off the OWA_DTD_* constants, so a dialect that spells VARCHAR differently
+     * still resolves. A hard-coded 'VARCHAR(255)' would fail this.
+     */
+    public function testTheLengthMapIsKeyedOffDeclaredTypes(): void {
+
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+
+        $m = new ReflectionMethod( $c, 'maxLength' );
+        $m->setAccessible( true );
+
+        $this->assertSame( 255, $m->invoke( $c ),
+            'the declared VARCHAR255 type must resolve to its length through the constant' );
+
+        $unknown = $this->column( 'SOMETHING_NO_DIALECT_DECLARES' );
+        $m2 = new ReflectionMethod( $unknown, 'maxLength' );
+        $m2->setAccessible( true );
+
+        $this->assertSame( 0, $m2->invoke( $unknown ),
+            'an unrecognised type must report no limit rather than guessing one' );
+    }
+
+    /**
+     * The point of the whole change: an entity write that strict mode would have
+     * refused now succeeds. Uses a TEMPORARY table so nothing real is touched,
+     * and sets the strict mode explicitly so the test does not depend on the
+     * installation's configured default.
+     */
+    public function testAnOverLongValueSurvivesAWriteUnderStrictMode(): void {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->query( 'CREATE TEMPORARY TABLE heal_probe (id BIGINT, page_title VARCHAR(255))' );
+        $db->query( "SET SESSION sql_mode = 'STRICT_ALL_TABLES'" );
+
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setValue( str_repeat( 'z', 300 ) );
+
+        $ok = $db->query( sprintf(
+            "INSERT INTO heal_probe (id, page_title) VALUES (1, '%s')",
+            $c->getValue()
+        ) );
+
+        $row = $db->get_row( 'SELECT COUNT(*) AS n, CHAR_LENGTH(page_title) AS len FROM heal_probe' );
+
+        $db->query( "SET SESSION sql_mode = ''" );
+
+        $this->assertSame( 1, (int) $row['n'],
+            'strict mode refused the row -- the value was not healed before the write' );
+        $this->assertSame( 255, (int) $row['len'] );
+    }
+
+    /**
+     * An identity-bearing column can opt out.
+     *
+     * Trimming a value that something derives a key from is not the same
+     * operation as trimming one nobody reads back: the stored value stops
+     * deriving to the id that names it. Nothing sets this today -- the database
+     * was trimming those columns anyway -- but the flag is what lets such a
+     * column be handled deliberately rather than disappearing into the general
+     * case.
+     */
+    public function testAColumnCanOptOutOfBeingTrimmed(): void
+    {
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+        $c->setTruncatable( false );
+
+        $long = str_repeat( 'x', 300 );
+        $c->setValue( $long );
+
+        $this->assertSame( $long, $c->getValue(),
+            'a column marked not-truncatable must keep the value it was given' );
+    }
+
+    public function testColumnsAreTruncatableByDefault(): void
+    {
+        $c = $this->column( OWA_DTD_VARCHAR255 );
+
+        $this->assertTrue( $c->get( 'truncatable' ),
+            'the default must match what the database was already doing' );
+    }
+}

--- a/tests/ColumnLengthHealTest.php
+++ b/tests/ColumnLengthHealTest.php
@@ -125,6 +125,11 @@ final class ColumnLengthHealTest extends TestCase {
      */
     public function testAnOverLongValueSurvivesAWriteUnderStrictMode(): void {
 
+        if ( ! owa_test_db_available() ) {
+
+            $this->markTestSkipped( 'No database available.' );
+        }
+
         $db = \OWA\Core\CoreAPI::dbSingleton();
 
         $db->query( 'CREATE TEMPORARY TABLE heal_probe (id BIGINT, page_title VARCHAR(255))' );


### PR DESCRIPTION
**Prerequisite for strict sql_mode**, which was deployed, dropped page views, and had to be reverted on both live installs. Two separate reasons a value fails to store, both healed at `DbColumn::setValue()` — the column is what knows its own type, so values heal on arrival rather than being checked at every write site.

## 1. Over-long values

MySQL was silently truncating, and OWA depended on it without saying so. Measured on a live install — a row at exactly the limit is the fingerprint of a value that arrived longer:

| column | at the limit | of | rate |
|---|---|---|---|
| `owa_document.url` | 135 | 874 | **15.4%** |
| `owa_referer.url` | 2,429 | 25,454 | **9.5%** |
| `owa_document.uri` | 52 | 874 | 5.9% |
| `owa_ua.ua` | 180 | 39,953 | 0.45% |

Under strict mode the INSERT is refused, so the page view isn't truncated — it's lost, and the write path doesn't surface DB errors, so lost quietly. Roughly one document in seven.

Trimmed by **characters, not bytes**: a half-cut UTF-8 sequence is rejected by strict mode for a different reason, trading one silent loss for another. Both results are about the right size, so only a test separates them.

## 2. Unstorable characters — a live bug, not just a strict-mode one

OWA declares `utf8`, which in MySQL is utf8mb3 and holds nothing above U+FFFF. An emoji in a page title is unstorable — and MySQL doesn't drop the character, it **drops the rest of the string**.

Measured: a 35-character title with one emoji stores as **13 characters**. Everything after it is gone, silently, under the permissive mode running today. Under strict the whole row is refused.

Dropping the one character costs a character instead of the remainder. Stripping runs **before** the length trim, since what gets stored is what survives stripping — the ordering has its own test.

Conditional on the *declared* encoding, by name: `utf8`/`utf8mb3` are MySQL's three-byte encoding, while PostgreSQL's `UTF8` is the full range and must not match. Default is to leave values alone, and this stops doing anything once the schema moves to utf8mb4.

## `truncatable` flag

True by default, matching what the database was already doing. It exists for identity-bearing columns, where a trimmed value and the full one are not the same thing. `owa_document.url` is the known candidate: the document id derives from the event's full `page_url` while the column stores a trimmed copy, so **~15% of rows already hold a url that does not derive to the id naming them**. Predates this PR, not fixed by it — the flag keeps it visible.

## Not attempted here

The real fix for §2 is migrating to utf8mb4. It has a prerequisite worth recording: **19 of 45 tables are still `ROW_FORMAT=Compact`**, whose 767-byte index key limit cannot hold a `varchar(255)` utf8mb4 key at 1020 bytes. Those need converting to Dynamic first.

Also open: **the write path swallows DB errors** — a refused INSERT produced nothing in the OWA log, which is why this was invisible.

Full suite 785 · PHPStan clean · CI green on both driver legs. Three mutants fail the suite: no healing, byte-wise trimming, and stripping after the length trim instead of before.