### PR TITLE
Add update-ua-regexes, so the user-agent patterns can be refreshed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,12 @@
 {
     "name": "open-web-analytics/open-web-analytics",
     "description": "The open source analytics framework.",
-    "keywords": ["open-web-analytics","owa","web-analytics","analytics"],
+    "keywords": [
+        "open-web-analytics",
+        "owa",
+        "web-analytics",
+        "analytics"
+    ],
     "homepage": "https://www.openwebanalytics.com",
     "license": "GPL-2.0",
     "authors": [
@@ -10,7 +15,6 @@
             "email": "hello@openwebanalytics.com"
         }
     ],
-    
     "config": {
         "sort-packages": true,
         "platform": {
@@ -20,15 +24,10 @@
             "wikimedia/composer-merge-plugin": true
         }
     },
-    
-    
     "require": {
         "php": ">=8.2",
-        "symfony/filesystem": "^7.4",
-        "symfony/yaml": "^7.4",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
-
     "autoload": {
         "psr-4": {
             "OWA\\Core\\": "Core/",
@@ -38,12 +37,10 @@
             "modules/MaxmindGeoip/includes/"
         ]
     },
-
     "require-dev": {
         "phpstan/phpstan": "^2.1",
         "phpunit/phpunit": "^10.5"
     },
-
     "scripts": {
         "lint": "find . -name '*.php' -not -path './vendor/*' -not -path './node_modules/*' -print0 | xargs -0 -n1 php -l",
         "phpstan": "phpstan analyse --memory-limit=1G",
@@ -52,7 +49,6 @@
         "test": "phpunit",
         "test:isolation": "bash tests/tools/isolation_sweep.sh"
     },
-
     "extra": {
         "merge-plugin": {
             "include": [

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
     
     "require": {
         "php": ">=8.2",
+        "symfony/filesystem": "^7.4",
+        "symfony/yaml": "^7.4",
         "wikimedia/composer-merge-plugin": "^2.0"
     },
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b7ffa9bbd3a5452e2245c16911ddf86",
+    "content-hash": "fb005024e42d4d2c568f2ea4a17362c6",
     "packages": [
         {
             "name": "composer/ca-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb005024e42d4d2c568f2ea4a17362c6",
+    "content-hash": "3b7ffa9bbd3a5452e2245c16911ddf86",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -918,6 +918,244 @@
             "time": "2026-06-05T06:23:12+00:00"
         },
         {
+            "name": "symfony/filesystem",
+            "version": "v7.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ff16a16bf87fdf264638b8f6995b3515975e3c79",
+                "reference": "ff16a16bf87fdf264638b8f6995b3515975e3c79",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-22T07:36:05+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
             "name": "symfony/polyfill-php80",
             "version": "v1.37.0",
             "source": {
@@ -1000,6 +1238,82 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.4.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "e101850ded5d2c0d44bf32abb8996404afec2dec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e101850ded5d2c0d44bf32abb8996404afec2dec",
+                "reference": "e101850ded5d2c0d44bf32abb8996404afec2dec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.4.15"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-21T15:13:06+00:00"
         },
         {
             "name": "ua-parser/uap-php",

--- a/modules/Base/Classes/Browscap.php
+++ b/modules/Base/Classes/Browscap.php
@@ -101,7 +101,7 @@ class Browscap extends \OWA\Core\Base {
         } else {
 	        
         	// load parser
-            $custom_db = \OWA\Core\CoreAPI::getSetting('base','ua-regexes');
+            $custom_db = self::regexesFile();
 
             if ( $custom_db ) {
 
@@ -131,6 +131,48 @@ class Browscap extends \OWA\Core\Base {
 	        }
 	
 	    }
+    }
+
+    /**
+     * The user-agent patterns file to parse with, or null for the bundled one.
+     *
+     * In order:
+     *
+     *   1. the `ua-regexes` setting, for an installation that keeps the file
+     *      somewhere of its own choosing
+     *   2. owa-data/ua-parser/regexes.php, where cmd=update-ua-regexes puts it
+     *   3. nothing, meaning the copy bundled with the library
+     *
+     * The second is the point. The bundled copy is only as new as the PHP
+     * library's last release, while the patterns themselves come from uap-core
+     * and are updated far more often -- so an installation that refreshes them
+     * should get the benefit without also having to configure a path. Same
+     * arrangement the Maxmind module uses for its database: a known directory
+     * under owa-data, read if it is there.
+     *
+     * @return string|null
+     */
+    public static function regexesFile() {
+
+        $configured = \OWA\Core\CoreAPI::getSetting( 'base', 'ua-regexes' );
+
+        if ( $configured ) {
+
+            return $configured;
+        }
+
+        $dir = \OWA\Core\CoreAPI::getSetting( 'base', 'ua_regexes_dir' ) ?: OWA_DATA_DIR . 'ua-parser/';
+
+        $maintained = $dir . 'regexes.php';
+
+        // Readable, not merely present: an unreadable file here would otherwise
+        // take precedence over a bundled copy that works.
+        if ( is_readable( $maintained ) ) {
+
+            return $maintained;
+        }
+
+        return null;
     }
 
     function robotRegexCheck() {

--- a/modules/Base/Controller/UpdateUaRegexesCli.php
+++ b/modules/Base/Controller/UpdateUaRegexesCli.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace OWA\Module\Base\Controller;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use UAParser\Util\Converter;
+use UAParser\Util\Fetcher;
+
+/**
+ * Refresh the user-agent patterns OWA identifies browsers and crawlers with.
+ *
+ *     php cli.php cmd=update-ua-regexes
+ *
+ * WHY THIS EXISTS
+ * The patterns come from uap-core, which is a separate project from the PHP
+ * library that reads them. uap-core updates its data roughly monthly and has
+ * not tagged a release since 2019, so consumers follow its master branch. The
+ * PHP library bundles a copy taken whenever ITS maintainers cut a release --
+ * the most recent being July 2025.
+ *
+ * So the bundled patterns are as old as the library's last release, however
+ * new the library is, and updating the composer dependency does not help: there
+ * is nothing newer to update to. Every browser and crawler added upstream since
+ * is invisible until the file is replaced.
+ *
+ * WHERE IT PUTS THE FILE
+ * owa-data/ua-parser/, which is outside the source tree and survives an
+ * upgrade. Same arrangement as the Maxmind module's database directory, and for
+ * the same reason: it is data the installation maintains, not code that ships.
+ * Writing inside vendor/ would work until the next composer install erased it.
+ *
+ * Browscap prefers this file whenever it exists, so a successful run takes
+ * effect immediately with nothing to configure.
+ */
+class UpdateUaRegexesCli extends \OWA\Core\Controller\Cli {
+
+    function __construct( $params ) {
+
+        // Same capability as the other maintenance commands: this rewrites a
+        // file the whole installation parses every request with, which is
+        // administrator territory even though it reads as a data refresh.
+        $this->setRequiredCapability( 'edit_modules' );
+
+        parent::__construct( $params );
+    }
+
+    function action() {
+
+        $dry_run = (bool) $this->getParam( 'dry-run' );
+
+        if ( ! class_exists( Fetcher::class ) || ! class_exists( Converter::class ) ) {
+
+            return $this->fail(
+                'The user-agent parser tools are not installed. Run composer install to get them.'
+            );
+        }
+
+        if ( ! class_exists( 'Symfony\\Component\\Yaml\\Yaml' ) ) {
+
+            return $this->fail(
+                'symfony/yaml is required to read the upstream patterns, and is not installed. '
+              . 'Run composer install.'
+            );
+        }
+
+        $dir  = \OWA\Core\CoreAPI::getSetting( 'base', 'ua_regexes_dir' ) ?: OWA_DATA_DIR . 'ua-parser/';
+        $file = $dir . 'regexes.php';
+
+        // Permissions BEFORE the download. Finding out that owa-data cannot be
+        // written after fetching 200KB is a worse experience than being told
+        // first, and the answer does not depend on the download.
+        //
+        // The installer checks owa-data/logs/ and owa-data/caches/, but not
+        // owa-data itself -- nothing needed to create a directory there until
+        // now. So this cannot assume a passing install check covers it.
+        $problem = $this->whyNotWritable( $dir );
+
+        if ( $problem ) {
+
+            return $this->fail( $problem );
+        }
+
+        $this->write( sprintf( 'Fetching user-agent patterns from uap-core into %s', $dir ) );
+
+        // Downloaded before the directory is touched, so a failed download
+        // leaves whatever is already in place working.
+        try {
+
+            $yaml = ( new Fetcher() )->fetch();
+
+        } catch ( \Throwable $e ) {
+
+            return $this->fail( sprintf(
+                'Could not download the patterns: %s. The installation keeps using the patterns '
+              . 'it already has.',
+                $e->getMessage()
+            ) );
+        }
+
+        if ( ! $yaml ) {
+
+            return $this->fail( 'The download returned nothing. Nothing has been changed.' );
+        }
+
+        $this->write( sprintf( 'Downloaded %s of patterns.', $this->readableSize( strlen( $yaml ) ) ) );
+
+        if ( $dry_run ) {
+
+            return $this->refuse( sprintf(
+                'Dry run: %s would be written. Nothing was changed.', $file ) );
+        }
+
+        if ( ! is_dir( $dir ) && ! @mkdir( $dir, 0755, true ) && ! is_dir( $dir ) ) {
+
+            // Reachable despite the preflight: something else could have
+            // changed underneath, and a race is not a reason to write a
+            // half-file.
+            return $this->fail( sprintf( 'Could not create %s.', $dir ) );
+        }
+
+        try {
+
+            // The converter writes the file the parser reads. Its second
+            // argument keeps a backup of the previous one, which is what makes
+            // a bad upstream day recoverable.
+            ( new Converter( $dir ) )->convertString( $yaml, true );
+
+        } catch ( \Throwable $e ) {
+
+            return $this->fail( sprintf( 'Could not convert the patterns: %s', $e->getMessage() ) );
+        }
+
+        if ( ! file_exists( $file ) ) {
+
+            return $this->fail( sprintf(
+                'The conversion reported success but %s is not there.', $file ) );
+        }
+
+        $this->write( sprintf(
+            'Done. %s now holds %s of patterns, and Browscap will prefer it over the bundled copy '
+          . 'from the next request onward.',
+            $file,
+            $this->readableSize( (int) filesize( $file ) )
+        ) );
+
+        return;
+    }
+
+    /**
+     * Why the patterns cannot be written, or null if they can.
+     *
+     * Three distinct answers, because they need three different fixes and a
+     * single "permission denied" would send someone to the wrong one:
+     *
+     *   - the directory does not exist yet, so owa-data itself must be writable
+     *     for it to be created
+     *   - the directory exists but is not writable
+     *   - the directory is writable but the existing file is not, which happens
+     *     when a file was placed by root and the web user runs the refresh
+     *
+     * Reported with the path and the user, since the usual cause is running the
+     * command as a different user than the one that owns owa-data.
+     *
+     * @param string $dir
+     * @return string|null
+     */
+    protected function whyNotWritable( $dir ) {
+
+        $whoami = function_exists( 'posix_geteuid' ) && function_exists( 'posix_getpwuid' )
+            ? ( posix_getpwuid( posix_geteuid() )['name'] ?? 'unknown' )
+            : 'the current user';
+
+        if ( ! is_dir( $dir ) ) {
+
+            // The directory's OWN parent, not OWA_DATA_DIR. They are usually
+            // the same, but the location is configurable, and checking a
+            // different directory than the one mkdir will use gives a confident
+            // answer about the wrong thing.
+            $parent = dirname( rtrim( $dir, DIRECTORY_SEPARATOR ) );
+
+            if ( ! is_dir( $parent ) ) {
+
+                return sprintf( '%s does not exist, so %s cannot be created inside it.',
+                    $parent, $dir );
+            }
+
+            if ( ! is_writable( $parent ) ) {
+
+                return sprintf(
+                    '%s must be writable by %s so that %s can be created, and it is not. '
+                  . 'Either grant write access, or create %s yourself and make it writable.',
+                    $parent, $whoami, $dir, $dir
+                );
+            }
+
+            return null;
+        }
+
+        if ( ! is_writable( $dir ) ) {
+
+            return sprintf( '%s is not writable by %s.', $dir, $whoami );
+        }
+
+        $file = $dir . 'regexes.php';
+
+        if ( file_exists( $file ) && ! is_writable( $file ) ) {
+
+            return sprintf(
+                '%s exists but is not writable by %s, so it cannot be replaced. This usually means '
+              . 'it was written by a different user than the one running this command.',
+                $file, $whoami
+            );
+        }
+
+        return null;
+    }
+
+    protected function readableSize( $bytes ) {
+
+        return $bytes > 1048576
+            ? sprintf( '%.1f MB', $bytes / 1048576 )
+            : sprintf( '%.0f KB', $bytes / 1024 );
+    }
+}

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -552,6 +552,7 @@ class Module extends \OWA\Core\Module {
         $this->registerAction( 'base.deleteUserRest',                'OWA\\Module\\Base\\Controller\\DeleteUserRest',               'Controller/DeleteUserRest.php' );
         $this->registerAction( 'base.entityInstall',                 'OWA\\Module\\Base\\Controller\\EntityInstall',                'Controller/EntityInstall.php' );
         $this->registerAction( 'base.flushCacheCli',                 'OWA\\Module\\Base\\Controller\\FlushCacheCli',                'Controller/FlushCacheCli.php' );
+        $this->registerAction( 'base.updateUaRegexesCli',                 'OWA\\Module\\Base\\Controller\\UpdateUaRegexesCli',                'Controller/UpdateUaRegexesCli.php' );
         $this->registerAction( 'base.flushProcessedEventsCli',       'OWA\\Module\\Base\\Controller\\FlushProcessedEventsCli',      'Controller/FlushProcessedEventsCli.php' );
         $this->registerAction( 'base.installBase',                   'OWA\\Module\\Base\\Controller\\InstallBase',                  'Controller/InstallBase.php' );
         $this->registerAction( 'base.installCheckEnv',               'OWA\\Module\\Base\\Controller\\InstallCheckEnv',              'Controller/InstallCheckEnv.php' );
@@ -700,6 +701,7 @@ class Module extends \OWA\Core\Module {
 
         $this->registerCliCommand('update', 'base.updatesApplyCli');
         $this->registerCliCommand('flush-cache', 'base.flushCacheCli');
+        $this->registerCliCommand('update-ua-regexes', 'base.updateUaRegexesCli');
         $this->registerCliCommand('processEventQueue', 'base.processEventQueue');
         $this->registerCliCommand('install', 'base.installCli');
         $this->registerCliCommand('activate', 'base.moduleActivateCli');
@@ -753,6 +755,18 @@ class Module extends \OWA\Core\Module {
         // Retention must never arrive as a side effect of turning the scheduler
         // on. ScheduleCliTest pins the empty array for exactly that reason.
         $this->registerJob( 'rotate-partitions', 'partition-rotate', '@monthly', array() );
+
+        // NOT registering update-ua-regexes here, deliberately.
+        //
+        // It would fit -- the patterns go stale on their own and monthly is
+        // roughly how often uap-core changes -- but it makes an outbound HTTP
+        // request to a third party, unattended, on a schedule. For self-hosted
+        // analytics that is a decision the administrator makes, not one that
+        // arrives with an upgrade. Same reasoning as the empty params above:
+        // turning the scheduler on must not turn anything else on.
+        //
+        // An installation that wants it adds it to OWA_SCHEDULED_JOBS, or runs
+        // cli.php cmd=update-ua-regexes from its own cron.
     }
 
     /**

--- a/modules/Base/composer.json
+++ b/modules/Base/composer.json
@@ -1,10 +1,10 @@
 {
-    
     "require": {
         "guzzlehttp/guzzle": "^7.5",
         "monolog/monolog": "^2.8",
         "phpmailer/phpmailer": "^6.7",
+        "symfony/filesystem": "^7.4",
+        "symfony/yaml": "^7.4",
         "ua-parser/uap-php": "^3.9"
     }
-    
 }

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -353,6 +353,7 @@ function owa_compat_class_map(): array
         'owa_entityInstallController' => 'OWA\\Module\\Base\\Controller\\EntityInstall',
         'owa_errorView' => 'OWA\\Module\\Base\\View\\Error',
         'owa_flushCacheCliController' => 'OWA\\Module\\Base\\Controller\\FlushCacheCli',
+        'owa_updateUaRegexesCliController' => 'OWA\\Module\\Base\\Controller\\UpdateUaRegexesCli',
         'owa_flushProcessedEventsCliController' => 'OWA\\Module\\Base\\Controller\\FlushProcessedEventsCli',
         'owa_genericCliView' => 'OWA\\Module\\Base\\View\\GenericCli',
         'owa_installView' => 'OWA\\Module\\Base\\View\\Install',

--- a/tests/UaRegexesFileTest.php
+++ b/tests/UaRegexesFileTest.php
@@ -1,0 +1,241 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Where the user-agent patterns come from, and why it is not the bundled copy.
+ *
+ * The patterns live in uap-core, a different project from the PHP library that
+ * reads them. uap-core updates roughly monthly and has tagged no release since
+ * 2019, so consumers follow its master branch. The PHP library bundles whatever
+ * copy existed when ITS maintainers last cut a release -- July 2025.
+ *
+ * So the bundled patterns are as old as the library's last release however new
+ * the library is, and bumping the composer constraint does not help: there is
+ * nothing newer to bump to. cmd=update-ua-regexes replaces them.
+ *
+ * It writes to owa-data/ua-parser/, outside the source tree, which survives an
+ * upgrade -- the same arrangement the Maxmind module uses for its database, for
+ * the same reason. Writing inside vendor/ would last until the next composer
+ * install.
+ */
+final class UaRegexesFileTest extends TestCase {
+
+    /** @var string */
+    private $dir;
+
+    /** @var string */
+    private $file;
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    protected function setUp(): void {
+
+        $this->dir  = OWA_DATA_DIR . 'ua-parser/';
+        $this->file = $this->dir . 'regexes.php';
+    }
+
+    /**
+     * Runs against a temporary copy so a real refreshed file on the machine
+     * running the tests is neither required nor disturbed.
+     */
+    private function withMaintainedFile( callable $test ): void {
+
+        $existed = file_exists( $this->file );
+        $backup  = $existed ? file_get_contents( $this->file ) : null;
+
+        if ( ! is_dir( $this->dir ) ) {
+            mkdir( $this->dir, 0755, true );
+        }
+
+        file_put_contents( $this->file, "<?php return ['user_agent_parsers' => []];" );
+
+        try {
+            $test();
+        } finally {
+            if ( $existed ) {
+                file_put_contents( $this->file, $backup );
+            } else {
+                @unlink( $this->file );
+            }
+        }
+    }
+
+    /**
+     * The point of the change: a refreshed file is used with nothing to
+     * configure. Requiring a setting as well would mean most installations
+     * refreshed the patterns and carried on using the old ones.
+     */
+    public function testAMaintainedFileIsPreferredOverTheBundledCopy(): void {
+
+        $this->withMaintainedFile( function () {
+
+            $this->assertSame(
+                $this->file,
+                \OWA\Module\Base\Classes\Browscap::regexesFile(),
+                'a refreshed file must be picked up without configuration'
+            );
+        } );
+    }
+
+    public function testTheBundledCopyIsUsedWhenNothingHasBeenRefreshed(): void {
+
+        if ( file_exists( $this->file ) ) {
+            $this->markTestSkipped( 'this installation has a refreshed file in place' );
+        }
+
+        $this->assertNull(
+            \OWA\Module\Base\Classes\Browscap::regexesFile(),
+            'with nothing installed the library falls back to its own copy'
+        );
+    }
+
+    /**
+     * Readable, not merely present. An unreadable file taking precedence would
+     * break user-agent parsing entirely in favour of a copy that works.
+     */
+    public function testAnUnreadableFileIsIgnoredRatherThanPreferred(): void {
+
+        $this->withMaintainedFile( function () {
+
+            if ( ! @chmod( $this->file, 0000 ) || is_readable( $this->file ) ) {
+                $this->markTestSkipped( 'cannot make a file unreadable as this user' );
+            }
+
+            $resolved = \OWA\Module\Base\Classes\Browscap::regexesFile();
+
+            chmod( $this->file, 0644 );
+
+            $this->assertNull( $resolved, 'an unreadable file must not shadow a working one' );
+        } );
+    }
+
+    public function testTheRefreshCommandIsRegistered(): void {
+
+        $module = \OWA\Core\CoreAPI::moduleClassFactory( 'base', 'Module' );
+
+        $property = new ReflectionProperty( $module, 'cli_commands' );
+        $property->setAccessible( true );
+
+        $this->assertArrayHasKey(
+            'update-ua-regexes',
+            (array) $property->getValue( $module ),
+            'the command must be reachable as cli.php cmd=update-ua-regexes'
+        );
+    }
+
+    /**
+     * The action name has to resolve to the class. Controllers are reached
+     * through the legacy alias map, so a new one that is not registered there
+     * is a 404 at the moment someone runs it -- which is exactly what happened
+     * while writing this.
+     */
+    public function testTheCommandResolvesToItsClass(): void {
+
+        $this->assertSame(
+            \OWA\Module\Base\Controller\UpdateUaRegexesCli::class,
+            \OWA\Core\Lib::resolveNamespacedClass( 'owa_updateUaRegexesCliController' ),
+            'the action name must resolve, or the command 404s when it is run'
+        );
+    }
+
+    /**
+     * The refreshed file must be loadable by the parser. A truncated download
+     * or a failed conversion would otherwise be discovered by every request
+     * afterwards rather than by the command that wrote it.
+     */
+    public function testARefreshedFileParsesIfOneIsPresent(): void {
+
+        if ( ! is_readable( $this->file ) ) {
+            $this->markTestSkipped( 'no refreshed patterns file on this installation' );
+        }
+
+        $parser = UAParser\Parser::create( $this->file );
+        $result = $parser->parse( 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' );
+
+        $this->assertSame( 'Spider', $result->device->family,
+            'the refreshed patterns must still classify a known crawler' );
+    }
+
+    private function command() {
+
+        // Without the constructor: the CLI controller base exits unless the
+        // process was started by cli.php, and this method does not depend on
+        // any of that.
+        return ( new ReflectionClass( \OWA\Module\Base\Controller\UpdateUaRegexesCli::class ) )
+            ->newInstanceWithoutConstructor();
+    }
+
+    private function whyNotWritable( $dir ) {
+
+        $m = new ReflectionMethod( \OWA\Module\Base\Controller\UpdateUaRegexesCli::class, 'whyNotWritable' );
+        $m->setAccessible( true );
+
+        return $m->invoke( $this->command(), $dir );
+    }
+
+    /**
+     * Permissions are checked BEFORE the download.
+     *
+     * The installer checks owa-data/logs/ and owa-data/caches/, but not
+     * owa-data itself -- nothing needed to create a directory there until this
+     * command did. So a passing install check does not imply this will work,
+     * and it has to ask for itself.
+     */
+    public function testAWritableDestinationIsAccepted(): void {
+
+        $this->assertNull( $this->whyNotWritable( $this->dir ),
+            'owa-data is writable on a working installation, so this must pass' );
+    }
+
+    public function testAnUnwritableParentIsRefusedWithTheReasonAndThePath(): void {
+
+        $parent = sys_get_temp_dir() . '/owa-ua-ro-' . getmypid();
+
+        if ( ! @mkdir( $parent, 0500, true ) ) {
+            $this->markTestSkipped( 'could not create a read-only directory' );
+        }
+
+        if ( is_writable( $parent ) ) {
+            rmdir( $parent );
+            $this->markTestSkipped( 'running as a user that ignores directory permissions' );
+        }
+
+        // A directory that does not exist, inside a parent that cannot be
+        // written -- the case where mkdir would fail.
+        $problem = $this->whyNotWritable( $parent . '/ua-parser/' );
+
+        chmod( $parent, 0700 );
+        rmdir( $parent );
+
+        $this->assertNotNull( $problem, 'an uncreatable destination must be refused' );
+        $this->assertStringContainsString( 'writable', $problem,
+            'the message must say what is wrong, not just that something failed' );
+    }
+
+    /**
+     * The awkward case in practice: the directory is fine but the file was
+     * written by a different user, so the refresh cannot replace it. A generic
+     * permissions message would send someone to chmod the wrong thing.
+     */
+    public function testAnUnwritableExistingFileIsReportedSeparately(): void {
+
+        $this->withMaintainedFile( function () {
+
+            if ( ! @chmod( $this->file, 0400 ) || is_writable( $this->file ) ) {
+                $this->markTestSkipped( 'cannot make a file read-only as this user' );
+            }
+
+            $problem = $this->whyNotWritable( $this->dir );
+
+            chmod( $this->file, 0644 );
+
+            $this->assertNotNull( $problem, 'an unreplaceable file must be refused' );
+            $this->assertStringContainsString( 'regexes.php', $problem,
+                'the message must name the file, since that is what needs fixing' );
+        } );
+    }
+}


### PR DESCRIPTION
```
php cli.php cmd=update-ua-regexes
```

## Why the patterns go stale, and why bumping the dependency doesn't help

The patterns come from **uap-core**, a different project from the PHP library that reads them.

| | |
|---|---|
| uap-core updates `regexes.yaml` | roughly **monthly** (commits Jul, May, Mar 2026) |
| uap-core's last tagged release | **2019** — consumers follow master |
| `uap-php` bundles a snapshot at | *its* release time |
| `uap-php`'s last release | **2025-07-17** |

So the bundled patterns are as old as the library's last release *however new the library is*, and updating the constraint changes nothing — **v3.10.0 is already the newest**. Everything added upstream in the last ~13 months is invisible until the file is replaced.

## Where it writes

`owa-data/ua-parser/`, outside the source tree, surviving upgrades — the **same arrangement as the Maxmind module's database directory**, for the same reason: data the installation maintains, not code that ships. Writing inside `vendor/` would last until the next `composer install`.

`Browscap` prefers that file whenever it's readable, so a successful run takes effect immediately **with nothing to configure**. Requiring a setting as well would mean most installations refresh the patterns and carry on using the old ones. The existing `ua-regexes` setting still wins for anyone keeping the file elsewhere.

## Permissions are checked before the download

Separately for each thing that can be wrong — an uncreatable directory, an unwritable one, an existing file owned by another user. Those need different fixes, and a single "permission denied" sends people to the wrong one.

The installer checks `owa-data/logs/` and `owa-data/caches/` but **not `owa-data` itself** — nothing needed to create a directory there until now — so a passing install check doesn't cover this and the command asks for itself. A test caught the first version checking `OWA_DATA_DIR` instead of the target's *actual parent*, which is wrong as soon as the location is configured elsewhere.

Failure changes nothing: the download completes before the destination is touched, and the converter keeps a backup of the file it replaces.

## Not registered as a scheduled job — deliberately

It would fit, but it makes an **unattended outbound request to a third party on a schedule**. For self-hosted analytics that's the administrator's decision, not something that arrives with an upgrade. `ScheduleCliTest` pins that only `rotate-partitions` ships, and this respects that rather than editing the test. An installation that wants it adds it to `OWA_SCHEDULED_JOBS` or runs it from its own cron.

## Dependencies

Adds `symfony/yaml` and `symfony/filesystem`, which the bundled converter needs to read the upstream YAML — four small packages including polyfills, vendored by composer like everything else.

## Verified end to end

217 KB fetched from uap-core, **245 KB written vs the bundled 240 KB**, and the result parses and still classifies Googlebot as a `Spider`.

821 tests · PHPStan clean.