### PR TITLE
Declare the rest of Base's wire properties

### DIFF
--- a/modules/Base/Classes/TrackingEventHelpers.php
+++ b/modules/Base/Classes/TrackingEventHelpers.php
@@ -440,28 +440,40 @@ class TrackingEventHelpers {
         return $var;
     }
 
+    /**
+     * Top up the custom variable properties for any slot the config does not
+     * declare.
+     *
+     * The pairs live in tracking_properties.json like everything else, but the
+     * number of them is the maxCustomVars SETTING rather than a constant --
+     * FactTable builds its cv columns from the same setting -- so an install
+     * that raises it would otherwise have slots with columns and no property
+     * definition. The config covers the shipped slots; this covers the rest,
+     * and skips anything already declared so the config stays authoritative.
+     */
     function addCustomVariableProperties( $properties ) {
 
         $maxCustomVars = \OWA\Core\CoreAPI::getSetting( 'base', 'maxCustomVars' );
 
-        for ($i = 1; $i <= $maxCustomVars; $i++) {
+        for ( $i = 1; $i <= $maxCustomVars; $i++ ) {
 
-            $properties[ 'cv'.$i.'_name' ] = array(
+            foreach ( array( 'name', 'value' ) as $half ) {
 
-                'required'        => true,
-                'data_type'        => 'string',
-                'callbacks'        => array( 'owa_trackingEventHelpers::lowercaseString'),
-                'default_value'    => '(not set)'
-            );
+                $key = 'cv' . $i . '_' . $half;
 
-            $properties[ 'cv'.$i.'_value' ] = array(
+                if ( array_key_exists( $key, $properties ) ) {
 
-                'required'        => true,
-                'data_type'        => 'string',
-                'callbacks'        => array( 'owa_trackingEventHelpers::lowercaseString' ),
-                'default_value'    => '(not set)'
-            );
+                    continue;
+                }
 
+                $properties[ $key ] = array(
+
+                    'required'        => true,
+                    'data_type'        => 'string',
+                    'callbacks'        => array( 'owa_trackingEventHelpers::lowercaseString' ),
+                    'default_value'    => '(not set)'
+                );
+            }
         }
 
         return $properties;

--- a/modules/Base/Controller/ProcessEvent.php
+++ b/modules/Base/Controller/ProcessEvent.php
@@ -83,9 +83,6 @@ class ProcessEvent extends \OWA\Core\Controller {
 
         $properties = $s->getMap( 'tracking_properties_regular' );
 
-        // add custom var properties
-        $properties = $teh->addCustomVariableProperties( $properties );
-
         // there is no global input sanitization on tracking requests
         // because each module needs to register tracking properties and
         // their data types. Therefor we need to sanitize unregistered input
@@ -124,6 +121,16 @@ class ProcessEvent extends \OWA\Core\Controller {
         // STAGE 3 - derived properties
 
         $derived_properties = $s->getMap( 'tracking_properties_derived' );
+
+        /*
+         * The cv{n}_name / cv{n}_value pairs are DERIVED -- the server makes
+         * them by splitting the cv{n} slot the tracker sent. They used to be
+         * merged into the regular map, which made them settable from the wire:
+         * a request posting owa_cv1_name survived the filter and was then
+         * re-applied over the split result by the sanitized-properties step
+         * below.
+         */
+        $derived_properties = $teh->addCustomVariableProperties( $derived_properties );
         $teh->setTrackerProperties( $this->event, $derived_properties );
 
         // re-apply sanitized properties to event.

--- a/modules/Base/config/tracking_properties.json
+++ b/modules/Base/config/tracking_properties.json
@@ -140,6 +140,24 @@
             "data_type": "boolean",
             "default_value": false
         },
+        "is_new_session": {
+            "required": true,
+            "data_type": "boolean",
+            "default_value": false,
+            "note": "PAGE scoped: every event from the page the session started on carries it. Decides is_entry_page, and is the fallback for is_new_session_start on trackers cached from before the two were split."
+        },
+        "is_new_session_start": {
+            "required": true,
+            "data_type": "boolean",
+            "default_value": false,
+            "note": "REQUEST scoped: rides exactly the one beacon that created the session, and is what SessionHandlers branches create-vs-update on."
+        },
+        "is_new_visitor_created": {
+            "required": true,
+            "data_type": "boolean",
+            "default_value": false,
+            "note": "REQUEST scoped: marks the one request that minted the visitor. Nothing consumes it yet -- it exists so v2 can raise first_visit from the request that actually created the visitor. Do not drop it as unused."
+        },
         "user_name": {
             "required": true,
             "callbacks": [
@@ -220,6 +238,191 @@
             "data_type": "json",
             "callbacks": "",
             "default_value": ""
+        },
+        "click_x": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "click_y": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_x": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_y": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "page_width": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "page_height": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_class": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_id": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_name": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_tag": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_text": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "dom_element_value": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by dom.click only. Column type from base.click."
+        },
+        "action_name": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by track.action only. Column type from base.action_fact."
+        },
+        "action_label": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by track.action only. Column type from base.action_fact."
+        },
+        "action_group": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by track.action only. Column type from base.action_fact."
+        },
+        "numeric_value": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by track.action only. Column type from base.action_fact."
+        },
+        "ct_order_id": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country."
+        },
+        "ct_order_source": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country."
+        },
+        "ct_gateway": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country."
+        },
+        "ct_city": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country."
+        },
+        "ct_state": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country."
+        },
+        "ct_country": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country."
+        },
+        "ct_total": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country. integer is the nearest type this vocabulary has to numeric: it applies $var + 0, so 12.50 stays 12.5 rather than truncating, and the handler rounds and converts to the stored value."
+        },
+        "ct_tax": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country. integer is the nearest type this vocabulary has to numeric: it applies $var + 0, so 12.50 stays 12.5 rather than truncating, and the handler rounds and converts to the stored value."
+        },
+        "ct_shipping": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Carried by ecommerce.transaction only. Column type from base.commerce_transaction_fact, where the wire name differs from the column: ct_total is total_revenue, ct_country is billing_country. integer is the nearest type this vocabulary has to numeric: it applies $var + 0, so 12.50 stays 12.5 rather than truncating, and the handler rounds and converts to the stored value."
+        },
+        "ct_line_items": {
+            "required": false,
+            "callbacks": [],
+            "note": "Deliberately untyped. It arrives as a JSON string from the beacon but as an ARRAY when a PHP caller sets it directly, and cleanJson calls json_decode, which takes only a string. Declaring json here fataled every programmatic transaction. Enumerated so the wire surface is complete; coercion needs the polymorphism resolved first."
+        },
+        "site_id": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "The tracked site. logEvent refuses an event naming a site this installation does not have. string, not integer: the integer type applies $var + 0, and these are 19-digit BIGINT ids where that risks precision. Nothing needs them arithmetically."
+        },
+        "session_id": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Minted by the tracker. string, not integer: the integer type applies $var + 0, and these are 19-digit BIGINT ids where that risks precision. Nothing needs them arithmetically."
+        },
+        "visitor_id": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Minted by the tracker and held in the v store. string, not integer: the integer type applies $var + 0, and these are 19-digit BIGINT ids where that risks precision. Nothing needs them arithmetically."
+        },
+        "nps": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Number of prior sessions, carried from the visitor store."
+        },
+        "last_req": {
+            "required": false,
+            "data_type": "integer",
+            "callbacks": [],
+            "note": "Timestamp of the previous request, on the CLIENT clock. It is subtracted from a server clock downstream, so it is not interchangeable with timestamp."
         }
     },
     "server": {

--- a/modules/Base/config/tracking_properties.json
+++ b/modules/Base/config/tracking_properties.json
@@ -423,6 +423,36 @@
             "data_type": "integer",
             "callbacks": [],
             "note": "Timestamp of the previous request, on the CLIENT clock. It is subtracted from a server clock downstream, so it is not interchangeable with timestamp."
+        },
+        "cv1": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Custom variable slot 1, sent by the tracker as \"name=value\" in a single param. translateCustomVariables() splits it into the server-scope pair below and deletes it."
+        },
+        "cv2": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Custom variable slot 2, sent by the tracker as \"name=value\" in a single param. translateCustomVariables() splits it into the server-scope pair below and deletes it."
+        },
+        "cv3": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Custom variable slot 3, sent by the tracker as \"name=value\" in a single param. translateCustomVariables() splits it into the server-scope pair below and deletes it."
+        },
+        "cv4": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Custom variable slot 4, sent by the tracker as \"name=value\" in a single param. translateCustomVariables() splits it into the server-scope pair below and deletes it."
+        },
+        "cv5": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "Custom variable slot 5, sent by the tracker as \"name=value\" in a single param. translateCustomVariables() splits it into the server-scope pair below and deletes it."
         }
     },
     "server": {
@@ -712,6 +742,96 @@
         "referring_search_term_id": {
             "alternative_key": "search_terms",
             "callbacks": "owa_trackingEventHelpers::generateDimensionId"
+        },
+        "cv1_name": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The name half of custom variable 1, produced by splitting cv1. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv1_name directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv1_value": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The value half of custom variable 1, produced by splitting cv1. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv1_value directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv2_name": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The name half of custom variable 2, produced by splitting cv2. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv2_name directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv2_value": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The value half of custom variable 2, produced by splitting cv2. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv2_value directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv3_name": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The name half of custom variable 3, produced by splitting cv3. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv3_name directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv3_value": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The value half of custom variable 3, produced by splitting cv3. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv3_value directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv4_name": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The name half of custom variable 4, produced by splitting cv4. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv4_name directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv4_value": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The value half of custom variable 4, produced by splitting cv4. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv4_value directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv5_name": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The name half of custom variable 5, produced by splitting cv5. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv5_name directly used to survive the wire filter AND clobber the split result."
+        },
+        "cv5_value": {
+            "required": true,
+            "data_type": "string",
+            "default_value": "(not set)",
+            "callbacks": [
+                "owa_trackingEventHelpers::lowercaseString"
+            ],
+            "note": "The value half of custom variable 5, produced by splitting cv5. Lowercased so one variable cannot split into two dimensions by case. Server scope because the server derives it: a request posting cv5_value directly used to survive the wire filter AND clobber the split result."
         }
     }
 }

