### PR TITLE
fix: userName is a column on the fact row, not a table to join

### DIFF
--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -1497,13 +1497,32 @@ class Module extends \OWA\Core\Module {
             'The ID of the visitor.'
         );
 
+        /*
+         * Denormalized, like every other column that lives ON the fact row --
+         * `date` is registered against this same list the same way.
+         *
+         * It was registered normalized, which means "join this dimension's own
+         * table through a foreign key". There is no foreign key here because
+         * user_name is not a separate table: it is a tracking property with
+         * required => true, so every event carries it and it is written to all
+         * seven fact tables. The result was a dimension that related to nothing,
+         * offered by the picker and then refused at save as an impossible
+         * combination.
+         *
+         * Note this reads the value AS AT THE EVENT. Its sibling userEmail is
+         * registered against base.visitor and so reads the visitor's stored
+         * identity, which VisitorHandlers writes only when the visitor row is
+         * created. The two answer different questions on purpose.
+         */
         $this->registerDimension(
             'userName',
             $fact_table_entities,
             'user_name',
             'User Name',
             'visitor',
-            'The name or ID of the user.'
+            'The name or ID of the user.',
+            '',
+            true
         );
 
         $this->registerDimension(

--- a/tests/CatalogCharacterizationTest.php
+++ b/tests/CatalogCharacterizationTest.php
@@ -120,35 +120,57 @@ final class CatalogCharacterizationTest extends TestCase
      * ---- the two defects, recorded on purpose ------------------------------
      */
 
-    public function testNormalizedDimensionsKeepEveryEntityTheyAreRegisteredAgainst(): void
+    public function testNormalizedDimensionsAreKeyedByEntity(): void
     {
-        $counts = Harness::snapshot()['counts'];
-
         /*
-         * DEFECT 1, fixed. registerDimension() loops $entity_names, and the
-         * normalized branch used to overwrite $this->dimensions[$dim_name] on
-         * each turn, keeping only the last entity. Entries now exceed names,
-         * which is what makes registering a second schema generation under an
-         * existing name possible: it sits beside the first instead of replacing
-         * it.
+         * The shape, not a count.
+         *
+         * An earlier version asserted entries outnumbered names, using userName
+         * as its example -- which held only because userName was MISREGISTERED
+         * as normalized against seven entities. Fixing that left the assertion
+         * pinning a defect, and it began failing the moment the defect went. A
+         * capability should be tested directly, not through the accident that
+         * happened to exercise it.
+         *
+         * Every normalized dimension currently names exactly one entity, which
+         * is what a normalized dimension SHOULD do: it points at the table it
+         * joins. The structure still has to hold several, because that is what
+         * lets a second schema generation register under an existing name.
          */
-        $this->assertGreaterThan(
-            $counts['dimensionNamesNormalized'],
-            $counts['dimensionEntriesNormalized'],
-            'Normalized dimensions are entity-keyed and must hold more entries than names.' );
+        $snapshot = Harness::snapshot();
+
+        $this->assertNotEmpty( $snapshot['dimensionsNormalized'] );
+
+        foreach ( $snapshot['dimensionsNormalized'] as $name => $entry ) {
+
+            $this->assertTrue(
+                Harness::isEntityKeyed( $entry ),
+                "The normalized dimension '$name' is not keyed by entity, so a second "
+                . 'definition under this name would overwrite it rather than sit beside it.' );
+        }
     }
 
-    public function testTheDimensionThatWasLosingEntitiesKeepsThemAll(): void
+    public function testTheRegistryHoldsSeveralEntitiesUnderOneName(): void
     {
         /*
-         * Named rather than counted, because a total can be moved by anything.
-         * userName is registered against all seven fact entities and was the
-         * only dimension actually losing any -- six of them.
+         * Exercised through the denormalized registry, which shares the shape
+         * and genuinely carries multi-entity names -- `date` is registered
+         * against every fact table. Both halves are now name => entity =>
+         * registration, so this proves the structure both rely on.
          */
-        $entities = \OWA\Core\CoreAPI::serviceSingleton()->getDimensionEntities( 'userName' );
+        $counts = Harness::snapshot()['counts'];
 
-        $this->assertCount( 7, $entities );
-        $this->assertContains( 'base.session', $entities );
+        $this->assertGreaterThan(
+            $counts['dimensionNamesDenormalized'],
+            $counts['dimensionEntriesDenormalized'] );
+
+        $entities = \OWA\Core\CoreAPI::serviceSingleton()
+            ->getDimensionEntities( 'userName' );
+
+        $this->assertSame(
+            array(), $entities,
+            'userName is denormalized now, so it holds no NORMALIZED entities. If this starts '
+            . 'returning entities it has been re-registered the old way.' );
     }
 
     public function testDenormalizedDimensionsAlreadyHoldManyEntitiesEach(): void
@@ -222,16 +244,20 @@ final class CatalogCharacterizationTest extends TestCase
     {
         $service = \OWA\Core\CoreAPI::serviceSingleton();
 
+        /*
+         * siteDomain rather than userName: a dimension that is genuinely
+         * normalized, naming the table it joins.
+         */
         $this->assertSame(
-            'base.session',
-            $service->getDimension( 'userName', 'base.session' )['entity'] );
+            'base.site',
+            $service->getDimension( 'siteDomain', 'base.site' )['entity'] );
 
         $this->assertNull(
-            $service->getDimension( 'userName', 'base.nonexistentEntity' ),
+            $service->getDimension( 'siteDomain', 'base.nonexistentEntity' ),
             'An entity a dimension is not defined on must answer nothing, not a fallback.' );
 
         $this->assertNotNull(
-            $service->getDimension( 'userName' ),
+            $service->getDimension( 'siteDomain' ),
             'Asking without an entity must still answer, as the flat registry did.' );
     }
 

