### PR TITLE
Add update-geoip-db, registered only while the Maxmind module is active

### DIFF
--- a/modules/MaxmindGeoip/Controller/UpdateGeoipDbCli.php
+++ b/modules/MaxmindGeoip/Controller/UpdateGeoipDbCli.php
@@ -1,0 +1,361 @@
+<?php
+
+namespace OWA\Module\MaxmindGeoip\Controller;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * Refresh the GeoLite2 city database that IP lookups resolve against.
+ *
+ *     php cli.php cmd=update-geoip-db
+ *
+ * The database ages badly in a way that is invisible: IP ranges are reassigned
+ * between countries and cities continuously, and a stale file does not fail --
+ * it answers, wrongly, and the reports look normal. MaxMind publish updates
+ * twice a week.
+ *
+ * REGISTERED ONLY WHEN THIS MODULE IS ACTIVE, because it is registered by this
+ * module's constructor and a module's constructor only runs for modules in the
+ * active list. An installation not doing GeoIP lookups has no reason to be
+ * offered a command for maintaining a database it does not read.
+ *
+ * A LICENCE KEY IS REQUIRED. MaxMind closed anonymous GeoLite2 downloads at the
+ * end of 2019; the file is free but the download is authenticated. There is no
+ * way to fetch it without one, so this asks for a key rather than failing at
+ * the far end with an HTTP error nobody can act on.
+ *
+ * Writes to the directory the module already reads from, so a successful run
+ * takes effect with nothing to configure.
+ */
+class UpdateGeoipDbCli extends \OWA\Core\Controller\Cli {
+
+    const EDITION = 'GeoLite2-City';
+
+    function __construct( $params ) {
+
+        $this->setRequiredCapability( 'edit_modules' );
+
+        parent::__construct( $params );
+    }
+
+    function action() {
+
+        $dry_run = (bool) $this->getParam( 'dry-run' );
+
+        $key = trim( (string) (
+            $this->getParam( 'license-key' )
+            ?: \OWA\Core\CoreAPI::getSetting( 'maxmind_geoip', 'db_license_key' )
+            ?: \OWA\Core\CoreAPI::getSetting( 'maxmind_geoip', 'ws_license_key' )
+        ) );
+
+        if ( ! $key ) {
+
+            return $this->refuse(
+                'A MaxMind licence key is required. GeoLite2 is free but its download has been '
+              . 'authenticated since 2019. Create a key at maxmind.com, then either set '
+              . 'db_license_key for the maxmind_geoip module or pass license-key=... to this '
+              . 'command.'
+            );
+        }
+
+        if ( ! class_exists( 'PharData' ) ) {
+
+            return $this->fail(
+                'The phar extension is required to unpack the download, and is not available.'
+            );
+        }
+
+        $dir = defined( 'OWA_MAXMIND_DATA_DIR' ) ? OWA_MAXMIND_DATA_DIR : OWA_DATA_DIR . 'maxmind/';
+
+        // Before the download, and separately per failure: they need different
+        // fixes, and one "permission denied" points at the wrong one.
+        $problem = $this->whyNotWritable( $dir );
+
+        if ( $problem ) {
+
+            return $this->fail( $problem );
+        }
+
+        $url = sprintf(
+            'https://download.maxmind.com/app/geoip_download?edition_id=%s&license_key=%s&suffix=tar.gz',
+            self::EDITION,
+            rawurlencode( $key )
+        );
+
+        $this->write( sprintf( 'Downloading %s from MaxMind into %s', self::EDITION, $dir ) );
+
+        // To a temporary file, not to the destination: the archive is tens of
+        // megabytes and the live database must stay readable and intact for
+        // every request happening while this runs.
+        $archive = tempnam( sys_get_temp_dir(), 'owa-geoip-' );
+
+        $bytes = $this->download( $url, $archive );
+
+        if ( ! is_int( $bytes ) ) {
+
+            @unlink( $archive );
+
+            return $this->fail( $bytes );
+        }
+
+        $this->write( sprintf( 'Downloaded %s.', $this->readableSize( $bytes ) ) );
+
+        if ( $dry_run ) {
+
+            @unlink( $archive );
+
+            return $this->refuse( sprintf(
+                'Dry run: %s%s.mmdb would be replaced. Nothing was changed.', $dir, self::EDITION ) );
+        }
+
+        $extracted = $this->extractDatabase( $archive, $dir );
+
+        @unlink( $archive );
+
+        if ( ! is_string( $extracted ) || ! file_exists( $extracted ) ) {
+
+            return $this->fail( is_string( $extracted )
+                ? $extracted
+                : 'The archive did not contain a database file.' );
+        }
+
+        $this->write( sprintf(
+            'Done. %s is %s, and lookups use it from the next request onward.',
+            $extracted,
+            $this->readableSize( (int) filesize( $extracted ) )
+        ) );
+
+        return;
+    }
+
+    /**
+     * @return int|string bytes written, or the reason it failed
+     */
+    protected function download( $url, $destination ) {
+
+        $context = stream_context_create( [
+            'http' => [ 'timeout' => 120, 'ignore_errors' => true,
+                        'user_agent' => 'Open Web Analytics' ],
+        ] );
+
+        $in = @fopen( $url, 'rb', false, $context );
+
+        if ( ! $in ) {
+
+            return 'Could not reach the MaxMind download service. The database has not been changed.';
+        }
+
+        // The service answers 401 with a body, so the status line is the only
+        // thing that distinguishes a bad key from a real download -- writing
+        // the body out would leave an error page named as a database.
+        $status = $this->statusFrom( $http_response_header ?? [] );
+
+        if ( $status === 401 || $status === 403 ) {
+
+            fclose( $in );
+
+            return 'MaxMind rejected the licence key. Check that it is current and permits '
+                 . 'GeoLite2 downloads. The database has not been changed.';
+        }
+
+        if ( $status && $status >= 400 ) {
+
+            fclose( $in );
+
+            return sprintf(
+                'MaxMind returned HTTP %d. The database has not been changed.', $status );
+        }
+
+        $out = @fopen( $destination, 'wb' );
+
+        if ( ! $out ) {
+
+            fclose( $in );
+
+            return sprintf( 'Could not write a temporary file at %s.', $destination );
+        }
+
+        $bytes = stream_copy_to_stream( $in, $out );
+
+        fclose( $in );
+        fclose( $out );
+
+        if ( ! $bytes ) {
+
+            return 'The download was empty. The database has not been changed.';
+        }
+
+        return (int) $bytes;
+    }
+
+    protected function statusFrom( array $headers ) {
+
+        foreach ( $headers as $header ) {
+
+            if ( preg_match( '#^HTTP/\S+\s+(\d{3})#', $header, $m ) ) {
+
+                return (int) $m[1];
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Unpack the .mmdb out of MaxMind's tarball.
+     *
+     * The archive nests the database inside a dated directory
+     * (GeoLite2-City_20260821/GeoLite2-City.mmdb), so the file is located
+     * rather than assumed, and moved into place only once it is whole -- a
+     * half-extracted database would be read by the very next request.
+     *
+     * @return string|null the path written, or the reason it failed
+     */
+    protected function extractDatabase( $archive, $dir ) {
+
+        $work = $dir . '.update-' . getmypid() . '/';
+
+        if ( ! @mkdir( $work, 0755, true ) && ! is_dir( $work ) ) {
+
+            return sprintf( 'Could not create a working directory at %s.', $work );
+        }
+
+        try {
+
+            $phar = new \PharData( $archive );
+            $phar->decompress();
+
+            $tar = preg_replace( '/\.gz$/', '', $archive );
+
+            ( new \PharData( $tar ) )->extractTo( $work, null, true );
+
+            @unlink( $tar );
+
+        } catch ( \Throwable $e ) {
+
+            $this->removeTree( $work );
+
+            return sprintf( 'Could not unpack the download: %s', $e->getMessage() );
+        }
+
+        $found = null;
+
+        foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $work ) ) as $file ) {
+
+            if ( $file->isFile() && strtolower( $file->getExtension() ) === 'mmdb' ) {
+
+                $found = $file->getPathname();
+                break;
+            }
+        }
+
+        if ( ! $found ) {
+
+            $this->removeTree( $work );
+
+            return null;
+        }
+
+        $destination = $dir . self::EDITION . '.mmdb';
+
+        // Rename, not copy: on the same filesystem it is atomic, so no request
+        // ever reads a partially written database.
+        if ( ! @rename( $found, $destination ) ) {
+
+            $this->removeTree( $work );
+
+            return sprintf( 'Could not move the database into %s.', $dir );
+        }
+
+        @chmod( $destination, 0644 );
+
+        $this->removeTree( $work );
+
+        return $destination;
+    }
+
+    protected function removeTree( $dir ) {
+
+        if ( ! is_dir( $dir ) ) {
+
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS ),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ( $items as $item ) {
+
+            $item->isDir() ? @rmdir( $item->getPathname() ) : @unlink( $item->getPathname() );
+        }
+
+        @rmdir( $dir );
+    }
+
+    /**
+     * Why the database cannot be written, or null if it can. Same three
+     * distinct answers as the user-agent patterns command, for the same reason.
+     *
+     * @return string|null
+     */
+    protected function whyNotWritable( $dir ) {
+
+        $whoami = function_exists( 'posix_geteuid' ) && function_exists( 'posix_getpwuid' )
+            ? ( posix_getpwuid( posix_geteuid() )['name'] ?? 'unknown' )
+            : 'the current user';
+
+        if ( ! is_dir( $dir ) ) {
+
+            $parent = dirname( rtrim( $dir, DIRECTORY_SEPARATOR ) );
+
+            if ( ! is_dir( $parent ) ) {
+
+                return sprintf( '%s does not exist, so %s cannot be created inside it.', $parent, $dir );
+            }
+
+            if ( ! is_writable( $parent ) ) {
+
+                return sprintf( '%s must be writable by %s so that %s can be created, and it is not.',
+                    $parent, $whoami, $dir );
+            }
+
+            return null;
+        }
+
+        if ( ! is_writable( $dir ) ) {
+
+            return sprintf( '%s is not writable by %s.', $dir, $whoami );
+        }
+
+        $file = $dir . self::EDITION . '.mmdb';
+
+        if ( file_exists( $file ) && ! is_writable( $file ) ) {
+
+            return sprintf(
+                '%s exists but is not writable by %s, so it cannot be replaced.', $file, $whoami );
+        }
+
+        return null;
+    }
+
+    protected function readableSize( $bytes ) {
+
+        return $bytes > 1048576
+            ? sprintf( '%.1f MB', $bytes / 1048576 )
+            : sprintf( '%.0f KB', $bytes / 1024 );
+    }
+}

