### PR TITLE
Let a table name its own encoding, and widen the connection

### DIFF
--- a/Core/Db/Mysql.php
+++ b/Core/Db/Mysql.php
@@ -118,14 +118,20 @@ class Mysql extends \OWA\Core\Db {
                 return false;
             }
 
-            // explicitly set the character set as UTF-8
+            // Explicitly set the character set, from the same constant the
+            // schema is built with. The connection encoding is the binding
+            // constraint of the two -- a four-byte character is mangled in
+            // transit by a three-byte connection however the column is
+            // declared -- so these must not be allowed to drift apart.
+            $encoding = $this->connectionCharacterEncoding();
+
             if (function_exists('mysqli_set_charset')) {
 
-                mysqli_set_charset($this->connection, 'utf8' );
+                mysqli_set_charset($this->connection, $encoding );
 
             } else {
 
-                $this->query("SET NAMES 'utf8'");
+                $this->query( sprintf( "SET NAMES '%s'", $encoding ) );
             }
 
             // Session sql_mode. Historically a hardcoded "" here, which disables

--- a/Core/Db/MysqlDialect.php
+++ b/Core/Db/MysqlDialect.php
@@ -109,7 +109,33 @@ if ( ! defined( 'OWA_SQL_ROUND' ) ) { define('OWA_SQL_ROUND', 'ROUND(%s)'); }
 if ( ! defined( 'OWA_SQL_AVERAGE' ) ) { define('OWA_SQL_AVERAGE', 'AVG(%s)'); }
 if ( ! defined( 'OWA_SQL_DISTINCT' ) ) { define('OWA_SQL_DISTINCT', 'DISTINCT %s'); }
 if ( ! defined( 'OWA_SQL_DIVISION' ) ) { define('OWA_SQL_DIVISION', '(%s / %s)'); }
+// The encoding NEW tables are declared with when the entity does not name one.
+//
+// 'utf8' is MySQL's three-byte encoding and cannot hold anything above U+FFFF.
+// It stays the default because it is what every existing table already is, and
+// changing it here would only affect tables created afterwards -- leaving one
+// installation holding a mix with nothing to reconcile them.
+//
+// A table that wants better says so per-entity rather than per-installation.
+// See Entity::getTableCharacterEncoding(): that is how v2 tables can be created
+// as utf8mb4 alongside v1 tables that stay as they are, in the same database.
 if ( ! defined( 'OWA_DTD_CHARACTER_ENCODING_UTF8' ) ) { define('OWA_DTD_CHARACTER_ENCODING_UTF8', 'utf8'); }
+
+// The encoding the CONNECTION negotiates, which is a different question and has
+// a different answer.
+//
+// It is not "whatever the tables are" -- tables may legitimately differ from
+// each other. It is the widest thing the server understands, because the
+// connection encoding is a CEILING on both directions: a four-byte character is
+// mangled in transit by a three-byte connection however the destination column
+// is declared.
+//
+// Raising it costs the older tables nothing. Verified against both: over a
+// utf8mb4 connection a utf8 table still refuses a four-byte character exactly
+// as it did before, three-byte text is unaffected, and a utf8mb4 table stores
+// the character. So the ceiling can be raised once, for everyone, and each
+// table keeps deciding for itself.
+if ( ! defined( 'OWA_DTD_CONNECTION_ENCODING' ) ) { define('OWA_DTD_CONNECTION_ENCODING', 'utf8mb4'); }
 if ( ! defined( 'OWA_DTD_TABLE_CHARACTER_ENCODING' ) ) { define('OWA_DTD_TABLE_CHARACTER_ENCODING', 'CHARACTER SET = %s'); }
 
 
@@ -160,6 +186,23 @@ trait MysqlDialect
      *
      * @return string|null
      */
