### PR TITLE
fix: an unset column is written as its type's zero, not as NULL

### DIFF
--- a/Core/Entity.php
+++ b/Core/Entity.php
@@ -448,24 +448,115 @@ class Entity {
      * Persist new object
      *
      */
+    /**
+     * The value to WRITE for a column, resolving an unset one by its declared type.
+     *
+     * create() sets EVERY column, so a column nobody assigned goes into the
+     * INSERT explicitly. Until the PDO driver landed (#1028) that did not
+     * matter: the old driver interpolated values as quoted literals, so a PHP
+     * null became '' and MySQL -- with sql_mode empty -- coerced '' to 0 for a
+     * numeric column. Eleven years of rows were written that way.
+     *
+     * PDO binds the null instead, so the same code now stores a real NULL. On
+     * demo that flipped ~70 session columns and ~14 request columns from 0 to
+     * NULL overnight (2026-08-21), including is_repeat_visitor, every goal_N,
+     * and every commerce_*. Each distinct value is its own GROUP BY bucket, so
+     * a two-state fact started reporting as three.
+     *
+     * This restores the pre-#1028 STORED REPRESENTATION rather than inventing a
+     * new one -- the point is that old rows and new rows agree, which is what
+     * anything reading across the boundary depends on.
+     *
+     * TIMESTAMP and anything unrecognised are deliberately left NULL: the old
+     * path turned those into '0000-00-00', which is not a value worth
+     * restoring and is refused outright under STRICT_ALL_TABLES.
+     *
+     * @param string $col column name
+     * @return mixed the value to write
+     */
+    protected function writeValue( $col ) {
+
+        $value = $this->get( $col, false );
+
+        if ( $value !== null ) {
+
+            return $value;
+        }
+
+        if ( ! isset( $this->properties[ $col ] ) ) {
+
+            return $value;
+        }
+
+        $type = (string) $this->properties[ $col ]->get( 'data_type' );
+
+        // Numeric: '' coerced to 0 under the old driver.
+        if ( in_array( $type, $this->numericColumnTypes(), true ) ) {
+
+            return 0;
+        }
+
+        // Character and binary: '' stayed '' under the old driver.
+        if ( in_array( $type, $this->textColumnTypes(), true ) ) {
+
+            return '';
+        }
+
+        return $value;
+    }
+
+    /**
+     * The declared column types that hold characters or bytes, as the loaded
+     * dialect spells them.
+     *
+     * Derived from the constants for the same reason as numericColumnTypes():
+     * a literal list of MySQL spellings would be a DDL grammar sitting in the
+     * entity layer, and would stop matching -- silently -- on the first dialect
+     * that names its string types differently.
+     *
+     * OWA_DTD_VARCHAR is deliberately excluded: its value is a sprintf template
+     * ('VARCHAR(%s)'), never a type a column actually carries.
+     *
+     * @return array
+     */
+    protected function textColumnTypes() {
+
+        $text = array();
+
+        foreach ( array(
+            'OWA_DTD_VARCHAR10',
+            'OWA_DTD_VARCHAR255',
+            'OWA_DTD_TEXT',
+            'OWA_DTD_BLOB',
+        ) as $constant ) {
+
+            if ( defined( $constant ) ) {
+
+                $text[] = (string) constant( $constant );
+            }
+        }
+
+        return array_values( array_unique( $text ) );
+    }
+
     function create() {
-        
+
         $db = \OWA\Core\CoreAPI::dbSingleton();
         $all_cols = $this->getColumns();
-        
+
         $db->insertInto($this->getTableName());
-        
+
         // Control loop
         foreach ($all_cols as $k => $v){
-        
+
             // drop column is it is marked as auto-incement as DB will take care of that.
             if ($this->properties[$v]->auto_increment === true) {
                 ;
             } else {
-                
-                $db->set($v, $this->get($v, false));
+
+                $db->set($v, $this->writeValue($v));
             }
-                
+
         }
     
         // Persist object
@@ -528,8 +619,11 @@ class Entity {
             // change a property without going through set(), so those values are
             // not marked dirty, and a dirty-only update would silently stop
             // persisting them. Every column written before is still written.
+            // Same type resolution as create(): a column that IS written must
+            // not land as NULL where the column has only a zero meaning. See
+            // writeValue().
             if ($this->get($v, false) || array_key_exists($v, $this->dirty)) {
-                $db->set($v, $this->get($v, false));
+                $db->set($v, $this->writeValue($v));
             }
         }
         

--- a/modules/Base/Classes/TrackingEventHelpers.php
+++ b/modules/Base/Classes/TrackingEventHelpers.php
@@ -155,10 +155,36 @@ class TrackingEventHelpers {
             // filter value
             $value = $eq->filter( $name, $value, $event );
 
+            /*
+             * Re-apply the declared type AFTER filtering.
+             *
+             * setDataType() above runs on the value as it arrived, so it only
+             * ever sanitised input. A callback runs after it and its return
+             * value went to the database untouched -- which is how a derivation
+             * that falls off the end (returning null) wrote NULL into a column
+             * whose declared type is boolean. setRepeatVisitorFlag did exactly
+             * that from 2015 until 8d24fc65.
+             *
+             * Only when a value actually came back null: a callback that
+             * deliberately returns 0, '' or false keeps what it returned.
+             */
+            if ( $data_type && $value === null ) {
+
+                $value = $this->setDataType( $value, $data_type );
+            }
+
             //set default value
             if ( $required && ! $value && $value !== 0 && $value !== "0") {
 
-                if ( isset( $property['default_value'] ) && $property['default_value'] ) {
+                /*
+                 * array_key_exists, not isset() && truthiness.
+                 *
+                 * The old test could never apply a FALSY default -- `false` and
+                 * `0` are the only defaults a boolean or counter would want, and
+                 * both failed the truthy check. So the one case a default exists
+                 * for was the one case it was skipped.
+                 */
+                if ( array_key_exists( 'default_value', $property ) ) {
 
                     $value = $property['default_value'];
                 }

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -227,7 +227,9 @@ class Module extends \OWA\Core\Module {
             'is_new_visitor'                => array (
                 'required'                        => true,
                 'data_type'                        => 'boolean',
-                ' default_value'                => false
+                // Key had a LEADING SPACE, so isset($property['default_value'])
+                // never matched and this default was dead for its whole life.
+                'default_value'                => false
             ),
 
             'user_name'                        => array(
@@ -371,6 +373,11 @@ class Module extends \OWA\Core\Module {
 
             'is_repeat_visitor' => array(
                 'required'            => true,
+                // Declared, so the pipeline can resolve the value by type when a
+                // callback returns nothing. Without it setDataType() is a no-op
+                // for this property and a null derivation reached the database.
+                'data_type'            => 'boolean',
+                'default_value'        => false,
                 'callbacks'            => array('owa_trackingEventHelpers::setRepeatVisitorFlag')
             ),
 

--- a/tests/EntityUnsetColumnWriteTest.php
+++ b/tests/EntityUnsetColumnWriteTest.php
@@ -1,0 +1,248 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A column nobody assigned is written as its type's zero, not as NULL.
+ *
+ * WHAT WAS WRONG
+ * Entity::create() sets EVERY column, so a column no caller touched still goes
+ * into the INSERT -- explicitly, as null. That was harmless until the PDO
+ * driver landed (#1028, 2026-08-21): the old driver interpolated values as
+ * quoted literals, so a PHP null became '' and MySQL -- with sql_mode empty --
+ * coerced '' to 0 on a numeric column. Eleven years of rows were written that
+ * way. PDO binds the null instead, so identical application code began storing
+ * a real NULL.
+ *
+ * On the demo install that flipped ~70 owa_session columns and ~14 owa_request
+ * columns from 0 to NULL overnight: is_repeat_visitor, every goal_N, every
+ * commerce_*, num_goals, the prior_session_* group. Measured, not inferred --
+ * '0' rows stop dead on 20260821 and NULL rows start there, while
+ * is_new_visitor (which the tracker always sends) is unchanged across the same
+ * boundary.
+ *
+ * WHY IT MATTERS
+ * Each distinct value is its own GROUP BY bucket, so a two-state fact starts
+ * reporting as three and a counter that meant "none" stops being comparable to
+ * the eleven years of 0s above it.
+ *
+ * WHY RESTORE 0 RATHER THAN EMBRACE NULL
+ * The point is that old rows and new rows AGREE. Anything reading across
+ * 20260821 -- every report, and the v2 migration's parity harness -- depends on
+ * one representation, not two. v2 then declares these columns NOT NULL
+ * DEFAULT 0 in the schema, which is where the guarantee belongs.
+ */
+final class EntityUnsetColumnWriteTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function session()
+    {
+        return owa_coreAPI::entityFactory('base.session');
+    }
+
+    /** writeValue() is protected; it is the seam, so reach it directly. */
+    private function writeValue($entity, string $column)
+    {
+        $m = new ReflectionMethod($entity, 'writeValue');
+        $m->setAccessible(true);
+
+        return $m->invoke($entity, $column);
+    }
+
+    public function testAnUnsetNumericColumnIsWrittenAsZero(): void
+    {
+        $s = $this->session();
+
+        // num_goals is TINYINT and nobody assigned it.
+        $this->assertNull($s->get('num_goals'), 'precondition: the column is unset');
+        $this->assertSame(0, $this->writeValue($s, 'num_goals'),
+            'an unset numeric column would be written as NULL');
+    }
+
+    public function testAnUnsetBooleanColumnIsWrittenAsZero(): void
+    {
+        $s = $this->session();
+
+        $this->assertSame(0, $this->writeValue($s, 'is_repeat_visitor'),
+            'the column that started this: a two-state fact stored as three');
+    }
+
+    public function testAnUnsetTextColumnIsWrittenAsEmptyString(): void
+    {
+        $s = $this->session();
+
+        // 'site' is VARCHAR255 and went NULL on the same date as the rest.
+        $this->assertSame('', $this->writeValue($s, 'site'),
+            "a string column's absent value was '' for eleven years, not NULL");
+    }
+
+    /**
+     * Only NULL is resolved. A caller that deliberately stored 0, false or ''
+     * must get back exactly what it stored -- otherwise this would undo
+     * EntityFalsyWriteTest's guarantee from the other direction.
+     */
+    public function testAnAssignedValueIsWrittenUnchanged(): void
+    {
+        $s = $this->session();
+
+        $s->set('num_goals', 4);
+        $this->assertSame(4, $this->writeValue($s, 'num_goals'));
+
+        $s->set('is_bounce', 0);
+        $this->assertSame(0, $this->writeValue($s, 'is_bounce'));
+
+        $s->set('site', 'example.test');
+        $this->assertSame('example.test', $this->writeValue($s, 'site'));
+    }
+
+    /**
+     * A type with no sensible zero keeps NULL.
+     *
+     * The old path turned these into '0000-00-00', which is not a value worth
+     * restoring and is refused outright under STRICT_ALL_TABLES.
+     */
+    public function testAnUnrecognisedTypeIsLeftAlone(): void
+    {
+        $s = $this->session();
+
+        $unknown = new \OWA\Module\Base\Classes\DbColumn('probe_col', 'SOME_FUTURE_TYPE');
+        $s->setProperty($unknown);
+
+        $this->assertNull($this->writeValue($s, 'probe_col'),
+            'a type with no defined zero must not be guessed at');
+    }
+
+    /**
+     * The text-type list must read OWA's vocabulary, not MySQL's spelling --
+     * the same requirement EntityFalsyWriteTest imposes on the numeric list.
+     *
+     * A regex over 'CHAR|TEXT|BLOB' is a MySQL DDL grammar sitting in the
+     * entity layer. It would go wrong quietly on the first dialect that spells
+     * its string types differently: nothing would match, absent values would go
+     * back to being NULL, and the failure would look like missing data rather
+     * than a type check that stopped recognising types.
+     */
+    public function testTheTextTypeListIsDerivedFromDeclaredTypesNotLiterals(): void
+    {
+        $entity = \OWA\Core\CoreAPI::entityFactory('base.click');
+
+        $m = new ReflectionMethod($entity, 'textColumnTypes');
+        $m->setAccessible(true);
+        $types = $m->invoke($entity);
+
+        $this->assertNotEmpty($types, 'no text column types resolved at all');
+
+        $declared = [];
+        foreach (get_defined_constants() as $name => $value) {
+            if (strpos($name, 'OWA_DTD_') === 0) {
+                $declared[] = (string) $value;
+            }
+        }
+
+        foreach ($types as $type) {
+            $this->assertContains($type, $declared,
+                sprintf('"%s" is a hand-written spelling, not a declared OWA_DTD_* value', $type));
+        }
+
+        // The sprintf template is not a type any column carries.
+        if (defined('OWA_DTD_VARCHAR')) {
+            $this->assertNotContains((string) constant('OWA_DTD_VARCHAR'), $types,
+                'OWA_DTD_VARCHAR is a template (VARCHAR(%s)), not a concrete column type');
+        }
+    }
+
+    /**
+     * No column on a tracked fact entity is written as NULL.
+     *
+     * This is the invariant, and it is why the fix lives at the WRITE layer
+     * rather than in the tracking-property map. Most fact columns are not
+     * declared as tracking properties at all: base.session has 121 columns and
+     * only 35 of them appear in any of the three maps, base.request 58 and 37.
+     * Fixing the map would have covered 29% of the surface and left the rest
+     * writing NULL exactly as before.
+     *
+     * A column that genuinely wants NULL is a deliberate decision -- it needs a
+     * three-state type and a reason, per the v2 plan's §1.12 -- so it should
+     * fail here and be argued for, not appear by accident because someone
+     * declared a type this layer does not recognise.
+     */
+    public function testNoFactColumnIsWrittenAsNull(): void
+    {
+        $entities = [
+            'base.session',
+            'base.request',
+            'base.action_fact',
+            'base.commerce_transaction_fact',
+            'base.commerce_line_item_fact',
+        ];
+
+        $unresolved = [];
+        $checked    = 0;
+
+        foreach ($entities as $name) {
+
+            $entity = owa_coreAPI::entityFactory($name);
+
+            foreach ($entity->getColumns() as $column) {
+
+                $checked++;
+
+                if ($this->writeValue($entity, $column) === null) {
+                    $unresolved[] = $name . '.' . $column;
+                }
+            }
+        }
+
+        $this->assertGreaterThan(100, $checked, 'the entity columns were not enumerated');
+        $this->assertSame([], $unresolved,
+            'these columns would still be written as NULL: ' . implode(', ', $unresolved));
+    }
+
+    /**
+     * End to end: the only place the create() change is actually observable.
+     */
+    public function testUnsetColumnsSurviveACreateAsZeroNotNull(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('No database available.');
+        }
+
+        $db = owa_coreAPI::dbSingleton();
+        $id = '9111222333444555778';
+        $db->query("DELETE FROM owa_session WHERE id = $id");
+
+        try {
+            $s = $this->session();
+            $s->set('id', $id);
+            $s->set('site_id', 'entity-unset-test');
+            $s->set('yyyymmdd', (int) date('Ymd'));
+            $s->set('timestamp', time());
+            // is_repeat_visitor, num_goals and commerce_trans_count are all
+            // deliberately left alone -- that is the case under test.
+            $s->create();
+
+            $row = $db->get_row(
+                "SELECT is_repeat_visitor, num_goals, commerce_trans_count, site
+                   FROM owa_session WHERE id = ?", [$id]);
+
+            $this->assertNotNull($row, 'the row was not created');
+
+            foreach (['is_repeat_visitor', 'num_goals', 'commerce_trans_count'] as $col) {
+                $this->assertNotNull($row[$col],
+                    sprintf('%s was stored as NULL', $col));
+                $this->assertSame('0', (string) $row[$col],
+                    sprintf('%s should be 0, the value eleven years of rows carry', $col));
+            }
+
+            $this->assertSame('', (string) $row['site'],
+                'an absent string column should be empty, not NULL');
+
+        } finally {
+            $db->query("DELETE FROM owa_session WHERE id = $id");
+        }
+    }
+}

--- a/tests/TrackingPropertyDefaultsTest.php
+++ b/tests/TrackingPropertyDefaultsTest.php
@@ -1,0 +1,208 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A required tracking property resolves to a value, never to null.
+ *
+ * Three separate defects in setTrackerProperties() let a null reach the
+ * database, and each one hid the next:
+ *
+ *  1. THE TYPE WAS APPLIED TOO EARLY. setDataType() ran on the value as it
+ *     arrived, BEFORE the callback. So it only ever sanitised input, and
+ *     whatever a callback returned went onward untouched -- which is how a
+ *     derivation that falls off the end wrote NULL into a column whose declared
+ *     type is boolean. setRepeatVisitorFlag did exactly that from 2015 until
+ *     8d24fc65.
+ *
+ *  2. THE DEFAULT COULD NEVER BE FALSY. The guard was
+ *     `isset($property['default_value']) && $property['default_value']`, so
+ *     `false` and `0` -- the only defaults a boolean or a counter would ever
+ *     want -- failed the truthy test. The one case a default exists for was the
+ *     one case it was skipped.
+ *
+ *  3. is_new_visitor's DEFAULT KEY HAD A LEADING SPACE (' default_value'), so
+ *     isset() never matched it at all. Dead for the whole life of the file, and
+ *     invisible because defect 2 would have discarded it anyway.
+ *
+ * Why it matters now: until #1028 a null was interpolated as '' and MySQL
+ * coerced it to 0, so none of this was observable. PDO binds the null, so it
+ * reaches the column intact.
+ */
+final class TrackingPropertyDefaultsTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+    }
+
+    private function helpers()
+    {
+        return \OWA\Module\Base\Classes\TrackingEventHelpers::getInstance();
+    }
+
+    private function event()
+    {
+        $e = owa_coreAPI::supportClassFactory('base', 'event');
+        $e->setEventType('base.page_request');
+
+        return $e;
+    }
+
+    /**
+     * Defect 3, as a rule rather than a single fix: no option key in any
+     * tracking-property map may carry surrounding whitespace.
+     *
+     * A typo'd key is not a syntax error and not a warning -- it is simply a
+     * setting that never applies, and nothing in the suite would have noticed.
+     */
+    public function testNoPropertyOptionKeyHasStrayWhitespace(): void
+    {
+        $service = \OWA\Core\CoreAPI::serviceSingleton();
+        $bad     = [];
+        $seen    = 0;
+
+        foreach (['environmental', 'regular', 'derived'] as $type) {
+
+            $map = $service->getMap('tracking_properties_' . $type);
+
+            if (! is_array($map)) {
+                continue;
+            }
+
+            foreach ($map as $property => $options) {
+
+                if (! is_array($options)) {
+                    continue;
+                }
+
+                foreach (array_keys($options) as $key) {
+
+                    $seen++;
+
+                    if (! is_string($key) || $key !== trim($key)) {
+                        $bad[] = sprintf('%s.%s -> "%s"', $type, $property, $key);
+                    }
+                }
+            }
+        }
+
+        $this->assertGreaterThan(0, $seen, 'no tracking property options were read at all');
+        $this->assertSame([], $bad,
+            'these option keys have surrounding whitespace, so they silently do nothing: '
+            . implode(', ', $bad));
+    }
+
+    /** is_new_visitor specifically -- the one that carried the typo. */
+    public function testIsNewVisitorDeclaresAUsableDefault(): void
+    {
+        $map = \OWA\Core\CoreAPI::serviceSingleton()->getMap('tracking_properties_regular');
+
+        $this->assertIsArray($map);
+        $this->assertArrayHasKey('is_new_visitor', $map);
+        $this->assertArrayHasKey('default_value', $map['is_new_visitor'],
+            "the key was ' default_value' with a leading space, so it never applied");
+    }
+
+    /**
+     * Defect 2: a falsy default is applied.
+     *
+     * No callbacks, no incoming value -- so the default is the only thing that
+     * can supply one.
+     */
+    public function testAFalsyDefaultIsApplied(): void
+    {
+        $event = $this->event();
+
+        // NO data_type on purpose. With one, the post-filter type resolution
+        // supplies false by itself and this passes whether or not the default
+        // works -- which is what the first version of this test did.
+        $this->helpers()->setTrackerProperties($event, [
+            'probe_falsy_default' => [
+                'required'      => true,
+                'default_value' => false,
+            ],
+        ]);
+
+        $this->assertNotNull($event->get('probe_falsy_default'),
+            'a falsy default was discarded, leaving the property null');
+        $this->assertFalse($event->get('probe_falsy_default'));
+    }
+
+    public function testAZeroDefaultIsApplied(): void
+    {
+        $event = $this->event();
+
+        // Likewise untyped: 'integer' would coerce null to 0 on its own.
+        $this->helpers()->setTrackerProperties($event, [
+            'probe_zero_default' => [
+                'required'      => true,
+                'default_value' => 0,
+            ],
+        ]);
+
+        $this->assertSame(0, $event->get('probe_zero_default'));
+    }
+
+    /**
+     * Defect 1: a callback that returns nothing must not leave the property
+     * null when the property declares a type.
+     *
+     * This is the exact shape of the 2015 bug, reproduced with a callback that
+     * still has it.
+     */
+    public function testACallbackReturningNullIsResolvedByTheDeclaredType(): void
+    {
+        $event = $this->event();
+
+        $this->helpers()->setTrackerProperties($event, [
+            'probe_null_callback' => [
+                'required'  => true,
+                'data_type' => 'boolean',
+                'callbacks' => ['OwaProbeNullCallback::fallsOffTheEnd'],
+            ],
+        ]);
+
+        $value = $event->get('probe_null_callback');
+
+        $this->assertNotNull($value,
+            'a derivation that falls off the end still reaches the column as NULL');
+        $this->assertFalse($value, 'a boolean property should resolve to false, not null');
+    }
+
+    /**
+     * The resolution must be narrow: a callback that deliberately returns a
+     * value keeps it. Otherwise this would flatten every real derivation.
+     */
+    public function testACallbackThatReturnsAValueKeepsIt(): void
+    {
+        $event = $this->event();
+
+        $this->helpers()->setTrackerProperties($event, [
+            'probe_real_callback' => [
+                'required'  => true,
+                'data_type' => 'boolean',
+                'callbacks' => ['OwaProbeNullCallback::returnsTrue'],
+            ],
+        ]);
+
+        $this->assertTrue($event->get('probe_real_callback'));
+    }
+}
+
+/** Callbacks are resolved by name, so these need to be a real class. */
+class OwaProbeNullCallback
+{
+    /** Returns true for one branch and nothing for the other -- the 2015 shape. */
+    public static function fallsOffTheEnd($value, $event)
+    {
+        if (false) {
+            return true;
+        }
+    }
+
+    public static function returnsTrue($value, $event)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
## The regression

`Entity::create()` sets **every** column, so a column no caller touched still goes into the INSERT explicitly as null. That was invisible until the PDO driver landed (#1028, deployed 2026-08-21): the old driver interpolated values as quoted literals, so a PHP `null` became `''` and MySQL — `sql_mode` empty — coerced it to `0` on a numeric column. Eleven years of rows were written that way. PDO *binds* the null, so identical application code now stores a real `NULL`.

## Measured on the demo install

`'0'` rows stop dead on 20260821 and `NULL` rows start there, while `is_new_visitor` (which the tracker always sends) is unchanged across the same boundary — same input, different stored value:

| day | is_new_visitor N/0/1 | is_repeat_visitor N/0/1 |
|---|---|---|
| 20260820 | 0 / 1 / 3 | 0 / 3 / 1 |
| **20260821** | 0 / 0 / 3 | **2** / 1 / 0 |
| 20260822 | 0 / 0 / 6 | **6** / 0 / 0 |

Roughly **70 `owa_session` columns and 14 `owa_request` columns** flipped from `0` to `NULL`: `is_repeat_visitor`, every `goal_N`, every `commerce_*`, `num_goals`, the `prior_session_*` group. Column schema is identical on both installs (`tinyint(1)`, nullable, default NULL) and did not change — nothing was ever defaulting those zeros.

Each distinct value is its own `GROUP BY` bucket, so a two-state fact starts reporting as three, and a counter meaning "none" stops being comparable to the zeros above it.

## The fix

`Entity::writeValue()` resolves an unset column by its **declared type** — numeric to `0`, text/binary to `''` — restoring the pre-#1028 stored representation rather than inventing a third. What matters is that old and new rows agree, which is what every report and the v2 parity harness read across. TIMESTAMP and unrecognised types keep NULL deliberately: the old path made those `'0000-00-00'`, which is not worth restoring and is refused under `STRICT_ALL_TABLES`.

Fixed at the write layer rather than in the tracking-property map, because the map does not cover the surface: **86 of `base.session`'s 121 columns** and 21 of `base.request`'s 58 are not declared as tracking properties — the handlers populate them. A map-level fix would have reached 29% of the columns.

Types resolve through the `OWA_DTD_*` constants (`numericColumnTypes()`, and a new `textColumnTypes()`), never a regex over MySQL spellings — the entity layer must not carry a DDL grammar, per the existing `EntityFalsyWriteTest`.

## Three pipeline defects found alongside it

Each was hiding the next:

- `setDataType()` ran **before** the callback, so it only ever sanitised input and a callback's return reached the column untouched. Now re-applied after the filter, and only when the value came back null.
- The default guard was `isset(...) && $property['default_value']`, so a **falsy** default — the only kind a boolean or counter wants — could never apply. Now `array_key_exists`.
- `is_new_visitor`'s key was `' default_value'`, with a **leading space**, so `isset()` never matched it. Dead for the life of the file, and invisible because the truthy guard would have discarded it anyway.

`is_repeat_visitor` now declares its boolean type and default so the pipeline can resolve it too, rather than relying on the entity layer alone.

## Tests

Cover both layers, including the invariant that **no fact column resolves to NULL** across five entities, and a scan for stray whitespace in any property option key. Every guard mutation-checked. The two default tests were vacuous when first written — the new type resolution masked them — and are now untyped so the default is the only thing that can supply a value.

## Deploying this matters before any schema change

`ALTER ... NOT NULL DEFAULT 0` must not be applied to an install still running code that binds an explicit NULL. Under `STRICT_ALL_TABLES` the insert is **silently dropped** — not an exception, the row simply does not exist. Measured on a scratch table:

```
INSERT (id, flag) VALUES (1, NULL)  ->  row MISSING
INSERT (id)       VALUES (2)        ->  stored, flag = 0
INSERT (id, flag) VALUES (3, 0)     ->  stored, flag = 0
```

So the order per install is: deploy this → backfill the existing NULLs → only then ALTER.