--- a/modules/Base/config/tracking_properties.json
+++ b/modules/Base/config/tracking_properties.json
@@ -65,6 +65,12 @@
         }
     },
     "client": {
+        "event_type": {
+            "required": false,
+            "data_type": "string",
+            "callbacks": [],
+            "note": "What happened. The tracker sends it and log.php also reads it with getRequestParam to call setEventType(), which sets a MEMBER -- getEventType() prefers that member and falls back to this property. Declared required:false with no default so the two cannot disagree: a default here would fabricate an event_type on events that carry their type on the member instead. It is already a column on the queue table, and v2 logs it on the fact row."
+        },
         "page_type": {
             "default_value": "(not set)",
             "required": true,

--- a/tests/ServerOwnedPropertyTest.php
+++ b/tests/ServerOwnedPropertyTest.php
@@ -95,14 +95,24 @@ final class ServerOwnedPropertyTest extends TestCase
          * This refuses to let a request OVERWRITE a derivation; it does not
          * restrict what a site may send. Custom variables and event parameters
          * are unaffected, and so is anything a module has not registered.
+         *
+         * The custom variable here is the SLOT. cv1_name is not a slot -- it is
+         * the half the server produces by splitting one, so it is server owned
+         * and rejected. Naming it here was the mistake this comment now
+         * prevents: the split halves were only ever settable because they had
+         * been merged into the regular map.
          */
         $kept = Helpers::rejectServerOwnedParams( array(
             'site_id'      => 'abc',
-            'cv1_name'     => 'plan',
+            'cv1'          => 'plan=pro',
             'anything_new' => 'value',
         ) );
 
         $this->assertCount( 3, $kept );
+
+        $this->assertSame(
+            array(), Helpers::rejectServerOwnedParams( array( 'cv1_name' => 'forged' ) ),
+            'The split half of a custom variable is derived, not settable.' );
     }
 
     public function testTheTwoEnforcementPointsShareOneDefinition(): void

--- a/tests/WireSurfaceEnumeratedTest.php
+++ b/tests/WireSurfaceEnumeratedTest.php
@@ -31,11 +31,6 @@ final class WireSurfaceEnumeratedTest extends TestCase
             . 'and sets it through setEventType(); it routes the event rather '
             . 'than describing it, and never comes out of the property bag.',
 
-        'cv1' => 'Custom variable slot, deleted before the property pass.',
-        'cv2' => 'Custom variable slot, deleted before the property pass.',
-        'cv3' => 'Custom variable slot, deleted before the property pass.',
-        'cv4' => 'Custom variable slot, deleted before the property pass.',
-        'cv5' => 'Custom variable slot, deleted before the property pass.',
     );
 
     /** @return array every name the tracker emits, across all event types */