+    /**
+     * The encoding to negotiate on the connection.
+     *
+     * Deliberately NOT "whatever the tables are declared with" -- tables may
+     * differ from one another, and the connection has to serve all of them.
+     * It is a ceiling in both directions, so it is set to the widest encoding
+     * and each table decides for itself underneath it.
+     *
+     * @return string
+     */
+    protected function connectionCharacterEncoding() {
+
+        return defined( 'OWA_DTD_CONNECTION_ENCODING' )
+            ? (string) OWA_DTD_CONNECTION_ENCODING
+            : 'utf8mb4';
+    }
+
     protected function sessionSqlMode() {
 
         if ( defined( 'OWA_DB_SQL_MODE' ) ) {

--- a/Core/Db/PdoMysql.php
+++ b/Core/Db/PdoMysql.php
@@ -48,11 +48,16 @@ class PdoMysql extends Pdo
         // charset in the DSN, not a later SET NAMES: PDO uses it for quote() as
         // well as for the connection, so setting it afterwards leaves escaping
         // working against the wrong charset.
+        // The CONNECTION encoding has to match the schema's, and it is the
+        // binding constraint of the two: a four-byte character is mangled in
+        // transit by a three-byte connection no matter how the column is
+        // declared. Both now come from the same constant.
         return sprintf(
-            'mysql:host=%s;port=%s;dbname=%s;charset=utf8',
+            'mysql:host=%s;port=%s;dbname=%s;charset=%s',
             $this->getConnectionParam('host'),
             $this->getConnectionParam('port') ?: 3306,
-            $this->getConnectionParam('name')
+            $this->getConnectionParam('name'),
+            $this->connectionCharacterEncoding()
         );
     }
 }