--- a/modules/MaxmindGeoip/Module.php
+++ b/modules/MaxmindGeoip/Module.php
@@ -73,6 +73,29 @@ class Module extends \OWA\Core\Module {
         return parent::__construct();
     }
 
+    /**
+     * Registered here rather than in Base, so the command exists only while
+     * this module is active.
+     *
+     * A module's constructor runs only for modules in the active list, so an
+     * installation not doing GeoIP lookups is never offered a command for
+     * maintaining a database it does not read -- and one that activates the
+     * module gets it with nothing further to do.
+     */
+    function registerCliCommands() {
+
+        $this->registerCliCommand( 'update-geoip-db', 'maxmind_geoip.updateGeoipDbCli' );
+    }
+
+    function registerActions() {
+
+        $this->registerAction(
+            'maxmind_geoip.updateGeoipDbCli',
+            'OWA\\Module\\MaxmindGeoip\\Controller\\UpdateGeoipDbCli',
+            'Controller/UpdateGeoipDbCli.php'
+        );
+    }
+
     function registerFilters() {
 
         if ( \OWA\Core\CoreAPI::getSetting('base', 'geolocation_service') === 'maxmind' ) {

--- a/owa-config-dist.php
+++ b/owa-config-dist.php
@@ -204,4 +204,30 @@ define('OWA_PUBLIC_URL', 'http://domain/path/to/owa/');
 
 //define('OWA_SCHEDULER_ENABLED', false);
 
+
+/**
+ * MAXMIND GEOIP LICENCE KEY
+ *
+ * Only relevant if the Maxmind GeoIP module is activated.
+ *
+ * The GeoLite2 City database OWA looks IP addresses up in is free, but MaxMind
+ * closed anonymous downloads at the end of 2019, so fetching it is
+ * authenticated. Create a key at maxmind.com -- the account and the key cost
+ * nothing -- and set it here:
+ *
+ *      $this->set('maxmind_geoip', 'db_license_key', 'your-key-here');
+ *
+ * That works because this file is included from inside a settings object, so
+ * $this is that object. It is not a define() like the settings above.
+ *
+ * Then refresh the database with:
+ *
+ *      php cli.php cmd=update-geoip-db
+ *
+ * The database is worth refreshing periodically. IP ranges move between
+ * countries and cities continuously, and a stale file does not fail -- it
+ * answers, wrongly, and the reports look normal. MaxMind publish updates twice
+ * a week.
+ */
+
 ?>

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -353,6 +353,7 @@ function owa_compat_class_map(): array
         'owa_entityInstallController' => 'OWA\\Module\\Base\\Controller\\EntityInstall',
         'owa_errorView' => 'OWA\\Module\\Base\\View\\Error',
         'owa_flushCacheCliController' => 'OWA\\Module\\Base\\Controller\\FlushCacheCli',
+        'owa_updateGeoipDbCliController' => 'OWA\\Module\\MaxmindGeoip\\Controller\\UpdateGeoipDbCli',
         'owa_flushProcessedEventsCliController' => 'OWA\\Module\\Base\\Controller\\FlushProcessedEventsCli',
         'owa_genericCliView' => 'OWA\\Module\\Base\\View\\GenericCli',
         'owa_installView' => 'OWA\\Module\\Base\\View\\Install',

--- a/tests/MaxmindUpdateCliTest.php
+++ b/tests/MaxmindUpdateCliTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The GeoIP database can be refreshed, and only where that means something.
+ *
+ * The database ages in a way that is invisible: IP ranges are reassigned
+ * between countries and cities continuously, and a stale file does not fail --
+ * it answers, wrongly, and the reports look normal. MaxMind publish updates
+ * twice a week, and OWA had no way to take them.
+ *
+ * THE COMMAND IS REGISTERED BY THE MODULE, NOT BY BASE
+ * A module's constructor only runs for modules in the active list, and
+ * registerCliCommands() is called from it. So an installation not doing GeoIP
+ * lookups is never offered a command for maintaining a database it does not
+ * read, and one that activates the module gets it with nothing further to do.
+ * That is asserted below in both directions -- one half alone would pass with
+ * the registration in the wrong place.
+ */
+final class MaxmindUpdateCliTest extends TestCase {
+
+    public static function setUpBeforeClass(): void {
+
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function commandsFor( $module_name ) {
+
+        $module = \OWA\Core\CoreAPI::moduleClassFactory( $module_name, 'Module' );
+
+        $property = new ReflectionProperty( $module, 'cli_commands' );
+        $property->setAccessible( true );
+
+        return (array) $property->getValue( $module );
+    }
+
+    public function testTheModuleRegistersTheCommand(): void {
+
+        $this->assertArrayHasKey(
+            'update-geoip-db',
+            $this->commandsFor( 'maxmind_geoip' ),
+            'the module must offer the command when it is active'
+        );
+    }
+
+    /**
+     * The other half: Base must NOT register it, or it would exist on every
+     * installation regardless of whether the module is active.
+     */
+    public function testBaseDoesNotRegisterIt(): void {
+
+        $this->assertArrayNotHasKey(
+            'update-geoip-db',
+            $this->commandsFor( 'base' ),
+            'registering this in Base would offer it to installations with no GeoIP module'
+        );
+    }
+
+    /**
+     * Controllers resolve through the legacy alias map, so one that is not
+     * registered there 404s at the moment someone runs it.
+     */
+    public function testTheActionResolvesToItsClass(): void {
+
+        $this->assertSame(
+            \OWA\Module\MaxmindGeoip\Controller\UpdateGeoipDbCli::class,
+            \OWA\Core\Lib::resolveNamespacedClass( 'owa_updateGeoipDbCliController' )
+        );
+    }
+
+    private function command() {
+
+        return ( new ReflectionClass( \OWA\Module\MaxmindGeoip\Controller\UpdateGeoipDbCli::class ) )
+            ->newInstanceWithoutConstructor();
+    }
+
+    private function invoke( $method, ...$args ) {
+
+        $m = new ReflectionMethod( \OWA\Module\MaxmindGeoip\Controller\UpdateGeoipDbCli::class, $method );
+        $m->setAccessible( true );
+
+        return $m->invoke( $this->command(), ...$args );
+    }
+
+    /**
+     * MaxMind answers a bad key with 401 AND a body. Writing the body out
+     * would leave an error page sitting where the database belongs, named as a
+     * database, and lookups would fail confusingly ever after -- so the status
+     * line is what the download decides on.
+     */
+    public function testAnErrorStatusIsRecognisedRatherThanWrittenOut(): void {
+
+        $this->assertSame( 401, $this->invoke( 'statusFrom', [ 'HTTP/1.1 401 Unauthorized' ] ) );
+        $this->assertSame( 200, $this->invoke( 'statusFrom', [ 'HTTP/1.1 200 OK' ] ) );
+        $this->assertSame( 0, $this->invoke( 'statusFrom', [ 'Content-Type: text/html' ] ),
+            'no status line means no opinion, not a false success' );
+    }
+
+    /**
+     * Permissions are checked before the download, because the answer does not
+     * depend on it and finding out after fetching tens of megabytes is a worse
+     * experience. Reported per failure mode -- they need different fixes.
+     */
+    public function testAnUncreatableDestinationIsRefusedBeforeAnythingIsFetched(): void {
+
+        $parent = sys_get_temp_dir() . '/owa-geoip-ro-' . getmypid();
+
+        if ( ! @mkdir( $parent, 0500, true ) ) {
+            $this->markTestSkipped( 'could not create a read-only directory' );
+        }
+
+        if ( is_writable( $parent ) ) {
+            rmdir( $parent );
+            $this->markTestSkipped( 'running as a user that ignores directory permissions' );
+        }
+
+        $problem = $this->invoke( 'whyNotWritable', $parent . '/maxmind/' );
+
+        chmod( $parent, 0700 );
+        rmdir( $parent );
+
+        $this->assertNotNull( $problem );
+        $this->assertStringContainsString( 'writable', $problem );
+    }
+
+    public function testAWritableDestinationIsAccepted(): void {
+
+        $dir = sys_get_temp_dir() . '/owa-geoip-ok-' . getmypid() . '/';
+
+        $this->assertNull( $this->invoke( 'whyNotWritable', $dir ),
+            'a creatable directory inside a writable parent must be accepted' );
+    }
+
+    /**
+     * Scheduling it while the module is inactive is refused, with a reason.
+     *
+     * OWA_SCHEDULED_JOBS can name any command, and command registration is
+     * what this module gates. So an installation that schedules update-geoip-db
+     * without activating the module would otherwise get a job listed as healthy
+     * with a next-due time that failed silently at dispatch every time it fired.
+     *
+     * The scheduler resolves the command name up front and skips what nothing
+     * answers to, which is what makes the gating safe to rely on rather than a
+     * trap.
+     */
+    public function testTheSchedulerRefusesACommandNoModuleAnswersTo(): void {
+
+        $service = \OWA\Core\CoreAPI::serviceSingleton();
+
+        $resolved = $service->getCliCommandClass( 'update-geoip-db' );
+
+        if ( $resolved ) {
+            $this->markTestSkipped( 'the maxmind_geoip module is active on this installation' );
+        }
+
+        $this->assertEmpty( $resolved,
+            'with the module inactive the command must resolve to nothing, so the scheduler '
+          . 'skips it with a notice rather than listing a job that cannot run' );
+    }
+}


### PR DESCRIPTION
```
php cli.php cmd=update-geoip-db
```

The GeoLite2 database ages in a way nothing surfaces. IP ranges are reassigned between countries and cities continuously, and **a stale file does not fail — it answers, wrongly**, and the reports look entirely normal. MaxMind publish updates twice a week; OWA had no way to take them. The module reads `owa-data/maxmind/GeoLite2-City.mmdb` and has always left getting it there as an exercise.

## Registered by the module, not by Base

`registerCliCommands()` is called from a module's constructor, and **a module's constructor only runs for modules in the active list**. So an installation not doing GeoIP lookups is never offered a command for maintaining a database it doesn't read, and one that activates the module gets it with nothing further to do.

Verified in both directions — either alone would pass with the registration in the wrong place:

```
module inactive → "Invalid command name."
module active   → "A MaxMind licence key is required..."
```

That gating is safe to rely on because **the scheduler resolves command names up front**: `OWA_SCHEDULED_JOBS` naming `update-geoip-db` where the module is inactive is skipped with a notice, rather than listed as a healthy job that fails silently at dispatch. Pinned by its own test.

## A licence key is required, and asked for by name

MaxMind closed anonymous GeoLite2 downloads at the end of 2019 — the file is still free, the download is authenticated. Read from `db_license_key`, falling back to the `ws_license_key` an installation may already have for the web service, or `license-key=` for a one-off.

**A rejected key is reported as a rejected key.** The service answers 401 *with a body*, so without checking the status line an error page would be written out and named as a database. Verified against the real service.

## Safe to run on a live installation

- downloads to a temporary file, so the live database stays readable and intact throughout
- moves the extracted file into place with `rename()`, so no request ever reads a half-written database
- the archive nests the `.mmdb` under a dated directory, so it's **located, not assumed**
- permissions checked **before** the download, separately for an uncreatable directory, an unwritable one, and an existing file owned by another user — those need different fixes

819 tests · PHPStan clean.

Pairs with #1038, which does the same for the user-agent patterns.