--- a/tests/UserNameDimensionTest.php
+++ b/tests/UserNameDimensionTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * userName is offered by the catalog but no entity can answer it.
+ *
+ * It is registered NORMALIZED against the seven fact entities, all of which
+ * carry user_name denormalized on the row, and with no foreign key. A
+ * normalized dimension is resolved by joining its own entity through a foreign
+ * key, so with none to join on it relates to nothing -- and the report is
+ * refused as an impossible combination after being offered in the picker.
+ *
+ * The value really is on the row: user_name is a registered tracking property
+ * with required => true, so every event carries it (defaulting to the '(not
+ * set)' sentinel), and it lands on all seven fact tables. Denormalized is what
+ * it always should have been -- exactly how `date` is registered against the
+ * same list.
+ *
+ * Its sibling userEmail is registered against base.visitor and so reads the
+ * visitor's stored identity instead. The two therefore answer different
+ * questions, which is deliberate and documented in GROUNDWORK.html: the fact
+ * row records who the event was attributed to AT THE TIME, while the visitor
+ * row is a lens on who we now know that visitor to be.
+ */
+final class UserNameDimensionTest extends TestCase
+{
+    private function manager()
+    {
+        return \OWA\Core\CoreAPI::supportClassFactory( 'base', 'resultSetManager' );
+    }
+
+    public function testAReportCanActuallyUseUserName(): void
+    {
+        /*
+         * The user-facing bug. The dimension is listed by the picker, so it can
+         * be chosen; compatibleEntities() then finds no table able to answer
+         * for it, and the custom report builder refuses the set at save time.
+         * An offered dimension that can never be used.
+         */
+        $entities = $this->manager()->compatibleEntities( array( 'visits' ), array( 'userName' ) );
+
+        $this->assertNotEmpty(
+            $entities,
+            'No entity can answer visits by userName, so the report is refused -- yet the '
+            . 'dimension is offered in the picker.' );
+
+        $this->assertContains( 'base.session', $entities );
+    }
+
+    public function testItBehavesLikeTheOtherDimensionsOnTheSameTables(): void
+    {
+        /*
+         * Compared against a sibling rather than asserted in isolation, so this
+         * says "userName is not special" rather than restating the fix.
+         */
+        $manager = $this->manager();
+
+        $reference = $manager->compatibleEntities( array( 'visits' ), array( 'browserType' ) );
+        $subject   = $manager->compatibleEntities( array( 'visits' ), array( 'userName' ) );
+
+        $this->assertSame(
+            $reference, $subject,
+            'userName sits on the same fact tables as browserType and should be answerable by '
+            . 'exactly the same ones.' );
+    }
+
+    public function testItResolvesAgainstTheEntityBeingQueried(): void
+    {
+        /*
+         * The mechanism behind the symptom. Registered against seven entities
+         * but stored flat, the registry kept only the last -- so it resolved to
+         * base.commerce_line_item_fact whatever was being reported on, and the
+         * join was built from an empty foreign key.
+         */
+        $manager = $this->manager();
+
+        $this->assertTrue(
+            (bool) $manager->isDimensionRelated( 'userName', 'base.session' ),
+            'userName must be reachable from the session table, whose rows carry user_name.' );
+
+        $this->assertTrue(
+            (bool) $manager->isDimensionRelated( 'userName', 'base.request' ) );
+    }
+
+    public function testItIsRegisteredDenormalisedLikeTheColumnItReads(): void
+    {
+        /*
+         * user_name is a column ON each fact row, not a key pointing at another
+         * table, so denormalized is what describes it. Asserted through the
+         * registry rather than by reading Module.php, so this tracks what the
+         * application does.
+         */
+        $service = \OWA\Core\CoreAPI::serviceSingleton();
+
+        $this->assertNotNull(
+            $service->getDenormalizedDimension( 'userName', 'base.session' ),
+            'userName should resolve as a denormalized dimension of base.session.' );
+
+        $entry = $service->getDenormalizedDimension( 'userName', 'base.request' );
+
+        $this->assertSame( 'user_name', $entry['column'] );
+        $this->assertSame( 'base.request', $entry['entity'] );
+    }
+}