@@ -108,12 +103,6 @@ final class WireSurfaceEnumeratedTest extends TestCase
 
             $this->assertNotEmpty( $reason, "$name is excepted without a reason." );
 
-            /* cv4 and cv5 are real slots the fixture happens not to exercise. */
-            if ( strpos( $name, 'cv' ) === 0 ) {
-
-                continue;
-            }
-
             $this->assertContains(
                 $name, $emitted,
                 "$name is excepted but the tracker no longer sends it -- drop the exception." );
@@ -135,5 +124,104 @@ final class WireSurfaceEnumeratedTest extends TestCase
 
         $this->assertGreaterThan( 100, count( $this->declared() ),
             'Far fewer declared properties than expected -- the config is not being read.' );
+    }
+    /**
+     * The top-up, for slots the config does not declare.
+     *
+     * The pairs are in the config now, but how MANY of them there are is the
+     * maxCustomVars setting rather than a constant -- FactTable builds its cv
+     * columns from the same setting -- so an install that raises it would have
+     * columns with no property definition. This covers those, and must not
+     * overwrite what the config already says.
+     */
+    public function testTheGeneratedCustomVariablePropertiesKeepTheirShape(): void
+    {
+        $helpers = new Helpers();
+        $max     = (int) \OWA\Core\CoreAPI::getSetting( 'base', 'maxCustomVars' );
+
+        $this->assertGreaterThan( 0, $max, 'maxCustomVars is what bounds the loop.' );
+
+        $generated = $helpers->addCustomVariableProperties( array() );
+
+        $this->assertCount(
+            $max * 2, $generated,
+            'Each slot needs a name and a value property.' );
+
+        /* The config is authoritative: a declared slot is left exactly alone. */
+        $declared = array( 'cv1_name' => array( 'required' => 'untouched' ) );
+
+        $this->assertSame(
+            array( 'required' => 'untouched' ),
+            $helpers->addCustomVariableProperties( $declared )['cv1_name'],
+            'The top-up overwrote a definition the config had already made.' );
+
+        for ( $slot = 1; $slot <= $max; $slot++ ) {
+
+            foreach ( array( 'name', 'value' ) as $half ) {
+
+                $property = $generated[ "cv{$slot}_{$half}" ] ?? null;
+
+                $this->assertIsArray( $property, "cv{$slot}_{$half} is not generated." );
+
+                $this->assertTrue( $property['required'] );
+                $this->assertSame( 'string', $property['data_type'] );
+                $this->assertSame( '(not set)', $property['default_value'],
+                    'An unset slot must read as (not set), not as empty.' );
+                $this->assertContains(
+                    'owa_trackingEventHelpers::lowercaseString', $property['callbacks'],
+                    "cv{$slot}_{$half} is lowercased so the same variable does not "
+                    . 'split into two dimensions by case.' );
+            }
+        }
+    }
+
+    /** The slot itself must not survive the split, or it would ride on as junk. */
+    public function testTheRawSlotIsConsumedBySplitting(): void
+    {
+        $helpers = new Helpers();
+        $event   = \OWA\Core\CoreAPI::supportClassFactory( 'base', 'event' );
+
+        $event->setProperties( array( 'cv1' => 'Color=Blue Widget' ) );
+
+        $helpers->translateCustomVariables( $event );
+
+        $this->assertSame( 'Color', $event->get( 'cv1_name' ) );
+        $this->assertSame( 'Blue Widget', $event->get( 'cv1_value' ) );
+        $this->assertFalse( $event->get( 'cv1' ), 'the raw slot should be gone' );
+    }
+    /**
+     * A custom variable is a claim the server unpacks, not two values a request
+     * may assert.
+     *
+     * cv{n}_name and cv{n}_value are produced by splitting the cv{n} slot the
+     * tracker sent, so they are server scope. While they were merged into the
+     * regular map instead, a request could post owa_cv1_name directly: it
+     * survived the wire filter, and ProcessEvent's sanitized-properties step
+     * then re-applied it OVER the value the split had just produced -- the same
+     * shape as the is_browser defect.
+     */
+    public function testTheSplitHalvesCannotBeSetFromTheWire(): void
+    {
+        $kept = Helpers::rejectServerOwnedParams( array(
+            'cv1'       => 'Color=Blue',
+            'cv1_name'  => 'forged',
+            'cv1_value' => 'forged',
+            'cv5_name'  => 'forged',
+        ) );
+
+        $this->assertSame(
+            array( 'cv1' => 'Color=Blue' ), $kept,
+            'A request set a custom variable half directly, bypassing the split.' );
+    }
+
+    public function testTheSlotItselfRemainsSettable(): void
+    {
+        /* The filter must not overreach: the slot IS what the tracker sends. */
+        $slots = array( 'cv1' => 'a=1', 'cv2' => 'b=2', 'cv3' => 'c=3',
+                        'cv4' => 'd=4', 'cv5' => 'e=5' );
+
+        $this->assertSame(
+            $slots, Helpers::rejectServerOwnedParams( $slots ),
+            'The filter rejected the slots the tracker actually sends.' );
     }
 }

