### PR TITLE
A mistyped password no longer ends the password reset

### DIFF
--- a/modules/Base/Controller/UsersChangePassword.php
+++ b/modules/Base/Controller/UsersChangePassword.php
@@ -62,12 +62,12 @@ class UsersChangePassword extends \OWA\Core\Controller {
 		
 		
         $auth = \OWA\Core\Auth::get_instance();
-        $status = $auth->authenticateUserTempPasskey($this->params['k']);
+        $status = $auth->authenticateUserTempPasskey($this->getParam('k'));
 
         // log to event queue
         if ($status === true) {
             $ed = \OWA\Core\CoreAPI::getEventDispatch();
-            $new_password = array('key' => $this->params['k'], 'password' => $this->params['password'], 'ip' => $_SERVER['REMOTE_ADDR'], 'user_id' => $auth->u->get('user_id'));
+            $new_password = array('key' => $this->getParam('k'), 'password' => $this->getParam('password'), 'ip' => $_SERVER['REMOTE_ADDR'], 'user_id' => $auth->u->get('user_id'));
             $ed->log($new_password, 'base.set_password');
             $auth->deleteCredentials();
             $this->setRedirectAction('base.loginForm');
@@ -81,7 +81,23 @@ class UsersChangePassword extends \OWA\Core\Controller {
     function errorAction() {
 
         $this->setView('base.usersPasswordEntry');
-        $this->set('k', $this->getParam('k'));
+
+        /*
+         * 'key', not 'k'.
+         *
+         * The view reads 'key' -- UsersPasswordEntry::action() sets it under
+         * that name, and View::get() answers FALSE for a name nobody set. So
+         * setting 'k' here rendered the hidden field as value="", and the
+         * passkey was gone from the form the moment any validation failed.
+         *
+         * The effect was a reset that could not be completed: mistype the
+         * confirmation once, get "Your passwords must match", correct it, and
+         * the next submit carried no key at all -- authenticateUserTempPasskey
+         * refused it and the user was redirected to the login form with "can't
+         * find key in the db". Only a brand new reset email, typed correctly
+         * first time, could get through.
+         */
+        $this->set('key', $this->getParam('k'));
     }
 }
 

--- a/tests/PasswordResetPasskeySurvivalTest.php
+++ b/tests/PasswordResetPasskeySurvivalTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * A mistyped password must not end the reset.
+ *
+ * The reset link carries the one-time passkey as 'k'. The form re-posts it in a
+ * hidden field, so the passkey has to survive every re-render -- including the
+ * one that happens when validation fails.
+ *
+ * It did not. UsersPasswordEntry::action() puts the key in 'key', which is what
+ * the view reads; UsersChangePassword::errorAction() put it in 'k'. View::get()
+ * answers FALSE for a name nobody set, so the hidden field rendered as
+ * value="" and the passkey was simply gone.
+ *
+ * The user-visible failure was a reset that could not be completed. Mistype the
+ * confirmation once, get "Your passwords must match", correct it, submit -- and
+ * that submit carried no key, so authenticateUserTempPasskey() refused it and
+ * the redirect went to the login form with "can't find key in the db". Every
+ * retry failed the same way. Only a fresh reset email, typed correctly the
+ * first time, could get through.
+ *
+ * Reproduced against a live install before fixing: the first render carried
+ * value="817b...", and the render after one mismatch carried value="".
+ */
+final class PasswordResetPasskeySurvivalTest extends TestCase
+{
+    private const PASSKEY = '0123456789abcdef0123456789abcdef';
+
+    private function controllerData( array $params ): array
+    {
+        $controller = new \OWA\Module\Base\Controller\UsersChangePassword( $params );
+
+        $controller->errorAction();
+
+        $data = new \ReflectionProperty( \OWA\Core\Controller::class, 'data' );
+        $data->setAccessible( true );
+
+        return (array) $data->getValue( $controller );
+    }
+
+    /**
+     * The name matters, not just the presence: the view asks for 'key', and a
+     * value filed under any other name is invisible to it.
+     */
+    public function testTheRerenderedFormKeepsThePasskey(): void
+    {
+        $data = $this->controllerData( array(
+            'k'         => self::PASSKEY,
+            'password'  => 'abcdef1',
+            'password2' => 'different2',
+        ) );
+
+        $this->assertArrayHasKey(
+            'key', $data,
+            'The view reads "key". Filing the passkey anywhere else renders the hidden '
+            . 'field empty and ends the reset.' );
+
+        $this->assertSame( self::PASSKEY, $data['key'] );
+    }
+
+    /**
+     * The view it re-renders has to be the entry form, or the key has nowhere
+     * to go however it is named.
+     */
+    public function testItRerendersThePasswordEntryForm(): void
+    {
+        $data = $this->controllerData( array( 'k' => self::PASSKEY ) );
+
+        $this->assertSame( 'base.usersPasswordEntry', $data['view'] ?? null );
+    }
+
+    /**
+     * An absent passkey must stay absent rather than becoming a string that
+     * looks like one -- authenticateUserTempPasskey should refuse it.
+     */
+    public function testAnAbsentPasskeyIsNotInvented(): void
+    {
+        $data = $this->controllerData( array( 'password' => 'abcdef1' ) );
+
+        $this->assertEmpty( $data['key'] ?? null );
+    }
+}


### PR DESCRIPTION
Found while investigating a report that password reset was failing on a live install.

## What happens

The reset link carries a one-time passkey as `k`, and the form re-posts it in a hidden field — so it has to survive every re-render, including the one after a validation failure.

It didn't:

- `UsersPasswordEntry::action()` files the key under **`key`**, which is what the view reads.
- `UsersChangePassword::errorAction()` filed it under **`k`**.

`View::get()` answers `false` for a name nobody set, so the hidden field rendered as `value=""` and the passkey was simply gone.

For someone resetting their password: mistype the confirmation once, get *"Your passwords must match"*, correct it, submit — and that submit carries no key. `authenticateUserTempPasskey()` refuses it and the redirect lands on the login form with *"can't find key in the db"*. Every retry fails the same way. The only route through is a fresh reset email typed correctly first time, and nothing on screen says so.

## Reproduced before fixing

Against the live install, with a dummy passkey:

```
1. GET the entry form (as the emailed link does)
   <input type="hidden" name="k" value="00000000000000000000000000000000"

2. POST with MISMATCHED passwords
   must match
   <input type="hidden" name="k" value=""
```

## The fix

`errorAction()` sets `key`. Also reads the passkey through `getParam('k')` in `action()` rather than `$this->params['k']`, so one value isn't fetched two different ways in one file — the direct index is an undefined-key warning on PHP 8 in exactly the case this bug produced.

## Tests

`PasswordResetPasskeySurvivalTest` asserts the name, not just the presence — a value filed under any other name is invisible to the view. Mutation-checked by restoring `set('k', ...)`: it fails and names the reason.

Full suite green (1699), configless green.

## Not covered here

The mailer and the WAF are both fine — I checked. The reset mail is accepted by the relay (`status=sent`, 250), and the OWA login form and password-entry page both serve 200. A 403 I saw initially was my own `curl` user-agent tripping the bot rule, not a real block.