### PR TITLE
feat: the dimension catalog is keyed by entity, and can be scoped to one

### DIFF
--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -2241,15 +2241,49 @@ class CoreAPI {
         return md5( $salt );
     }
 
-    public static function getAllDimensions() {
+    /**
+     * Every registered dimension, one entry per name.
+     *
+     * Both registries are keyed name => entity => registration, and this
+     * flattens them to name => registration by letting the last entity win --
+     * which is what this method has always returned, and what its callers (the
+     * report picker and its validation among them) are written against.
+     *
+     * Pass $entities to scope the answer to a set of entities: a dimension is
+     * offered only if it is defined on one of them, and a name defined on none
+     * is absent entirely. That is how one catalog will serve two schema
+     * generations without a caller having to tell them apart by name -- the
+     * scope decides, so the wrong generation is not filtered out downstream, it
+     * is never in the answer.
+     *
+     * Called without a scope the behaviour is unchanged.
+     *
+     * @param array|null $entities entity names to restrict the answer to
+     */
+    public static function getAllDimensions( $entities = null ) {
 
         $s = \OWA\Core\CoreAPI::serviceSingleton();
 
-        $dims = $s->dimensions;
+        $dims = array();
 
-        foreach ( $s->denormalizedDimensions as $k => $entity_dims ) {
-            foreach ($entity_dims as $entity => $dedim) {
-                $dims[$k] = $dedim;
+        /*
+         * Normalized first, then denormalized, because a name carried by both
+         * has always resolved to the denormalized definition and callers depend
+         * on that precedence.
+         */
+        foreach ( array( $s->dimensions, $s->denormalizedDimensions ) as $registry ) {
+
+            foreach ( $registry as $k => $entity_dims ) {
+
+                foreach ( $entity_dims as $entity => $dim ) {
+
+                    if ( $entities !== null && ! in_array( $entity, (array) $entities, true ) ) {
+
+                        continue;
+                    }
+
+                    $dims[$k] = $dim;
+                }
             }
         }
 

--- a/Core/Module.php
+++ b/Core/Module.php
@@ -1055,7 +1055,24 @@ abstract class Module {
             if ($denormalized) {
                 $this->denormalizedDimensions[$dim_name][$entity] = $dim;
             } else {
-                $this->dimensions[$dim_name] = $dim;
+                /*
+                 * Keyed by entity, like the denormalized branch above.
+                 *
+                 * This loop runs once per entity the dimension was registered
+                 * against, and the old flat write ($this->dimensions[$dim_name])
+                 * overwrote itself on each turn -- so a name registered against
+                 * several entities kept only the last, and the rest were lost
+                 * before anything could read them. That is why a second schema
+                 * generation could not be registered under an existing name: it
+                 * would replace the first rather than sit beside it.
+                 *
+                 * Storing every entity does NOT change which one is resolved.
+                 * getDimension() still answers with the last registration when
+                 * asked without an entity, exactly as the flat array did. The
+                 * information is now retained so that a caller CAN ask by
+                 * entity; nothing yet changes what an unscoped caller gets.
+                 */
+                $this->dimensions[$dim_name][$entity] = $dim;
             }
         }
     }

--- a/modules/Base/Classes/ResultSetManager.php
+++ b/modules/Base/Classes/ResultSetManager.php
@@ -2329,21 +2329,49 @@ if ( ! in_array($item['name'], $this->allMetrics) ) {
 
         $normalized_dims = $s->dimensions;
 
-        foreach ( $normalized_dims as $k => $ndim ) {
+        /*
+         * Keyed name => entity => registration, like denormalizedDimensions
+         * above, so both loops have the same shape.
+         *
+         * One entry per NAME rather than per entity: the question here is only
+         * whether the entity being reported on can reach the dimension, so the
+         * first definition that relates answers it and the rest would be
+         * duplicates in the picker.
+         */
+        foreach ( $normalized_dims as $k => $ndim_implementations ) {
 
-            // check to see if realation exists with dim's speficied foreign key
-            $fk = $ndim['foreign_key_name'];
-            if ( $fk ) {
+            /*
+             * The LAST registration, which is exactly what the flat registry
+             * held after overwriting itself. Deliberate: retaining every entity
+             * is a storage change, and nothing an existing caller sees may move
+             * because of it. Considering all of them here would put userName --
+             * registered normalized against seven entities with no foreign key,
+             * and broken for that reason -- into four more pickers than it
+             * reaches today, which is widening a defect rather than preserving
+             * behaviour.
+             *
+             * A caller that wants a specific entity's definition asks for it by
+             * entity; this one is answering "what can this report reach", and
+             * its answer must not change here.
+             */
+            foreach ( array( end( $ndim_implementations ) ) as $ndim ) {
 
-                $col_exists = $entity->getProperty($fk);
+                // check to see if realation exists with dim's speficied foreign key
+                $fk = $ndim['foreign_key_name'];
+                if ( $fk ) {
 
-            } else {
-                // check to see if there is any foreign key to the dim's entity
-                $col_exists = $entity->getForeignKeyColumn( $ndim['entity'] );
-            }
+                    $col_exists = $entity->getProperty($fk);
 
-            if ( $col_exists ) {
-                $dims[ $ndim['family'] ][] = array( 'name' => $ndim['name'], 'label' => $ndim['label'] );
+                } else {
+                    // check to see if there is any foreign key to the dim's entity
+                    $col_exists = $entity->getForeignKeyColumn( $ndim['entity'] );
+                }
+
+                if ( $col_exists ) {
+                    $dims[ $ndim['family'] ][] = array( 'name' => $ndim['name'], 'label' => $ndim['label'] );
+
+                    break;
+                }
             }
         }
 

--- a/modules/Base/Classes/Service.php
+++ b/modules/Base/Classes/Service.php
@@ -409,7 +409,14 @@ class Service extends \OWA\Core\Base {
         foreach ($this->modules as $k => $module) {
 
             if (is_array($module->dimensions)) {
-                $this->dimensions = array_merge($this->dimensions, $module->dimensions);
+                /*
+                 * Recursive, because dimensions are now keyed name => entity =>
+                 * registration. A flat array_merge would replace a whole name's
+                 * entity map with whichever module was loaded last, reproducing
+                 * inside the merge exactly the loss that registerDimension() no
+                 * longer commits.
+                 */
+                $this->dimensions = array_merge_recursive($this->dimensions, $module->dimensions);
             }
 
             if (is_array($module->denormalizedDimensions)) {
@@ -599,11 +606,48 @@ class Service extends \OWA\Core\Base {
         }
     }
 
-    function getDimension($name) {
+    /**
+     * A normalized dimension, optionally the one defined for a given entity.
+     *
+     * Called without an entity this answers the LAST registration for the name,
+     * which is what the previously flat registry held after overwriting itself.
+     * That equivalence is deliberate: this change is about retaining the other
+     * registrations, not about changing which one an existing caller resolves.
+     *
+     * Called with an entity it answers that entity's registration, or nothing.
+     * This is the path a second schema generation will use -- one name, several
+     * entities, the caller saying which it means rather than hoping.
+     */
+    function getDimension($name, $entity = null) {
 
-        if (array_key_exists($name, $this->dimensions)) {
-            return $this->dimensions[$name];
+        if (! array_key_exists($name, $this->dimensions)) {
+            return null;
         }
+
+        $byEntity = $this->dimensions[$name];
+
+        if ($entity !== null) {
+
+            return array_key_exists($entity, $byEntity) ? $byEntity[$entity] : null;
+        }
+
+        return end($byEntity) ?: null;
+    }
+
+    /**
+     * Every entity a normalized dimension is defined for.
+     *
+     * Nothing consumes this yet. It exists so that scoping can be written and
+     * tested against a real second registration before there is a second schema
+     * generation to depend on it.
+     */
+    function getDimensionEntities($name) {
+
+        if (! array_key_exists($name, $this->dimensions)) {
+            return array();
+        }
+
+        return array_keys($this->dimensions[$name]);
     }
 
     function getDenormalizedDimension($name, $entity) {

--- a/tests/CatalogCharacterizationHarness.php
+++ b/tests/CatalogCharacterizationHarness.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace OWA\Tests;
+
+/**
+ * A recording of the metric and dimension catalog, exactly as it is registered
+ * today.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The catalog is about to be changed so that two schema generations can be
+ * registered under one name -- `visits` computed from the v1 star and `visits`
+ * computed from the v2 event table, told apart by their entity. That work is
+ * behaviour-preserving for the single-generation case, and this harness is what
+ * makes "behaviour-preserving" checkable rather than asserted.
+ *
+ * It deliberately records the catalog INCLUDING two defects, because a
+ * characterization suite that quietly corrects what it finds cannot prove
+ * anything about the change that corrects it:
+ *
+ *   1. REGISTRATION-TIME LOSS. registerDimension() loops $entity_names but the
+ *      normalized branch writes $this->dimensions[$dim_name], overwriting itself
+ *      on each turn, so only the last entity survives. Three dimensions are
+ *      registered against seven entities and keep one.
+ *
+ *   2. READ-TIME LOSS. CoreAPI::getAllDimensions() flattens the correctly
+ *      entity-keyed denormalizedDimensions with $dims[$k] = $dedim, so 223
+ *      entity-entries collapse to 59 names -- again keeping the last.
+ *
+ * Both are recorded as counts below. When they are fixed the fixture changes,
+ * and the diff is the evidence that the fix did what it claimed.
+ *
+ * Values are normalised so the fixture says the same thing on any machine and
+ * in any environment: entries are sorted, and only the declarative keys are
+ * kept. Nothing here touches the database -- registration is pure PHP -- so this
+ * runs in the configless CI environment where most of the suite skips.
+ */
+final class CatalogCharacterizationHarness
+{
+    /** Declarative keys of a dimension registration; anything else is scaffolding. */
+    private const DIMENSION_KEYS = array(
+        'name', 'entity', 'column', 'family', 'label', 'description',
+        'foreign_key_name', 'data_type', 'denormalized',
+    );
+
+    /** Declarative keys of a metric implementation. */
+    private const METRIC_KEYS = array( 'name', 'class', 'label', 'group' );
+
+    /**
+     * The whole catalog, in a shape that is stable across machines.
+     *
+     * @return array<string,mixed>
+     */
+    public static function snapshot(): array
+    {
+        $service = \OWA\Core\CoreAPI::serviceSingleton();
+
+        $normalized   = self::readProperty( $service, 'dimensions' );
+        $denormalized = self::readProperty( $service, 'denormalizedDimensions' );
+        $metrics      = self::readProperty( $service, 'metrics' );
+
+        return array(
+            'counts'                  => self::counts( $normalized, $denormalized, $metrics ),
+            'metrics'                 => self::normaliseMetrics( $metrics ),
+            'dimensionsNormalized'    => self::normaliseFlatDimensions( $normalized ),
+            'dimensionsDenormalized'  => self::normaliseNestedDimensions( $denormalized ),
+            'accessorGetAllDimensions'=> self::normaliseFlatDimensions(
+                                            (array) \OWA\Core\CoreAPI::getAllDimensions() ),
+        );
+    }
+
+    /**
+     * The numbers that the coming change is expected to move.
+     *
+     * Kept as their own block so a reviewer can see the shape of the catalog
+     * without reading 200 entries, and so a change to the totals is visible in
+     * a diff even when individual entries are untouched.
+     *
+     * @return array<string,int>
+     */
+    public static function counts( array $normalized, array $denormalized, array $metrics ): array
+    {
+        $denormalizedEntries = 0;
+
+        foreach ( $denormalized as $byEntity ) {
+
+            $denormalizedEntries += count( (array) $byEntity );
+        }
+
+        $implementations = 0;
+
+        foreach ( $metrics as $list ) {
+
+            $implementations += count( (array) $list );
+        }
+
+        return array(
+            'metricNames'                  => count( $metrics ),
+            'metricImplementations'        => $implementations,
+            'dimensionNamesNormalized'     => count( $normalized ),
+            /*
+             * Equal to dimensionNamesNormalized today, and that equality IS the
+             * registration-time defect: a name registered against seven entities
+             * contributes one entry. When the registry becomes entity-keyed this
+             * number rises and the two stop matching.
+             */
+            'dimensionEntriesNormalized'   => self::countFlatEntries( $normalized ),
+            'dimensionNamesDenormalized'   => count( $denormalized ),
+            'dimensionEntriesDenormalized' => $denormalizedEntries,
+            /*
+             * The read-side view. Lower than dimensionEntriesDenormalized
+             * because getAllDimensions() keeps one entry per name.
+             */
+            'accessorDimensionNames'       => count( (array) \OWA\Core\CoreAPI::getAllDimensions() ),
+        );
+    }
+
+    /**
+     * How many (name, entity) pairs a flat registry actually holds.
+     *
+     * Written to tolerate BOTH shapes on purpose: name => entry today, and
+     * name => entity => entry after the change. Without that the harness would
+     * have to be rewritten by the same commit it is meant to be judging, which
+     * would leave nothing independent to judge with.
+     */
+    public static function countFlatEntries( array $registry ): int
+    {
+        $entries = 0;
+
+        foreach ( $registry as $entry ) {
+
+            $entries += self::isEntityKeyed( $entry ) ? count( $entry ) : 1;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * True when an entry is a map of entity name => registration rather than a
+     * registration itself.
+     *
+     * A registration always carries a 'name'; a map of them never does.
+     */
+    public static function isEntityKeyed( $entry ): bool
+    {
+        return is_array( $entry ) && ! array_key_exists( 'name', $entry );
+    }
+
+    /** @return array<string,mixed> */
+    private static function normaliseFlatDimensions( array $registry ): array
+    {
+        $out = array();
+
+        foreach ( $registry as $name => $entry ) {
+
+            $out[ $name ] = self::isEntityKeyed( $entry )
+                ? self::normaliseNestedEntry( (array) $entry )
+                : self::pick( (array) $entry, self::DIMENSION_KEYS );
+        }
+
+        ksort( $out );
+
+        return $out;
+    }
+
+    /** @return array<string,mixed> */
+    private static function normaliseNestedDimensions( array $registry ): array
+    {
+        $out = array();
+
+        foreach ( $registry as $name => $byEntity ) {
+
+            $out[ $name ] = self::normaliseNestedEntry( (array) $byEntity );
+        }
+
+        ksort( $out );
+
+        return $out;
+    }
+
+    /** @return array<string,mixed> */
+    private static function normaliseNestedEntry( array $byEntity ): array
+    {
+        $entities = array();
+
+        foreach ( $byEntity as $entity => $entry ) {
+
+            $entities[ $entity ] = self::pick( (array) $entry, self::DIMENSION_KEYS );
+        }
+
+        ksort( $entities );
+
+        return $entities;
+    }
+
+    /** @return array<string,array<int,array>> */
+    private static function normaliseMetrics( array $metrics ): array
+    {
+        $out = array();
+
+        foreach ( $metrics as $name => $implementations ) {
+
+            $rows = array();
+
+            foreach ( (array) $implementations as $implementation ) {
+
+                $row = self::pick( (array) $implementation, self::METRIC_KEYS );
+
+                /*
+                 * params carries the entity and column for a configured metric,
+                 * and the formula and children for a calculated one. It is the
+                 * part that says WHERE a number comes from, so it is the part
+                 * this change is most likely to disturb.
+                 */
+                $row['params'] = self::normaliseParams(
+                    (array) ( $implementation['params'] ?? array() ) );
+
+                $rows[] = $row;
+            }
+
+            /* Registration order is not part of the contract; content is. */
+            usort( $rows, static function ( array $a, array $b ): int {
+
+                return strcmp( json_encode( $a ), json_encode( $b ) );
+            } );
+
+            $out[ $name ] = $rows;
+        }
+
+        ksort( $out );
+
+        return $out;
+    }
+
+    /** @return array<string,mixed> */
+    private static function normaliseParams( array $params ): array
+    {
+        ksort( $params );
+
+        foreach ( $params as $key => $value ) {
+
+            if ( is_array( $value ) ) {
+
+                sort( $value );
+
+                $params[ $key ] = $value;
+            }
+        }
+
+        return $params;
+    }
+
+    /** @return array<string,mixed> */
+    private static function pick( array $entry, array $keys ): array
+    {
+        $out = array();
+
+        foreach ( $keys as $key ) {
+
+            if ( array_key_exists( $key, $entry ) ) {
+
+                $out[ $key ] = $entry[ $key ];
+            }
+        }
+
+        return $out;
+    }
+
+    /** Read a public-but-undeclared registry off the service. */
+    private static function readProperty( object $service, string $name ): array
+    {
+        $reflection = new \ReflectionObject( $service );
+
+        if ( ! $reflection->hasProperty( $name ) ) {
+
+            return array();
+        }
+
+        $property = $reflection->getProperty( $name );
+
+        $property->setAccessible( true );
+
+        return (array) $property->getValue( $service );
+    }
+
+    /** Absolute path to the recorded catalog. */
+    public static function fixturePath(): string
+    {
+        return __DIR__ . '/fixtures/catalog.json';
+    }
+}

--- a/tests/CatalogCharacterizationHarness.php
+++ b/tests/CatalogCharacterizationHarness.php
@@ -66,6 +66,7 @@ final class CatalogCharacterizationHarness
             'dimensionsDenormalized'  => self::normaliseNestedDimensions( $denormalized ),
             'accessorGetAllDimensions'=> self::normaliseFlatDimensions(
                                             (array) \OWA\Core\CoreAPI::getAllDimensions() ),
+            'relatedDimensions'       => self::relatedDimensions(),
         );
     }
 
@@ -281,6 +282,61 @@ final class CatalogCharacterizationHarness
         $property->setAccessible( true );
 
         return (array) $property->getValue( $service );
+    }
+
+    /** Entities a report is commonly built on. */
+    public const RELATED_ENTITIES = array(
+        'base.session', 'base.request', 'base.action_fact', 'base.click', 'base.domstream',
+    );
+
+    /**
+     * Which dimensions each entity can actually reach.
+     *
+     * Recorded because ResultSetManager::getAllRelatedDimensions() reads the
+     * dimension registry as a PUBLIC PROPERTY rather than through an accessor,
+     * so changing the registry's shape changes what it sees without any
+     * accessor being involved. Nothing covered it, and a shape change silently
+     * halved its answer -- 305 dimensions to 153 -- while every unit test and
+     * both accessors stayed byte-identical. The reports that broke did so by
+     * dropping constraints, which is the failure this codebase already knows
+     * to be silent.
+     *
+     * @return array<string,array<string,array<int,string>>>
+     */
+    public static function relatedDimensions(): array
+    {
+        $manager = \OWA\Core\CoreAPI::supportClassFactory( 'base', 'resultSetManager' );
+
+        $out = array();
+
+        foreach ( self::RELATED_ENTITIES as $entityName ) {
+
+            $entity = \OWA\Core\CoreAPI::entityFactory( $entityName );
+
+            $families = (array) $manager->getAllRelatedDimensions( $entity );
+
+            $normalised = array();
+
+            foreach ( $families as $family => $dimensions ) {
+
+                $names = array();
+
+                foreach ( (array) $dimensions as $dimension ) {
+
+                    $names[] = (string) ( $dimension['name'] ?? '' );
+                }
+
+                sort( $names );
+
+                $normalised[ $family ] = $names;
+            }
+
+            ksort( $normalised );
+
+            $out[ $entityName ] = $normalised;
+        }
+
+        return $out;
     }
 
     /** Absolute path to the recorded catalog. */

--- a/tests/CatalogCharacterizationTest.php
+++ b/tests/CatalogCharacterizationTest.php
@@ -235,6 +235,56 @@ final class CatalogCharacterizationTest extends TestCase
             'Asking without an entity must still answer, as the flat registry did.' );
     }
 
+    public function testEveryEntityStillReachesTheDimensionsItDid(): void
+    {
+        /*
+         * The regression this file failed to catch the first time.
+         *
+         * getAllRelatedDimensions() reads $service->dimensions as a PUBLIC
+         * PROPERTY, so re-keying the registry changed what it saw without any
+         * accessor being involved -- and both accessors were verified
+         * byte-identical against master, which is exactly why the change looked
+         * safe. Its answer silently halved, 305 dimensions to 153, and the
+         * reports that broke did so by dropping constraints and returning MORE
+         * rows than asked for.
+         *
+         * Counted per entity rather than in total so a compensating pair of
+         * changes cannot cancel out.
+         */
+        $recorded = $this->recorded()['relatedDimensions'];
+        $actual   = Harness::relatedDimensions();
+
+        $this->assertSame( array_keys( $recorded ), array_keys( $actual ) );
+
+        foreach ( $recorded as $entity => $families ) {
+
+            $this->assertSame(
+                $families, $actual[ $entity ],
+                "The dimensions reachable from $entity changed. A report can only constrain by "
+                . 'a dimension it can reach, and an unreachable constraint is dropped silently.' );
+        }
+    }
+
+    public function testTheRelatedRecordingIsSubstantial(): void
+    {
+        /*
+         * Guards the guard. If getAllRelatedDimensions() ever returns nothing --
+         * a construction failure, say -- every per-entity comparison above would
+         * still pass against an equally empty recording.
+         */
+        $total = 0;
+
+        foreach ( Harness::relatedDimensions() as $families ) {
+
+            foreach ( $families as $names ) {
+
+                $total += count( $names );
+            }
+        }
+
+        $this->assertGreaterThan( 250, $total );
+    }
+
     public function testTheRecordingIsNotEmpty(): void
     {
         /*

--- a/tests/CatalogCharacterizationTest.php
+++ b/tests/CatalogCharacterizationTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+require_once __DIR__ . '/CatalogCharacterizationHarness.php';
+
+use OWA\Tests\CatalogCharacterizationHarness as Harness;
+
+/**
+ * Pins the metric and dimension catalog before it is changed to hold two schema
+ * generations under one name.
+ *
+ * The recording includes two known defects rather than correcting them, so that
+ * fixing them produces a visible, intentional diff. Each has a test below that
+ * names it, and those tests are EXPECTED TO CHANGE -- they mark where the
+ * behaviour moved, and are not a claim that today's behaviour is right.
+ */
+final class CatalogCharacterizationTest extends TestCase
+{
+    /** @return array<string,mixed> */
+    private function recorded(): array
+    {
+        $this->assertFileExists(
+            Harness::fixturePath(),
+            'The catalog recording is missing. Regenerate it deliberately, never as a side effect.' );
+
+        return (array) json_decode(
+            (string) file_get_contents( Harness::fixturePath() ), true );
+    }
+
+    public function testTheCatalogMatchesItsRecording(): void
+    {
+        $this->assertSame(
+            $this->recorded(),
+            Harness::snapshot(),
+            'The catalog changed. If that was intended, regenerate the fixture and let the diff '
+            . 'be the evidence; if not, something registered or stopped registering.' );
+    }
+
+    /*
+     * ---- the recording must be able to fail --------------------------------
+     *
+     * A characterization suite is only worth the confidence placed in it if it
+     * can be shown to notice. These feed doctored input to the harness rather
+     * than mutating the live registry, so sensitivity is proved without leaving
+     * global state behind for the next test.
+     */
+
+    public function testTheRecordingWouldNoticeADimensionChangingItsEntity(): void
+    {
+        $before = Harness::snapshot();
+
+        $name = array_key_first( $before['dimensionsNormalized'] );
+
+        $after = $before;
+        $after['dimensionsNormalized'][ $name ]['entity'] = 'base.somethingElse';
+
+        $this->assertNotSame(
+            $before, $after,
+            'A dimension pointing at a different entity must show in the recording.' );
+    }
+
+    public function testTheRecordingWouldNoticeAMetricLosingAnImplementation(): void
+    {
+        $snapshot = Harness::snapshot();
+
+        $multi = null;
+
+        foreach ( $snapshot['metrics'] as $name => $implementations ) {
+
+            if ( count( $implementations ) > 1 ) {
+
+                $multi = $name;
+
+                break;
+            }
+        }
+
+        $this->assertNotNull(
+            $multi,
+            'No metric has more than one implementation, so this test proves nothing. One name '
+            . 'resolving to several entities is the mechanism the coming change relies on.' );
+
+        $reduced = $snapshot;
+        array_pop( $reduced['metrics'][ $multi ] );
+
+        $this->assertNotSame( $snapshot, $reduced );
+        $this->assertCount(
+            count( $snapshot['metrics'][ $multi ] ) - 1,
+            $reduced['metrics'][ $multi ] );
+    }
+
+    public function testTheEntryCounterHandlesBothTheCurrentAndTheComingShape(): void
+    {
+        /*
+         * The harness has to survive the commit it is judging. If counting only
+         * understood today's flat shape it would have to be edited by the very
+         * change it measures, leaving nothing independent.
+         */
+        $flat = array(
+            'pageTitle' => array( 'name' => 'pageTitle', 'entity' => 'base.document' ),
+        );
+
+        $entityKeyed = array(
+            'pageTitle' => array(
+                'base.document' => array( 'name' => 'pageTitle', 'entity' => 'base.document' ),
+                'base.event'    => array( 'name' => 'pageTitle', 'entity' => 'base.event' ),
+            ),
+        );
+
+        $this->assertSame( 1, Harness::countFlatEntries( $flat ) );
+        $this->assertSame( 2, Harness::countFlatEntries( $entityKeyed ) );
+
+        $this->assertFalse( Harness::isEntityKeyed( $flat['pageTitle'] ) );
+        $this->assertTrue( Harness::isEntityKeyed( $entityKeyed['pageTitle'] ) );
+    }
+
+    /*
+     * ---- the two defects, recorded on purpose ------------------------------
+     */
+
+    public function testNormalizedDimensionsCurrentlyHoldExactlyOneEntityEach(): void
+    {
+        $counts = Harness::snapshot()['counts'];
+
+        /*
+         * DEFECT 1, registration-time. registerDimension() loops $entity_names
+         * but the normalized branch overwrites $this->dimensions[$dim_name] on
+         * each turn, so a name registered against seven entities keeps one.
+         * The equality IS the defect: when the registry becomes entity-keyed
+         * the entry count rises above the name count and this test changes.
+         */
+        $this->assertSame(
+            $counts['dimensionNamesNormalized'],
+            $counts['dimensionEntriesNormalized'],
+            'Normalized dimensions now hold more than one entity each -- which is the intended '
+            . 'fix. Update this test and the fixture together.' );
+    }
+
+    public function testDenormalizedDimensionsAlreadyHoldManyEntitiesEach(): void
+    {
+        $counts = Harness::snapshot()['counts'];
+
+        /*
+         * The contrast that shows defect 1 is a defect and not a design: the
+         * denormalized branch of the very same loop is entity-keyed, and carries
+         * several times as many entries as names.
+         */
+        $this->assertGreaterThan(
+            $counts['dimensionNamesDenormalized'],
+            $counts['dimensionEntriesDenormalized'],
+            'Denormalized dimensions are entity-keyed and must hold more entries than names.' );
+    }
+
+    public function testTheReadAccessorFlattensDenormalizedDimensions(): void
+    {
+        $counts = Harness::snapshot()['counts'];
+
+        /*
+         * DEFECT 2, read-time. CoreAPI::getAllDimensions() collapses the
+         * entity-keyed registry with $dims[$k] = $dedim, keeping the last
+         * entity. So the accessor the picker UI reads cannot express two
+         * generations however well the registry stores them.
+         */
+        $this->assertLessThan(
+            $counts['dimensionEntriesDenormalized'],
+            $counts['accessorDimensionNames'],
+            'getAllDimensions() no longer flattens -- which is the intended fix.' );
+
+        $this->assertSame(
+            $counts['dimensionNamesNormalized'] + $counts['dimensionNamesDenormalized'],
+            $counts['accessorDimensionNames'],
+            'The accessor should return exactly one entry per registered name today.' );
+    }
+
+    public function testTheRecordingIsNotEmpty(): void
+    {
+        /*
+         * Cheap, and it catches the failure mode where a boot problem yields an
+         * empty catalog that then matches an equally empty regenerated fixture.
+         */
+        $counts = Harness::snapshot()['counts'];
+
+        $this->assertGreaterThan( 50, $counts['metricNames'] );
+        $this->assertGreaterThan( 50, $counts['accessorDimensionNames'] );
+        $this->assertGreaterThan(
+            $counts['metricNames'],
+            $counts['metricImplementations'],
+            'Some metric must resolve to more than one entity, or the entity-keyed mechanism the '
+            . 'coming change depends on is not actually in use.' );
+    }
+}

--- a/tests/CatalogCharacterizationTest.php
+++ b/tests/CatalogCharacterizationTest.php
@@ -120,22 +120,35 @@ final class CatalogCharacterizationTest extends TestCase
      * ---- the two defects, recorded on purpose ------------------------------
      */
 
-    public function testNormalizedDimensionsCurrentlyHoldExactlyOneEntityEach(): void
+    public function testNormalizedDimensionsKeepEveryEntityTheyAreRegisteredAgainst(): void
     {
         $counts = Harness::snapshot()['counts'];
 
         /*
-         * DEFECT 1, registration-time. registerDimension() loops $entity_names
-         * but the normalized branch overwrites $this->dimensions[$dim_name] on
-         * each turn, so a name registered against seven entities keeps one.
-         * The equality IS the defect: when the registry becomes entity-keyed
-         * the entry count rises above the name count and this test changes.
+         * DEFECT 1, fixed. registerDimension() loops $entity_names, and the
+         * normalized branch used to overwrite $this->dimensions[$dim_name] on
+         * each turn, keeping only the last entity. Entries now exceed names,
+         * which is what makes registering a second schema generation under an
+         * existing name possible: it sits beside the first instead of replacing
+         * it.
          */
-        $this->assertSame(
+        $this->assertGreaterThan(
             $counts['dimensionNamesNormalized'],
             $counts['dimensionEntriesNormalized'],
-            'Normalized dimensions now hold more than one entity each -- which is the intended '
-            . 'fix. Update this test and the fixture together.' );
+            'Normalized dimensions are entity-keyed and must hold more entries than names.' );
+    }
+
+    public function testTheDimensionThatWasLosingEntitiesKeepsThemAll(): void
+    {
+        /*
+         * Named rather than counted, because a total can be moved by anything.
+         * userName is registered against all seven fact entities and was the
+         * only dimension actually losing any -- six of them.
+         */
+        $entities = \OWA\Core\CoreAPI::serviceSingleton()->getDimensionEntities( 'userName' );
+
+        $this->assertCount( 7, $entities );
+        $this->assertContains( 'base.session', $entities );
     }
 
     public function testDenormalizedDimensionsAlreadyHoldManyEntitiesEach(): void
@@ -153,25 +166,73 @@ final class CatalogCharacterizationTest extends TestCase
             'Denormalized dimensions are entity-keyed and must hold more entries than names.' );
     }
 
-    public function testTheReadAccessorFlattensDenormalizedDimensions(): void
+    public function testAnUnscopedAnswerStillReturnsOneEntryPerName(): void
     {
         $counts = Harness::snapshot()['counts'];
 
         /*
-         * DEFECT 2, read-time. CoreAPI::getAllDimensions() collapses the
-         * entity-keyed registry with $dims[$k] = $dedim, keeping the last
-         * entity. So the accessor the picker UI reads cannot express two
-         * generations however well the registry stores them.
+         * getAllDimensions() flattens by letting the last entity win. That was
+         * DEFECT 2 while it was the only thing on offer; it is now the
+         * deliberate unscoped behaviour, kept because the picker and its
+         * validation are written against one entry per name. The scoped call
+         * below is what a second generation will use.
          */
-        $this->assertLessThan(
-            $counts['dimensionEntriesDenormalized'],
-            $counts['accessorDimensionNames'],
-            'getAllDimensions() no longer flattens -- which is the intended fix.' );
-
         $this->assertSame(
             $counts['dimensionNamesNormalized'] + $counts['dimensionNamesDenormalized'],
-            $counts['accessorDimensionNames'],
-            'The accessor should return exactly one entry per registered name today.' );
+            $counts['accessorDimensionNames'] );
+
+        $entry = \OWA\Core\CoreAPI::getAllDimensions()['userName'];
+
+        $this->assertArrayHasKey(
+            'column', $entry,
+            'An unscoped entry must still be a registration, not a map of them -- ten callers '
+            . 'read it directly.' );
+    }
+
+    public function testScopingAnswersOnlyDimensionsDefinedOnThoseEntities(): void
+    {
+        $scoped = \OWA\Core\CoreAPI::getAllDimensions( array( 'base.session' ) );
+        $all    = \OWA\Core\CoreAPI::getAllDimensions();
+
+        $this->assertLessThan(
+            count( $all ), count( $scoped ),
+            'Scoping to one entity must narrow the catalog.' );
+
+        $this->assertArrayHasKey( 'userName', $scoped );
+
+        $this->assertSame(
+            'base.session', $scoped['userName']['entity'],
+            'A scoped answer must give the definition for the entity asked for, not whichever '
+            . 'was registered last.' );
+    }
+
+    public function testANameDefinedOnNoScopedEntityIsAbsentEntirely(): void
+    {
+        /*
+         * Absent rather than present-and-wrong. This is the property that makes
+         * scoping structural: a caller cannot accidentally use a dimension from
+         * the other generation, because it is not in the answer to filter out.
+         */
+        $scoped = \OWA\Core\CoreAPI::getAllDimensions( array( 'base.nonexistentEntity' ) );
+
+        $this->assertSame( array(), $scoped );
+    }
+
+    public function testGetDimensionAnswersByEntityWhenAsked(): void
+    {
+        $service = \OWA\Core\CoreAPI::serviceSingleton();
+
+        $this->assertSame(
+            'base.session',
+            $service->getDimension( 'userName', 'base.session' )['entity'] );
+
+        $this->assertNull(
+            $service->getDimension( 'userName', 'base.nonexistentEntity' ),
+            'An entity a dimension is not defined on must answer nothing, not a fallback.' );
+
+        $this->assertNotNull(
+            $service->getDimension( 'userName' ),
+            'Asking without an entity must still answer, as the flat registry did.' );
     }
 
     public function testTheRecordingIsNotEmpty(): void

--- a/tests/fixtures/catalog.json
+++ b/tests/fixtures/catalog.json
@@ -3,7 +3,7 @@
         "metricNames": 78,
         "metricImplementations": 99,
         "dimensionNamesNormalized": 42,
-        "dimensionEntriesNormalized": 42,
+        "dimensionEntriesNormalized": 48,
         "dimensionNamesDenormalized": 59,
         "dimensionEntriesDenormalized": 223,
         "accessorDimensionNames": 101
@@ -1221,466 +1221,616 @@
     },
     "dimensionsNormalized": {
         "ad": {
-            "name": "ad",
-            "entity": "base.ad_dim",
-            "column": "name",
-            "family": "campaign",
-            "label": "Ad",
-            "description": "The name of the ad that originated the visit.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.ad_dim": {
+                "name": "ad",
+                "entity": "base.ad_dim",
+                "column": "name",
+                "family": "campaign",
+                "label": "Ad",
+                "description": "The name of the ad that originated the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "adType": {
-            "name": "adType",
-            "entity": "base.ad_dim",
-            "column": "type",
-            "family": "campaign",
-            "label": "Ad Type",
-            "description": "The type of ad that originated the visit.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.ad_dim": {
+                "name": "adType",
+                "entity": "base.ad_dim",
+                "column": "type",
+                "family": "campaign",
+                "label": "Ad Type",
+                "description": "The type of ad that originated the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "browserType": {
-            "name": "browserType",
-            "entity": "base.ua",
-            "column": "browser_type",
-            "family": "system",
-            "label": "Browser Type",
-            "description": "The browser type of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.ua": {
+                "name": "browserType",
+                "entity": "base.ua",
+                "column": "browser_type",
+                "family": "system",
+                "label": "Browser Type",
+                "description": "The browser type of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "browserVersion": {
-            "name": "browserVersion",
-            "entity": "base.ua",
-            "column": "browser",
-            "family": "system",
-            "label": "Browser Version",
-            "description": "The browser version of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.ua": {
+                "name": "browserVersion",
+                "entity": "base.ua",
+                "column": "browser",
+                "family": "system",
+                "label": "Browser Version",
+                "description": "The browser version of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "campaign": {
-            "name": "campaign",
-            "entity": "base.campaign_dim",
-            "column": "name",
-            "family": "campaign",
-            "label": "Campaign",
-            "description": "The campaign that originated the visit.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.campaign_dim": {
+                "name": "campaign",
+                "entity": "base.campaign_dim",
+                "column": "name",
+                "family": "campaign",
+                "label": "Campaign",
+                "description": "The campaign that originated the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "city": {
-            "name": "city",
-            "entity": "base.location_dim",
-            "column": "city",
-            "family": "geo",
-            "label": "City",
-            "description": "The city of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.location_dim": {
+                "name": "city",
+                "entity": "base.location_dim",
+                "column": "city",
+                "family": "geo",
+                "label": "City",
+                "description": "The city of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "country": {
-            "name": "country",
-            "entity": "base.location_dim",
-            "column": "country",
-            "family": "geo",
-            "label": "Country",
-            "description": "The country of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.location_dim": {
+                "name": "country",
+                "entity": "base.location_dim",
+                "column": "country",
+                "family": "geo",
+                "label": "Country",
+                "description": "The country of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "countryCode": {
-            "name": "countryCode",
-            "entity": "base.location_dim",
-            "column": "country_code",
-            "family": "geo",
-            "label": "Country Code",
-            "description": "The ISO country code of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.location_dim": {
+                "name": "countryCode",
+                "entity": "base.location_dim",
+                "column": "country_code",
+                "family": "geo",
+                "label": "Country Code",
+                "description": "The ISO country code of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "entryPagePath": {
-            "name": "entryPagePath",
-            "entity": "base.document",
-            "column": "uri",
-            "family": "visit",
-            "label": "Entry Page Path",
-            "description": "The URI of the entry page.",
-            "foreign_key_name": "first_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "entryPagePath",
+                "entity": "base.document",
+                "column": "uri",
+                "family": "visit",
+                "label": "Entry Page Path",
+                "description": "The URI of the entry page.",
+                "foreign_key_name": "first_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "entryPageTitle": {
-            "name": "entryPageTitle",
-            "entity": "base.document",
-            "column": "page_title",
-            "family": "visit",
-            "label": "Entry Page Title",
-            "description": "The title of the entry page.",
-            "foreign_key_name": "first_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "entryPageTitle",
+                "entity": "base.document",
+                "column": "page_title",
+                "family": "visit",
+                "label": "Entry Page Title",
+                "description": "The title of the entry page.",
+                "foreign_key_name": "first_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "entryPageType": {
-            "name": "entryPageType",
-            "entity": "base.document",
-            "column": "page_type",
-            "family": "visit",
-            "label": "Entry Page Type",
-            "description": "The page type of the entry page.",
-            "foreign_key_name": "first_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "entryPageType",
+                "entity": "base.document",
+                "column": "page_type",
+                "family": "visit",
+                "label": "Entry Page Type",
+                "description": "The page type of the entry page.",
+                "foreign_key_name": "first_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "entryPageUrl": {
-            "name": "entryPageUrl",
-            "entity": "base.document",
-            "column": "url",
-            "family": "visit",
-            "label": "Entry Page URL",
-            "description": "The URL of the entry page.",
-            "foreign_key_name": "first_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "entryPageUrl",
+                "entity": "base.document",
+                "column": "url",
+                "family": "visit",
+                "label": "Entry Page URL",
+                "description": "The URL of the entry page.",
+                "foreign_key_name": "first_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "exitPagePath": {
-            "name": "exitPagePath",
-            "entity": "base.document",
-            "column": "uri",
-            "family": "visit",
-            "label": "Exit Page Path",
-            "description": "The URI of the exit page.",
-            "foreign_key_name": "last_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "exitPagePath",
+                "entity": "base.document",
+                "column": "uri",
+                "family": "visit",
+                "label": "Exit Page Path",
+                "description": "The URI of the exit page.",
+                "foreign_key_name": "last_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "exitPageTitle": {
-            "name": "exitPageTitle",
-            "entity": "base.document",
-            "column": "page_title",
-            "family": "visit",
-            "label": "Exit Page Title",
-            "description": "The title of the exit page.",
-            "foreign_key_name": "last_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "exitPageTitle",
+                "entity": "base.document",
+                "column": "page_title",
+                "family": "visit",
+                "label": "Exit Page Title",
+                "description": "The title of the exit page.",
+                "foreign_key_name": "last_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "exitPageType": {
-            "name": "exitPageType",
-            "entity": "base.document",
-            "column": "page_type",
-            "family": "visit",
-            "label": "Exit Page Type",
-            "description": "The page type of the exit page.",
-            "foreign_key_name": "last_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "exitPageType",
+                "entity": "base.document",
+                "column": "page_type",
+                "family": "visit",
+                "label": "Exit Page Type",
+                "description": "The page type of the exit page.",
+                "foreign_key_name": "last_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "exitPageUrl": {
-            "name": "exitPageUrl",
-            "entity": "base.document",
-            "column": "url",
-            "family": "visit",
-            "label": "Exit Page URL",
-            "description": "The URL of the exit page.",
-            "foreign_key_name": "last_page_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "exitPageUrl",
+                "entity": "base.document",
+                "column": "url",
+                "family": "visit",
+                "label": "Exit Page URL",
+                "description": "The URL of the exit page.",
+                "foreign_key_name": "last_page_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "hostName": {
-            "name": "hostName",
-            "entity": "base.host",
-            "column": "host",
-            "family": "network",
-            "label": "Host Name",
-            "description": "The host name of the network used by the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.host": {
+                "name": "hostName",
+                "entity": "base.host",
+                "column": "host",
+                "family": "network",
+                "label": "Host Name",
+                "description": "The host name of the network used by the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "isSearchEngine": {
-            "name": "isSearchEngine",
-            "entity": "base.referer",
-            "column": "is_searchengine",
-            "family": "campaign",
-            "label": "Search Engine",
-            "description": "Is traffic source a search engine.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.referer": {
+                "name": "isSearchEngine",
+                "entity": "base.referer",
+                "column": "is_searchengine",
+                "family": "campaign",
+                "label": "Search Engine",
+                "description": "Is traffic source a search engine.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "latitude": {
-            "name": "latitude",
-            "entity": "base.location_dim",
-            "column": "latitude",
-            "family": "geo",
-            "label": "Latitude",
-            "description": "The latitude of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.location_dim": {
+                "name": "latitude",
+                "entity": "base.location_dim",
+                "column": "latitude",
+                "family": "geo",
+                "label": "Latitude",
+                "description": "The latitude of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "longitude": {
-            "name": "longitude",
-            "entity": "base.location_dim",
-            "column": "longitude",
-            "family": "geo",
-            "label": "Longitude",
-            "description": "The longitude of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.location_dim": {
+                "name": "longitude",
+                "entity": "base.location_dim",
+                "column": "longitude",
+                "family": "geo",
+                "label": "Longitude",
+                "description": "The longitude of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "osType": {
-            "name": "osType",
-            "entity": "base.os",
-            "column": "name",
-            "family": "system",
-            "label": "Operating System",
-            "description": "The operating System of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.os": {
+                "name": "osType",
+                "entity": "base.os",
+                "column": "name",
+                "family": "system",
+                "label": "Operating System",
+                "description": "The operating System of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "pagePath": {
-            "name": "pagePath",
-            "entity": "base.document",
-            "column": "uri",
-            "family": "content",
-            "label": "Page Path",
-            "description": "The path of the web page.",
-            "foreign_key_name": "document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "pagePath",
+                "entity": "base.document",
+                "column": "uri",
+                "family": "content",
+                "label": "Page Path",
+                "description": "The path of the web page.",
+                "foreign_key_name": "document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "pageTitle": {
-            "name": "pageTitle",
-            "entity": "base.document",
-            "column": "page_title",
-            "family": "content",
-            "label": "Page Title",
-            "description": "The title of the web page.",
-            "foreign_key_name": "document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "pageTitle",
+                "entity": "base.document",
+                "column": "page_title",
+                "family": "content",
+                "label": "Page Title",
+                "description": "The title of the web page.",
+                "foreign_key_name": "document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "pageType": {
-            "name": "pageType",
-            "entity": "base.document",
-            "column": "page_type",
-            "family": "content",
-            "label": "Page Type",
-            "description": "The page type of the web page.",
-            "foreign_key_name": "document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "pageType",
+                "entity": "base.document",
+                "column": "page_type",
+                "family": "content",
+                "label": "Page Type",
+                "description": "The page type of the web page.",
+                "foreign_key_name": "document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "pageUrl": {
-            "name": "pageUrl",
-            "entity": "base.document",
-            "column": "url",
-            "family": "content",
-            "label": "Page URL",
-            "description": "The URL of the web page.",
-            "foreign_key_name": "document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "pageUrl",
+                "entity": "base.document",
+                "column": "url",
+                "family": "content",
+                "label": "Page URL",
+                "description": "The URL of the web page.",
+                "foreign_key_name": "document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "priorPagePath": {
-            "name": "priorPagePath",
-            "entity": "base.document",
-            "column": "uri",
-            "family": "content",
-            "label": "Prior Page Path",
-            "description": "The URI of the prior page.",
-            "foreign_key_name": "prior_document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "priorPagePath",
+                "entity": "base.document",
+                "column": "uri",
+                "family": "content",
+                "label": "Prior Page Path",
+                "description": "The URI of the prior page.",
+                "foreign_key_name": "prior_document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "priorPageTitle": {
-            "name": "priorPageTitle",
-            "entity": "base.document",
-            "column": "page_title",
-            "family": "content",
-            "label": "Prior Page Title",
-            "description": "The title of the prior page.",
-            "foreign_key_name": "prior_document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "priorPageTitle",
+                "entity": "base.document",
+                "column": "page_title",
+                "family": "content",
+                "label": "Prior Page Title",
+                "description": "The title of the prior page.",
+                "foreign_key_name": "prior_document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "priorPageType": {
-            "name": "priorPageType",
-            "entity": "base.document",
-            "column": "page_type",
-            "family": "content",
-            "label": "Prior Page Type",
-            "description": "The page type of the prior page.",
-            "foreign_key_name": "prior_document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "priorPageType",
+                "entity": "base.document",
+                "column": "page_type",
+                "family": "content",
+                "label": "Prior Page Type",
+                "description": "The page type of the prior page.",
+                "foreign_key_name": "prior_document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "priorPageUrl": {
-            "name": "priorPageUrl",
-            "entity": "base.document",
-            "column": "url",
-            "family": "content",
-            "label": "Prior Page URL",
-            "description": "The URL of the prior page.",
-            "foreign_key_name": "prior_document_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.document": {
+                "name": "priorPageUrl",
+                "entity": "base.document",
+                "column": "url",
+                "family": "content",
+                "label": "Prior Page URL",
+                "description": "The URL of the prior page.",
+                "foreign_key_name": "prior_document_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "referralLinkText": {
-            "name": "referralLinkText",
-            "entity": "base.referer",
-            "column": "refering_anchortext",
-            "family": "campaign",
-            "label": "Referral Link Text",
-            "description": "The text of the referring link.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.referer": {
+                "name": "referralLinkText",
+                "entity": "base.referer",
+                "column": "refering_anchortext",
+                "family": "campaign",
+                "label": "Referral Link Text",
+                "description": "The text of the referring link.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "referralPageTitle": {
-            "name": "referralPageTitle",
-            "entity": "base.referer",
-            "column": "page_title",
-            "family": "campaign",
-            "label": "Referral Page Title",
-            "description": "The title of the referring web page.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.referer": {
+                "name": "referralPageTitle",
+                "entity": "base.referer",
+                "column": "page_title",
+                "family": "campaign",
+                "label": "Referral Page Title",
+                "description": "The title of the referring web page.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "referralPageUrl": {
-            "name": "referralPageUrl",
-            "entity": "base.referer",
-            "column": "url",
-            "family": "campaign",
-            "label": "Referral Page URL",
-            "description": "The url of the referring web page.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.referer": {
+                "name": "referralPageUrl",
+                "entity": "base.referer",
+                "column": "url",
+                "family": "campaign",
+                "label": "Referral Page URL",
+                "description": "The url of the referring web page.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "referralSearchTerms": {
-            "name": "referralSearchTerms",
-            "entity": "base.search_term_dim",
-            "column": "terms",
-            "family": "campaign",
-            "label": "Search Terms",
-            "description": "The referring search terms.",
-            "foreign_key_name": "referring_search_term_id",
-            "data_type": "string",
-            "denormalized": false
+            "base.search_term_dim": {
+                "name": "referralSearchTerms",
+                "entity": "base.search_term_dim",
+                "column": "terms",
+                "family": "campaign",
+                "label": "Search Terms",
+                "description": "The referring search terms.",
+                "foreign_key_name": "referring_search_term_id",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "referralWebSite": {
-            "name": "referralWebSite",
-            "entity": "base.referer",
-            "column": "site",
-            "family": "campaign",
-            "label": "Referral Web Site",
-            "description": "The full domain of the referring web site.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.referer": {
+                "name": "referralWebSite",
+                "entity": "base.referer",
+                "column": "site",
+                "family": "campaign",
+                "label": "Referral Web Site",
+                "description": "The full domain of the referring web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "sessionId": {
-            "name": "sessionId",
-            "entity": "base.session",
-            "column": "id",
-            "family": "visit-special",
-            "label": "Session ID",
-            "description": "The ID of the session/visit.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.session": {
+                "name": "sessionId",
+                "entity": "base.session",
+                "column": "id",
+                "family": "visit-special",
+                "label": "Session ID",
+                "description": "The ID of the session/visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "siteDomain": {
-            "name": "siteDomain",
-            "entity": "base.site",
-            "column": "domain",
-            "family": "site",
-            "label": "Site Domain",
-            "description": "The domain of the web site.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.site": {
+                "name": "siteDomain",
+                "entity": "base.site",
+                "column": "domain",
+                "family": "site",
+                "label": "Site Domain",
+                "description": "The domain of the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "siteName": {
-            "name": "siteName",
-            "entity": "base.site",
-            "column": "name",
-            "family": "site",
-            "label": "Site Name",
-            "description": "The name of the site.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.site": {
+                "name": "siteName",
+                "entity": "base.site",
+                "column": "name",
+                "family": "site",
+                "label": "Site Name",
+                "description": "The name of the site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "source": {
-            "name": "source",
-            "entity": "base.source_dim",
-            "column": "source_domain",
-            "family": "campaign",
-            "label": "Source",
-            "description": "The traffic source of the visit.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.source_dim": {
+                "name": "source",
+                "entity": "base.source_dim",
+                "column": "source_domain",
+                "family": "campaign",
+                "label": "Source",
+                "description": "The traffic source of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "stateRegion": {
-            "name": "stateRegion",
-            "entity": "base.location_dim",
-            "column": "state",
-            "family": "geo",
-            "label": "State/Region",
-            "description": "The state or region of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.location_dim": {
+                "name": "stateRegion",
+                "entity": "base.location_dim",
+                "column": "state",
+                "family": "geo",
+                "label": "State/Region",
+                "description": "The state or region of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "userEmail": {
-            "name": "userEmail",
-            "entity": "base.visitor",
-            "column": "user_email",
-            "family": "visitor",
-            "label": "Email Address",
-            "description": "The email address of the user.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.visitor": {
+                "name": "userEmail",
+                "entity": "base.visitor",
+                "column": "user_email",
+                "family": "visitor",
+                "label": "Email Address",
+                "description": "The email address of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "userName": {
-            "name": "userName",
-            "entity": "base.commerce_line_item_fact",
-            "column": "user_name",
-            "family": "visitor",
-            "label": "User Name",
-            "description": "The name or ID of the user.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.action_fact": {
+                "name": "userName",
+                "entity": "base.action_fact",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            },
+            "base.click": {
+                "name": "userName",
+                "entity": "base.click",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            },
+            "base.commerce_line_item_fact": {
+                "name": "userName",
+                "entity": "base.commerce_line_item_fact",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            },
+            "base.commerce_transaction_fact": {
+                "name": "userName",
+                "entity": "base.commerce_transaction_fact",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            },
+            "base.domstream": {
+                "name": "userName",
+                "entity": "base.domstream",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            },
+            "base.request": {
+                "name": "userName",
+                "entity": "base.request",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            },
+            "base.session": {
+                "name": "userName",
+                "entity": "base.session",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         },
         "visitorId": {
-            "name": "visitorId",
-            "entity": "base.visitor",
-            "column": "id",
-            "family": "visitor",
-            "label": "Visitor ID",
-            "description": "The ID of the visitor.",
-            "foreign_key_name": "",
-            "data_type": "string",
-            "denormalized": false
+            "base.visitor": {
+                "name": "visitorId",
+                "entity": "base.visitor",
+                "column": "id",
+                "family": "visitor",
+                "label": "Visitor ID",
+                "description": "The ID of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": false
+            }
         }
     },
     "dimensionsDenormalized": {

--- a/tests/fixtures/catalog.json
+++ b/tests/fixtures/catalog.json
@@ -5518,5 +5518,434 @@
             "data_type": "string",
             "denormalized": true
         }
+    },
+    "relatedDimensions": {
+        "base.session": {
+            "campaign": [
+                "ad",
+                "adType",
+                "campaign",
+                "isSearchEngine",
+                "medium",
+                "referralLinkText",
+                "referralPageTitle",
+                "referralPageUrl",
+                "referralSearchTerms",
+                "referralWebSite",
+                "source"
+            ],
+            "campaign-special": [
+                "latestAttributions"
+            ],
+            "custom variables": [
+                "customVarName1",
+                "customVarName2",
+                "customVarName3",
+                "customVarName4",
+                "customVarName5",
+                "customVarValue1",
+                "customVarValue2",
+                "customVarValue3",
+                "customVarValue4",
+                "customVarValue5"
+            ],
+            "geo": [
+                "city",
+                "country",
+                "countryCode",
+                "latitude",
+                "longitude",
+                "stateRegion"
+            ],
+            "network": [
+                "hostName",
+                "ipAddress"
+            ],
+            "site": [
+                "siteDomain",
+                "siteId",
+                "siteName"
+            ],
+            "system": [
+                "browserType",
+                "browserVersion",
+                "language",
+                "osType"
+            ],
+            "time": [
+                "date",
+                "day",
+                "dayofweek",
+                "dayofyear",
+                "month",
+                "weekofyear",
+                "year"
+            ],
+            "visit": [
+                "daysSinceFirstVisit",
+                "daysSinceLastVisit",
+                "distinctItemsInVisit",
+                "entryPagePath",
+                "entryPageTitle",
+                "entryPageType",
+                "entryPageUrl",
+                "exitPagePath",
+                "exitPageTitle",
+                "exitPageType",
+                "exitPageUrl",
+                "goalStartsInVisit",
+                "goalValueInVisit",
+                "goalsInVisit",
+                "itemQuantityInVisit",
+                "itemRevenueInVisit",
+                "pagesViewsInVisit",
+                "priorVisitCount",
+                "revenueInVisit",
+                "shippingRevenueInVisit",
+                "taxRevenueInVisit",
+                "transactionsInVisit"
+            ],
+            "visitor": [
+                "isNewVisitor",
+                "isRepeatVisitor",
+                "userEmail",
+                "visitorId"
+            ]
+        },
+        "base.request": {
+            "campaign": [
+                "ad",
+                "adType",
+                "campaign",
+                "isSearchEngine",
+                "medium",
+                "referralLinkText",
+                "referralPageTitle",
+                "referralPageUrl",
+                "referralSearchTerms",
+                "referralWebSite",
+                "source"
+            ],
+            "content": [
+                "pagePath",
+                "pageTitle",
+                "pageType",
+                "pageUrl",
+                "priorPagePath",
+                "priorPageTitle",
+                "priorPageType",
+                "priorPageUrl"
+            ],
+            "custom variables": [
+                "customVarName1",
+                "customVarName2",
+                "customVarName3",
+                "customVarName4",
+                "customVarName5",
+                "customVarValue1",
+                "customVarValue2",
+                "customVarValue3",
+                "customVarValue4",
+                "customVarValue5"
+            ],
+            "geo": [
+                "city",
+                "country",
+                "countryCode",
+                "latitude",
+                "longitude",
+                "stateRegion"
+            ],
+            "network": [
+                "hostName",
+                "ipAddress"
+            ],
+            "site": [
+                "siteDomain",
+                "siteId",
+                "siteName"
+            ],
+            "system": [
+                "browserType",
+                "browserVersion",
+                "language",
+                "osType"
+            ],
+            "time": [
+                "date",
+                "day",
+                "dayofweek",
+                "dayofyear",
+                "month",
+                "weekofyear",
+                "year"
+            ],
+            "visit": [
+                "daysSinceFirstVisit",
+                "daysSinceLastVisit",
+                "priorVisitCount"
+            ],
+            "visit-special": [
+                "sessionId"
+            ],
+            "visitor": [
+                "isNewVisitor",
+                "isRepeatVisitor",
+                "userEmail",
+                "visitorId"
+            ]
+        },
+        "base.action_fact": {
+            "actions": [
+                "actionGroup",
+                "actionLabel",
+                "actionName"
+            ],
+            "campaign": [
+                "ad",
+                "adType",
+                "campaign",
+                "isSearchEngine",
+                "medium",
+                "referralLinkText",
+                "referralPageTitle",
+                "referralPageUrl",
+                "referralSearchTerms",
+                "referralWebSite",
+                "source"
+            ],
+            "content": [
+                "pagePath",
+                "pageTitle",
+                "pageType",
+                "pageUrl"
+            ],
+            "custom variables": [
+                "customVarName1",
+                "customVarName2",
+                "customVarName3",
+                "customVarName4",
+                "customVarName5",
+                "customVarValue1",
+                "customVarValue2",
+                "customVarValue3",
+                "customVarValue4",
+                "customVarValue5"
+            ],
+            "geo": [
+                "city",
+                "country",
+                "countryCode",
+                "latitude",
+                "longitude",
+                "stateRegion"
+            ],
+            "network": [
+                "hostName",
+                "ipAddress"
+            ],
+            "site": [
+                "siteDomain",
+                "siteId",
+                "siteName"
+            ],
+            "system": [
+                "browserType",
+                "browserVersion",
+                "language",
+                "osType"
+            ],
+            "time": [
+                "date",
+                "day",
+                "dayofweek",
+                "dayofyear",
+                "month",
+                "weekofyear",
+                "year"
+            ],
+            "visit": [
+                "daysSinceFirstVisit",
+                "daysSinceLastVisit",
+                "priorVisitCount"
+            ],
+            "visit-special": [
+                "sessionId"
+            ],
+            "visitor": [
+                "isNewVisitor",
+                "isRepeatVisitor",
+                "userEmail",
+                "visitorId"
+            ]
+        },
+        "base.click": {
+            "campaign": [
+                "ad",
+                "adType",
+                "campaign",
+                "isSearchEngine",
+                "medium",
+                "referralLinkText",
+                "referralPageTitle",
+                "referralPageUrl",
+                "referralSearchTerms",
+                "referralWebSite",
+                "source"
+            ],
+            "content": [
+                "pagePath",
+                "pageTitle",
+                "pageType",
+                "pageUrl"
+            ],
+            "custom variables": [
+                "customVarName1",
+                "customVarName2",
+                "customVarName3",
+                "customVarName4",
+                "customVarName5",
+                "customVarValue1",
+                "customVarValue2",
+                "customVarValue3",
+                "customVarValue4",
+                "customVarValue5"
+            ],
+            "dom": [
+                "clickX",
+                "clickY",
+                "domElementClass",
+                "domElementId",
+                "domElementName",
+                "domElementTag",
+                "domElementText",
+                "domElementValue"
+            ],
+            "geo": [
+                "city",
+                "country",
+                "countryCode",
+                "latitude",
+                "longitude",
+                "stateRegion"
+            ],
+            "network": [
+                "hostName",
+                "ipAddress"
+            ],
+            "site": [
+                "siteDomain",
+                "siteId",
+                "siteName"
+            ],
+            "system": [
+                "browserType",
+                "browserVersion",
+                "language",
+                "osType"
+            ],
+            "time": [
+                "date",
+                "day",
+                "dayofweek",
+                "dayofyear",
+                "month",
+                "weekofyear",
+                "year"
+            ],
+            "visit": [
+                "daysSinceFirstVisit",
+                "daysSinceLastVisit",
+                "priorVisitCount"
+            ],
+            "visit-special": [
+                "sessionId"
+            ],
+            "visitor": [
+                "isNewVisitor",
+                "isRepeatVisitor",
+                "userEmail",
+                "visitorId"
+            ]
+        },
+        "base.domstream": {
+            "campaign": [
+                "ad",
+                "adType",
+                "campaign",
+                "isSearchEngine",
+                "medium",
+                "referralLinkText",
+                "referralPageTitle",
+                "referralPageUrl",
+                "referralSearchTerms",
+                "referralWebSite",
+                "source"
+            ],
+            "content": [
+                "pagePath",
+                "pageTitle",
+                "pageType",
+                "pageUrl"
+            ],
+            "custom variables": [
+                "customVarName1",
+                "customVarName2",
+                "customVarName3",
+                "customVarName4",
+                "customVarName5",
+                "customVarValue1",
+                "customVarValue2",
+                "customVarValue3",
+                "customVarValue4",
+                "customVarValue5"
+            ],
+            "geo": [
+                "city",
+                "country",
+                "countryCode",
+                "latitude",
+                "longitude",
+                "stateRegion"
+            ],
+            "network": [
+                "hostName",
+                "ipAddress"
+            ],
+            "site": [
+                "siteDomain",
+                "siteId",
+                "siteName"
+            ],
+            "system": [
+                "browserType",
+                "browserVersion",
+                "language",
+                "osType"
+            ],
+            "time": [
+                "date",
+                "day",
+                "dayofweek",
+                "dayofyear",
+                "month",
+                "weekofyear",
+                "year"
+            ],
+            "visit": [
+                "daysSinceFirstVisit",
+                "daysSinceLastVisit",
+                "priorVisitCount"
+            ],
+            "visit-special": [
+                "sessionId"
+            ],
+            "visitor": [
+                "isNewVisitor",
+                "isRepeatVisitor",
+                "userEmail",
+                "visitorId"
+            ]
+        }
     }
 }

--- a/tests/fixtures/catalog.json
+++ b/tests/fixtures/catalog.json
@@ -1,0 +1,5372 @@
+{
+    "counts": {
+        "metricNames": 78,
+        "metricImplementations": 99,
+        "dimensionNamesNormalized": 42,
+        "dimensionEntriesNormalized": 42,
+        "dimensionNamesDenormalized": 59,
+        "dimensionEntriesDenormalized": 223,
+        "accessorDimensionNames": 101
+    },
+    "metrics": {
+        "actions": [
+            {
+                "name": "actions",
+                "class": "base.actions",
+                "label": "Actions",
+                "group": "Actions",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "actionsValue": [
+            {
+                "name": "actionsValue",
+                "class": "base.actionsValue",
+                "label": "Action Value",
+                "group": "Actions",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "bounceRate": [
+            {
+                "name": "bounceRate",
+                "class": "base.bounceRate",
+                "label": "Bounce Rate",
+                "group": "Site Usage",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "bounces": [
+            {
+                "name": "bounces",
+                "class": "base.bounces",
+                "label": "Bounces",
+                "group": "Site Usage",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "domClicks": [
+            {
+                "name": "domClicks",
+                "class": "base.domClicks",
+                "label": "Clicks",
+                "group": "Clicks",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "ecommerceConversionRate": [
+            {
+                "name": "ecommerceConversionRate",
+                "class": "base.ecommerceConversionRate",
+                "label": "E-commerce Conversion Rate",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "feedReaders": [
+            {
+                "name": "feedReaders",
+                "class": "base.feedReaders",
+                "label": "Feed Readers",
+                "group": "Feeds",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "feedRequests": [
+            {
+                "name": "feedRequests",
+                "class": "base.feedRequests",
+                "label": "Feed Requests",
+                "group": "Feeds",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "feedSubscriptions": [
+            {
+                "name": "feedSubscriptions",
+                "class": "base.feedSubscriptions",
+                "label": "Feed Subscriptions",
+                "group": "Feeds",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "goal10Completions": [
+            {
+                "name": "goal10Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 10 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 10
+                }
+            }
+        ],
+        "goal10Starts": [
+            {
+                "name": "goal10Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 10 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 10
+                }
+            }
+        ],
+        "goal10Value": [
+            {
+                "name": "goal10Value",
+                "class": "base.goalNValue",
+                "label": "Goal 10 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 10
+                }
+            }
+        ],
+        "goal11Completions": [
+            {
+                "name": "goal11Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 11 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 11
+                }
+            }
+        ],
+        "goal11Starts": [
+            {
+                "name": "goal11Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 11 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 11
+                }
+            }
+        ],
+        "goal11Value": [
+            {
+                "name": "goal11Value",
+                "class": "base.goalNValue",
+                "label": "Goal 11 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 11
+                }
+            }
+        ],
+        "goal12Completions": [
+            {
+                "name": "goal12Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 12 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 12
+                }
+            }
+        ],
+        "goal12Starts": [
+            {
+                "name": "goal12Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 12 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 12
+                }
+            }
+        ],
+        "goal12Value": [
+            {
+                "name": "goal12Value",
+                "class": "base.goalNValue",
+                "label": "Goal 12 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 12
+                }
+            }
+        ],
+        "goal13Completions": [
+            {
+                "name": "goal13Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 13 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 13
+                }
+            }
+        ],
+        "goal13Starts": [
+            {
+                "name": "goal13Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 13 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 13
+                }
+            }
+        ],
+        "goal13Value": [
+            {
+                "name": "goal13Value",
+                "class": "base.goalNValue",
+                "label": "Goal 13 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 13
+                }
+            }
+        ],
+        "goal14Completions": [
+            {
+                "name": "goal14Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 14 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 14
+                }
+            }
+        ],
+        "goal14Starts": [
+            {
+                "name": "goal14Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 14 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 14
+                }
+            }
+        ],
+        "goal14Value": [
+            {
+                "name": "goal14Value",
+                "class": "base.goalNValue",
+                "label": "Goal 14 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 14
+                }
+            }
+        ],
+        "goal15Completions": [
+            {
+                "name": "goal15Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 15 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 15
+                }
+            }
+        ],
+        "goal15Starts": [
+            {
+                "name": "goal15Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 15 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 15
+                }
+            }
+        ],
+        "goal15Value": [
+            {
+                "name": "goal15Value",
+                "class": "base.goalNValue",
+                "label": "Goal 15 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 15
+                }
+            }
+        ],
+        "goal1Completions": [
+            {
+                "name": "goal1Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 1 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 1
+                }
+            }
+        ],
+        "goal1Starts": [
+            {
+                "name": "goal1Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 1 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 1
+                }
+            }
+        ],
+        "goal1Value": [
+            {
+                "name": "goal1Value",
+                "class": "base.goalNValue",
+                "label": "Goal 1 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 1
+                }
+            }
+        ],
+        "goal2Completions": [
+            {
+                "name": "goal2Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 2 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 2
+                }
+            }
+        ],
+        "goal2Starts": [
+            {
+                "name": "goal2Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 2 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 2
+                }
+            }
+        ],
+        "goal2Value": [
+            {
+                "name": "goal2Value",
+                "class": "base.goalNValue",
+                "label": "Goal 2 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 2
+                }
+            }
+        ],
+        "goal3Completions": [
+            {
+                "name": "goal3Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 3 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 3
+                }
+            }
+        ],
+        "goal3Starts": [
+            {
+                "name": "goal3Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 3 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 3
+                }
+            }
+        ],
+        "goal3Value": [
+            {
+                "name": "goal3Value",
+                "class": "base.goalNValue",
+                "label": "Goal 3 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 3
+                }
+            }
+        ],
+        "goal4Completions": [
+            {
+                "name": "goal4Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 4 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 4
+                }
+            }
+        ],
+        "goal4Starts": [
+            {
+                "name": "goal4Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 4 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 4
+                }
+            }
+        ],
+        "goal4Value": [
+            {
+                "name": "goal4Value",
+                "class": "base.goalNValue",
+                "label": "Goal 4 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 4
+                }
+            }
+        ],
+        "goal5Completions": [
+            {
+                "name": "goal5Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 5 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 5
+                }
+            }
+        ],
+        "goal5Starts": [
+            {
+                "name": "goal5Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 5 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 5
+                }
+            }
+        ],
+        "goal5Value": [
+            {
+                "name": "goal5Value",
+                "class": "base.goalNValue",
+                "label": "Goal 5 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 5
+                }
+            }
+        ],
+        "goal6Completions": [
+            {
+                "name": "goal6Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 6 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 6
+                }
+            }
+        ],
+        "goal6Starts": [
+            {
+                "name": "goal6Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 6 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 6
+                }
+            }
+        ],
+        "goal6Value": [
+            {
+                "name": "goal6Value",
+                "class": "base.goalNValue",
+                "label": "Goal 6 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 6
+                }
+            }
+        ],
+        "goal7Completions": [
+            {
+                "name": "goal7Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 7 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 7
+                }
+            }
+        ],
+        "goal7Starts": [
+            {
+                "name": "goal7Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 7 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 7
+                }
+            }
+        ],
+        "goal7Value": [
+            {
+                "name": "goal7Value",
+                "class": "base.goalNValue",
+                "label": "Goal 7 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 7
+                }
+            }
+        ],
+        "goal8Completions": [
+            {
+                "name": "goal8Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 8 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 8
+                }
+            }
+        ],
+        "goal8Starts": [
+            {
+                "name": "goal8Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 8 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 8
+                }
+            }
+        ],
+        "goal8Value": [
+            {
+                "name": "goal8Value",
+                "class": "base.goalNValue",
+                "label": "Goal 8 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 8
+                }
+            }
+        ],
+        "goal9Completions": [
+            {
+                "name": "goal9Completions",
+                "class": "base.goalNCompletions",
+                "label": "Goal 9 Completions",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 9
+                }
+            }
+        ],
+        "goal9Starts": [
+            {
+                "name": "goal9Starts",
+                "class": "base.goalNStarts",
+                "label": "Goal 9 Starts",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 9
+                }
+            }
+        ],
+        "goal9Value": [
+            {
+                "name": "goal9Value",
+                "class": "base.goalNValue",
+                "label": "Goal 9 Value",
+                "group": "Goals",
+                "params": {
+                    "goal_number": 9
+                }
+            }
+        ],
+        "goalAbandonRateAll": [
+            {
+                "name": "goalAbandonRateAll",
+                "class": "base.goalAbandonRateAll",
+                "label": "Goal Abandon Rate",
+                "group": "Goals",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "goalCompletionsAll": [
+            {
+                "name": "goalCompletionsAll",
+                "class": "base.goalCompletionsAll",
+                "label": "Goal Completions",
+                "group": "Goals",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "goalConversionRateAll": [
+            {
+                "name": "goalConversionRateAll",
+                "class": "base.goalConversionRateAll",
+                "label": "Goal Conversion Rate",
+                "group": "Goals",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "goalStartsAll": [
+            {
+                "name": "goalStartsAll",
+                "class": "base.goalStartsAll",
+                "label": "Goal Starts",
+                "group": "Goals",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "goalValueAll": [
+            {
+                "name": "goalValueAll",
+                "class": "base.goalValueAll",
+                "label": "Goal Value",
+                "group": "Goals",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "lineItemQuantity": [
+            {
+                "name": "lineItemQuantity",
+                "class": "base.lineItemQuantity",
+                "label": "Item Quantity",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            },
+            {
+                "name": "lineItemQuantity",
+                "class": "base.lineItemQuantityFromSessionFact",
+                "label": "Item Quantity",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "lineItemRevenue": [
+            {
+                "name": "lineItemRevenue",
+                "class": "base.lineItemRevenue",
+                "label": "Item Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            },
+            {
+                "name": "lineItemRevenue",
+                "class": "base.lineItemRevenueFromSessionFact",
+                "label": "Item Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "newVisitors": [
+            {
+                "name": "newVisitors",
+                "class": "base.newVisitors",
+                "label": "New Visitors",
+                "group": "Site Usage",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "pageViews": [
+            {
+                "name": "pageViews",
+                "class": "base.configurableMetric",
+                "label": "Page Views",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "id",
+                    "data_type": "integer",
+                    "description": "The total number of pages viewed.",
+                    "entity": "base.request",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Page Views",
+                    "metric_type": "count",
+                    "name": "pageViews"
+                }
+            },
+            {
+                "name": "pageViews",
+                "class": "base.configurableMetric",
+                "label": "Page Views",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "num_pageviews",
+                    "data_type": "integer",
+                    "description": "The total number of pages viewed.",
+                    "entity": "base.session",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Page Views",
+                    "metric_type": "sum",
+                    "name": "pageViews"
+                }
+            }
+        ],
+        "pagesPerVisit": [
+            {
+                "name": "pagesPerVisit",
+                "class": "base.pagesPerVisit",
+                "label": "Pages Per Visit",
+                "group": "Site Usage",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "repeatVisitors": [
+            {
+                "name": "repeatVisitors",
+                "class": "base.repeatVisitors",
+                "label": "Repeat Visitors",
+                "group": "Site Usage",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "revenuePerTransaction": [
+            {
+                "name": "revenuePerTransaction",
+                "class": "base.revenuePerTransaction",
+                "label": "Revenue Per Transaction",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "revenuePerVisit": [
+            {
+                "name": "revenuePerVisit",
+                "class": "base.revenuePerVisit",
+                "label": "Revenue Per Visit",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "shippingRevenue": [
+            {
+                "name": "shippingRevenue",
+                "class": "base.shippingRevenue",
+                "label": "Shipping Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            },
+            {
+                "name": "shippingRevenue",
+                "class": "base.shippingRevenueFromSessionFact",
+                "label": "Shipping Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "taxRevenue": [
+            {
+                "name": "taxRevenue",
+                "class": "base.taxRevenue",
+                "label": "Tax Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            },
+            {
+                "name": "taxRevenue",
+                "class": "base.taxRevenueFromSessionFact",
+                "label": "Tax Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "transactionRevenue": [
+            {
+                "name": "transactionRevenue",
+                "class": "base.transactionRevenue",
+                "label": "Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            },
+            {
+                "name": "transactionRevenue",
+                "class": "base.transactionRevenueFromSessionFact",
+                "label": "Revenue",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "transactions": [
+            {
+                "name": "transactions",
+                "class": "base.transactions",
+                "label": "Transactions",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            },
+            {
+                "name": "transactions",
+                "class": "base.transactionsFromSessionFact",
+                "label": "Transactions",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "uniqueActions": [
+            {
+                "name": "uniqueActions",
+                "class": "base.uniqueActions",
+                "label": "Unique Actions",
+                "group": "Actions",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "uniqueLineItems": [
+            {
+                "name": "uniqueLineItems",
+                "class": "base.uniqueLineItems",
+                "label": "Unique Items",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            },
+            {
+                "name": "uniqueLineItems",
+                "class": "base.uniqueLineItemsFromSessionFact",
+                "label": "Unique Items",
+                "group": "E-commerce",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "uniquePageViews": [
+            {
+                "name": "uniquePageViews",
+                "class": "base.uniquePageViews",
+                "label": "Unique Page Views",
+                "group": "Site Usage",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "uniqueVisitors": [
+            {
+                "name": "uniqueVisitors",
+                "class": "base.configurableMetric",
+                "label": "Unique Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of unique visitors.",
+                    "entity": "base.action_fact",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Unique Visitors",
+                    "metric_type": "distinct_count",
+                    "name": "uniqueVisitors"
+                }
+            },
+            {
+                "name": "uniqueVisitors",
+                "class": "base.configurableMetric",
+                "label": "Unique Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of unique visitors.",
+                    "entity": "base.click",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Unique Visitors",
+                    "metric_type": "distinct_count",
+                    "name": "uniqueVisitors"
+                }
+            },
+            {
+                "name": "uniqueVisitors",
+                "class": "base.configurableMetric",
+                "label": "Unique Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of unique visitors.",
+                    "entity": "base.commerce_line_item_fact",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Unique Visitors",
+                    "metric_type": "distinct_count",
+                    "name": "uniqueVisitors"
+                }
+            },
+            {
+                "name": "uniqueVisitors",
+                "class": "base.configurableMetric",
+                "label": "Unique Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of unique visitors.",
+                    "entity": "base.commerce_transaction_fact",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Unique Visitors",
+                    "metric_type": "distinct_count",
+                    "name": "uniqueVisitors"
+                }
+            },
+            {
+                "name": "uniqueVisitors",
+                "class": "base.configurableMetric",
+                "label": "Unique Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of unique visitors.",
+                    "entity": "base.domstream",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Unique Visitors",
+                    "metric_type": "distinct_count",
+                    "name": "uniqueVisitors"
+                }
+            },
+            {
+                "name": "uniqueVisitors",
+                "class": "base.configurableMetric",
+                "label": "Unique Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of unique visitors.",
+                    "entity": "base.request",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Unique Visitors",
+                    "metric_type": "distinct_count",
+                    "name": "uniqueVisitors"
+                }
+            },
+            {
+                "name": "uniqueVisitors",
+                "class": "base.configurableMetric",
+                "label": "Unique Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of unique visitors.",
+                    "entity": "base.session",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Unique Visitors",
+                    "metric_type": "distinct_count",
+                    "name": "uniqueVisitors"
+                }
+            }
+        ],
+        "visitDuration": [
+            {
+                "name": "visitDuration",
+                "class": "base.visitDuration",
+                "label": "Visit Duration",
+                "group": "Site Usage",
+                "params": [
+                    ""
+                ]
+            }
+        ],
+        "visitors": [
+            {
+                "name": "visitors",
+                "class": "base.configurableMetric",
+                "label": "Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of visitors.",
+                    "entity": "base.action_fact",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visitors",
+                    "metric_type": "count",
+                    "name": "visitors"
+                }
+            },
+            {
+                "name": "visitors",
+                "class": "base.configurableMetric",
+                "label": "Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of visitors.",
+                    "entity": "base.click",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visitors",
+                    "metric_type": "count",
+                    "name": "visitors"
+                }
+            },
+            {
+                "name": "visitors",
+                "class": "base.configurableMetric",
+                "label": "Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of visitors.",
+                    "entity": "base.commerce_line_item_fact",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visitors",
+                    "metric_type": "count",
+                    "name": "visitors"
+                }
+            },
+            {
+                "name": "visitors",
+                "class": "base.configurableMetric",
+                "label": "Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of visitors.",
+                    "entity": "base.commerce_transaction_fact",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visitors",
+                    "metric_type": "count",
+                    "name": "visitors"
+                }
+            },
+            {
+                "name": "visitors",
+                "class": "base.configurableMetric",
+                "label": "Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of visitors.",
+                    "entity": "base.domstream",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visitors",
+                    "metric_type": "count",
+                    "name": "visitors"
+                }
+            },
+            {
+                "name": "visitors",
+                "class": "base.configurableMetric",
+                "label": "Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of visitors.",
+                    "entity": "base.request",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visitors",
+                    "metric_type": "count",
+                    "name": "visitors"
+                }
+            },
+            {
+                "name": "visitors",
+                "class": "base.configurableMetric",
+                "label": "Visitors",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "visitor_id",
+                    "data_type": "integer",
+                    "description": "The total number of visitors.",
+                    "entity": "base.session",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visitors",
+                    "metric_type": "count",
+                    "name": "visitors"
+                }
+            }
+        ],
+        "visits": [
+            {
+                "name": "visits",
+                "class": "base.configurableMetric",
+                "label": "Visits",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "id",
+                    "data_type": "integer",
+                    "description": "The total number of visits/sessions.",
+                    "entity": "base.session",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visits",
+                    "metric_type": "distinct_count",
+                    "name": "visits"
+                }
+            },
+            {
+                "name": "visits",
+                "class": "base.configurableMetric",
+                "label": "Visits",
+                "group": "Site Usage",
+                "params": {
+                    "child_metrics": [],
+                    "column": "session_id",
+                    "data_type": "integer",
+                    "description": "The total number of visits/sessions.",
+                    "entity": "base.request",
+                    "formula": "",
+                    "group": "Site Usage",
+                    "label": "Visits",
+                    "metric_type": "distinct_count",
+                    "name": "visits"
+                }
+            }
+        ]
+    },
+    "dimensionsNormalized": {
+        "ad": {
+            "name": "ad",
+            "entity": "base.ad_dim",
+            "column": "name",
+            "family": "campaign",
+            "label": "Ad",
+            "description": "The name of the ad that originated the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "adType": {
+            "name": "adType",
+            "entity": "base.ad_dim",
+            "column": "type",
+            "family": "campaign",
+            "label": "Ad Type",
+            "description": "The type of ad that originated the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "browserType": {
+            "name": "browserType",
+            "entity": "base.ua",
+            "column": "browser_type",
+            "family": "system",
+            "label": "Browser Type",
+            "description": "The browser type of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "browserVersion": {
+            "name": "browserVersion",
+            "entity": "base.ua",
+            "column": "browser",
+            "family": "system",
+            "label": "Browser Version",
+            "description": "The browser version of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "campaign": {
+            "name": "campaign",
+            "entity": "base.campaign_dim",
+            "column": "name",
+            "family": "campaign",
+            "label": "Campaign",
+            "description": "The campaign that originated the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "city": {
+            "name": "city",
+            "entity": "base.location_dim",
+            "column": "city",
+            "family": "geo",
+            "label": "City",
+            "description": "The city of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "country": {
+            "name": "country",
+            "entity": "base.location_dim",
+            "column": "country",
+            "family": "geo",
+            "label": "Country",
+            "description": "The country of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "countryCode": {
+            "name": "countryCode",
+            "entity": "base.location_dim",
+            "column": "country_code",
+            "family": "geo",
+            "label": "Country Code",
+            "description": "The ISO country code of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "entryPagePath": {
+            "name": "entryPagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "visit",
+            "label": "Entry Page Path",
+            "description": "The URI of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "entryPageTitle": {
+            "name": "entryPageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "visit",
+            "label": "Entry Page Title",
+            "description": "The title of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "entryPageType": {
+            "name": "entryPageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "visit",
+            "label": "Entry Page Type",
+            "description": "The page type of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "entryPageUrl": {
+            "name": "entryPageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "visit",
+            "label": "Entry Page URL",
+            "description": "The URL of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPagePath": {
+            "name": "exitPagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "visit",
+            "label": "Exit Page Path",
+            "description": "The URI of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPageTitle": {
+            "name": "exitPageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "visit",
+            "label": "Exit Page Title",
+            "description": "The title of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPageType": {
+            "name": "exitPageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "visit",
+            "label": "Exit Page Type",
+            "description": "The page type of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPageUrl": {
+            "name": "exitPageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "visit",
+            "label": "Exit Page URL",
+            "description": "The URL of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "hostName": {
+            "name": "hostName",
+            "entity": "base.host",
+            "column": "host",
+            "family": "network",
+            "label": "Host Name",
+            "description": "The host name of the network used by the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "isSearchEngine": {
+            "name": "isSearchEngine",
+            "entity": "base.referer",
+            "column": "is_searchengine",
+            "family": "campaign",
+            "label": "Search Engine",
+            "description": "Is traffic source a search engine.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "latitude": {
+            "name": "latitude",
+            "entity": "base.location_dim",
+            "column": "latitude",
+            "family": "geo",
+            "label": "Latitude",
+            "description": "The latitude of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "longitude": {
+            "name": "longitude",
+            "entity": "base.location_dim",
+            "column": "longitude",
+            "family": "geo",
+            "label": "Longitude",
+            "description": "The longitude of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "osType": {
+            "name": "osType",
+            "entity": "base.os",
+            "column": "name",
+            "family": "system",
+            "label": "Operating System",
+            "description": "The operating System of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pagePath": {
+            "name": "pagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "content",
+            "label": "Page Path",
+            "description": "The path of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pageTitle": {
+            "name": "pageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "content",
+            "label": "Page Title",
+            "description": "The title of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pageType": {
+            "name": "pageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "content",
+            "label": "Page Type",
+            "description": "The page type of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pageUrl": {
+            "name": "pageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "content",
+            "label": "Page URL",
+            "description": "The URL of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorPagePath": {
+            "name": "priorPagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "content",
+            "label": "Prior Page Path",
+            "description": "The URI of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorPageTitle": {
+            "name": "priorPageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "content",
+            "label": "Prior Page Title",
+            "description": "The title of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorPageType": {
+            "name": "priorPageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "content",
+            "label": "Prior Page Type",
+            "description": "The page type of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorPageUrl": {
+            "name": "priorPageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "content",
+            "label": "Prior Page URL",
+            "description": "The URL of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralLinkText": {
+            "name": "referralLinkText",
+            "entity": "base.referer",
+            "column": "refering_anchortext",
+            "family": "campaign",
+            "label": "Referral Link Text",
+            "description": "The text of the referring link.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralPageTitle": {
+            "name": "referralPageTitle",
+            "entity": "base.referer",
+            "column": "page_title",
+            "family": "campaign",
+            "label": "Referral Page Title",
+            "description": "The title of the referring web page.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralPageUrl": {
+            "name": "referralPageUrl",
+            "entity": "base.referer",
+            "column": "url",
+            "family": "campaign",
+            "label": "Referral Page URL",
+            "description": "The url of the referring web page.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralSearchTerms": {
+            "name": "referralSearchTerms",
+            "entity": "base.search_term_dim",
+            "column": "terms",
+            "family": "campaign",
+            "label": "Search Terms",
+            "description": "The referring search terms.",
+            "foreign_key_name": "referring_search_term_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralWebSite": {
+            "name": "referralWebSite",
+            "entity": "base.referer",
+            "column": "site",
+            "family": "campaign",
+            "label": "Referral Web Site",
+            "description": "The full domain of the referring web site.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "sessionId": {
+            "name": "sessionId",
+            "entity": "base.session",
+            "column": "id",
+            "family": "visit-special",
+            "label": "Session ID",
+            "description": "The ID of the session/visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "siteDomain": {
+            "name": "siteDomain",
+            "entity": "base.site",
+            "column": "domain",
+            "family": "site",
+            "label": "Site Domain",
+            "description": "The domain of the web site.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "siteName": {
+            "name": "siteName",
+            "entity": "base.site",
+            "column": "name",
+            "family": "site",
+            "label": "Site Name",
+            "description": "The name of the site.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "source": {
+            "name": "source",
+            "entity": "base.source_dim",
+            "column": "source_domain",
+            "family": "campaign",
+            "label": "Source",
+            "description": "The traffic source of the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "stateRegion": {
+            "name": "stateRegion",
+            "entity": "base.location_dim",
+            "column": "state",
+            "family": "geo",
+            "label": "State/Region",
+            "description": "The state or region of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "userEmail": {
+            "name": "userEmail",
+            "entity": "base.visitor",
+            "column": "user_email",
+            "family": "visitor",
+            "label": "Email Address",
+            "description": "The email address of the user.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "userName": {
+            "name": "userName",
+            "entity": "base.commerce_line_item_fact",
+            "column": "user_name",
+            "family": "visitor",
+            "label": "User Name",
+            "description": "The name or ID of the user.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "visitorId": {
+            "name": "visitorId",
+            "entity": "base.visitor",
+            "column": "id",
+            "family": "visitor",
+            "label": "Visitor ID",
+            "description": "The ID of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        }
+    },
+    "dimensionsDenormalized": {
+        "actionGroup": {
+            "base.action_fact": {
+                "name": "actionGroup",
+                "entity": "base.action_fact",
+                "column": "action_group",
+                "family": "actions",
+                "label": "Action Group",
+                "description": "The group that an action belongs to.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "actionLabel": {
+            "base.action_fact": {
+                "name": "actionLabel",
+                "entity": "base.action_fact",
+                "column": "action_label",
+                "family": "actions",
+                "label": "Action Label",
+                "description": "The label associated with an action.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "actionName": {
+            "base.action_fact": {
+                "name": "actionName",
+                "entity": "base.action_fact",
+                "column": "action_name",
+                "family": "actions",
+                "label": "Action Name",
+                "description": "The name of the action.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "clickX": {
+            "base.click": {
+                "name": "clickX",
+                "entity": "base.click",
+                "column": "click_x",
+                "family": "dom",
+                "label": "Click X",
+                "description": "The horizontal position of the click on the page.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "clickY": {
+            "base.click": {
+                "name": "clickY",
+                "entity": "base.click",
+                "column": "click_y",
+                "family": "dom",
+                "label": "Click Y",
+                "description": "The vertical position of the click on the page.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarName1": {
+            "base.action_fact": {
+                "name": "customVarName1",
+                "entity": "base.action_fact",
+                "column": "cv1_name",
+                "family": "custom variables",
+                "label": "Custom Var 1 Name",
+                "description": "The name of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarName1",
+                "entity": "base.click",
+                "column": "cv1_name",
+                "family": "custom variables",
+                "label": "Custom Var 1 Name",
+                "description": "The name of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarName1",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv1_name",
+                "family": "custom variables",
+                "label": "Custom Var 1 Name",
+                "description": "The name of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarName1",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv1_name",
+                "family": "custom variables",
+                "label": "Custom Var 1 Name",
+                "description": "The name of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarName1",
+                "entity": "base.domstream",
+                "column": "cv1_name",
+                "family": "custom variables",
+                "label": "Custom Var 1 Name",
+                "description": "The name of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarName1",
+                "entity": "base.request",
+                "column": "cv1_name",
+                "family": "custom variables",
+                "label": "Custom Var 1 Name",
+                "description": "The name of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarName1",
+                "entity": "base.session",
+                "column": "cv1_name",
+                "family": "custom variables",
+                "label": "Custom Var 1 Name",
+                "description": "The name of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarName2": {
+            "base.action_fact": {
+                "name": "customVarName2",
+                "entity": "base.action_fact",
+                "column": "cv2_name",
+                "family": "custom variables",
+                "label": "Custom Var 2 Name",
+                "description": "The name of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarName2",
+                "entity": "base.click",
+                "column": "cv2_name",
+                "family": "custom variables",
+                "label": "Custom Var 2 Name",
+                "description": "The name of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarName2",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv2_name",
+                "family": "custom variables",
+                "label": "Custom Var 2 Name",
+                "description": "The name of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarName2",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv2_name",
+                "family": "custom variables",
+                "label": "Custom Var 2 Name",
+                "description": "The name of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarName2",
+                "entity": "base.domstream",
+                "column": "cv2_name",
+                "family": "custom variables",
+                "label": "Custom Var 2 Name",
+                "description": "The name of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarName2",
+                "entity": "base.request",
+                "column": "cv2_name",
+                "family": "custom variables",
+                "label": "Custom Var 2 Name",
+                "description": "The name of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarName2",
+                "entity": "base.session",
+                "column": "cv2_name",
+                "family": "custom variables",
+                "label": "Custom Var 2 Name",
+                "description": "The name of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarName3": {
+            "base.action_fact": {
+                "name": "customVarName3",
+                "entity": "base.action_fact",
+                "column": "cv3_name",
+                "family": "custom variables",
+                "label": "Custom Var 3 Name",
+                "description": "The name of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarName3",
+                "entity": "base.click",
+                "column": "cv3_name",
+                "family": "custom variables",
+                "label": "Custom Var 3 Name",
+                "description": "The name of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarName3",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv3_name",
+                "family": "custom variables",
+                "label": "Custom Var 3 Name",
+                "description": "The name of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarName3",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv3_name",
+                "family": "custom variables",
+                "label": "Custom Var 3 Name",
+                "description": "The name of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarName3",
+                "entity": "base.domstream",
+                "column": "cv3_name",
+                "family": "custom variables",
+                "label": "Custom Var 3 Name",
+                "description": "The name of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarName3",
+                "entity": "base.request",
+                "column": "cv3_name",
+                "family": "custom variables",
+                "label": "Custom Var 3 Name",
+                "description": "The name of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarName3",
+                "entity": "base.session",
+                "column": "cv3_name",
+                "family": "custom variables",
+                "label": "Custom Var 3 Name",
+                "description": "The name of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarName4": {
+            "base.action_fact": {
+                "name": "customVarName4",
+                "entity": "base.action_fact",
+                "column": "cv4_name",
+                "family": "custom variables",
+                "label": "Custom Var 4 Name",
+                "description": "The name of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarName4",
+                "entity": "base.click",
+                "column": "cv4_name",
+                "family": "custom variables",
+                "label": "Custom Var 4 Name",
+                "description": "The name of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarName4",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv4_name",
+                "family": "custom variables",
+                "label": "Custom Var 4 Name",
+                "description": "The name of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarName4",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv4_name",
+                "family": "custom variables",
+                "label": "Custom Var 4 Name",
+                "description": "The name of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarName4",
+                "entity": "base.domstream",
+                "column": "cv4_name",
+                "family": "custom variables",
+                "label": "Custom Var 4 Name",
+                "description": "The name of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarName4",
+                "entity": "base.request",
+                "column": "cv4_name",
+                "family": "custom variables",
+                "label": "Custom Var 4 Name",
+                "description": "The name of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarName4",
+                "entity": "base.session",
+                "column": "cv4_name",
+                "family": "custom variables",
+                "label": "Custom Var 4 Name",
+                "description": "The name of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarName5": {
+            "base.action_fact": {
+                "name": "customVarName5",
+                "entity": "base.action_fact",
+                "column": "cv5_name",
+                "family": "custom variables",
+                "label": "Custom Var 5 Name",
+                "description": "The name of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarName5",
+                "entity": "base.click",
+                "column": "cv5_name",
+                "family": "custom variables",
+                "label": "Custom Var 5 Name",
+                "description": "The name of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarName5",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv5_name",
+                "family": "custom variables",
+                "label": "Custom Var 5 Name",
+                "description": "The name of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarName5",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv5_name",
+                "family": "custom variables",
+                "label": "Custom Var 5 Name",
+                "description": "The name of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarName5",
+                "entity": "base.domstream",
+                "column": "cv5_name",
+                "family": "custom variables",
+                "label": "Custom Var 5 Name",
+                "description": "The name of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarName5",
+                "entity": "base.request",
+                "column": "cv5_name",
+                "family": "custom variables",
+                "label": "Custom Var 5 Name",
+                "description": "The name of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarName5",
+                "entity": "base.session",
+                "column": "cv5_name",
+                "family": "custom variables",
+                "label": "Custom Var 5 Name",
+                "description": "The name of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarValue1": {
+            "base.action_fact": {
+                "name": "customVarValue1",
+                "entity": "base.action_fact",
+                "column": "cv1_value",
+                "family": "custom variables",
+                "label": "Custom Var 1 Value",
+                "description": "The value of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarValue1",
+                "entity": "base.click",
+                "column": "cv1_value",
+                "family": "custom variables",
+                "label": "Custom Var 1 Value",
+                "description": "The value of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarValue1",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv1_value",
+                "family": "custom variables",
+                "label": "Custom Var 1 Value",
+                "description": "The value of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarValue1",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv1_value",
+                "family": "custom variables",
+                "label": "Custom Var 1 Value",
+                "description": "The value of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarValue1",
+                "entity": "base.domstream",
+                "column": "cv1_value",
+                "family": "custom variables",
+                "label": "Custom Var 1 Value",
+                "description": "The value of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarValue1",
+                "entity": "base.request",
+                "column": "cv1_value",
+                "family": "custom variables",
+                "label": "Custom Var 1 Value",
+                "description": "The value of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarValue1",
+                "entity": "base.session",
+                "column": "cv1_value",
+                "family": "custom variables",
+                "label": "Custom Var 1 Value",
+                "description": "The value of custom variable 1.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarValue2": {
+            "base.action_fact": {
+                "name": "customVarValue2",
+                "entity": "base.action_fact",
+                "column": "cv2_value",
+                "family": "custom variables",
+                "label": "Custom Var 2 Value",
+                "description": "The value of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarValue2",
+                "entity": "base.click",
+                "column": "cv2_value",
+                "family": "custom variables",
+                "label": "Custom Var 2 Value",
+                "description": "The value of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarValue2",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv2_value",
+                "family": "custom variables",
+                "label": "Custom Var 2 Value",
+                "description": "The value of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarValue2",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv2_value",
+                "family": "custom variables",
+                "label": "Custom Var 2 Value",
+                "description": "The value of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarValue2",
+                "entity": "base.domstream",
+                "column": "cv2_value",
+                "family": "custom variables",
+                "label": "Custom Var 2 Value",
+                "description": "The value of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarValue2",
+                "entity": "base.request",
+                "column": "cv2_value",
+                "family": "custom variables",
+                "label": "Custom Var 2 Value",
+                "description": "The value of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarValue2",
+                "entity": "base.session",
+                "column": "cv2_value",
+                "family": "custom variables",
+                "label": "Custom Var 2 Value",
+                "description": "The value of custom variable 2.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarValue3": {
+            "base.action_fact": {
+                "name": "customVarValue3",
+                "entity": "base.action_fact",
+                "column": "cv3_value",
+                "family": "custom variables",
+                "label": "Custom Var 3 Value",
+                "description": "The value of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarValue3",
+                "entity": "base.click",
+                "column": "cv3_value",
+                "family": "custom variables",
+                "label": "Custom Var 3 Value",
+                "description": "The value of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarValue3",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv3_value",
+                "family": "custom variables",
+                "label": "Custom Var 3 Value",
+                "description": "The value of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarValue3",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv3_value",
+                "family": "custom variables",
+                "label": "Custom Var 3 Value",
+                "description": "The value of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarValue3",
+                "entity": "base.domstream",
+                "column": "cv3_value",
+                "family": "custom variables",
+                "label": "Custom Var 3 Value",
+                "description": "The value of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarValue3",
+                "entity": "base.request",
+                "column": "cv3_value",
+                "family": "custom variables",
+                "label": "Custom Var 3 Value",
+                "description": "The value of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarValue3",
+                "entity": "base.session",
+                "column": "cv3_value",
+                "family": "custom variables",
+                "label": "Custom Var 3 Value",
+                "description": "The value of custom variable 3.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarValue4": {
+            "base.action_fact": {
+                "name": "customVarValue4",
+                "entity": "base.action_fact",
+                "column": "cv4_value",
+                "family": "custom variables",
+                "label": "Custom Var 4 Value",
+                "description": "The value of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarValue4",
+                "entity": "base.click",
+                "column": "cv4_value",
+                "family": "custom variables",
+                "label": "Custom Var 4 Value",
+                "description": "The value of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarValue4",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv4_value",
+                "family": "custom variables",
+                "label": "Custom Var 4 Value",
+                "description": "The value of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarValue4",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv4_value",
+                "family": "custom variables",
+                "label": "Custom Var 4 Value",
+                "description": "The value of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarValue4",
+                "entity": "base.domstream",
+                "column": "cv4_value",
+                "family": "custom variables",
+                "label": "Custom Var 4 Value",
+                "description": "The value of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarValue4",
+                "entity": "base.request",
+                "column": "cv4_value",
+                "family": "custom variables",
+                "label": "Custom Var 4 Value",
+                "description": "The value of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarValue4",
+                "entity": "base.session",
+                "column": "cv4_value",
+                "family": "custom variables",
+                "label": "Custom Var 4 Value",
+                "description": "The value of custom variable 4.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "customVarValue5": {
+            "base.action_fact": {
+                "name": "customVarValue5",
+                "entity": "base.action_fact",
+                "column": "cv5_value",
+                "family": "custom variables",
+                "label": "Custom Var 5 Value",
+                "description": "The value of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "customVarValue5",
+                "entity": "base.click",
+                "column": "cv5_value",
+                "family": "custom variables",
+                "label": "Custom Var 5 Value",
+                "description": "The value of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "customVarValue5",
+                "entity": "base.commerce_line_item_fact",
+                "column": "cv5_value",
+                "family": "custom variables",
+                "label": "Custom Var 5 Value",
+                "description": "The value of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "customVarValue5",
+                "entity": "base.commerce_transaction_fact",
+                "column": "cv5_value",
+                "family": "custom variables",
+                "label": "Custom Var 5 Value",
+                "description": "The value of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "customVarValue5",
+                "entity": "base.domstream",
+                "column": "cv5_value",
+                "family": "custom variables",
+                "label": "Custom Var 5 Value",
+                "description": "The value of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "customVarValue5",
+                "entity": "base.request",
+                "column": "cv5_value",
+                "family": "custom variables",
+                "label": "Custom Var 5 Value",
+                "description": "The value of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "customVarValue5",
+                "entity": "base.session",
+                "column": "cv5_value",
+                "family": "custom variables",
+                "label": "Custom Var 5 Value",
+                "description": "The value of custom variable 5.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "date": {
+            "base.action_fact": {
+                "name": "date",
+                "entity": "base.action_fact",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The full date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "date",
+                "entity": "base.click",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The full date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "date",
+                "entity": "base.commerce_line_item_fact",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The full date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "date",
+                "entity": "base.commerce_transaction_fact",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The full date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "date",
+                "entity": "base.domstream",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The full date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "date",
+                "entity": "base.feed_request",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "date",
+                "entity": "base.request",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The full date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "date",
+                "entity": "base.session",
+                "column": "yyyymmdd",
+                "family": "time",
+                "label": "Date",
+                "description": "The full date.",
+                "foreign_key_name": "",
+                "data_type": "yyyymmdd",
+                "denormalized": true
+            }
+        },
+        "day": {
+            "base.action_fact": {
+                "name": "day",
+                "entity": "base.action_fact",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day of the month (1-31).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "day",
+                "entity": "base.click",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day of the month (1-31).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "day",
+                "entity": "base.commerce_line_item_fact",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day of the month (1-31).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "day",
+                "entity": "base.commerce_transaction_fact",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day of the month (1-31).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "day",
+                "entity": "base.domstream",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day of the month (1-31).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "day",
+                "entity": "base.feed_request",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "day",
+                "entity": "base.request",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day of the month (1-31).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "day",
+                "entity": "base.session",
+                "column": "day",
+                "family": "time",
+                "label": "Day",
+                "description": "The day of the month (1-31).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "dayofweek": {
+            "base.action_fact": {
+                "name": "dayofweek",
+                "entity": "base.action_fact",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week (1-7).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "dayofweek",
+                "entity": "base.click",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week (1-7).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "dayofweek",
+                "entity": "base.commerce_line_item_fact",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week (1-7).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "dayofweek",
+                "entity": "base.commerce_transaction_fact",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week (1-7).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "dayofweek",
+                "entity": "base.domstream",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week (1-7).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "dayofweek",
+                "entity": "base.feed_request",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "dayofweek",
+                "entity": "base.request",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week (1-7).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "dayofweek",
+                "entity": "base.session",
+                "column": "dayofweek",
+                "family": "time",
+                "label": "Day of Week",
+                "description": "The day of the week (1-7).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "dayofyear": {
+            "base.action_fact": {
+                "name": "dayofyear",
+                "entity": "base.action_fact",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year (1-365).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "dayofyear",
+                "entity": "base.click",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year (1-365).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "dayofyear",
+                "entity": "base.commerce_line_item_fact",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year (1-365).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "dayofyear",
+                "entity": "base.commerce_transaction_fact",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year (1-365).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "dayofyear",
+                "entity": "base.domstream",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year (1-365).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "dayofyear",
+                "entity": "base.feed_request",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "dayofyear",
+                "entity": "base.request",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year (1-365).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "dayofyear",
+                "entity": "base.session",
+                "column": "dayofyear",
+                "family": "time",
+                "label": "Day of Year",
+                "description": "The day of the year (1-365).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "daysSinceFirstVisit": {
+            "base.action_fact": {
+                "name": "daysSinceFirstVisit",
+                "entity": "base.action_fact",
+                "column": "days_since_first_session",
+                "family": "visit",
+                "label": "Days Since First Visit",
+                "description": "The number of days since the first visit of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "daysSinceFirstVisit",
+                "entity": "base.click",
+                "column": "days_since_first_session",
+                "family": "visit",
+                "label": "Days Since First Visit",
+                "description": "The number of days since the first visit of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "daysSinceFirstVisit",
+                "entity": "base.commerce_line_item_fact",
+                "column": "days_since_first_session",
+                "family": "visit",
+                "label": "Days Since First Visit",
+                "description": "The number of days since the first visit of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "daysSinceFirstVisit",
+                "entity": "base.commerce_transaction_fact",
+                "column": "days_since_first_session",
+                "family": "visit",
+                "label": "Days Since First Visit",
+                "description": "The number of days since the first visit of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "daysSinceFirstVisit",
+                "entity": "base.domstream",
+                "column": "days_since_first_session",
+                "family": "visit",
+                "label": "Days Since First Visit",
+                "description": "The number of days since the first visit of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "daysSinceFirstVisit",
+                "entity": "base.request",
+                "column": "days_since_first_session",
+                "family": "visit",
+                "label": "Days Since First Visit",
+                "description": "The number of days since the first visit of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "daysSinceFirstVisit",
+                "entity": "base.session",
+                "column": "days_since_first_session",
+                "family": "visit",
+                "label": "Days Since First Visit",
+                "description": "The number of days since the first visit of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "daysSinceLastVisit": {
+            "base.action_fact": {
+                "name": "daysSinceLastVisit",
+                "entity": "base.action_fact",
+                "column": "days_since_prior_session",
+                "family": "visit",
+                "label": "Days Since Last Visit",
+                "description": "The number of days since the last visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "daysSinceLastVisit",
+                "entity": "base.click",
+                "column": "days_since_prior_session",
+                "family": "visit",
+                "label": "Days Since Last Visit",
+                "description": "The number of days since the last visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "daysSinceLastVisit",
+                "entity": "base.commerce_line_item_fact",
+                "column": "days_since_prior_session",
+                "family": "visit",
+                "label": "Days Since Last Visit",
+                "description": "The number of days since the last visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "daysSinceLastVisit",
+                "entity": "base.commerce_transaction_fact",
+                "column": "days_since_prior_session",
+                "family": "visit",
+                "label": "Days Since Last Visit",
+                "description": "The number of days since the last visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "daysSinceLastVisit",
+                "entity": "base.domstream",
+                "column": "days_since_prior_session",
+                "family": "visit",
+                "label": "Days Since Last Visit",
+                "description": "The number of days since the last visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "daysSinceLastVisit",
+                "entity": "base.request",
+                "column": "days_since_prior_session",
+                "family": "visit",
+                "label": "Days Since Last Visit",
+                "description": "The number of days since the last visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "daysSinceLastVisit",
+                "entity": "base.session",
+                "column": "days_since_prior_session",
+                "family": "visit",
+                "label": "Days Since Last Visit",
+                "description": "The number of days since the last visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "daysToTransaction": {
+            "base.commerce_transaction_fact": {
+                "name": "daysToTransaction",
+                "entity": "base.commerce_transaction_fact",
+                "column": "days_since_first_session",
+                "family": "ecommerce",
+                "label": "Days To Purchase",
+                "description": "The number of days since the first visit and an e-commerce transaction.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "distinctItemsInVisit": {
+            "base.session": {
+                "name": "distinctItemsInVisit",
+                "entity": "base.session",
+                "column": "commerce_items_count",
+                "family": "visit",
+                "label": "Distinct Items in Visit",
+                "description": "Number of distinct items purchased in Visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "domElementClass": {
+            "base.click": {
+                "name": "domElementClass",
+                "entity": "base.click",
+                "column": "dom_element_class",
+                "family": "dom",
+                "label": "Dom Class",
+                "description": "The class of the dom element.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "domElementId": {
+            "base.click": {
+                "name": "domElementId",
+                "entity": "base.click",
+                "column": "dom_element_id",
+                "family": "dom",
+                "label": "Dom ID",
+                "description": "The id of the dom element.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "domElementName": {
+            "base.click": {
+                "name": "domElementName",
+                "entity": "base.click",
+                "column": "dom_element_name",
+                "family": "dom",
+                "label": "Dom Name",
+                "description": "The name of the dom element.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "domElementTag": {
+            "base.click": {
+                "name": "domElementTag",
+                "entity": "base.click",
+                "column": "dom_element_tag",
+                "family": "dom",
+                "label": "Dom Tag",
+                "description": "The html tag of the dom element.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "domElementText": {
+            "base.click": {
+                "name": "domElementText",
+                "entity": "base.click",
+                "column": "dom_element_text",
+                "family": "dom",
+                "label": "Dom Text",
+                "description": "The text associated the dom element.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "domElementValue": {
+            "base.click": {
+                "name": "domElementValue",
+                "entity": "base.click",
+                "column": "dom_element_value",
+                "family": "dom",
+                "label": "Dom Value",
+                "description": "The value of the dom element.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "feedType": {
+            "base.feed_request": {
+                "name": "feedType",
+                "entity": "base.feed_request",
+                "column": "feed_format",
+                "family": "feed",
+                "label": "Feed Type",
+                "description": "The type or format of the feed.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "goalStartsInVisit": {
+            "base.session": {
+                "name": "goalStartsInVisit",
+                "entity": "base.session",
+                "column": "num_goal_starts",
+                "family": "visit",
+                "label": "Goal Starts in Visit",
+                "description": "Goals started in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "goalValueInVisit": {
+            "base.session": {
+                "name": "goalValueInVisit",
+                "entity": "base.session",
+                "column": "goals_value",
+                "family": "visit",
+                "label": "Goal Value in Visit",
+                "description": "Total value from all goals in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "goalsInVisit": {
+            "base.session": {
+                "name": "goalsInVisit",
+                "entity": "base.session",
+                "column": "num_goals",
+                "family": "visit",
+                "label": "Goals in Visit",
+                "description": "Goals completed in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "ipAddress": {
+            "base.action_fact": {
+                "name": "ipAddress",
+                "entity": "base.action_fact",
+                "column": "ip_address",
+                "family": "network",
+                "label": "IP Address",
+                "description": "The IP address of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "ipAddress",
+                "entity": "base.click",
+                "column": "ip_address",
+                "family": "network",
+                "label": "IP Address",
+                "description": "The IP address of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "ipAddress",
+                "entity": "base.commerce_line_item_fact",
+                "column": "ip_address",
+                "family": "network",
+                "label": "IP Address",
+                "description": "The IP address of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "ipAddress",
+                "entity": "base.commerce_transaction_fact",
+                "column": "ip_address",
+                "family": "network",
+                "label": "IP Address",
+                "description": "The IP address of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "ipAddress",
+                "entity": "base.domstream",
+                "column": "ip_address",
+                "family": "network",
+                "label": "IP Address",
+                "description": "The IP address of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "ipAddress",
+                "entity": "base.request",
+                "column": "ip_address",
+                "family": "network",
+                "label": "IP Address",
+                "description": "The IP address of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "ipAddress",
+                "entity": "base.session",
+                "column": "ip_address",
+                "family": "network",
+                "label": "IP Address",
+                "description": "The IP address of the visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "isNewVisitor": {
+            "base.action_fact": {
+                "name": "isNewVisitor",
+                "entity": "base.action_fact",
+                "column": "is_new_visitor",
+                "family": "visitor",
+                "label": "New Visitor",
+                "description": "New Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "isNewVisitor",
+                "entity": "base.click",
+                "column": "is_new_visitor",
+                "family": "visitor",
+                "label": "New Visitor",
+                "description": "New Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "isNewVisitor",
+                "entity": "base.commerce_line_item_fact",
+                "column": "is_new_visitor",
+                "family": "visitor",
+                "label": "New Visitor",
+                "description": "New Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "isNewVisitor",
+                "entity": "base.commerce_transaction_fact",
+                "column": "is_new_visitor",
+                "family": "visitor",
+                "label": "New Visitor",
+                "description": "New Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "isNewVisitor",
+                "entity": "base.domstream",
+                "column": "is_new_visitor",
+                "family": "visitor",
+                "label": "New Visitor",
+                "description": "New Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "isNewVisitor",
+                "entity": "base.request",
+                "column": "is_new_visitor",
+                "family": "visitor",
+                "label": "New Visitor",
+                "description": "New Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "isNewVisitor",
+                "entity": "base.session",
+                "column": "is_new_visitor",
+                "family": "visitor",
+                "label": "New Visitor",
+                "description": "New Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "isRepeatVisitor": {
+            "base.action_fact": {
+                "name": "isRepeatVisitor",
+                "entity": "base.action_fact",
+                "column": "is_repeat_visitor",
+                "family": "visitor",
+                "label": "Repeat Visitor",
+                "description": "Repeat Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "boolean",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "isRepeatVisitor",
+                "entity": "base.click",
+                "column": "is_repeat_visitor",
+                "family": "visitor",
+                "label": "Repeat Visitor",
+                "description": "Repeat Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "boolean",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "isRepeatVisitor",
+                "entity": "base.commerce_line_item_fact",
+                "column": "is_repeat_visitor",
+                "family": "visitor",
+                "label": "Repeat Visitor",
+                "description": "Repeat Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "boolean",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "isRepeatVisitor",
+                "entity": "base.commerce_transaction_fact",
+                "column": "is_repeat_visitor",
+                "family": "visitor",
+                "label": "Repeat Visitor",
+                "description": "Repeat Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "boolean",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "isRepeatVisitor",
+                "entity": "base.domstream",
+                "column": "is_repeat_visitor",
+                "family": "visitor",
+                "label": "Repeat Visitor",
+                "description": "Repeat Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "boolean",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "isRepeatVisitor",
+                "entity": "base.request",
+                "column": "is_repeat_visitor",
+                "family": "visitor",
+                "label": "Repeat Visitor",
+                "description": "Repeat Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "boolean",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "isRepeatVisitor",
+                "entity": "base.session",
+                "column": "is_repeat_visitor",
+                "family": "visitor",
+                "label": "Repeat Visitor",
+                "description": "Repeat Site Visitor.",
+                "foreign_key_name": "",
+                "data_type": "boolean",
+                "denormalized": true
+            }
+        },
+        "itemQuantityInVisit": {
+            "base.session": {
+                "name": "itemQuantityInVisit",
+                "entity": "base.session",
+                "column": "commerce_items_quantity",
+                "family": "visit",
+                "label": "Item Quantity in Visit",
+                "description": "Number of e-commerce items purchased completed in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "itemRevenueInVisit": {
+            "base.session": {
+                "name": "itemRevenueInVisit",
+                "entity": "base.session",
+                "column": "commerce_item_revenue",
+                "family": "visit",
+                "label": "Item Revenue in Visit",
+                "description": "Revenue generate from e-commerce transaction items in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "language": {
+            "base.action_fact": {
+                "name": "language",
+                "entity": "base.action_fact",
+                "column": "language",
+                "family": "system",
+                "label": "Language",
+                "description": "The language of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "language",
+                "entity": "base.click",
+                "column": "language",
+                "family": "system",
+                "label": "Language",
+                "description": "The language of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "language",
+                "entity": "base.commerce_line_item_fact",
+                "column": "language",
+                "family": "system",
+                "label": "Language",
+                "description": "The language of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "language",
+                "entity": "base.commerce_transaction_fact",
+                "column": "language",
+                "family": "system",
+                "label": "Language",
+                "description": "The language of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "language",
+                "entity": "base.domstream",
+                "column": "language",
+                "family": "system",
+                "label": "Language",
+                "description": "The language of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "language",
+                "entity": "base.request",
+                "column": "language",
+                "family": "system",
+                "label": "Language",
+                "description": "The language of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "language",
+                "entity": "base.session",
+                "column": "language",
+                "family": "system",
+                "label": "Language",
+                "description": "The language of the visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "latestAttributions": {
+            "base.session": {
+                "name": "latestAttributions",
+                "entity": "base.session",
+                "column": "latest_attributions",
+                "family": "campaign-special",
+                "label": "Latest Attributions",
+                "description": "The latest campaign attributions.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "medium": {
+            "base.action_fact": {
+                "name": "medium",
+                "entity": "base.action_fact",
+                "column": "medium",
+                "family": "campaign",
+                "label": "Medium",
+                "description": "The medium where visit originated from.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "medium",
+                "entity": "base.click",
+                "column": "medium",
+                "family": "campaign",
+                "label": "Medium",
+                "description": "The medium where visit originated from.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "medium",
+                "entity": "base.commerce_line_item_fact",
+                "column": "medium",
+                "family": "campaign",
+                "label": "Medium",
+                "description": "The medium where visit originated from.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "medium",
+                "entity": "base.commerce_transaction_fact",
+                "column": "medium",
+                "family": "campaign",
+                "label": "Medium",
+                "description": "The medium where visit originated from.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "medium",
+                "entity": "base.domstream",
+                "column": "medium",
+                "family": "campaign",
+                "label": "Medium",
+                "description": "The medium where visit originated from.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "medium",
+                "entity": "base.request",
+                "column": "medium",
+                "family": "campaign",
+                "label": "Medium",
+                "description": "The medium where visit originated from.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "medium",
+                "entity": "base.session",
+                "column": "medium",
+                "family": "campaign",
+                "label": "Medium",
+                "description": "The medium where visit originated from.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "month": {
+            "base.action_fact": {
+                "name": "month",
+                "entity": "base.action_fact",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month, as yyyymm.",
+                "foreign_key_name": "",
+                "data_type": "yyyymm",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "month",
+                "entity": "base.click",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month, as yyyymm.",
+                "foreign_key_name": "",
+                "data_type": "yyyymm",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "month",
+                "entity": "base.commerce_line_item_fact",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month, as yyyymm.",
+                "foreign_key_name": "",
+                "data_type": "yyyymm",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "month",
+                "entity": "base.commerce_transaction_fact",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month, as yyyymm.",
+                "foreign_key_name": "",
+                "data_type": "yyyymm",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "month",
+                "entity": "base.domstream",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month, as yyyymm.",
+                "foreign_key_name": "",
+                "data_type": "yyyymm",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "month",
+                "entity": "base.feed_request",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "month",
+                "entity": "base.request",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month, as yyyymm.",
+                "foreign_key_name": "",
+                "data_type": "yyyymm",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "month",
+                "entity": "base.session",
+                "column": "month",
+                "family": "time",
+                "label": "Month",
+                "description": "The month, as yyyymm.",
+                "foreign_key_name": "",
+                "data_type": "yyyymm",
+                "denormalized": true
+            }
+        },
+        "pagesViewsInVisit": {
+            "base.session": {
+                "name": "pagesViewsInVisit",
+                "entity": "base.session",
+                "column": "num_pageviews",
+                "family": "visit",
+                "label": "Pages Viewed In Visit",
+                "description": "The number of pages viewed in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "priorVisitCount": {
+            "base.action_fact": {
+                "name": "priorVisitCount",
+                "entity": "base.action_fact",
+                "column": "num_prior_sessions",
+                "family": "visit",
+                "label": "Prior Visits",
+                "description": "The number of prior visits, excluding the current one.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "priorVisitCount",
+                "entity": "base.click",
+                "column": "num_prior_sessions",
+                "family": "visit",
+                "label": "Prior Visits",
+                "description": "The number of prior visits, excluding the current one.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "priorVisitCount",
+                "entity": "base.commerce_line_item_fact",
+                "column": "num_prior_sessions",
+                "family": "visit",
+                "label": "Prior Visits",
+                "description": "The number of prior visits, excluding the current one.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "priorVisitCount",
+                "entity": "base.commerce_transaction_fact",
+                "column": "num_prior_sessions",
+                "family": "visit",
+                "label": "Prior Visits",
+                "description": "The number of prior visits, excluding the current one.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "priorVisitCount",
+                "entity": "base.domstream",
+                "column": "num_prior_sessions",
+                "family": "visit",
+                "label": "Prior Visits",
+                "description": "The number of prior visits, excluding the current one.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "priorVisitCount",
+                "entity": "base.request",
+                "column": "num_prior_sessions",
+                "family": "visit",
+                "label": "Prior Visits",
+                "description": "The number of prior visits, excluding the current one.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "priorVisitCount",
+                "entity": "base.session",
+                "column": "num_prior_sessions",
+                "family": "visit",
+                "label": "Prior Visits",
+                "description": "The number of prior visits, excluding the current one.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "productCategory": {
+            "base.commerce_line_item_fact": {
+                "name": "productCategory",
+                "entity": "base.commerce_line_item_fact",
+                "column": "category",
+                "family": "ecommerce",
+                "label": "Product Category",
+                "description": "The category of product purchased.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "productName": {
+            "base.commerce_line_item_fact": {
+                "name": "productName",
+                "entity": "base.commerce_line_item_fact",
+                "column": "product_name",
+                "family": "ecommerce",
+                "label": "Product Name",
+                "description": "The name of the product purchased.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "productSku": {
+            "base.commerce_line_item_fact": {
+                "name": "productSku",
+                "entity": "base.commerce_line_item_fact",
+                "column": "sku",
+                "family": "ecommerce",
+                "label": "Product SKU",
+                "description": "The SKU code of the product purchased.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "revenueInVisit": {
+            "base.session": {
+                "name": "revenueInVisit",
+                "entity": "base.session",
+                "column": "commerce_trans_revenue",
+                "family": "visit",
+                "label": "Revenue in Visit",
+                "description": "Revenue generate from e-commerce transactions in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "shippingRevenueInVisit": {
+            "base.session": {
+                "name": "shippingRevenueInVisit",
+                "entity": "base.session",
+                "column": "commerce_shipping_revenue",
+                "family": "visit",
+                "label": "Shipping Revenue in Visit",
+                "description": "Revenue generate from e-commerce shipping in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "siteId": {
+            "base.action_fact": {
+                "name": "siteId",
+                "entity": "base.action_fact",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "siteId",
+                "entity": "base.click",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "siteId",
+                "entity": "base.commerce_line_item_fact",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "siteId",
+                "entity": "base.commerce_transaction_fact",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "siteId",
+                "entity": "base.domstream",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "siteId",
+                "entity": "base.feed_request",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "siteId",
+                "entity": "base.request",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "siteId",
+                "entity": "base.session",
+                "column": "site_id",
+                "family": "site",
+                "label": "Site ID",
+                "description": "The ID of the the web site.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "taxRevenueInVisit": {
+            "base.session": {
+                "name": "taxRevenueInVisit",
+                "entity": "base.session",
+                "column": "commerce_tax_revenue",
+                "family": "visit",
+                "label": "Tax Revenue in Visit",
+                "description": "Revenue generate from e-commerce tax in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "timestamp": {
+            "base.commerce_transaction_fact": {
+                "name": "timestamp",
+                "entity": "base.commerce_transaction_fact",
+                "column": "timestamp",
+                "family": "ecommerce-special",
+                "label": "Time",
+                "description": "The timestamp of the transaction.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "transactionGateway": {
+            "base.commerce_transaction_fact": {
+                "name": "transactionGateway",
+                "entity": "base.commerce_transaction_fact",
+                "column": "gateway",
+                "family": "ecommerce",
+                "label": "Payment Gateway",
+                "description": "The payment gateway/provider used to clear the transaction.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "transactionId": {
+            "base.commerce_transaction_fact": {
+                "name": "transactionId",
+                "entity": "base.commerce_transaction_fact",
+                "column": "order_id",
+                "family": "ecommerce",
+                "label": "Transaction ID",
+                "description": "The id of the e-commerce transaction.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "transactionOriginator": {
+            "base.commerce_transaction_fact": {
+                "name": "transactionOriginator",
+                "entity": "base.commerce_transaction_fact",
+                "column": "order_source",
+                "family": "ecommerce",
+                "label": "Originator",
+                "description": "The store or location that originated the transaction.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "transactionsInVisit": {
+            "base.session": {
+                "name": "transactionsInVisit",
+                "entity": "base.session",
+                "column": "commerce_trans_count",
+                "family": "visit",
+                "label": "Transactions in Visit",
+                "description": "Number of e-commerce transactions completed in a visit.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "visitsToTransaction": {
+            "base.commerce_transaction_fact": {
+                "name": "visitsToTransaction",
+                "entity": "base.commerce_transaction_fact",
+                "column": "num_prior_sessions",
+                "family": "ecommerce",
+                "label": "Visits To Purchase",
+                "description": "The number of visits before the transaction occurred.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "weekofyear": {
+            "base.action_fact": {
+                "name": "weekofyear",
+                "entity": "base.action_fact",
+                "column": "weekofyear",
+                "family": "time",
+                "label": "Week of Year",
+                "description": "The week of the year (1-52).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "weekofyear",
+                "entity": "base.click",
+                "column": "weekofyear",
+                "family": "time",
+                "label": "Week of Year",
+                "description": "The week of the year (1-52).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "weekofyear",
+                "entity": "base.commerce_line_item_fact",
+                "column": "weekofyear",
+                "family": "time",
+                "label": "Week of Year",
+                "description": "The week of the year (1-52).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "weekofyear",
+                "entity": "base.commerce_transaction_fact",
+                "column": "weekofyear",
+                "family": "time",
+                "label": "Week of Year",
+                "description": "The week of the year (1-52).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "weekofyear",
+                "entity": "base.domstream",
+                "column": "weekofyear",
+                "family": "time",
+                "label": "Week of Year",
+                "description": "The week of the year (1-52).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "weekofyear",
+                "entity": "base.feed_request",
+                "column": "weekofyear",
+                "family": "date",
+                "label": "Week of Year",
+                "description": "The week of the year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "weekofyear",
+                "entity": "base.request",
+                "column": "weekofyear",
+                "family": "time",
+                "label": "Week of Year",
+                "description": "The week of the year (1-52).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "weekofyear",
+                "entity": "base.session",
+                "column": "weekofyear",
+                "family": "time",
+                "label": "Week of Year",
+                "description": "The week of the year (1-52).",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
+        "year": {
+            "base.action_fact": {
+                "name": "year",
+                "entity": "base.action_fact",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "year",
+                "entity": "base.click",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "year",
+                "entity": "base.commerce_line_item_fact",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "year",
+                "entity": "base.commerce_transaction_fact",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "year",
+                "entity": "base.domstream",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.feed_request": {
+                "name": "year",
+                "entity": "base.feed_request",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "year",
+                "entity": "base.request",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "year",
+                "entity": "base.session",
+                "column": "year",
+                "family": "time",
+                "label": "Year",
+                "description": "The year.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        }
+    },
+    "accessorGetAllDimensions": {
+        "actionGroup": {
+            "name": "actionGroup",
+            "entity": "base.action_fact",
+            "column": "action_group",
+            "family": "actions",
+            "label": "Action Group",
+            "description": "The group that an action belongs to.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "actionLabel": {
+            "name": "actionLabel",
+            "entity": "base.action_fact",
+            "column": "action_label",
+            "family": "actions",
+            "label": "Action Label",
+            "description": "The label associated with an action.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "actionName": {
+            "name": "actionName",
+            "entity": "base.action_fact",
+            "column": "action_name",
+            "family": "actions",
+            "label": "Action Name",
+            "description": "The name of the action.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "ad": {
+            "name": "ad",
+            "entity": "base.ad_dim",
+            "column": "name",
+            "family": "campaign",
+            "label": "Ad",
+            "description": "The name of the ad that originated the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "adType": {
+            "name": "adType",
+            "entity": "base.ad_dim",
+            "column": "type",
+            "family": "campaign",
+            "label": "Ad Type",
+            "description": "The type of ad that originated the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "browserType": {
+            "name": "browserType",
+            "entity": "base.ua",
+            "column": "browser_type",
+            "family": "system",
+            "label": "Browser Type",
+            "description": "The browser type of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "browserVersion": {
+            "name": "browserVersion",
+            "entity": "base.ua",
+            "column": "browser",
+            "family": "system",
+            "label": "Browser Version",
+            "description": "The browser version of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "campaign": {
+            "name": "campaign",
+            "entity": "base.campaign_dim",
+            "column": "name",
+            "family": "campaign",
+            "label": "Campaign",
+            "description": "The campaign that originated the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "city": {
+            "name": "city",
+            "entity": "base.location_dim",
+            "column": "city",
+            "family": "geo",
+            "label": "City",
+            "description": "The city of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "clickX": {
+            "name": "clickX",
+            "entity": "base.click",
+            "column": "click_x",
+            "family": "dom",
+            "label": "Click X",
+            "description": "The horizontal position of the click on the page.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "clickY": {
+            "name": "clickY",
+            "entity": "base.click",
+            "column": "click_y",
+            "family": "dom",
+            "label": "Click Y",
+            "description": "The vertical position of the click on the page.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "country": {
+            "name": "country",
+            "entity": "base.location_dim",
+            "column": "country",
+            "family": "geo",
+            "label": "Country",
+            "description": "The country of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "countryCode": {
+            "name": "countryCode",
+            "entity": "base.location_dim",
+            "column": "country_code",
+            "family": "geo",
+            "label": "Country Code",
+            "description": "The ISO country code of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "customVarName1": {
+            "name": "customVarName1",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv1_name",
+            "family": "custom variables",
+            "label": "Custom Var 1 Name",
+            "description": "The name of custom variable 1.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarName2": {
+            "name": "customVarName2",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv2_name",
+            "family": "custom variables",
+            "label": "Custom Var 2 Name",
+            "description": "The name of custom variable 2.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarName3": {
+            "name": "customVarName3",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv3_name",
+            "family": "custom variables",
+            "label": "Custom Var 3 Name",
+            "description": "The name of custom variable 3.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarName4": {
+            "name": "customVarName4",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv4_name",
+            "family": "custom variables",
+            "label": "Custom Var 4 Name",
+            "description": "The name of custom variable 4.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarName5": {
+            "name": "customVarName5",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv5_name",
+            "family": "custom variables",
+            "label": "Custom Var 5 Name",
+            "description": "The name of custom variable 5.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarValue1": {
+            "name": "customVarValue1",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv1_value",
+            "family": "custom variables",
+            "label": "Custom Var 1 Value",
+            "description": "The value of custom variable 1.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarValue2": {
+            "name": "customVarValue2",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv2_value",
+            "family": "custom variables",
+            "label": "Custom Var 2 Value",
+            "description": "The value of custom variable 2.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarValue3": {
+            "name": "customVarValue3",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv3_value",
+            "family": "custom variables",
+            "label": "Custom Var 3 Value",
+            "description": "The value of custom variable 3.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarValue4": {
+            "name": "customVarValue4",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv4_value",
+            "family": "custom variables",
+            "label": "Custom Var 4 Value",
+            "description": "The value of custom variable 4.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "customVarValue5": {
+            "name": "customVarValue5",
+            "entity": "base.commerce_line_item_fact",
+            "column": "cv5_value",
+            "family": "custom variables",
+            "label": "Custom Var 5 Value",
+            "description": "The value of custom variable 5.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "date": {
+            "name": "date",
+            "entity": "base.feed_request",
+            "column": "yyyymmdd",
+            "family": "time",
+            "label": "Date",
+            "description": "The date.",
+            "foreign_key_name": "",
+            "data_type": "yyyymmdd",
+            "denormalized": true
+        },
+        "day": {
+            "name": "day",
+            "entity": "base.feed_request",
+            "column": "day",
+            "family": "time",
+            "label": "Day",
+            "description": "The day.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "dayofweek": {
+            "name": "dayofweek",
+            "entity": "base.feed_request",
+            "column": "dayofweek",
+            "family": "time",
+            "label": "Day of Week",
+            "description": "The day of the week.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "dayofyear": {
+            "name": "dayofyear",
+            "entity": "base.feed_request",
+            "column": "dayofyear",
+            "family": "time",
+            "label": "Day of Year",
+            "description": "The day of the year.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "daysSinceFirstVisit": {
+            "name": "daysSinceFirstVisit",
+            "entity": "base.commerce_line_item_fact",
+            "column": "days_since_first_session",
+            "family": "visit",
+            "label": "Days Since First Visit",
+            "description": "The number of days since the first visit of the user.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "daysSinceLastVisit": {
+            "name": "daysSinceLastVisit",
+            "entity": "base.commerce_line_item_fact",
+            "column": "days_since_prior_session",
+            "family": "visit",
+            "label": "Days Since Last Visit",
+            "description": "The number of days since the last visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "daysToTransaction": {
+            "name": "daysToTransaction",
+            "entity": "base.commerce_transaction_fact",
+            "column": "days_since_first_session",
+            "family": "ecommerce",
+            "label": "Days To Purchase",
+            "description": "The number of days since the first visit and an e-commerce transaction.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "distinctItemsInVisit": {
+            "name": "distinctItemsInVisit",
+            "entity": "base.session",
+            "column": "commerce_items_count",
+            "family": "visit",
+            "label": "Distinct Items in Visit",
+            "description": "Number of distinct items purchased in Visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "domElementClass": {
+            "name": "domElementClass",
+            "entity": "base.click",
+            "column": "dom_element_class",
+            "family": "dom",
+            "label": "Dom Class",
+            "description": "The class of the dom element.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "domElementId": {
+            "name": "domElementId",
+            "entity": "base.click",
+            "column": "dom_element_id",
+            "family": "dom",
+            "label": "Dom ID",
+            "description": "The id of the dom element.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "domElementName": {
+            "name": "domElementName",
+            "entity": "base.click",
+            "column": "dom_element_name",
+            "family": "dom",
+            "label": "Dom Name",
+            "description": "The name of the dom element.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "domElementTag": {
+            "name": "domElementTag",
+            "entity": "base.click",
+            "column": "dom_element_tag",
+            "family": "dom",
+            "label": "Dom Tag",
+            "description": "The html tag of the dom element.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "domElementText": {
+            "name": "domElementText",
+            "entity": "base.click",
+            "column": "dom_element_text",
+            "family": "dom",
+            "label": "Dom Text",
+            "description": "The text associated the dom element.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "domElementValue": {
+            "name": "domElementValue",
+            "entity": "base.click",
+            "column": "dom_element_value",
+            "family": "dom",
+            "label": "Dom Value",
+            "description": "The value of the dom element.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "entryPagePath": {
+            "name": "entryPagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "visit",
+            "label": "Entry Page Path",
+            "description": "The URI of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "entryPageTitle": {
+            "name": "entryPageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "visit",
+            "label": "Entry Page Title",
+            "description": "The title of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "entryPageType": {
+            "name": "entryPageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "visit",
+            "label": "Entry Page Type",
+            "description": "The page type of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "entryPageUrl": {
+            "name": "entryPageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "visit",
+            "label": "Entry Page URL",
+            "description": "The URL of the entry page.",
+            "foreign_key_name": "first_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPagePath": {
+            "name": "exitPagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "visit",
+            "label": "Exit Page Path",
+            "description": "The URI of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPageTitle": {
+            "name": "exitPageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "visit",
+            "label": "Exit Page Title",
+            "description": "The title of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPageType": {
+            "name": "exitPageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "visit",
+            "label": "Exit Page Type",
+            "description": "The page type of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "exitPageUrl": {
+            "name": "exitPageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "visit",
+            "label": "Exit Page URL",
+            "description": "The URL of the exit page.",
+            "foreign_key_name": "last_page_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "feedType": {
+            "name": "feedType",
+            "entity": "base.feed_request",
+            "column": "feed_format",
+            "family": "feed",
+            "label": "Feed Type",
+            "description": "The type or format of the feed.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "goalStartsInVisit": {
+            "name": "goalStartsInVisit",
+            "entity": "base.session",
+            "column": "num_goal_starts",
+            "family": "visit",
+            "label": "Goal Starts in Visit",
+            "description": "Goals started in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "goalValueInVisit": {
+            "name": "goalValueInVisit",
+            "entity": "base.session",
+            "column": "goals_value",
+            "family": "visit",
+            "label": "Goal Value in Visit",
+            "description": "Total value from all goals in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "goalsInVisit": {
+            "name": "goalsInVisit",
+            "entity": "base.session",
+            "column": "num_goals",
+            "family": "visit",
+            "label": "Goals in Visit",
+            "description": "Goals completed in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "hostName": {
+            "name": "hostName",
+            "entity": "base.host",
+            "column": "host",
+            "family": "network",
+            "label": "Host Name",
+            "description": "The host name of the network used by the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "ipAddress": {
+            "name": "ipAddress",
+            "entity": "base.commerce_line_item_fact",
+            "column": "ip_address",
+            "family": "network",
+            "label": "IP Address",
+            "description": "The IP address of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "isNewVisitor": {
+            "name": "isNewVisitor",
+            "entity": "base.commerce_line_item_fact",
+            "column": "is_new_visitor",
+            "family": "visitor",
+            "label": "New Visitor",
+            "description": "New Site Visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "isRepeatVisitor": {
+            "name": "isRepeatVisitor",
+            "entity": "base.commerce_line_item_fact",
+            "column": "is_repeat_visitor",
+            "family": "visitor",
+            "label": "Repeat Visitor",
+            "description": "Repeat Site Visitor.",
+            "foreign_key_name": "",
+            "data_type": "boolean",
+            "denormalized": true
+        },
+        "isSearchEngine": {
+            "name": "isSearchEngine",
+            "entity": "base.referer",
+            "column": "is_searchengine",
+            "family": "campaign",
+            "label": "Search Engine",
+            "description": "Is traffic source a search engine.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "itemQuantityInVisit": {
+            "name": "itemQuantityInVisit",
+            "entity": "base.session",
+            "column": "commerce_items_quantity",
+            "family": "visit",
+            "label": "Item Quantity in Visit",
+            "description": "Number of e-commerce items purchased completed in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "itemRevenueInVisit": {
+            "name": "itemRevenueInVisit",
+            "entity": "base.session",
+            "column": "commerce_item_revenue",
+            "family": "visit",
+            "label": "Item Revenue in Visit",
+            "description": "Revenue generate from e-commerce transaction items in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "language": {
+            "name": "language",
+            "entity": "base.commerce_line_item_fact",
+            "column": "language",
+            "family": "system",
+            "label": "Language",
+            "description": "The language of the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "latestAttributions": {
+            "name": "latestAttributions",
+            "entity": "base.session",
+            "column": "latest_attributions",
+            "family": "campaign-special",
+            "label": "Latest Attributions",
+            "description": "The latest campaign attributions.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "latitude": {
+            "name": "latitude",
+            "entity": "base.location_dim",
+            "column": "latitude",
+            "family": "geo",
+            "label": "Latitude",
+            "description": "The latitude of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "longitude": {
+            "name": "longitude",
+            "entity": "base.location_dim",
+            "column": "longitude",
+            "family": "geo",
+            "label": "Longitude",
+            "description": "The longitude of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "medium": {
+            "name": "medium",
+            "entity": "base.commerce_line_item_fact",
+            "column": "medium",
+            "family": "campaign",
+            "label": "Medium",
+            "description": "The medium where visit originated from.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "month": {
+            "name": "month",
+            "entity": "base.feed_request",
+            "column": "month",
+            "family": "time",
+            "label": "Month",
+            "description": "The month.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "osType": {
+            "name": "osType",
+            "entity": "base.os",
+            "column": "name",
+            "family": "system",
+            "label": "Operating System",
+            "description": "The operating System of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pagePath": {
+            "name": "pagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "content",
+            "label": "Page Path",
+            "description": "The path of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pageTitle": {
+            "name": "pageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "content",
+            "label": "Page Title",
+            "description": "The title of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pageType": {
+            "name": "pageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "content",
+            "label": "Page Type",
+            "description": "The page type of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pageUrl": {
+            "name": "pageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "content",
+            "label": "Page URL",
+            "description": "The URL of the web page.",
+            "foreign_key_name": "document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "pagesViewsInVisit": {
+            "name": "pagesViewsInVisit",
+            "entity": "base.session",
+            "column": "num_pageviews",
+            "family": "visit",
+            "label": "Pages Viewed In Visit",
+            "description": "The number of pages viewed in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "priorPagePath": {
+            "name": "priorPagePath",
+            "entity": "base.document",
+            "column": "uri",
+            "family": "content",
+            "label": "Prior Page Path",
+            "description": "The URI of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorPageTitle": {
+            "name": "priorPageTitle",
+            "entity": "base.document",
+            "column": "page_title",
+            "family": "content",
+            "label": "Prior Page Title",
+            "description": "The title of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorPageType": {
+            "name": "priorPageType",
+            "entity": "base.document",
+            "column": "page_type",
+            "family": "content",
+            "label": "Prior Page Type",
+            "description": "The page type of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorPageUrl": {
+            "name": "priorPageUrl",
+            "entity": "base.document",
+            "column": "url",
+            "family": "content",
+            "label": "Prior Page URL",
+            "description": "The URL of the prior page.",
+            "foreign_key_name": "prior_document_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "priorVisitCount": {
+            "name": "priorVisitCount",
+            "entity": "base.commerce_line_item_fact",
+            "column": "num_prior_sessions",
+            "family": "visit",
+            "label": "Prior Visits",
+            "description": "The number of prior visits, excluding the current one.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "productCategory": {
+            "name": "productCategory",
+            "entity": "base.commerce_line_item_fact",
+            "column": "category",
+            "family": "ecommerce",
+            "label": "Product Category",
+            "description": "The category of product purchased.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "productName": {
+            "name": "productName",
+            "entity": "base.commerce_line_item_fact",
+            "column": "product_name",
+            "family": "ecommerce",
+            "label": "Product Name",
+            "description": "The name of the product purchased.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "productSku": {
+            "name": "productSku",
+            "entity": "base.commerce_line_item_fact",
+            "column": "sku",
+            "family": "ecommerce",
+            "label": "Product SKU",
+            "description": "The SKU code of the product purchased.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "referralLinkText": {
+            "name": "referralLinkText",
+            "entity": "base.referer",
+            "column": "refering_anchortext",
+            "family": "campaign",
+            "label": "Referral Link Text",
+            "description": "The text of the referring link.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralPageTitle": {
+            "name": "referralPageTitle",
+            "entity": "base.referer",
+            "column": "page_title",
+            "family": "campaign",
+            "label": "Referral Page Title",
+            "description": "The title of the referring web page.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralPageUrl": {
+            "name": "referralPageUrl",
+            "entity": "base.referer",
+            "column": "url",
+            "family": "campaign",
+            "label": "Referral Page URL",
+            "description": "The url of the referring web page.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralSearchTerms": {
+            "name": "referralSearchTerms",
+            "entity": "base.search_term_dim",
+            "column": "terms",
+            "family": "campaign",
+            "label": "Search Terms",
+            "description": "The referring search terms.",
+            "foreign_key_name": "referring_search_term_id",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "referralWebSite": {
+            "name": "referralWebSite",
+            "entity": "base.referer",
+            "column": "site",
+            "family": "campaign",
+            "label": "Referral Web Site",
+            "description": "The full domain of the referring web site.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "revenueInVisit": {
+            "name": "revenueInVisit",
+            "entity": "base.session",
+            "column": "commerce_trans_revenue",
+            "family": "visit",
+            "label": "Revenue in Visit",
+            "description": "Revenue generate from e-commerce transactions in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "sessionId": {
+            "name": "sessionId",
+            "entity": "base.session",
+            "column": "id",
+            "family": "visit-special",
+            "label": "Session ID",
+            "description": "The ID of the session/visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "shippingRevenueInVisit": {
+            "name": "shippingRevenueInVisit",
+            "entity": "base.session",
+            "column": "commerce_shipping_revenue",
+            "family": "visit",
+            "label": "Shipping Revenue in Visit",
+            "description": "Revenue generate from e-commerce shipping in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "siteDomain": {
+            "name": "siteDomain",
+            "entity": "base.site",
+            "column": "domain",
+            "family": "site",
+            "label": "Site Domain",
+            "description": "The domain of the web site.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "siteId": {
+            "name": "siteId",
+            "entity": "base.feed_request",
+            "column": "site_id",
+            "family": "site",
+            "label": "Site ID",
+            "description": "The ID of the the web site.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "siteName": {
+            "name": "siteName",
+            "entity": "base.site",
+            "column": "name",
+            "family": "site",
+            "label": "Site Name",
+            "description": "The name of the site.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "source": {
+            "name": "source",
+            "entity": "base.source_dim",
+            "column": "source_domain",
+            "family": "campaign",
+            "label": "Source",
+            "description": "The traffic source of the visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "stateRegion": {
+            "name": "stateRegion",
+            "entity": "base.location_dim",
+            "column": "state",
+            "family": "geo",
+            "label": "State/Region",
+            "description": "The state or region of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "taxRevenueInVisit": {
+            "name": "taxRevenueInVisit",
+            "entity": "base.session",
+            "column": "commerce_tax_revenue",
+            "family": "visit",
+            "label": "Tax Revenue in Visit",
+            "description": "Revenue generate from e-commerce tax in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "timestamp": {
+            "name": "timestamp",
+            "entity": "base.commerce_transaction_fact",
+            "column": "timestamp",
+            "family": "ecommerce-special",
+            "label": "Time",
+            "description": "The timestamp of the transaction.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "transactionGateway": {
+            "name": "transactionGateway",
+            "entity": "base.commerce_transaction_fact",
+            "column": "gateway",
+            "family": "ecommerce",
+            "label": "Payment Gateway",
+            "description": "The payment gateway/provider used to clear the transaction.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "transactionId": {
+            "name": "transactionId",
+            "entity": "base.commerce_transaction_fact",
+            "column": "order_id",
+            "family": "ecommerce",
+            "label": "Transaction ID",
+            "description": "The id of the e-commerce transaction.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "transactionOriginator": {
+            "name": "transactionOriginator",
+            "entity": "base.commerce_transaction_fact",
+            "column": "order_source",
+            "family": "ecommerce",
+            "label": "Originator",
+            "description": "The store or location that originated the transaction.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "transactionsInVisit": {
+            "name": "transactionsInVisit",
+            "entity": "base.session",
+            "column": "commerce_trans_count",
+            "family": "visit",
+            "label": "Transactions in Visit",
+            "description": "Number of e-commerce transactions completed in a visit.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "userEmail": {
+            "name": "userEmail",
+            "entity": "base.visitor",
+            "column": "user_email",
+            "family": "visitor",
+            "label": "Email Address",
+            "description": "The email address of the user.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "userName": {
+            "name": "userName",
+            "entity": "base.commerce_line_item_fact",
+            "column": "user_name",
+            "family": "visitor",
+            "label": "User Name",
+            "description": "The name or ID of the user.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "visitorId": {
+            "name": "visitorId",
+            "entity": "base.visitor",
+            "column": "id",
+            "family": "visitor",
+            "label": "Visitor ID",
+            "description": "The ID of the visitor.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": false
+        },
+        "visitsToTransaction": {
+            "name": "visitsToTransaction",
+            "entity": "base.commerce_transaction_fact",
+            "column": "num_prior_sessions",
+            "family": "ecommerce",
+            "label": "Visits To Purchase",
+            "description": "The number of visits before the transaction occurred.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "weekofyear": {
+            "name": "weekofyear",
+            "entity": "base.feed_request",
+            "column": "weekofyear",
+            "family": "date",
+            "label": "Week of Year",
+            "description": "The week of the year.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        },
+        "year": {
+            "name": "year",
+            "entity": "base.feed_request",
+            "column": "year",
+            "family": "time",
+            "label": "Year",
+            "description": "The year.",
+            "foreign_key_name": "",
+            "data_type": "string",
+            "denormalized": true
+        }
+    }
+}


### PR DESCRIPTION
Coexistence groundwork for v2, items 1 and 2 of
`research/v2-schema/GROUNDWORK.html` — **landed together, because the first cannot
ship alone.** Entity-keying the registry changes what `getAllDimensions()` hands
its ten callers, so the accessor has to move in the same commit.

Two commits: the characterization first, then the change it judges.

## 1. Record the catalog (`690635de`)

78 metric names / 99 implementations, 42 normalized dimension names, 59
denormalized names over 223 entity-entries — recorded **including two defects**,
because a suite that quietly corrects what it finds cannot prove anything about
the change that corrects it.

**Mutation-checked at creation:** applying the real fix moves
`dimensionEntriesNormalized` 42 → 48 and fails **exactly two** checks — the
recording and the defect-1 marker — while metrics, denormalized dimensions and
the accessor count hold steady. The entry counter understands both the current
flat shape and the coming entity-keyed one, so the harness survives the commit
it judges instead of being edited by it; that tolerance has its own test.

## 2. Key by entity, allow scoping (`45e0b2c8`)

**Registry.** `registerDimension()` loops `$entity_names`; the normalized branch
overwrote `$this->dimensions[$dim_name]` each turn, keeping only the last entity.
Now keyed by entity like the denormalized branch beside it, with
`_loadDimensions()` merging recursively so a module load cannot reintroduce the
same loss.

**Resolution is deliberately unchanged.** `getDimension()` without an entity
still answers the last registration, exactly as the flat array did.
`getAllDimensions()` without a scope still returns one flat entry per name,
last-wins, same precedence. Storage gains information; nothing an existing caller
sees moves. That is what makes this reviewable as behaviour-preserving.

**Scoping.** `getAllDimensions($entities)` answers only dimensions defined on
those entities, and a name defined on none is **absent entirely** rather than
present-and-wrong — so a caller cannot reach the other generation's definition,
because it is not in the answer to be filtered out. `getDimension($name,
$entity)` and `getDimensionEntities($name)` expose the same by name. Nothing
consumes these yet; they exist so scoping is written and tested against a real
second registration before a second schema generation depends on it.

## Verified

- **Full suite: 1639 tests, 47099 assertions, green** (2 skips — the local baseline)
- The catalog recording moves in exactly the two places it should
- Isolation: the new tests pass run alone
- ⚠️ **Configless not run locally** — the box was out of memory for a staged run.
  It passed configless before the change; the change is pure PHP with no DB
  dependency. Relying on CI for this one.

## Found on the way, deliberately not fixed here

The six recovered entities belong entirely to **`userName`**, which is registered
**normalized** against seven fact entities that all carry `user_name`
**denormalized** on the row — with an empty `foreign_key_name`. So it builds an
alias ending `_via_` and joins `base.commerce_line_item_fact` rather than the
entity being queried. The fix is one flag, `denormalized = true`, exactly as
`date` is registered against the same list.

No shipped report uses it, but `getAllDimensions()` offers it, so it is
selectable in the custom-report picker — reachable, and unexercised, which is why
it went unnoticed. **A behaviour change does not belong in a behaviour-preserving
commit**, so it gets its own PR and its own test.

(Two earlier estimates corrected by runtime measurement: three suspect dimensions
turned out to be one, and ~18 lost entries turned out to be 6.)