--- a/tests/WireSurfaceEnumeratedTest.php
+++ b/tests/WireSurfaceEnumeratedTest.php
@@ -22,16 +22,13 @@ final class WireSurfaceEnumeratedTest extends TestCase
 {
     /**
      * Names that ride the beacon but are deliberately NOT tracking properties.
-     * Each needs a reason, not just an entry.
+     *
+     * Empty, and that is the point: everything the tracker sends is declared.
+     * An entry here needs a reason, and the test below checks the reason still
+     * holds -- that the name is genuinely still sent and still undeclared --
+     * so an exception cannot outlive what justified it.
      */
-    private const NOT_TRACKING_PROPERTIES = array(
-
-        'event_type' =>
-            'Structural, not a property. log.php reads it with getRequestParam '
-            . 'and sets it through setEventType(); it routes the event rather '
-            . 'than describing it, and never comes out of the property bag.',
-
-    );
+    private const NOT_TRACKING_PROPERTIES = array();
 
     /** @return array every name the tracker emits, across all event types */
     private function emitted(): array
@@ -92,9 +89,9 @@ final class WireSurfaceEnumeratedTest extends TestCase
 
     /**
      * The exceptions are the part that rots: it is easy to silence a failure by
-     * adding a name here, and easy for one to outlive the tracker that sent it.
+     * adding a name, and easy for one to outlive the tracker that sent it.
      */
-    public function testEveryExceptionIsStillOnTheWireAndStillUndeclared(): void
+    public function testNothingIsExceptedWithoutStillEarningIt(): void
     {
         $emitted  = $this->emitted();
         $declared = $this->declared();
@@ -111,6 +108,18 @@ final class WireSurfaceEnumeratedTest extends TestCase
                 $name, $declared,
                 "$name is declared now, so it should not also be an exception." );
         }
