### PR TITLE
Declare the boolean flags' type, delete a dead config map

### DIFF
--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -1215,13 +1215,6 @@ namespace OWA\Module\Base\Classes;
                 'nonce_expiration_period'            => 7200,
                 'max_prior_campaigns'                => 5, //sdk
                 'default_reporting_period'            => 'last_seven_days',
-                'campaign_params'                    => array(
-                        'campaign'        => 'owa_campaign',
-                        'medium'        => 'owa_medium',
-                        'source'        => 'owa_source',
-                        'search_terms'    => 'owa_search_terms',
-                        'ad'            => 'owa_ad',
-                        'ad_type'        => 'owa_ad_type'),
                 'trafficAttributionMode'            => 'direct', //sdk
                 'campaignAttributionWindow'            => 60, //sdk
                  //list of capabilities that require access to the site

--- a/modules/Base/config/tracking_properties.json
+++ b/modules/Base/config/tracking_properties.json
@@ -331,10 +331,12 @@
         },
         "is_browser": {
             "required": true,
+            "data_type": "boolean",
             "callbacks": [
                 "owa_trackingEventHelpers::isBrowser"
             ],
-            "default_value": false
+            "default_value": false,
+            "note": "A second guard only: required + default_value false already turns the null this callback returns into false. The type matters if either of those is ever removed -- which is how is_repeat_visitor wrote NULL from 2015, back when a falsy default_value was skipped by a truthy test."
         },
         "browser": {
             "required": true,
@@ -345,10 +347,12 @@
         },
         "is_robot": {
             "required": true,
+            "data_type": "boolean",
             "callbacks": [
                 "owa_trackingEventHelpers::isRobot"
             ],
-            "default_value": false
+            "default_value": false,
+            "note": "A second guard only: required + default_value false already turns the null this callback returns into false. The type matters if either of those is ever removed -- which is how is_repeat_visitor wrote NULL from 2015, back when a falsy default_value was skipped by a truthy test."
         },
         "os": {
             "required": true,
@@ -359,10 +363,12 @@
         },
         "is_entry_page": {
             "required": true,
+            "data_type": "boolean",
             "callbacks": [
                 "owa_trackingEventHelpers::resolveEntryPage"
             ],
-            "default_value": false
+            "default_value": false,
+            "note": "A second guard only: required + default_value false already turns the null this callback returns into false. The type matters if either of those is ever removed -- which is how is_repeat_visitor wrote NULL from 2015, back when a falsy default_value was skipped by a truthy test."
         },
         "country": {
             "required": true,

--- a/tests/BooleanPropertyTypeTest.php
+++ b/tests/BooleanPropertyTypeTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use OWA\Module\Base\Classes\TrackingEventHelpers as Helpers;
+
+/**
+ * The boolean flags must not be able to write NULL.
+ *
+ * A boolean column that also holds NULL has three values, and each groups
+ * separately: a report counting is_browser = 0 silently misses every NULL row.
+ * is_repeat_visitor did exactly this from 2015 until 8d24fc65 -- its callback
+ * fell off the end returning null, and nothing turned that into false.
+ *
+ * Two independent guards stop it now, and they are worth telling apart because
+ * only one of them was ever the thing that broke:
+ *
+ *   - required + default_value false. This is what actually closed the hole,
+ *     once a falsy default stopped being skipped by a truthy test.
+ *   - data_type boolean, which re-resolves a null AFTER the callback runs.
+ *
+ * These tests pin both, and show the second one is not decoration: with the
+ * default removed it is the only thing standing between a null derivation and
+ * the column.
+ */
+final class BooleanPropertyTypeTest extends TestCase
+{
+    /** The three flags whose callback can fall off the end returning null. */
+    private const FLAGS = array( 'is_browser', 'is_robot', 'is_entry_page',
+                                 'is_repeat_visitor' );
+
+    private function runPipeline( array $definition )
+    {
+        $helpers = new Helpers();
+        $event   = \OWA\Core\CoreAPI::supportClassFactory( 'base', 'event' );
+
+        $helpers->setTrackerProperties( $event, array( 'probe' => $definition ) );
+
+        return $event->get( 'probe' );
+    }
+
+    /** A callback with a branch that returns nothing, like isBrowser's. */
+    public static function fallsOffTheEnd( $value, $event )
+    {
+        if ( $event->get( 'never_set' ) ) {
+
+            return true;
+        }
+    }
+
+    public function testEveryBooleanFlagDeclaresItsType(): void
+    {
+        $server = Helpers::serverProperties();
+
+        foreach ( self::FLAGS as $flag ) {
+
+            $this->assertArrayHasKey( $flag, $server );
+
+            $this->assertSame(
+                'boolean', $server[ $flag ]['data_type'] ?? null,
+                "$flag is a two-state fact and must say so." );
+        }
+    }
+
+    /**
+     * The flags are all required with a false default, which is the guard that
+     * actually closed the 2015 hole. Removing either is what this test exists
+     * to catch.
+     */
+    public function testEveryBooleanFlagIsRequiredWithAFalseDefault(): void
+    {
+        $server = Helpers::serverProperties();
+
+        foreach ( self::FLAGS as $flag ) {
+
+            $this->assertTrue(
+                $server[ $flag ]['required'] ?? false,
+                "$flag must be required, or an absent value is simply not written." );
+
+            $this->assertArrayHasKey(
+                'default_value', $server[ $flag ],
+                "$flag needs a default for a null derivation to fall back to." );
+
+            $this->assertFalse(
+                $server[ $flag ]['default_value'],
+                "$flag defaults to false; anything else makes a missing derivation look true." );
+        }
+    }
+
+    public function testANullDerivationBecomesFalseNotNull(): void
+    {
+        $value = $this->runPipeline( array(
+            'required'      => true,
+            'data_type'     => 'boolean',
+            'default_value' => false,
+            'callbacks'     => array( array( self::class, 'fallsOffTheEnd' ) ),
+        ) );
+
+        $this->assertFalse( $value );
+        $this->assertNotNull(
+            $value, 'null is a third value for a two-state fact and groups on its own.' );
+    }
+
+    /**
+     * The declared type is a SECOND guard, not the working one: with required
+     * and the default in place the null is already false without it. Stated so
+     * nobody reads the type as the thing that fixed is_repeat_visitor.
+     */
+    public function testTheDefaultAloneAlreadyHandlesTheNull(): void
+    {
+        $value = $this->runPipeline( array(
+            'required'      => true,
+            'default_value' => false,
+            'callbacks'     => array( array( self::class, 'fallsOffTheEnd' ) ),
+        ) );
+
+        $this->assertFalse( $value );
+    }
+
+    /**
+     * ...and it is not decoration either. Take the default away and the type is
+     * the only thing left between a null derivation and a boolean column.
+     */
+    public function testWithNoDefaultTheDeclaredTypeIsWhatStopsTheNull(): void
+    {
+        $typed = $this->runPipeline( array(
+            'required'  => true,
+            'data_type' => 'boolean',
+            'callbacks' => array( array( self::class, 'fallsOffTheEnd' ) ),
+        ) );
+
+        $untyped = $this->runPipeline( array(
+            'required'  => true,
+            'callbacks' => array( array( self::class, 'fallsOffTheEnd' ) ),
+        ) );
+
+        $this->assertFalse( $typed, 'the declared type should have resolved the null' );
+        $this->assertNull( $untyped, 'without either guard a null reaches the column' );
+    }
+}


### PR DESCRIPTION
Stacked on #1056 (which is stacked on #1055).

## The boolean flags

`is_browser`, `is_robot` and `is_entry_page` are two-state facts. `isBrowser` falls off the end returning null whenever `browser_type` is empty — the same shape as the `setRepeatVisitorFlag` defect. They now declare `data_type: boolean` like their sibling `is_repeat_visitor`.

**This changes nothing today**, and I checked rather than assuming. All three are `required: true` with `default_value: false`, and this pair already handles the null:

```php
if ( $required && ! $value && $value !== 0 && $value !== "0") {
    if ( array_key_exists( 'default_value', $property ) ) { $value = $property['default_value']; }
}
```

Running the real pipeline with and without the declared type returns `false` either way.

The 2015 `is_repeat_visitor` bug predates the change that let a *falsy* `default_value` apply at all — until then the truthy test skipped `false` and the null reached the column. So the declared type was never the thing that fixed it.

It is still worth declaring, and the test shows why rather than asserting it: with the default removed, an untyped property returns `null` and a typed one returns `false`. It is the second guard, and it is load-bearing if either of the other two is ever edited away.

Local distribution, for the record: `is_browser` all 1; `is_robot` 768×0 and 11 NULL; `is_entry_page` 650×0, 118×1, 11 NULL. Those eleven NULLs are the same rows in both columns, all from 2023-11-14, written before this pipeline — `resolveEntryPage` cannot return null. Left alone: per the standing rule a column that held NULL before keeps it rather than being backfilled into a different bucket.

## The dead map

`Settings::campaign_params` mapped the old internal attribution names to their URL parameters and had **no consumers anywhere**. After the `tagged_*` rename it also disagreed with the tracker, so it could only mislead. Deleted.