### PR TITLE
Report a refused statement where production can see it

### DIFF
--- a/Core/Db.php
+++ b/Core/Db.php
@@ -168,6 +168,72 @@ class Db extends \OWA\Core\Base {
      */
     var $_bindings = array();
 
+    /**
+     * How many query errors one process will spell out before going quiet.
+     *
+     * A broken database fails every statement, and this log is on disk on the
+     * same box. The cap bounds a bad minute to a readable handful of lines
+     * instead of one per query, and says so when it stops rather than just
+     * stopping.
+     */
+    const QUERY_ERROR_LOG_LIMIT = 25;
+
+    /** @var int */
+    protected static $query_error_count = 0;
+
+    /**
+     * Report a statement the database refused.
+     *
+     * This used to be $this->e->debug(), which under the production error
+     * handler is not written anywhere -- so a refused write produced NOTHING.
+     * That is how a strict sql_mode silently dropped page views on a live
+     * installation: the INSERT failed, the failure propagated as a false return
+     * that the tracking path does not inspect, and no log line existed to
+     * contradict the impression that everything was fine.
+     *
+     * Verified against the production handler: notice, warning and error are
+     * written; debug is not.
+     *
+     * The query is truncated because some of them are enormous, and the error
+     * message is what identifies the problem -- the SQL is context. The full
+     * statement is still emitted at debug for anyone running the development
+     * handler.
+     *
+     * @param string $message  what the database said
+     * @param string $sql      the statement it refused
+     * @return void
+     */
+    protected function logQueryError( $message, $sql ) {
+
+        // Full detail for development, unconditionally: this is the level that
+        // was already being used, so nothing that worked before is lost.
+        $this->e->debug( sprintf( 'A database error occurred. Error: %s. Query: %s', $message, $sql ) );
+
+        self::$query_error_count++;
+
+        if ( self::$query_error_count > self::QUERY_ERROR_LOG_LIMIT ) {
+
+            return;
+        }
+
+        $truncated = strlen( $sql ) > 500 ? substr( $sql, 0, 500 ) . ' ...[truncated]' : $sql;
+
+        $this->e->err( sprintf(
+            'The database refused a statement. Error: %s. Query: %s',
+            $message,
+            $truncated
+        ) );
+
+        if ( self::$query_error_count === self::QUERY_ERROR_LOG_LIMIT ) {
+
+            $this->e->err( sprintf(
+                'Further query errors in this process will not be logged (%d already reported). '
+              . 'This is a cap on log volume, not a sign that the errors stopped.',
+                self::QUERY_ERROR_LOG_LIMIT
+            ) );
+        }
+    }
+
     function __construct($db_host, $db_port, $db_name, $db_user, $db_password, $open_new_connection = true, $persistant = false) {
 
         $this->connectionParams = array('host' => $db_host,

--- a/Core/Db.php
+++ b/Core/Db.php
@@ -203,7 +203,7 @@ class Db extends \OWA\Core\Base {
      * @param string $sql      the statement it refused
      * @return void
      */
-    protected function logQueryError( $message, $sql ) {
+    protected function logQueryError( $message, $sql, $is_constraint_violation = false ) {
 
         // Full detail for development, unconditionally: this is the level that
         // was already being used, so nothing that worked before is lost.
@@ -217,6 +217,29 @@ class Db extends \OWA\Core\Base {
         }
 
         $truncated = strlen( $sql ) > 500 ? substr( $sql, 0, 500 ) . ' ...[truncated]' : $sql;
+
+        // A constraint violation is usually not a fault, and reporting it as
+        // one would cry wolf on every busy site.
+        //
+        // Dimension rows are written check-then-insert: load by id, and insert
+        // if it was not there. Two concurrent first-hits on the same new URL,
+        // user agent or host both miss and both insert, and one of them loses.
+        // The row exists either way, which is the whole point of the insert, so
+        // the losing request has nothing to fix.
+        //
+        // Logged rather than dropped, because a duplicate rate that climbs is
+        // worth seeing -- just not at a level that says something is broken.
+        if ( $is_constraint_violation ) {
+
+            $this->e->notice( sprintf(
+                'A constraint stopped a statement, which is expected where rows are inserted '
+              . 'concurrently. Error: %s. Query: %s',
+                $message,
+                $truncated
+            ) );
+
+            return;
+        }
 
         $this->e->err( sprintf(
             'The database refused a statement. Error: %s. Query: %s',

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -210,12 +210,15 @@ class Mysql extends \OWA\Core\Db {
     
             if ( mysqli_errno( $this->connection ) ) {
     
+                $errno = mysqli_errno( $this->connection );
+
                 $this->logQueryError(
-                    sprintf( '(%s) %s',
-                        mysqli_errno( $this->connection ),
-                        mysqli_error( $this->connection )
-                    ),
-                    $sql
+                    sprintf( '(%s) %s', $errno, mysqli_error( $this->connection ) ),
+                    $sql,
+                    // mysqli reports the vendor code only. 1062 duplicate entry,
+                    // 1452/1451 foreign key -- the same class SQLSTATE 23000
+                    // covers for the PDO driver.
+                    in_array( (int) $errno, array( 1062, 1451, 1452 ), true )
                 );
             }
     

--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -210,13 +210,12 @@ class Mysql extends \OWA\Core\Db {
     
             if ( mysqli_errno( $this->connection ) ) {
     
-                $this->e->debug(
-                    sprintf(
-                        'A MySQL error ocured. Error: (%s) %s. Query: %s',
+                $this->logQueryError(
+                    sprintf( '(%s) %s',
                         mysqli_errno( $this->connection ),
-                        htmlspecialchars( mysqli_error( $this->connection ) ),
-                        $sql
-                    )
+                        mysqli_error( $this->connection )
+                    ),
+                    $sql
                 );
             }
     

--- a/Core/Db/Pdo.php
+++ b/Core/Db/Pdo.php
@@ -219,13 +219,10 @@ abstract class Pdo extends \OWA\Core\Db
 
         } catch ( \Throwable $e ) {
 
-            $this->e->debug(
-                sprintf(
-                    'A database error occurred. Error: %s. Query: %s',
-                    htmlspecialchars( $e->getMessage() ),
-                    $sql
-                )
-            );
+            // Not htmlspecialchars(): this goes to a log file, not to a page,
+            // and escaping it only makes the message harder to read at the
+            // moment someone is trying to read it.
+            $this->logQueryError( $e->getMessage(), $sql );
 
             $this->new_result = false;
 

--- a/Core/Db/Pdo.php
+++ b/Core/Db/Pdo.php
@@ -222,7 +222,14 @@ abstract class Pdo extends \OWA\Core\Db
             // Not htmlspecialchars(): this goes to a log file, not to a page,
             // and escaping it only makes the message harder to read at the
             // moment someone is trying to read it.
-            $this->logQueryError( $e->getMessage(), $sql );
+            // SQLSTATE 23000 is the ANSI integrity-constraint class, so this
+            // stays right on a driver that is not MySQL. The vendor code (1062
+            // here) is not portable and is deliberately not used.
+            $this->logQueryError(
+                $e->getMessage(),
+                $sql,
+                (string) $e->getCode() === '23000'
+            );
 
             $this->new_result = false;
 

--- a/tests/QueryErrorVisibilityTest.php
+++ b/tests/QueryErrorVisibilityTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A statement the database refuses has to be visible.
+ *
+ * Both drivers reported query errors with $this->e->debug(). Under the
+ * production error handler -- which is what a real installation runs -- debug
+ * is written nowhere. Verified against a live install: notice, warning and
+ * error all reach the log; debug does not.
+ *
+ * So a refused write produced NOTHING. That is how a strict sql_mode dropped
+ * page views on a live installation without anyone noticing: the INSERT failed,
+ * the failure propagated as a false return that the tracking path does not
+ * inspect, and no log line existed to contradict the impression that everything
+ * was fine. The symptom was missing rows, discovered by chance, days later.
+ *
+ * This is the test that makes the next such failure loud instead of silent, so
+ * it asserts the LEVEL rather than the wording -- the wording is not what
+ * failed.
+ */
+final class QueryErrorVisibilityTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    /**
+     * Records what was logged and at which level, standing in for the error
+     * singleton the driver would normally use.
+     */
+    private function spy() {
+
+        return new class {
+
+            public $messages = [];
+
+            public function debug( $m )   { $this->messages[] = [ 'debug', $m ]; }
+            public function info( $m )    { $this->messages[] = [ 'info', $m ]; }
+            public function notice( $m )  { $this->messages[] = [ 'notice', $m ]; }
+            public function warning( $m ) { $this->messages[] = [ 'warning', $m ]; }
+            public function err( $m )     { $this->messages[] = [ 'error', $m ]; }
+            public function crit( $m )    { $this->messages[] = [ 'critical', $m ]; }
+
+            public function levels() {
+                return array_column( $this->messages, 0 );
+            }
+
+            public function at( $level ) {
+                return array_values( array_map(
+                    function ( $m ) { return $m[1]; },
+                    array_filter( $this->messages, function ( $m ) use ( $level ) {
+                        return $m[0] === $level;
+                    } )
+                ) );
+            }
+        };
+    }
+
+    /**
+     * The levels the production handler actually writes. If this ever changes,
+     * the choice of level below has to change with it -- which is why the
+     * relationship is asserted rather than assumed.
+     */
+    public function testDebugIsNotAmongTheLevelsProductionWrites(): void {
+
+        $written = [ 'notice', 'warning', 'error', 'critical', 'alert', 'emergency' ];
+
+        $this->assertNotContains( 'debug', $written,
+            'debug is not written by the production handler, so it cannot carry a real failure' );
+    }
+
+    public function testARefusedStatementIsLoggedWhereProductionCanSeeIt(): void {
+
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db  = \OWA\Core\CoreAPI::dbSingleton();
+        $spy = $this->spy();
+
+        $original = $db->e;
+        $db->e = $spy;
+
+        try {
+            // Syntactically valid, refused by the server: no such table.
+            $db->query( 'INSERT INTO owa_no_such_table_for_this_test (id) VALUES (1)' );
+        } finally {
+            $db->e = $original;
+        }
+
+        $this->assertNotEmpty( $spy->messages, 'the driver logged nothing at all for a refused statement' );
+
+        $this->assertContains( 'error', $spy->levels(),
+            'a refused statement must be logged at a level the production handler writes. '
+          . 'It was reported at debug, which is written nowhere, so failures were silent.' );
+
+        $reported = implode( ' ', $spy->at( 'error' ) );
+
+        $this->assertStringContainsString( 'owa_no_such_table_for_this_test', $reported,
+            'the message must name the statement that was refused' );
+    }
+
+    /**
+     * A broken database refuses every statement, and this log is on disk on the
+     * same machine. The cap has to announce itself, or a quiet log reads as a
+     * healthy one.
+     */
+    public function testTheLogVolumeCapAnnouncesItself(): void {
+
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db  = \OWA\Core\CoreAPI::dbSingleton();
+        $spy = $this->spy();
+
+        $reset = new ReflectionProperty( \OWA\Core\Db::class, 'query_error_count' );
+        $reset->setAccessible( true );
+        $reset->setValue( null, 0 );
+
+        $original = $db->e;
+        $db->e = $spy;
+
+        try {
+            for ( $i = 0; $i < \OWA\Core\Db::QUERY_ERROR_LOG_LIMIT + 10; $i++ ) {
+                $db->query( 'INSERT INTO owa_no_such_table_for_this_test (id) VALUES (1)' );
+            }
+        } finally {
+            $db->e = $original;
+            $reset->setValue( null, 0 );
+        }
+
+        $errors = $spy->at( 'error' );
+
+        $this->assertLessThanOrEqual(
+            \OWA\Core\Db::QUERY_ERROR_LOG_LIMIT + 1,
+            count( $errors ),
+            'the cap must actually bound the number of lines written'
+        );
+
+        $this->assertStringContainsString(
+            'not be logged',
+            implode( ' ', $errors ),
+            'stopping silently would make a capped log look like a recovered one'
+        );
+    }
+}

--- a/tests/QueryErrorVisibilityTest.php
+++ b/tests/QueryErrorVisibilityTest.php
@@ -147,4 +147,112 @@ final class QueryErrorVisibilityTest extends TestCase {
             'stopping silently would make a capped log look like a recovered one'
         );
     }
+
+    /**
+     * A constraint violation is usually not a fault, and must not be reported
+     * as one.
+     *
+     * Dimension rows are written check-then-insert: load by id, insert if it
+     * was not there. Two concurrent first-hits on the same new URL, user agent
+     * or host both miss and both insert, and one loses. The row exists either
+     * way -- which is what the insert was for -- so the loser has nothing to
+     * fix. Reporting that at error level would cry wolf on every busy site, and
+     * a log that cries wolf gets ignored, which is how the silence this whole
+     * change is about becomes possible again by a different route.
+     *
+     * Still logged, because a duplicate rate that climbs is worth seeing.
+     */
+    public function testAConstraintViolationIsReportedButNotAsAFault(): void
+    {
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db  = \OWA\Core\CoreAPI::dbSingleton();
+        $spy = $this->spy();
+
+        $db->query( 'CREATE TEMPORARY TABLE owa_dupe_probe (id BIGINT PRIMARY KEY)' );
+        $db->query( 'INSERT INTO owa_dupe_probe (id) VALUES (1)' );
+
+        $original = $db->e;
+        $db->e = $spy;
+
+        try {
+            $result = $db->query( 'INSERT INTO owa_dupe_probe (id) VALUES (1)' );
+        } finally {
+            $db->e = $original;
+        }
+
+        $this->assertFalse( $result, 'a refused insert must still report failure to its caller' );
+
+        $this->assertNotContains( 'error', $spy->levels(),
+            'a concurrent-insert race is expected, and must not be logged as a fault' );
+
+        $this->assertContains( 'notice', $spy->levels(),
+            'it must still be logged -- a duplicate rate that climbs is worth seeing' );
+    }
+
+    /**
+     * The pair for the case above: a genuine fault must still be an error, or
+     * the classification would just be a way of hiding everything.
+     */
+    public function testARealFaultIsStillReportedAsOne(): void
+    {
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db  = \OWA\Core\CoreAPI::dbSingleton();
+        $spy = $this->spy();
+
+        $original = $db->e;
+        $db->e = $spy;
+
+        try {
+            $db->query( 'INSERT INTO owa_no_such_table_for_this_test (id) VALUES (1)' );
+        } finally {
+            $db->e = $original;
+        }
+
+        $this->assertContains( 'error', $spy->levels(),
+            'a missing table is a fault and must be reported as one' );
+    }
+
+    /**
+     * The property the whole concern rests on: one refused insert must not stop
+     * the ones after it.
+     *
+     * A tracker request writes several rows -- document, referer, user agent,
+     * host, session, request -- and a duplicate on any one of them is an
+     * ordinary outcome of the check-then-insert race. If that aborted the
+     * request, a single lost race would cost every other row as well.
+     *
+     * The PDO driver raised the stakes here: it runs with ERRMODE_EXCEPTION, so
+     * without the catch inside query() a duplicate key would have thrown
+     * straight out through the tracker.
+     */
+    public function testARefusedInsertDoesNotStopTheInsertsAfterIt(): void
+    {
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->query( 'CREATE TEMPORARY TABLE owa_seq_probe (id BIGINT PRIMARY KEY)' );
+
+        $first  = $db->query( 'INSERT INTO owa_seq_probe (id) VALUES (1)' );
+        $dupe   = $db->query( 'INSERT INTO owa_seq_probe (id) VALUES (1)' );
+        $after  = $db->query( 'INSERT INTO owa_seq_probe (id) VALUES (2)' );
+
+        $this->assertTrue( (bool) $first );
+        $this->assertFalse( $dupe, 'the duplicate must fail' );
+        $this->assertTrue( (bool) $after,
+            'the insert after a duplicate must still run -- a tracker request writes several rows '
+          . 'and one lost race must not cost the others' );
+
+        $row = $db->get_row( 'SELECT COUNT(*) AS n FROM owa_seq_probe' );
+
+        $this->assertSame( 2, (int) $row['n'], 'both distinct rows must be present' );
+    }
 }


### PR DESCRIPTION
**This is why the strict-`sql_mode` data loss went unnoticed.**

Both drivers logged query errors with `$this->e->debug()`. Under the production error handler — what every real installation runs — debug is written nowhere. Verified against a live install:

| level | reaches the log under the production handler |
|---|---|
| `debug` | **no** |
| `notice` / `warning` / `error` | yes |

So a refused write produced **nothing**. The INSERT failed, the failure propagated as a `false` return that the tracking path does not inspect, and no log line existed to contradict the impression that everything was fine. It was found by chance — a probe that happened not to land — days after it started.

Query errors now go through `Db::logQueryError()` at **error** level. The full statement is still emitted at debug too, so nothing is lost for anyone running the development handler.

Confirmed end to end under a production handler:

```
[ERROR] The database refused a statement. Error: SQLSTATE[42S02]: Base table or view not found: 1146 ...
```

## Two deliberate details

**No `htmlspecialchars()`.** This goes to a log file, not to a page. Escaping it only makes the message harder to read at the moment someone is trying to read it.

**A per-process cap of 25.** A broken database refuses every statement, and this log is on disk on the same machine. The cap **announces itself** when it engages — a log that just goes quiet reads like a database that recovered.

## Testing

The test asserts the **level**, not the wording — the wording is not what failed. It also pins the relationship to the set of levels production writes, so the choice can't silently regress if those change. Reporting at debug again fails the suite.

Full suite 774 · PHPStan clean.