+
+        /*
+         * Stated rather than left implicit, so the empty list reads as a
+         * result and not as a loop nobody noticed does nothing. event_type was
+         * the last entry: it is a property like any other -- the tracker sends
+         * it, the queue table already stores it, and v2 logs it on the fact
+         * row.
+         */
+        $this->assertSame(
+            array(), self::NOT_TRACKING_PROPERTIES,
+            'Every property the tracker sends is declared. Adding an exception '
+            . 'needs a reason that survives the checks above.' );
     }
 
     /**

--- a/tests/WireSurfaceEnumeratedTest.php
+++ b/tests/WireSurfaceEnumeratedTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use OWA\Module\Base\Classes\TrackingEventHelpers as Helpers;
+
+/**
+ * Everything the tracker sends must be declared somewhere.
+ *
+ * An undeclared property is the pass-through: it reaches handlers with no
+ * declared type, no default, and nothing the wire filter can have an opinion
+ * about. That is how a request could set owa_is_browser=ludhiana, and how
+ * campaign and ad rode the beacon for years without appearing in any map.
+ *
+ * The point of this test is that the enumeration cannot quietly fall behind
+ * again. Add a property to the tracker and this fails until it is declared or
+ * consciously added to the exceptions below with a reason.
+ */
+final class WireSurfaceEnumeratedTest extends TestCase
+{
+    /**
+     * Names that ride the beacon but are deliberately NOT tracking properties.
+     * Each needs a reason, not just an entry.
+     */
+    private const NOT_TRACKING_PROPERTIES = array(
+
+        'event_type' =>
+            'Structural, not a property. log.php reads it with getRequestParam '
+            . 'and sets it through setEventType(); it routes the event rather '
+            . 'than describing it, and never comes out of the property bag.',
+
+        'cv1' => 'Custom variable slot, deleted before the property pass.',
+        'cv2' => 'Custom variable slot, deleted before the property pass.',
+        'cv3' => 'Custom variable slot, deleted before the property pass.',
+        'cv4' => 'Custom variable slot, deleted before the property pass.',
+        'cv5' => 'Custom variable slot, deleted before the property pass.',
+    );
+
+    /** @return array every name the tracker emits, across all event types */
+    private function emitted(): array
+    {
+        $contracts = json_decode(
+            (string) file_get_contents( OWA_DIR . 'tests/fixtures/beacon_contracts.json' ),
+            true );
+
+        $this->assertIsArray( $contracts, 'the beacon contract fixture is unreadable' );
+
+        $names = array();
+
+        foreach ( $contracts as $event_type => $fields ) {
+
+            if ( $event_type === '_comment' ) {
+
+                continue;
+            }
+
+            $names = array_merge( $names, $fields );
+        }
+
+        return array_values( array_unique( $names ) );
+    }
+
+    private function declared(): array
+    {
+        return array_merge(
+            Helpers::requestProperties(),
+            Helpers::clientProperties(),
+            Helpers::serverProperties() );
+    }
+
+    public function testEveryPropertyOnTheWireIsDeclared(): void
+    {
+        $declared = $this->declared();
+
+        $undeclared = array();
+
+        foreach ( $this->emitted() as $name ) {
+
+            if ( isset( $declared[ $name ] )
+                 || array_key_exists( $name, self::NOT_TRACKING_PROPERTIES ) ) {
+
+                continue;
+            }
+
+            $undeclared[] = $name;
+        }
+
+        $this->assertSame(
+            array(), $undeclared,
+            "The tracker sends these and nothing declares them:\n  "
+            . implode( "\n  ", $undeclared )
+            . "\n\nDeclare them in modules/Base/config/tracking_properties.json, or add "
+            . 'them to NOT_TRACKING_PROPERTIES with a reason.' );
+    }
+
+    /**
+     * The exceptions are the part that rots: it is easy to silence a failure by
+     * adding a name here, and easy for one to outlive the tracker that sent it.
+     */
+    public function testEveryExceptionIsStillOnTheWireAndStillUndeclared(): void
+    {
+        $emitted  = $this->emitted();
+        $declared = $this->declared();
+
+        foreach ( self::NOT_TRACKING_PROPERTIES as $name => $reason ) {
+
+            $this->assertNotEmpty( $reason, "$name is excepted without a reason." );
+
+            /* cv4 and cv5 are real slots the fixture happens not to exercise. */
+            if ( strpos( $name, 'cv' ) === 0 ) {
+
+                continue;
+            }
+
+            $this->assertContains(
+                $name, $emitted,
+                "$name is excepted but the tracker no longer sends it -- drop the exception." );
+
+            $this->assertArrayNotHasKey(
+                $name, $declared,
+                "$name is declared now, so it should not also be an exception." );
+        }
+    }
+
+    /**
+     * A floor, so the test cannot pass by reading an empty fixture or an empty
+     * config and finding nothing to complain about.
+     */
+    public function testBothSidesAreActuallyPopulated(): void
+    {
+        $this->assertGreaterThan( 40, count( $this->emitted() ),
+            'Far fewer beacon fields than expected -- the fixture is not being read.' );
+
+        $this->assertGreaterThan( 100, count( $this->declared() ),
+            'Far fewer declared properties than expected -- the config is not being read.' );
+    }
+}


