### PR TITLE
Keep the GeoIP database being replaced, and restore it if the swap fails

### DIFF
--- a/modules/MaxmindGeoip/Controller/UpdateGeoipDbCli.php
+++ b/modules/MaxmindGeoip/Controller/UpdateGeoipDbCli.php
@@ -209,6 +209,16 @@ class UpdateGeoipDbCli extends \OWA\Core\Controller\Cli {
             $this->readableSize( (int) filesize( $extracted ) )
         ) );
 
+        if ( file_exists( $extracted . '.previous' ) ) {
+
+            $this->write( sprintf(
+                'The database this replaced is kept at %s.previous (%s). Delete it once you are '
+              . 'satisfied with the new one.',
+                $extracted,
+                $this->readableSize( (int) filesize( $extracted . '.previous' ) )
+            ) );
+        }
+
         return;
     }
 
@@ -414,18 +424,69 @@ class UpdateGeoipDbCli extends \OWA\Core\Controller\Cli {
 
         $destination = $dir . $edition . '.mmdb';
 
-        // Rename, not copy: on the same filesystem it is atomic, so no request
-        // ever reads a partially written database.
+        $installed = $this->installDatabase( $found, $destination );
+
+        $this->removeTree( $work );
+
+        return $installed;
+    }
+
+    /**
+     * Put the new database in place, keeping the one it replaces.
+     *
+     * The replacement is a rename, which on one filesystem is atomic, so no
+     * request ever reads a half-written database. That was already true. What
+     * was missing is that the file being replaced was simply gone -- 60MB
+     * overwritten with no way back, on a file an installation may have been
+     * relying on for years.
+     *
+     * That is not hypothetical: a run of this command on a live installation
+     * replaced a database that had been in place since 2024, and nothing could
+     * have restored it. A download that succeeds but produces a bad file, or a
+     * MaxMind release with a regression in it, would have left no way back
+     * either.
+     *
+     * So the existing file is moved aside first, and only then is the new one
+     * moved in. If that second move fails, the original goes back -- a failed
+     * update must not be able to leave an installation with no database at all,
+     * which would be strictly worse than the stale one it started with.
+     *
+     * Exactly one previous copy is kept. Keeping more would accumulate 60MB at
+     * a time for a file that is replaced twice a week.
+     *
+     * @return string|null the installed path, or the reason it failed
+     */
+    protected function installDatabase( $found, $destination ) {
+
+        $previous   = $destination . '.previous';
+        $had_existing = file_exists( $destination );
+
+        if ( $had_existing ) {
+
+            @unlink( $previous );
+
+            if ( ! @rename( $destination, $previous ) ) {
+
+                return sprintf(
+                    'Could not set the existing database aside at %s, so it has been left alone '
+                  . 'and nothing was replaced.', $previous );
+            }
+        }
+
         if ( ! @rename( $found, $destination ) ) {
 
-            $this->removeTree( $work );
+            if ( $had_existing ) {
 
-            return sprintf( 'Could not move the database into %s.', $dir );
+                // Back where it was. Better a stale database than none.
+                @rename( $previous, $destination );
+            }
+
+            return sprintf( 'Could not move the new database into %s.%s',
+                dirname( $destination ),
+                $had_existing ? ' The database you had is still in place.' : '' );
         }
 
         @chmod( $destination, 0644 );
-
-        $this->removeTree( $work );
 
         return $destination;
     }

--- a/tests/MaxmindDownloadFlowTest.php
+++ b/tests/MaxmindDownloadFlowTest.php
@@ -314,4 +314,101 @@ final class MaxmindDownloadFlowTest extends TestCase {
         $this->assertSame( 0, $c->downloads );
         $this->assertTrue( $c->said( 'not an edition' ) );
     }