--- a/tests/fixtures/catalog.json
+++ b/tests/fixtures/catalog.json
@@ -2,10 +2,10 @@
     "counts": {
         "metricNames": 78,
         "metricImplementations": 99,
-        "dimensionNamesNormalized": 42,
-        "dimensionEntriesNormalized": 48,
-        "dimensionNamesDenormalized": 59,
-        "dimensionEntriesDenormalized": 223,
+        "dimensionNamesNormalized": 41,
+        "dimensionEntriesNormalized": 41,
+        "dimensionNamesDenormalized": 60,
+        "dimensionEntriesDenormalized": 230,
         "accessorDimensionNames": 101
     },
     "metrics": {
@@ -1735,85 +1735,6 @@
                 "family": "visitor",
                 "label": "Email Address",
                 "description": "The email address of the user.",
-                "foreign_key_name": "",
-                "data_type": "string",
-                "denormalized": false
-            }
-        },
-        "userName": {
-            "base.action_fact": {
-                "name": "userName",
-                "entity": "base.action_fact",
-                "column": "user_name",
-                "family": "visitor",
-                "label": "User Name",
-                "description": "The name or ID of the user.",
-                "foreign_key_name": "",
-                "data_type": "string",
-                "denormalized": false
-            },
-            "base.click": {
-                "name": "userName",
-                "entity": "base.click",
-                "column": "user_name",
-                "family": "visitor",
-                "label": "User Name",
-                "description": "The name or ID of the user.",
-                "foreign_key_name": "",
-                "data_type": "string",
-                "denormalized": false
-            },
-            "base.commerce_line_item_fact": {
-                "name": "userName",
-                "entity": "base.commerce_line_item_fact",
-                "column": "user_name",
-                "family": "visitor",
-                "label": "User Name",
-                "description": "The name or ID of the user.",
-                "foreign_key_name": "",
-                "data_type": "string",
-                "denormalized": false
-            },
-            "base.commerce_transaction_fact": {
-                "name": "userName",
-                "entity": "base.commerce_transaction_fact",
-                "column": "user_name",
-                "family": "visitor",
-                "label": "User Name",
-                "description": "The name or ID of the user.",
-                "foreign_key_name": "",
-                "data_type": "string",
-                "denormalized": false
-            },
-            "base.domstream": {
-                "name": "userName",
-                "entity": "base.domstream",
-                "column": "user_name",
-                "family": "visitor",
-                "label": "User Name",
-                "description": "The name or ID of the user.",
-                "foreign_key_name": "",
-                "data_type": "string",
-                "denormalized": false
-            },
-            "base.request": {
-                "name": "userName",
-                "entity": "base.request",
-                "column": "user_name",
-                "family": "visitor",
-                "label": "User Name",
-                "description": "The name or ID of the user.",
-                "foreign_key_name": "",
-                "data_type": "string",
-                "denormalized": false
-            },
-            "base.session": {
-                "name": "userName",
-                "entity": "base.session",
-                "column": "user_name",
-                "family": "visitor",
-                "label": "User Name",
-                "description": "The name or ID of the user.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": false
@@ -4212,6 +4133,85 @@
                 "denormalized": true
             }
         },