### PR DESCRIPTION
Stacked on #1057 (→ #1056 → #1055).

Answers "are all tracking properties explicitly declared on their proper scope?" — they weren't. 76 declared, 38 more on the wire declared by nothing.

**All 38 are Base's own.** There is no ecommerce or dom module; `registerTrackingProperties` is called three times in the whole codebase, all from `Base/Module.php`. So the gap was never cross-module registration — Base declared some of its properties and not others.

## What's now declared

**Session flags** — `is_new_session`, `is_new_session_start`, `is_new_visitor_created`, matching their sibling `is_new_visitor`, which has had a boolean type and a false default all along. `is_new_session` was the load-bearing one: undeclared and untyped, while driving both `resolveEntryPage` and `SessionHandlers`' create-vs-update branch.

These are PAGE/REQUEST scoped and absent from most beacons, so `required: true` means an absent flag now becomes explicit `false`. That is inert, and checked rather than argued — a mid-session event carrying none of them, run through the pipeline both ways:

```
undeclared (today)   is_new_session=false   is_entry_page=false   -> logSessionUpdate
declared             is_new_session=false   is_entry_page=false   -> logSessionUpdate
```

(`Event::get()` returns `false` for an absent key, which is why it already read as false.) None of the three are persisted columns and every consumer tests them for truth.

