### PR TITLE
Delete stripSql, which corrupted values and defended nothing

### DIFF
--- a/Core/Db.php
+++ b/Core/Db.php
@@ -831,9 +831,37 @@ class Db extends \OWA\Core\Base {
 
     }
 
+    /**
+     * Escape a value for interpolation into a statement.
+     *
+     * Every driver must implement this, because escaping is a property of the
+     * connection -- it depends on the server's character set, which only the
+     * driver knows. There is no correct database-agnostic version, so the base
+     * class refuses rather than offering a plausible-looking one.
+     *
+     * It used to offer Sanitize::stripSql(), which was not escaping at all: it
+     * deleted parentheses, commas, and any word matching a list of SQL keywords
+     * from the value. That is not a defence -- values were already escaped by
+     * the real drivers -- and it silently corrupted data whenever it was
+     * reached. It ran on this installation's user agents for six months, giving
+     * every browser two identities and roughly quadrupling the cardinality of
+     * the user-agent dimension.
+     *
+     * A third-party driver at plugins/db/ that reaches this is not escaping its
+     * values, which is a defect worth hearing about immediately rather than
+     * discovering later.
+     *
+     * @param string $string
+     * @throws \RuntimeException always
+     */
     function prepare ( $string ) {
 
-        return \OWA\Module\Base\Classes\Sanitize::stripSql( $string );
+        throw new \RuntimeException( sprintf(
+            '%s does not implement prepare(). A database driver must escape values itself, '
+          . 'because escaping depends on the connection character set. Implement prepare() '
+          . 'on the driver.',
+            get_class( $this )
+        ) );
     }
 
     function _makeJoinClause() {

--- a/modules/Base/Classes/Sanitize.php
+++ b/modules/Base/Classes/Sanitize.php
@@ -92,44 +92,7 @@ class Sanitize {
         }
     }
 