+        "userName": {
+            "base.action_fact": {
+                "name": "userName",
+                "entity": "base.action_fact",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.click": {
+                "name": "userName",
+                "entity": "base.click",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_line_item_fact": {
+                "name": "userName",
+                "entity": "base.commerce_line_item_fact",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.commerce_transaction_fact": {
+                "name": "userName",
+                "entity": "base.commerce_transaction_fact",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.domstream": {
+                "name": "userName",
+                "entity": "base.domstream",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.request": {
+                "name": "userName",
+                "entity": "base.request",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            },
+            "base.session": {
+                "name": "userName",
+                "entity": "base.session",
+                "column": "user_name",
+                "family": "visitor",
+                "label": "User Name",
+                "description": "The name or ID of the user.",
+                "foreign_key_name": "",
+                "data_type": "string",
+                "denormalized": true
+            }
+        },
         "visitsToTransaction": {
             "base.commerce_transaction_fact": {
                 "name": "visitsToTransaction",
@@ -5472,7 +5472,7 @@
             "description": "The name or ID of the user.",
             "foreign_key_name": "",
             "data_type": "string",
-            "denormalized": false
+            "denormalized": true
         },
         "visitorId": {
             "name": "visitorId",
@@ -5609,6 +5609,7 @@
                 "isNewVisitor",
                 "isRepeatVisitor",
                 "userEmail",
+                "userName",
                 "visitorId"
             ]
         },
@@ -5692,6 +5693,7 @@
                 "isNewVisitor",
                 "isRepeatVisitor",
                 "userEmail",
+                "userName",
                 "visitorId"
             ]
         },
@@ -5776,6 +5778,7 @@
                 "isNewVisitor",
                 "isRepeatVisitor",
                 "userEmail",
+                "userName",
                 "visitorId"
             ]
         },
@@ -5865,6 +5868,7 @@
                 "isNewVisitor",
                 "isRepeatVisitor",
                 "userEmail",
+                "userName",
                 "visitorId"
             ]
         },
@@ -5944,6 +5948,7 @@
                 "isNewVisitor",
                 "isRepeatVisitor",
                 "userEmail",
+                "userName",
                 "visitorId"
             ]
         }


### PR DESCRIPTION
`userName` is offered in the custom-report picker, and any report using it is
**refused as an impossible combination**. Found while verifying the coexistence
groundwork (#1049).

## The bug

It is registered **normalized** against the seven fact entities, with no foreign
key. Normalized means *join this dimension's own table through a foreign key* —
and there is no key, because `user_name` isn't a separate table. It's a tracking
property with `required => true`, so every event carries it and it lands on all
seven fact tables.

So it relates to nothing:

```
visits + browserType  -> base.session, base.request
visits + country      -> base.session, base.request
visits + userEmail    -> base.session, base.request
visits + userName     -> EMPTY   (refused)
```

Registered `denormalized = true` now — exactly how `date` is registered against
the same list.

## Why it went unnoticed

No shipped report uses `userName`, so only a hand-built custom report reaches it.
And on most installs it would group into a single bucket anyway: `setUserName()`
fills a value only when one is already on the event, so the property falls back
to its `'(not set)'` default.

## Deliberately not fixed here

`userEmail` reads `base.visitor`, which `VisitorHandlers` writes **only when the
visitor row is created** — so an identity learned later never reaches it. After
this change `userName` reads the value *as at the event* and `userEmail` reads a
frozen one. That divergence is real, and deciding what visitor identity should
mean is a data-model question rather than a registration one.

## Three catalog tests repointed — worth reading

They asserted the normalized registry held more entries than names, using
`userName` as the example. That was true **only because `userName` was
misregistered**, so the assertion was pinning a defect, and it failed the moment
the defect went.

They now test the shape directly — every normalized entry is entity-keyed — and
exercise the multi-entity capability through the *denormalized* registry, which
genuinely carries multi-entity names (`date` covers eight). A capability should
be tested directly, not through the accident that happened to exercise it.

## Verified

- 4 new tests, written failing first, all 4 failing before the fix
- **Mutation-checked**: reverting the registration fails all four
- 656 affected tests green (catalog, dimensions, reports, constraints, metric sets)
- Fixture diff is exactly balanced: −1 name / −7 entries from normalized,
  +1 / +7 to denormalized, accessor total unchanged at 101