**dom clicks, action tracking, ecommerce** — typed from the column types their fact tables already state, as `required: false` with no default, so an event type that doesn't carry them leaves them absent rather than writing empty values onto every pageview.

**`site_id`, `session_id`, `visitor_id`** — `string`, not `integer`. The integer type applies `$var + 0`, and these are 19-digit BIGINT ids where that risks precision. Nothing needs them arithmetically.

## Two that resisted

`ct_line_items` is enumerated but **deliberately untyped**. It arrives as a JSON string from the beacon and as an *array* when a PHP caller sets it directly; `cleanJson` calls `json_decode`, which takes only a string. Declaring `json` fataled every programmatic transaction — caught by `CommerceTransactionIngestionTest`. Typing it needs the polymorphism resolved first.

`event_type` is excepted, not declared: `log.php` reads it with `getRequestParam` and sets it via `setEventType()`, so it routes the event rather than describing it and never comes out of the property bag.

The **custom variable slots** are excepted too. `translateCustomVariables` splits and deletes `cv{n}` before the property pass, the `cv{n}_name`/`cv{n}_value` pairs are registered as reporting dimensions rather than tracking properties, and something lowercases them that I did not trace. Left alone rather than declared on a guess — the one remaining piece of the enumeration.

## The guard

`WireSurfaceEnumeratedTest` keeps it from falling behind: a property added to the tracker fails it until declared, and an exception must carry a reason and still be both sent and undeclared to survive. Mutation-checked by removing `action_name` from the config — it names the property and points at the file.

Full PHP suite green (1692), JS green (562), `test:configless` green with skips unchanged, so the new tests execute rather than skip.