-    /**
-     * Strip SQL keywords and punctuation to prevent SQL injection.
-     *
-     * @param string $input String to sanitize
-     * @return string Sanitized string
-     * @access public
-     * @static
-     */
-    public static function stripSql( $input = '' ) {
-   
-        if ( ! $input ) {
-            return $input;
-        }
     
-        // Decode any encoded characters to reveal obfuscated SQL keywords.
-        $decoded = urldecode( $input );
-        $decoded = html_entity_decode( $decoded, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
-       
-        // Remove common SQL command keywords.
-        $sql_keywords = array(
-            'select', 'insert', 'update', 'delete', 'drop', 'union', 'create',
-            'alter', 'truncate', 'replace', 'merge', 'call', 'exec'
-        );
-        $pattern = '/\\b(' . implode( '|', $sql_keywords ) . ')\\b/i';
-        $decoded = preg_replace( $pattern, '', $decoded );
-        
-        // Remove commas and parentheses except for our allowed values.
-        $allowed_values = ['(not set)', '(unknown)'];
-        if ( ! in_array( $input, $allowed_values ) ) {
-            $decoded = str_replace( array( ',', '(', ')' ), '', $decoded );              
-        }
-        
-        // Remove any encoded commas or parentheses that may remain.
-        $decoded = preg_replace( '/%2C|%28|%29|&#40;|&#41;|&#44;/i', '', $decoded );
-    
-        return $decoded;
-    }
-
     /**
      * Strip Whitespace
      *

--- a/tests/NoContentManglingTest.php
+++ b/tests/NoContentManglingTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Values reach the database as they arrived.
+ *
+ * Sanitize::stripSql() presented itself as an SQL defence and was not one. It
+ * deleted parentheses, commas, and any word matching a list of SQL keywords
+ * from the value:
+ *
+ *   "How to update your camera"        -> "How to  your camera"
+ *   "https://example.com/select-a-print/" -> "https://example.com/-a-print/"
+ *   "Mozilla/5.0 (Macintosh; ...)"     -> "Mozilla/5.0 Macintosh; ..."
+ *
+ * It defended nothing -- values are escaped by the driver, identifiers are
+ * checked against the registry -- and it corrupted whatever passed through it.
+ * On this installation it ran on user agents for six months, giving every
+ * browser two identities and roughly quadrupling the cardinality of the
+ * user-agent dimension. Reports over that window are still wrong.
+ *
+ * It was reachable because Db::prepare() offered it as the base-class escape,
+ * so any driver that did not override prepare() silently mangled every value it
+ * wrote. There is no correct database-agnostic escape -- escaping depends on
+ * the connection's character set -- so the base class now refuses instead of
+ * offering a plausible-looking one.
+ */
+final class NoContentManglingTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    public function testTheManglingHelperIsGone(): void {
+
+        $this->assertFalse(
+            method_exists( \OWA\Module\Base\Classes\Sanitize::class, 'stripSql' ),
+            'stripSql corrupts every value it touches and defends nothing. It must not come back.'
+        );
+    }
+
+    /**
+     * A driver that does not escape is a defect, and must say so rather than
+     * quietly writing whatever it was given.
+     */
+    public function testTheBaseClassRefusesToPretendToEscape(): void {
+
+        // Without the constructor: prepare() does not depend on a connection,
+        // and the base class takes five arguments a test has no business
+        // inventing.
+        $driver = ( new ReflectionClass( \OWA\Core\Db::class ) )->newInstanceWithoutConstructor();
+
+        $this->expectException( \RuntimeException::class );
+
+        $driver->prepare( 'anything' );
+    }
+
+    /**
+     * The real drivers escape rather than delete. A stripped quote and an
+     * escaped quote both produce valid SQL, so only the round trip below tells
+     * them apart.
+     */
+    public function testTheDriverEscapesRatherThanRemoves(): void {
+
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $prepared = \OWA\Core\CoreAPI::dbSingleton()->prepare( "O'Brien (photographer), update" );
+
+        foreach ( [ 'O', 'Brien', '(', ')', ',', 'update' ] as $fragment ) {
+
+            $this->assertStringContainsString(
+                $fragment,
+                $prepared,
+                sprintf( 'escaping must preserve %s, not delete it', var_export( $fragment, true ) )
+            );
+        }
+    }
+
+    /**
+     * End to end, on the shapes that were actually corrupted: a user agent, a
+     * page title containing an SQL keyword, and a URL containing one.
+     */
+    public function testRealContentSurvivesAWriteAndReadIntact(): void {
+
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'No database available.' );
+        }
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->query( 'CREATE TEMPORARY TABLE owa_mangle_probe (id BIGINT, v VARCHAR(255))' );
+
+        $values = [
+            1 => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko)',
+            2 => 'How to update your camera settings',
+            3 => 'https://example.com/select-a-print/?merge=1',
+            4 => "Landscapes, Portraits (2026) - O'Brien",
+        ];
+
+        foreach ( $values as $id => $v ) {
+
+            $db->query( sprintf(
+                "INSERT INTO owa_mangle_probe (id, v) VALUES (%d, '%s')", $id, $db->prepare( $v ) ) );
+        }
+
+        foreach ( $values as $id => $expected ) {
+
+            $row = $db->get_row( sprintf( 'SELECT v FROM owa_mangle_probe WHERE id = %d', $id ) );
+
+            $this->assertSame(
+                $expected,
+                (string) ( $row['v'] ?? '' ),
+                'the value must come back exactly as it went in'
+            );
+        }
+    }
+}


### PR DESCRIPTION
`Sanitize::stripSql()` presented itself as an SQL defence. It deleted parentheses, commas, and any word matching a list of SQL keywords:

```
"How to update your camera"             ->  "How to  your camera"
"https://example.com/select-a-print/"  ->  "https://example.com/-a-print/"
"Mozilla/5.0 (Macintosh; ...)"         ->  "Mozilla/5.0 Macintosh; ..."
```

It defended nothing — values are escaped by the driver, identifiers are checked against the registry — and it corrupted whatever passed through it.

## This already happened

It ran on this installation's user agents from **February to early August 2026**:

| | |
|---|---|
| mangled UA rows | **2,122** |
| cardinality vs the correct form | ~**4×** (2,122 rows / 5,017 requests, against 577 / 5,584) |
| effect | every browser holds two identities; browser and OS reports over that window are wrong |

Confirmed server-side rather than assumed: the raw Apache access log shows **298 of 300** requests arriving with parentheses intact, so clients were sending well-formed strings. The stored ids hash the *stripped* text, so the mangling happened before id derivation. The strings cannot be recovered.

## Why it was reachable

`Db::prepare()` offered it as the base-class escape, so any driver not overriding `prepare()` mangled every value it wrote.

There is no correct database-agnostic escape — escaping depends on the connection's character set — so the base class now **refuses** rather than offering a plausible-looking one. A third-party driver at `plugins/db/` that reaches it is not escaping its values, which is a defect worth hearing about immediately rather than discovering later.

## Testing

The test that matters is the **round trip**: a stripped quote and an escaped quote both produce valid SQL, so only reading the value back separates them. It covers the shapes actually corrupted — a user agent, a title containing an SQL keyword, a URL containing one. Making the base `prepare()` silently return its input fails the suite.

Full suite 805 · PHPStan clean.