### PR TITLE
Stop the queue-drain e2e assertion racing the tracker

### DIFF
--- a/tests/e2e/event-queue-processing.spec.js
+++ b/tests/e2e/event-queue-processing.spec.js
@@ -157,11 +157,27 @@ test.describe('tracking events queue to a file and ingest on drain @selfhost-onl
         ).toBe(before.fact_rows);
 
         // --- drain: the real CLI processor ----------------------------------
+        // Close the page FIRST. The tracker is still live on it and can send
+        // another beacon at any moment; one landing after the drain recreates
+        // events.txt, and queue depth counts that file by existence rather than
+        // by content -- so an empty one still reads as depth 1. That is a race
+        // against the test, not a queue that failed to drain, and it is what
+        // made this assertion flake.
+        await page.close();
+
         drainQueue();
 
         // --- drained + ingested ---------------------------------------------
+        // Polled rather than read once: the drain is a separate process, and
+        // the queue is a directory, so "empty" becomes observable a moment
+        // after the CLI returns. This does not weaken the assertion -- the
+        // depth must still reach 0, and a queue that genuinely did not drain
+        // times out and fails.
+        await expect
+            .poll(() => helper('state', `site=${HARNESS_SITE_ID}`).queue_depth, { timeout: 20_000 })
+            .toBe(0);
+
         const after = helper('state', `site=${HARNESS_SITE_ID}`);
-        expect(after.queue_depth, 'the file queue should be empty after the drain').toBe(0);
         expect(after.fact_rows,
             'the drained beacon should now be persisted as a request fact'
         ).toBeGreaterThan(before.fact_rows);


### PR DESCRIPTION
It flaked once in CI on `queue_depth` after the drain, passed on re-run, and was left alone. Worth chasing rather than retrying — **a flaky queue-depth assertion is precisely the one that would hide a real queue bug**, and this project has had two of those (the notify poison-pill and the legacy-class decode stall).

## It was not a queue that failed to drain

The page is **still open** when the drain runs. The tracker on it can send another beacon at any moment, and a beacon landing after the drain recreates `events.txt` — and `fileQueueDepth()` counts that file by **existence, not content**, so an empty one still reads as depth 1.

The test was racing its own fixture.

## Two changes

**The cause:** `await page.close()` before the drain, so nothing can queue anything else.

**The timing:** poll for depth 0 rather than reading once, because the drain is a separate process and the queue is a directory — "empty" becomes observable a moment after the CLI returns.

Neither weakens the assertion. The depth must still reach **0**, and a queue that genuinely didn't drain times out and fails.

## Verification

Since the claim is about flakiness rather than correctness, one run proves little: full self-hosted suite once (**106 passed**), plus this spec twice more on its own (22.4s, 12.9s).