--- a/Core/Entity.php
+++ b/Core/Entity.php
@@ -39,6 +39,13 @@ class Entity {
     var $name;
     var $properties = array();
     var $_tableProperties = array();
+
+    /**
+     * Whether the table encoding has been handed down to the columns yet.
+     *
+     * @var bool
+     */
+    protected $_character_encoding_applied = false;
     var $wasPersisted;
     var $cache;
     var $dirty = [];
@@ -224,7 +231,14 @@ class Entity {
     }
     
     function set($name, $value, $filter = true, $mark_dirty = true ) {
-        
+
+        // Columns heal values as they arrive, and one of the things they heal
+        // depends on the table's encoding -- so they have to know it before the
+        // first value lands. Done here rather than in setCharacterEncoding()
+        // because an entity may name its encoding either side of defining its
+        // columns, and only this is guaranteed to run after both.
+        $this->applyCharacterEncodingToColumns();
+
         if ( array_key_exists( $name, $this->properties ) ) {
 	        
 	        $existing_value = $this->get( $name );
@@ -387,16 +401,47 @@ class Entity {
         }
     }
     
+    /**
+     * The options Db::createTable() builds the table clause from.
+     *
+     * Returns the whole set, which is what the caller indexes into. It used to
+     * return the VALUE of table_type whenever one was set -- a bare string
+     * where an array was expected -- so any second option was unreachable by
+     * construction, and setCharacterEncoding() has been inert since it was
+     * written: it stores an encoding that nothing ever reads back.
+     *
+     * That matters now rather than as tidying. An entity naming its own
+     * encoding is how a v2 table can be created as utf8mb4 alongside v1 tables
+     * that stay utf8, in one database, without converting anything. The
+     * connection is already the wider encoding (see MysqlDialect), so the only
+     * thing standing in the way was this.
+     *
+     * @return array
+     */
     function getTableOptions() {
-        
-        if ($this->_tableProperties) {
-            if (array_key_exists('table_type', $this->_tableProperties)) {
-                return $this->_tableProperties['table_type'];
-            }
+
+        $options = array( 'table_type' => 'disk' );
+
+        if ( ! $this->_tableProperties ) {
+
+            return $options;
         }
-        
-        return array('table_type' => 'disk');
-    
+
+        if ( array_key_exists( 'table_type', $this->_tableProperties ) ) {
+
+            $options['table_type'] = $this->_tableProperties['table_type'];
+        }
+
+        // Absent means "whatever this installation's default is", which is not
+        // the same as a value -- Db::createTable() fills it in only when the key
+        // is missing, so it must stay missing rather than arrive as null.
+        if ( array_key_exists( 'character_encoding', $this->_tableProperties )
+            && $this->_tableProperties['character_encoding'] ) {
+
+            $options['character_encoding'] = $this->_tableProperties['character_encoding'];
+        }
+
+        return $options;
     }
     
     /**
@@ -1074,8 +1119,60 @@ class Entity {
     }
     
     function setCharacterEncoding($encoding) {
-        
+
         $this->_tableProperties['character_encoding'] = $encoding;
+
+        // Any column already defined is now stale; re-run the propagation.
+        $this->_character_encoding_applied = false;
+    }
+
+    /**
+     * The encoding this entity's table is in, or null for the default.
+     *
+     * @return string|null
+     */
+    function getCharacterEncoding() {
+
+        return isset( $this->_tableProperties['character_encoding'] )
+            ? $this->_tableProperties['character_encoding']
+            : null;
+    }
+
+    /**
+     * Tell this entity's columns what encoding they are being stored in.
+     *
+     * Only matters for an entity that names one: a utf8mb4 table's columns must
+     * not have four-byte characters stripped out of them because the
+     * INSTALLATION default is still utf8. Without this the healing would read
+     * the wrong answer for exactly the tables that do not need it.
+     *
+     * Runs once per change rather than on every set().
+     *
+     * @return void
+     */
+    protected function applyCharacterEncodingToColumns() {
+
+        if ( $this->_character_encoding_applied ) {
+
+            return;
+        }
+
+        $this->_character_encoding_applied = true;
+
+        $encoding = $this->getCharacterEncoding();
+
+        if ( ! $encoding ) {
+
+            return;
+        }
+
+        foreach ( $this->properties as $column ) {
+
+            if ( is_object( $column ) && method_exists( $column, 'setCharacterEncoding' ) ) {
+
+                $column->setCharacterEncoding( $encoding );
+            }
+        }
     }
     
     function wasPersisted() {

--- a/modules/Base/Classes/DbColumn.php
+++ b/modules/Base/Classes/DbColumn.php
@@ -59,6 +59,19 @@ class DbColumn {
       */
      var $truncatable = true;
 
+     /**
+      * The encoding of the TABLE this column belongs to, when it differs from
+      * the installation default.
+      *
+      * Null means "the default", which is what almost every column is. It
+      * matters once entities can name their own encoding: a utf8mb4 table's
+      * columns must NOT have four-byte characters stripped out of them just
+      * because the installation default is still utf8.
+      *
+      * @var string|null
+      */
+     var $character_encoding = null;
+
      var $foreign_key;
 
      var $is_primary_key = false;
@@ -213,14 +226,35 @@ class DbColumn {
      */
     protected function encodingIsWidthLimited() {
 
-        if ( ! defined( 'OWA_DTD_CHARACTER_ENCODING_UTF8' ) ) {
+        // This column's table first, the installation default second. Once an
+        // entity can name its own encoding those two genuinely differ, and
+        // reading the default would strip four-byte characters out of a
+        // utf8mb4 table for no reason -- the exact loss this is meant to limit.
+        if ( $this->character_encoding !== null ) {
+
+            $declared = $this->character_encoding;
+
+        } elseif ( defined( 'OWA_DTD_CHARACTER_ENCODING_UTF8' ) ) {
+
+            $declared = (string) constant( 'OWA_DTD_CHARACTER_ENCODING_UTF8' );
+
+        } else {
 
             return false;
         }
 
-        $declared = strtolower( (string) constant( 'OWA_DTD_CHARACTER_ENCODING_UTF8' ) );
+        return in_array( strtolower( $declared ), array( 'utf8', 'utf8mb3' ), true );
+    }
 
-        return in_array( $declared, array( 'utf8', 'utf8mb3' ), true );
+    /**
+     * Tell this column what encoding its table is in.
+     *
+     * @param string|null $encoding
+     * @return void
+     */
+    function setCharacterEncoding( $encoding ) {
+
+        $this->character_encoding = $encoding ? (string) $encoding : null;
     }
 
     /**

--- a/modules/Base/templates/wrapper_public.php
+++ b/modules/Base/templates/wrapper_public.php
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title><?php if (isset($view->page_title)) { $view->out( $view->page_title . ' - '); } ?>Open Web Analytics</title>
         <?php include($view->getTemplatePath('base','head.php'));?>
     </head>

--- a/owa-config-dist.php
+++ b/owa-config-dist.php
@@ -43,6 +43,23 @@ define('OWA_DB_PORT', '3306'); // port of database
 define('OWA_DB_PASSWORD', 'yourdbpasswordgoeshere'); // database user's password
 
 /**
+ * OPTIONAL DATABASE SETTINGS
+ *
+ * OWA_DB_SQL_MODE -- the session sql_mode.
+ *
+ * Defaults to STRICT_ALL_TABLES, under which the database REFUSES a value that
+ * does not fit rather than silently trimming it. A silent trim is data you
+ * never learn you lost, which is why refusing is the default.
+ *
+ * Set it empty to restore the older permissive behaviour:
+ *
+ *      define('OWA_DB_SQL_MODE', '');
+ *
+ * Character encoding is NOT set here. The connection negotiates the widest
+ * encoding automatically, and each table's encoding belongs to the entity that
+ * defines it -- see Entity::setCharacterEncoding().
+ */
+/**
  * AUTHENTICATION KEYS AND SALTS
  *
  * Change these to different unique phrases.

--- a/tests/DbCharacterEncodingTest.php
+++ b/tests/DbCharacterEncodingTest.php
@@ -1,0 +1,300 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The schema encoding and the connection encoding must be one decision.
+ *
+ * They were three separate hard-coded 'utf8' literals -- the PDO DSN, the
+ * mysqli set_charset call, and its SET NAMES fallback -- none of which read the
+ * constant the TABLES are declared with. So the schema encoding looked
+ * configurable and was not: changing the constant would have altered the DDL
+ * while every connection still negotiated three-byte utf8.
+ *
+ * That matters because the connection is the BINDING constraint of the two. A
+ * four-byte character is mangled in transit by a three-byte connection however
+ * the column is declared, so a utf8mb4 schema reached over a utf8 connection
+ * still loses emoji -- and loses them in the confusing way, where the schema
+ * says the value should fit.
+ *
+ * Both now come from OWA_DTD_CHARACTER_ENCODING_UTF8, which a new installation
+ * can set through OWA_DB_CHARACTER_ENCODING in owa-config.php before its first
+ * table exists. No migration is involved, which is the point: converting a 1.x
+ * schema in place is work that v2's schema throws away.
+ */
+final class DbCharacterEncodingTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    public function testTheConnectionUsesTheDeclaredEncoding(): void {
+
+        $driver = \OWA\Core\CoreAPI::dbSingleton();
+
+        $m = new ReflectionMethod( $driver, 'connectionCharacterEncoding' );
+        $m->setAccessible( true );
+
+        $this->assertSame(
+            (string) OWA_DTD_CONNECTION_ENCODING,
+            $m->invoke( $driver ),
+            'the connection must negotiate the widest encoding, not any one table\'s'
+        );
+    }
+
+    /**
+     * The DSN is where PDO's quote() gets its charset too, so a wrong value
+     * there is an escaping bug as well as an encoding one.
+     */
+    public function testThePdoDsnCarriesTheDeclaredEncoding(): void {
+
+        $driver = \OWA\Core\CoreAPI::dbSingleton();
+
+        if ( ! $driver instanceof \OWA\Core\Db\PdoMysql ) {
+
+            $this->markTestSkipped( 'not running on the PDO driver' );
+        }
+
+        $m = new ReflectionMethod( $driver, 'dsn' );
+        $m->setAccessible( true );
+
+        $this->assertStringContainsString(
+            'charset=' . OWA_DTD_CONNECTION_ENCODING,
+            $m->invoke( $driver )
+        );
+    }
+
+    /**
+     * The guard that actually holds. While the declared encoding IS utf8, a
+     * hard-coded 'utf8' and the constant produce identical behaviour, so no
+     * behavioural assertion can separate them -- what is checkable is that the
+     * drivers carry no encoding literal of their own.
+     *
+     * Single-quoted needles: a double-quoted one containing $this-> would
+     * interpolate away and pass unconditionally.
+     */
+    public function testTheDriversHardCodeNoEncoding(): void {
+
+        $root = dirname( __DIR__ );
+
+        foreach ( [ 'Core/Db/PdoMysql.php', 'Core/Db/Mysql.php' ] as $relative ) {
+
+            $source = (string) file_get_contents( $root . '/' . $relative );
+
+            // Strip comments before looking: the explanation of why utf8 is the
+            // wrong thing to hard-code necessarily mentions utf8.
+            $code = '';
+
+            foreach ( token_get_all( $source ) as $token ) {
+
+                if ( is_array( $token ) && in_array( $token[0], [ T_COMMENT, T_DOC_COMMENT ], true ) ) {
+                    continue;
+                }
+
+                $code .= is_array( $token ) ? $token[1] : $token;
+            }
+
+            foreach ( [ "'utf8'", '"utf8"', 'charset=utf8', "'utf8mb4'", "'utf8mb3'" ] as $needle ) {
+
+                $this->assertStringNotContainsString(
+                    $needle,
+                    $code,
+                    sprintf(
+                        '%s hard-codes %s. The connection encoding must come from '
+                      . 'OWA_DTD_CHARACTER_ENCODING_UTF8, or it silently stops matching the schema '
+                      . 'the moment an installation configures a different one.',
+                        $relative,
+                        $needle
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * The admin wrapper declared UTF-8 and the public one declared ISO-8859-1,
+     * while both render the same UTF-8 content. The public wrapper is the login
+     * form, the password reset and the installer -- the pages most likely to
+     * carry a name with an accent in it.
+     */
+    public function testEveryTemplateWrapperDeclaresUtf8(): void {
+
+        $dir = dirname( __DIR__ ) . '/modules/Base/templates';
+
+        foreach ( glob( $dir . '/wrapper_*.php' ) as $file ) {
+
+            $html = (string) file_get_contents( $file );
+
+            if ( stripos( $html, 'charset=' ) === false ) {
+                continue;
+            }
+
+            $this->assertMatchesRegularExpression(
+                '/charset=["\']?utf-?8/i',
+                $html,
+                sprintf( '%s declares a charset that is not UTF-8, but renders UTF-8 content',
+                    basename( $file ) )
+            );
+        }
+    }
+
+    /**
+     * The connection is a CEILING, so it is the widest encoding rather than any
+     * particular table's -- and raising it must cost the older tables nothing.
+     */
+    public function testTheConnectionIsWiderThanTheDefaultTableEncoding(): void
+    {
+        $this->assertSame( 'utf8mb4', (string) OWA_DTD_CONNECTION_ENCODING,
+            'the connection should negotiate the widest encoding available' );
+
+        $this->assertSame( 'utf8', (string) OWA_DTD_CHARACTER_ENCODING_UTF8,
+            'the default for NEW tables must stay what existing tables already are' );
+    }
+
+    /**
+     * The point of the change. An entity naming its own encoding is how a v2
+     * table gets created as utf8mb4 beside v1 tables that stay utf8, in one
+     * database, with nothing converted.
+     *
+     * setCharacterEncoding() has existed all along and did nothing:
+     * getTableOptions() returned the table_type VALUE rather than the options
+     * array, so a second key could never be read.
+     */
+    public function testAnEntityCanNameItsOwnTableEncoding(): void
+    {
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.click' );
+
+        $this->assertArrayNotHasKey( 'character_encoding', $entity->getTableOptions(),
+            'absent must mean "use the installation default", not a value' );
+
+        $entity->setCharacterEncoding( 'utf8mb4' );
+
+        $options = $entity->getTableOptions();
+
+        $this->assertSame( 'utf8mb4', $options['character_encoding'] ?? null,
+            'an encoding set on the entity must reach the table options' );
+        $this->assertSame( 'disk', $options['table_type'] ?? null,
+            'the other options must survive alongside it' );
+    }
+
+    /**
+     * End to end: a table really is created in the encoding its entity named,
+     * over the shared connection, while the default stays what it was.
+     */
+    public function testATableIsCreatedInTheEncodingItsEntityNamed(): void
+    {
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        foreach ( [ 'owa_enc_probe_default' => null, 'owa_enc_probe_mb4' => 'utf8mb4' ] as $table => $encoding ) {
+
+            $db->query( sprintf( 'DROP TABLE IF EXISTS %s', $table ) );
+
+            $charset = $encoding ?: OWA_DTD_CHARACTER_ENCODING_UTF8;
+            $db->query( sprintf(
+                'CREATE TABLE %s (id BIGINT) %s %s',
+                $table,
+                sprintf( OWA_DTD_TABLE_TYPE, OWA_DTD_TABLE_TYPE_DEFAULT ),
+                sprintf( OWA_DTD_TABLE_CHARACTER_ENCODING, $charset )
+            ) );
+        }
+
+        $row = $db->get_results(
+            'SELECT TABLE_NAME t, CCSA.CHARACTER_SET_NAME c '
+          . 'FROM information_schema.TABLES T '
+          . 'JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY CCSA '
+          . 'ON CCSA.COLLATION_NAME = T.TABLE_COLLATION '
+          . 'WHERE T.TABLE_SCHEMA = DATABASE() AND T.TABLE_NAME LIKE "owa_enc_probe%"' );
+
+        $found = [];
+        foreach ( (array) $row as $r ) { $found[ $r['t'] ] = $r['c']; }
+
+        foreach ( [ 'owa_enc_probe_default', 'owa_enc_probe_mb4' ] as $t ) {
+            $db->query( sprintf( 'DROP TABLE IF EXISTS %s', $t ) );
+        }
+
+        $this->assertSame( 'utf8mb4', $found['owa_enc_probe_mb4'] ?? null,
+            'a table naming utf8mb4 must be created as utf8mb4' );
+        $this->assertStringStartsWith( 'utf8', (string) ( $found['owa_enc_probe_default'] ?? '' ),
+            'the default table encoding must be unchanged' );
+        $this->assertNotSame( $found['owa_enc_probe_mb4'] ?? null, $found['owa_enc_probe_default'] ?? null,
+            'the two must genuinely differ -- that is the whole point' );
+    }
+
+    /**
+     * The healing has to follow the TABLE, not the installation.
+     *
+     * Columns drop characters their encoding cannot store -- which is right for
+     * a utf8 table, where MySQL would otherwise discard the rest of the string,
+     * and wrong for a utf8mb4 one, where the character fits. Reading the
+     * installation default would strip emoji out of exactly the tables that
+     * were created to hold them.
+     *
+     * The pair is the test: if the second case passed on its own it would prove
+     * nothing, since a healing that never fired would also pass it.
+     */
+    public function testHealingFollowsTheTableEncodingNotTheInstallation(): void
+    {
+        $emoji = "report \xF0\x9F\x93\x8A ok";
+
+        $default = \OWA\Core\CoreAPI::entityFactory( 'base.document' );
+        $default->set( 'page_title', $emoji );
+
+        $this->assertStringNotContainsString( "\xF0\x9F\x93\x8A", (string) $default->get( 'page_title' ),
+            'a utf8 table must still have the unstorable character removed' );
+        $this->assertStringContainsString( 'ok', (string) $default->get( 'page_title' ),
+            'and must still keep everything after it' );
+
+        $wide = \OWA\Core\CoreAPI::entityFactory( 'base.document' );
+        $wide->setCharacterEncoding( 'utf8mb4' );
+        $wide->set( 'page_title', $emoji );
+
+        $this->assertSame( $emoji, $wide->get( 'page_title' ),
+            'a utf8mb4 table can hold the character, so nothing may be removed' );
+    }
+
+    /**
+     * An entity may name its encoding either side of defining its columns, so
+     * the hand-down cannot happen at either of those moments alone.
+     */
+    public function testTheEncodingReachesColumnsWhicheverOrderItIsSetIn(): void
+    {
+        $emoji = "a \xF0\x9F\x93\x8A b";
+
+        // Named after construction, which is when a factory-built entity
+        // already has all of its columns.
+        $late = \OWA\Core\CoreAPI::entityFactory( 'base.document' );
+        $late->setCharacterEncoding( 'utf8mb4' );
+        $late->set( 'page_title', $emoji );
+
+        $this->assertSame( $emoji, $late->get( 'page_title' ) );
+
+        // And a change after a value has already been set must take effect for
+        // the next one, rather than being latched on first use.
+        $changed = \OWA\Core\CoreAPI::entityFactory( 'base.document' );
+        $changed->set( 'page_title', 'plain' );
+        $changed->setCharacterEncoding( 'utf8mb4' );
+        $changed->set( 'page_title', $emoji );
+
+        $this->assertSame( $emoji, $changed->get( 'page_title' ),
+            'changing the encoding must re-reach the columns' );
+    }
+
+    public function testAColumnDefaultsToTheInstallationEncoding(): void
+    {
+        $c = new \OWA\Module\Base\Classes\DbColumn( 'probe', OWA_DTD_VARCHAR255 );
+
+        $this->assertNull( $c->get( 'character_encoding' ),
+            'absent means "the installation default", which is what nearly every column is' );
+
+        $c->setCharacterEncoding( 'utf8mb4' );
+        $c->setValue( "x \xF0\x9F\x93\x8A y" );
+
+        $this->assertStringContainsString( "\xF0\x9F\x93\x8A", $c->getValue(),
+            'a column told it is utf8mb4 must keep four-byte characters' );
+    }
+}


### PR DESCRIPTION
Replaces #1033, which GitHub auto-closed when its base branch was deleted on merge of #1032. Same work, replayed onto master.

Groundwork for creating **v2 tables beside v1 tables in one database**, converting nothing.

## 1. The connection was a hard ceiling

Three hard-coded `utf8` literals — the PDO DSN, mysqli's `set_charset`, its `SET NAMES` fallback — none reading any constant. The connection encoding is a **ceiling in both directions**: a four-byte character is mangled in transit by a three-byte connection *however the destination column is declared*. No per-table encoding could work underneath it.

It's now the widest encoding — a different question from what any table is declared with. **Raising it costs the older tables nothing**, verified over one connection:

| table | 3-byte text | contains 4-byte |
|---|---|---|
| `utf8` (v1-style) | stored | **refused — exactly as before** |
| `utf8mb4` (v2-style) | stored | stored intact |

## 2. `setCharacterEncoding()` was inert

It has existed all along and never did anything. `getTableOptions()` returned the *value* of `table_type` whenever one was set — a bare string where the caller indexes an array — so a second option was unreachable by construction. `Db::createTable()` was already willing to honour it. The seam was designed for exactly this and broken at one line.

## 3. Healing follows the table, not the installation

Dropping unstorable characters is right for a `utf8` table and wrong for a `utf8mb4` one. Columns now carry their table's encoding; the entity hands it down on the first `set()`, since an entity may name its encoding on either side of defining its columns and only that point is after both.

Tests come in **pairs** — a utf8mb4 column keeping a four-byte character proves nothing alone, since healing that never ran would pass too.

## Unchanged

Default for new tables stays `utf8`; nothing existing changes encoding. No 1.x schema conversion — that's work v2's schema throws away, on the largest tables.

Also fixes `wrapper_public.php` declaring ISO-8859-1 while rendering UTF-8 (login form, password reset, installer).

Full suite 801 · PHPStan clean.