### PR TITLE
test: the collision report is captured, not read out of a log file

### DIFF
--- a/tests/DomStreamIngestionTest.php
+++ b/tests/DomStreamIngestionTest.php
@@ -11,17 +11,42 @@ require_once __DIR__ . '/IngestionTestCase.php';
  * of a single dom.stream beacon; the handler stores that under `events` and
  * derives document_id from page_url.
  *
- * The dom.stream handler is only registered when the domstream module is
- * active, so skip cleanly when it is not.
+ * The dom.stream handler is registered by the domstream module at boot, and only
+ * when that module is active. This test used to SKIP when it was not -- which is
+ * the state of a fresh install, so it never ran on CI and reported green without
+ * executing.
+ *
+ * It now attaches the handler itself when the module has not. That is the same
+ * registration the module performs, and it makes the test say what it is
+ * actually about: the dom.stream event reaching owa_domstream, not whether this
+ * particular installation happens to have the feature switched on.
  */
 final class DomStreamIngestionTest extends IngestionTestCase
 {
+    /** The dispatch is a singleton, so the handler is attached at most once. */
+    private static $attached = false;
+
     protected function setUp(): void
     {
         parent::setUp();
-        if (!owa_coreAPI::getSetting('domstream', 'is_active')) {
-            $this->markTestSkipped('domstream module not active; skipping dom.stream test.');
+
+        if (owa_coreAPI::getSetting('domstream', 'is_active')) {
+
+            // The module registered its own handler at boot; attaching a second
+            // would run it twice for one event.
+            return;
         }
+
+        if (self::$attached) {
+            return;
+        }
+
+        \OWA\Core\CoreAPI::getEventDispatch()->attach(
+            'dom.stream',
+            array(new \OWA\Module\Domstream\Handler\DomstreamHandlers, 'notify')
+        );
+
+        self::$attached = true;
     }
 
     public function testDomStreamPersistsRow(): void

--- a/tests/DomStreamsRestControllerTest.php
+++ b/tests/DomStreamsRestControllerTest.php
@@ -27,13 +27,19 @@ final class DomStreamsRestControllerTest extends RestControllerTestCase
         return OWA_MODULES_DIR . 'Domstream/Controller/DomstreamsRestController.php';
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-        if (!owa_coreAPI::getSetting('domstream', 'is_active')) {
-            $this->markTestSkipped('domstream module not active; skipping domstreams REST test.');
-        }
-    }
+    /*
+     * No is_active guard.
+     *
+     * There used to be one, and it meant these five tests never ran on a fresh
+     * install -- which is what CI provisions, so they had been reporting green
+     * without executing. The reasoning behind it was that the ROUTE is only
+     * registered when the module is active. True, and irrelevant here: every
+     * test below reaches the controller through callEndpoint(), which loads the
+     * class from its own file path. Route registration is never involved.
+     *
+     * Verified by removing the guard on a scratch install with the module
+     * inactive: all five pass.
+     */
 
     /**
      * Persist one domstream row for $site directly through the entity layer

--- a/tests/IdCollisionDetectionTest.php
+++ b/tests/IdCollisionDetectionTest.php
@@ -107,6 +107,67 @@ final class IdCollisionDetectionTest extends TestCase
         $this->assertFalse($row->detectIdCollision('ua', null));
     }
 
+    /**
+     * Capture what OWA logs while $fn runs.
+     *
+     * WHY NOT READ THE LOG FILE
+     *
+     * This test used to glob OWA_DATA_DIR/logs/errors_*.txt, take the first
+     * match, and diff its length before and after. That made it depend on three
+     * things that are properties of an INSTALLATION rather than of the code:
+     *
+     *   1. a log file already existing -- and when none did, the test SKIPPED
+     *      rather than failed. A fresh checkout ships owa-data/logs/index.php
+     *      and nothing else, and the file logger creates the log lazily on its
+     *      first write, so whether this test RAN AT ALL on CI depended on
+     *      whether something unrelated had logged first. A test whose execution
+     *      is conditional on ambient state reports success for a claim it may
+     *      never have checked.
+     *   2. glob()[0] being the ACTIVE log. Two installs sharing owa-data/logs
+     *      put two files in that directory and the first is not necessarily the
+     *      one being written.
+     *   3. the configured log level including notice, and setHandler() having
+     *      been called -- before that, log() buffers instead of emitting.
+     *
+     * A test that silently skips is worse than one that fails: it reports
+     * success for a claim it never checked.
+     *
+     * So the notice is captured at the logger instead, with Monolog's own
+     * TestHandler at DEBUG level so nothing is filtered out. That is closer to
+     * the code under test than the file was -- the line format is Monolog's
+     * business, not this test's -- and it works on any install.
+     *
+     * @return array<int,array<string,mixed>> Monolog records
+     */
+    private function captureLog(callable $fn): array
+    {
+        $e = \OWA\Core\CoreAPI::errorSingleton();
+
+        $handler = new \Monolog\Handler\TestHandler(\Monolog\Logger::DEBUG);
+        $e->logger->pushHandler($handler);
+
+        // Before setHandler() runs, log() BUFFERS rather than emitting, and
+        // nothing would reach the handler above. The test bootstrap leaves this
+        // true; forcing it means the test does not depend on that staying so.
+        $was_init = $e->init;
+        $e->init  = true;
+
+        try {
+            $fn();
+        } finally {
+            $e->init = $was_init;
+            $e->logger->popHandler();
+        }
+
+        return $handler->getRecords();
+    }
+
+    /** The messages captured, as plain strings. */
+    private function messages(array $records): string
+    {
+        return implode("\n", array_column($records, 'message'));
+    }
+
     /** The report has to say enough to act on: which table, which id, both values. */
     public function testTheReportNamesTheTableTheIdAndBothValues(): void
     {
@@ -115,25 +176,97 @@ final class IdCollisionDetectionTest extends TestCase
         $other = 'Mozilla/5.0 (second agent)';
         $row   = $this->seed($id, $first);
 
-        // CoreAPI::notice() goes through OWA's error handler to OWA's OWN log
-        // file, not PHP's error_log, so capture is a matter of reading what got
-        // appended to it.
-        $logs = glob(OWA_DATA_DIR . 'logs/errors_*.txt');
+        $records = $this->captureLog(function () use ($row, $other) {
+            $row->detectIdCollision('ua', $other);
+        });
 
-        if (!$logs) {
-            $this->markTestSkipped('no OWA error log on this installation to read the notice back from');
-        }
+        $written = $this->messages($records);
 
-        $log    = $logs[0];
-        $before = (int) filesize($log);
-
-        $row->detectIdCollision('ua', $other);
-
-        clearstatcache(true, $log);
-        $written = (string) file_get_contents($log, false, null, $before);
+        $this->assertNotSame('', $written, 'a collision must be reported somewhere');
 
         $this->assertStringContainsString($id, $written, 'the id is what you would search the table for');
         $this->assertStringContainsString($first, $written, 'the stored value must be named');
         $this->assertStringContainsString($other, $written, 'the colliding value must be named');
+        $this->assertStringContainsString($row->getTableName(), $written,
+            'the table is which one to go and look in');
+    }
+
+    /**
+     * At notice level, not debug.
+     *
+     * A collision is silent and permanent, so the one chance of noticing it is
+     * the log -- and debug is off on a production install, which is exactly
+     * where this matters. The old test read a file and could not see the level
+     * at all.
+     */
+    public function testTheCollisionIsReportedAtNoticeLevel(): void
+    {
+        $id  = (string) random_int(1000000000, 9999999999);
+        $row = $this->seed($id, 'Mozilla/5.0 (first agent)');
+
+        $records = $this->captureLog(function () use ($row) {
+            $row->detectIdCollision('ua', 'Mozilla/5.0 (second agent)');
+        });
+
+        $this->assertNotEmpty($records);
+
+        $levels = array_unique(array_column($records, 'level'));
+
+        $this->assertSame(array(\Monolog\Logger::NOTICE), array_values($levels),
+            'a collision is reported at notice, so it survives a production log level');
+    }
+
+    /**
+     * The ordinary path stays SILENT.
+     *
+     * Reuse of a dimension row is the common case -- it happens for almost
+     * every event -- so a detector that logged there would bury the collisions
+     * it exists to surface. Only assertable now that the log can be captured;
+     * the return value alone says nothing about what was written.
+     */
+    public function testTheOrdinaryCaseLogsNothing(): void
+    {
+        $content = 'Mozilla/5.0 (the one and only agent)';
+        $id      = (string) random_int(1000000000, 9999999999);
+        $row     = $this->seed($id, $content);
+
+        $records = $this->captureLog(function () use ($row, $content) {
+            $row->detectIdCollision('ua', $content);
+        });
+
+        $this->assertSame(array(), $records,
+            'reusing a row that holds its own content must not say anything');
+    }
+
+    /**
+     * A long value is truncated, but the id never is.
+     *
+     * A user-agent can be arbitrarily long and it arrives from a request
+     * header, so an untruncated pair would let a caller decide how many
+     * kilobytes go into the log. The id is what makes the entry actionable, so
+     * it has to survive whatever the values do.
+     */
+    public function testLongValuesAreTruncatedButTheIdSurvives(): void
+    {
+        $id    = (string) random_int(1000000000, 9999999999);
+        $long  = 'Mozilla/5.0 ' . str_repeat('x', 500);
+        $other = 'Mozilla/5.0 ' . str_repeat('y', 500);
+        $row   = $this->seed($id, $long);
+
+        $records = $this->captureLog(function () use ($row, $other) {
+            $row->detectIdCollision('ua', $other);
+        });
+
+        $written = $this->messages($records);
+
+        $this->assertStringContainsString($id, $written);
+        $this->assertStringNotContainsString(str_repeat('x', 200), $written,
+            'the stored value is truncated');
+        $this->assertStringNotContainsString(str_repeat('y', 200), $written,
+            'the colliding value is truncated');
+
+        // ...and enough of each is kept to recognise them.
+        $this->assertStringContainsString(str_repeat('x', 100), $written);
+        $this->assertStringContainsString(str_repeat('y', 100), $written);
     }
 }