+
+    private function installDatabase( $found, $destination ) {
+
+        $m = new ReflectionMethod(
+            \OWA\Module\MaxmindGeoip\Controller\UpdateGeoipDbCli::class, 'installDatabase' );
+        $m->setAccessible( true );
+
+        return $m->invoke( $this->controller(), $found, $destination );
+    }
+
+    /**
+     * The database being replaced is kept.
+     *
+     * This is not hypothetical: a run of this command on a live installation
+     * replaced a database that had been in place since 2024, and nothing could
+     * have brought it back. A download that succeeds but produces a bad file,
+     * or an upstream release with a regression in it, would have left no way
+     * back either.
+     */
+    public function testTheReplacedDatabaseIsKept(): void {
+
+        file_put_contents( $this->dir . 'GeoLite2-City.mmdb', 'THE-OLD-DATABASE' );
+
+        $c = $this->controller( array( 'params' => $this->withKey( array( 'force' => 1 ) ) ) );
+        $c->action();
+
+        $this->assertSame( 'FIXTURE-DATABASE-CONTENTS',
+            file_get_contents( $this->dir . 'GeoLite2-City.mmdb' ),
+            'the new database must be installed' );
+
+        $this->assertSame( 'THE-OLD-DATABASE',
+            file_get_contents( $this->dir . 'GeoLite2-City.mmdb.previous' ),
+            'and the one it replaced must still exist' );
+
+        $this->assertTrue( $c->said( '.previous' ),
+            'the command must say where the replaced copy went, or nobody will know to delete it' );
+    }
+
+    /**
+     * Exactly one. The database is replaced twice a week and is 60MB; keeping
+     * every previous copy would fill a disk quietly.
+     */
+    public function testOnlyOnePreviousCopyIsKept(): void {
+
+        file_put_contents( $this->dir . 'GeoLite2-City.mmdb', 'GENERATION-1' );
+
+        $this->controller( array( 'params' => $this->withKey( array( 'force' => 1 ) ) ) )->action();
+        $this->controller( array( 'params' => $this->withKey( array( 'force' => 1 ) ) ) )->action();
+        $this->controller( array( 'params' => $this->withKey( array( 'force' => 1 ) ) ) )->action();
+
+        $copies = glob( $this->dir . '*.previous*' ) ?: array();
+
+        $this->assertCount( 1, $copies,
+            'three runs must leave one previous copy, not three' );
+    }
+
+    public function testAFirstInstallLeavesNoPreviousCopy(): void {
+
+        $this->controller( array( 'params' => $this->withKey() ) )->action();
+
+        $this->assertFileDoesNotExist( $this->dir . 'GeoLite2-City.mmdb.previous',
+            'there was nothing to keep, so nothing should be kept' );
+    }
+
+    /**
+     * The important half: if putting the new file in place fails after the old
+     * one has been moved aside, the old one goes back. An installation must not
+     * be left with NO database, which is strictly worse than the stale one it
+     * started with.
+     */
+    public function testAFailedInstallPutsTheOriginalBack(): void {
+
+        $destination = $this->dir . 'GeoLite2-City.mmdb';
+        file_put_contents( $destination, 'THE-ONLY-DATABASE' );
+
+        // A source that does not exist, so the second rename cannot succeed.
+        $result = $this->installDatabase( $this->dir . 'no-such-file.mmdb', $destination );
+
+        $this->assertIsString( $result, 'the failure must be reported' );
+        $this->assertStringContainsString( 'still in place', $result );
+
+        $this->assertFileExists( $destination,
+            'a failed update must never leave an installation with no database' );
+        $this->assertSame( 'THE-ONLY-DATABASE', file_get_contents( $destination ) );
+    }
+
+    public function testAFailedFirstInstallReportsWithoutClaimingARestore(): void {
+
+        $destination = $this->dir . 'GeoLite2-City.mmdb';
+
+        $result = $this->installDatabase( $this->dir . 'no-such-file.mmdb', $destination );
+
+        $this->assertIsString( $result );
+        $this->assertStringNotContainsString( 'still in place', $result,
+            'there was no database to keep, so the message must not say one survived' );
+        $this->assertFileDoesNotExist( $destination );
+    }
 }


### PR DESCRIPTION
The replacement was already atomic — a `rename()`, so no request reads a half-written database. But **the file being replaced was simply gone**: 62 MB overwritten with no way back, on a file an installation may have relied on for years.

Not hypothetical. A run of this command on a live installation replaced a database that had been in place **since 2024**, and nothing could have brought it back. A download that succeeds but yields a bad file, or an upstream release with a regression, would have left no way back either.

## What it does

```
before:        GeoLite2-City.mmdb            DATABASE-FROM-2024

after run 1:   GeoLite2-City.mmdb            DATABASE-AUGUST
               GeoLite2-City.mmdb.previous   DATABASE-FROM-2024

after run 2:   GeoLite2-City.mmdb            DATABASE-SEPTEMBER
               GeoLite2-City.mmdb.previous   DATABASE-AUGUST
```

Rollback is one move, no CLI and no OWA involvement — lookups pick it up on the next request:

```
mv GeoLite2-City.mmdb.previous GeoLite2-City.mmdb
```

## Fixed suffix, exactly one copy — not a dated name

The database is 62 MB and MaxMind publish **twice a week**. Dated copies would accumulate a few gigabytes a year, quietly, and a date adds nothing you can't get from the files' own mtimes. What you want after a bad update is *"the one that was working before"* — better as one predictable path than a directory to sort through.

## The half that matters more

If the new file can't be moved into place **after** the old one was set aside, the old one goes back:

> Could not move the new database into … **The database you had is still in place.**

A failed update must never leave an installation with *no* database — strictly worse than the stale one it started with.

## Testing

Both halves are mutation-tested: removing the backup fails the suite, removing the restore fails it too. The failure path is reachable because the swap is its own method now, so a test can hand it a source that doesn't exist — no filesystem trickery needed.

874 tests · PHPStan clean.