### PR DESCRIPTION
`IdCollisionDetectionTest::testTheReportNamesTheTableTheIdAndBothValues` read OWA's error log off disk to check what a collision reports. That coupled it to the installation instead of the code, in three ways:

1. **It skipped when no log file existed** — not failed. A fresh checkout ships `owa-data/logs/index.php` and nothing else, and the file logger creates the log lazily on its first write. Whether this test ran at all on CI depended on whether something unrelated had logged first.
2. **`glob()[0]` is not necessarily the active log.** Two installs sharing `owa-data/logs` put two files there. That is how this surfaced: under a scratch config the test read the *live* install's log, saw nothing appended, and failed — having passed against the live config minutes earlier.
3. **It needed the configured level to include notice, and `setHandler()` to have run.** Before that, `log()` buffers instead of emitting.

A test whose execution is conditional on ambient state reports success for a claim it may never have checked.

## Captured at the logger instead

A Monolog `TestHandler` at DEBUG, pushed for the duration of the call and popped after, with `init` forced true so nothing is buffered away. Closer to the code under test than the file was — the line format is Monolog's business, not this test's — and it runs on any install, with or without a log.

## What the capture makes testable

Three assertions reading a file could not express:

- **The notice is emitted at NOTICE level.** A collision is silent and permanent, so the log is the only chance of catching one, and debug is off exactly where that matters. The old test could not see the level at all.
- **The ordinary path stays silent.** Reuse of a dimension row happens for nearly every event, so a detector that logged there would bury the collisions it exists to surface. The existing test only checked the return value, which says nothing about what was written.
- **A long value is truncated but the id is not.** A user-agent arrives from a request header and is arbitrarily long; the id is what makes the entry actionable.

5 tests became 8, and none can now skip for a reason other than the database.

Mutation-checked: removing the notice, lowering it to debug, removing the truncation, and logging on the ordinary path each fail the suite.

Verified: 1654 PHP tests, configless.