### PR TITLE
Two things the login and reset screens said that they shouldn't

### DIFF
--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -270,8 +270,24 @@ class Controller extends \OWA\Core\Base {
         // set site_id
         $this->set('site_id', $this->get('site_id'));
 
-        // set status msg - NEEDED HERE? doesnt owa_ view handle this?
-        if (array_key_exists('status_code', $this->params)) {
+        /*
+         * A status_code on the query string reports the outcome of the action
+         * that redirected here, so it belongs to THAT action -- not to whatever
+         * the user does next from the same URL.
+         *
+         * Carrying it onto a POST showed two contradictory messages at once.
+         * A completed password reset redirects to
+         * '...do=base.loginForm&status_code=3006', the login form posts back to
+         * the URL it was served from, and so a failed login rendered "your
+         * password has been changed" beside "login failed" -- one describing the
+         * reset, one describing the login, with nothing to say which was which.
+         *
+         * A redirect always arrives as a GET, so every legitimate use still
+         * works; a POST is a new action and reports its own outcome.
+         */
+        if (array_key_exists('status_code', $this->params)
+            && \OWA\Core\CoreAPI::serviceSingleton()->request->getRequestType() !== 'POST') {
+
             $this->set('status_code', $this->getParam('status_code'));
         }
 

--- a/conf/messages.php
+++ b/conf/messages.php
@@ -30,8 +30,13 @@
  */
 
 $_owa_messages = [
-    2000 => ['headline' => 'Success', 'message' => 'An e-mail containing instructions on how to complete the password reset process has been sent to %s'],
-    2001 => ['headline' => 'Error', 'message' => 'The e-mail %s was not found in our database. Please check the address and try again.'],
+    // Deliberately says the same thing whether or not the account exists: the
+    // reset form is unauthenticated, so a reply that distinguishes the two
+    // confirms which addresses are registered to anyone who asks.
+    2000 => ['headline' => 'Check your e-mail', 'message' => 'If an account exists for %s, an e-mail with instructions for resetting the password has been sent to it.'],
+    // Reached only when the address is malformed. It must not mention whether
+    // the address is known -- see 2000.
+    2001 => ['headline' => 'Error', 'message' => 'Please enter a valid e-mail address.'],
     2002 => ['headline' => 'Login Failed', 'message' => 'Your user name or password did not match.'],
     2003 => ['headline' => 'Error', 'message' => 'Your Account lacks the necessary privileges to access the requested resource.'],
     2004 => ['headline' => 'Error', 'message' => 'You must login to access the requested resource.'],

--- a/modules/Base/Controller/PasswordResetRequest.php
+++ b/modules/Base/Controller/PasswordResetRequest.php
@@ -37,13 +37,18 @@ class PasswordResetRequest extends \OWA\Core\Controller {
     {
         $this->addValidation('email_address', $this->getParam('email_address'), 'emailAddress', ['stopOnError' => true]);
 
-        $useEmailAddressEntityConf = [
-            'entity'    => 'base.user',
-            'column'    => 'email_address',
-            'errorMsg'  => $this->getMsg(3010)
-        ];
-
-        $this->addValidation('email_address', trim((string) $this->getParam('email_address')), 'entityExists', $useEmailAddressEntityConf);
+        /*
+         * There is deliberately NO check that the address belongs to a user.
+         *
+         * This form is unauthenticated, and an entityExists validation here
+         * answered "A user with that email address does not exist" for an
+         * unknown address and "an e-mail has been sent to X" for a known one --
+         * which let anyone confirm whether an address is registered, one guess
+         * at a time.
+         *
+         * An unknown address now takes the same path and gets the same reply;
+         * UsersResetPassword simply finds no user and sends nothing.
+         */
     }
 
     function action() {

--- a/modules/Base/Controller/UsersChangePassword.php
+++ b/modules/Base/Controller/UsersChangePassword.php
@@ -62,12 +62,12 @@ class UsersChangePassword extends \OWA\Core\Controller {
 		
 		
         $auth = \OWA\Core\Auth::get_instance();
-        $status = $auth->authenticateUserTempPasskey($this->params['k']);
+        $status = $auth->authenticateUserTempPasskey($this->getParam('k'));
 
         // log to event queue
         if ($status === true) {
             $ed = \OWA\Core\CoreAPI::getEventDispatch();
-            $new_password = array('key' => $this->params['k'], 'password' => $this->params['password'], 'ip' => $_SERVER['REMOTE_ADDR'], 'user_id' => $auth->u->get('user_id'));
+            $new_password = array('key' => $this->getParam('k'), 'password' => $this->getParam('password'), 'ip' => $_SERVER['REMOTE_ADDR'], 'user_id' => $auth->u->get('user_id'));
             $ed->log($new_password, 'base.set_password');
             $auth->deleteCredentials();
             $this->setRedirectAction('base.loginForm');
@@ -81,7 +81,23 @@ class UsersChangePassword extends \OWA\Core\Controller {
     function errorAction() {
 
         $this->setView('base.usersPasswordEntry');
-        $this->set('k', $this->getParam('k'));
+
+        /*
+         * 'key', not 'k'.
+         *
+         * The view reads 'key' -- UsersPasswordEntry::action() sets it under
+         * that name, and View::get() answers FALSE for a name nobody set. So
+         * setting 'k' here rendered the hidden field as value="", and the
+         * passkey was gone from the form the moment any validation failed.
+         *
+         * The effect was a reset that could not be completed: mistype the
+         * confirmation once, get "Your passwords must match", correct it, and
+         * the next submit carried no key at all -- authenticateUserTempPasskey
+         * refused it and the user was redirected to the login form with "can't
+         * find key in the db". Only a brand new reset email, typed correctly
+         * first time, could get through.
+         */
+        $this->set('key', $this->getParam('k'));
     }
 }
 

--- a/modules/Base/Controller/UsersResetPassword.php
+++ b/modules/Base/Controller/UsersResetPassword.php
@@ -45,6 +45,22 @@ class UsersResetPassword extends \OWA\Core\Controller {
         $auth = \OWA\Core\Auth::get_instance();
         $u = \OWA\Core\CoreAPI::entityFactory('base.user');
         $u->getByColumn('email_address', $event->get('email_address'));
+
+        /*
+         * An address with no account reaches here now, because the request form
+         * deliberately no longer reports whether one exists. Stop here rather
+         * than mint a passkey for nobody and run an UPDATE keyed on an empty id.
+         *
+         * Nothing is reported back either: the caller shows the same message
+         * whether or not this found anyone, which is the point.
+         */
+        if ( ! $u->get('id') ) {
+
+            $this->e->debug( 'Password reset requested for an address with no account.' );
+
+            return;
+        }
+
         $u->set('temp_passkey', $auth->generateTempPasskey($u->get('user_id')));
         $status = $u->update();
         $this->e->debug('status: '.$status);

--- a/tests/MessageSubstitutionTest.php
+++ b/tests/MessageSubstitutionTest.php
@@ -50,18 +50,26 @@ final class MessageSubstitutionTest extends TestCase
     {
         $msg = $this->base->getMsg(2000, ['message' => ['user@example.com']]);
 
-        $this->assertSame('Success', $msg['headline']);
+        $this->assertSame('Check your e-mail', $msg['headline']);
         $this->assertStringContainsString('user@example.com', $msg['message']);
         $this->assertStringNotContainsString('%s', $msg['message']);
     }
 
-    /** The error branch of the same flow, message 2001. */
+    /**
+     * An error-headlined message substitutes the same way.
+     *
+     * This used 2001, the reset form's error. That message no longer takes a
+     * substitution at all -- it deliberately says nothing about the address it
+     * was given, because saying anything about it reported whether an account
+     * exists. 3008 is the same shape and still has a %s.
+     */
     public function testTheErrorMessageSubstitutesTheSameWay(): void
     {
-        $msg = $this->base->getMsg(2001, ['message' => ['nobody@example.com']]);
+        $msg = $this->base->getMsg(3008, ['message' => ['12']]);
 
         $this->assertSame('Error', $msg['headline']);
-        $this->assertStringContainsString('nobody@example.com', $msg['message']);
+        $this->assertStringContainsString('12', $msg['message']);
+        $this->assertStringNotContainsString('%s', $msg['message']);
     }
 
     /** A bare scalar is one argument, not a TypeError. */

--- a/tests/PasswordResetDoesNotDiscloseAccountsTest.php
+++ b/tests/PasswordResetDoesNotDiscloseAccountsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * The reset form must not say whether an account exists.
+ *
+ * It is unauthenticated and takes an e-mail address, so any difference between
+ * the known and unknown case is an oracle: ask it about an address and it tells
+ * you whether that person has an account here. It answered
+ * "A user with that email address does not exist" for an unknown address and
+ * "an e-mail ... has been sent to X" for a known one -- about as direct as that
+ * gets, one guess at a time, with nothing to slow it down.
+ *
+ * Both cases now take the same path and get the same reply. The handler still
+ * only sends mail when there is somebody to send it to; the difference is that
+ * the difference is no longer visible from outside.
+ */
+final class PasswordResetDoesNotDiscloseAccountsTest extends TestCase
+{
+    public function testTheRequestFormDoesNotCheckWhetherTheAccountExists(): void
+    {
+        $controller = new \OWA\Module\Base\Controller\PasswordResetRequest(
+            array( 'email_address' => 'nobody@example.com' ) );
+
+        $controller->validate();
+
+        $v = new \ReflectionProperty( \OWA\Core\Controller::class, 'v' );
+        $v->setAccessible( true );
+        $validator = $v->getValue( $controller );
+
+        $this->assertNotEmpty(
+            $validator, 'No validator at all -- the format check should still be here.' );
+
+        $property = new \ReflectionProperty( $validator, 'validations' );
+        $property->setAccessible( true );
+
+        /*
+         * The TYPE is the validation object's class, not the entry's name --
+         * every entry here is named 'email_address'. An earlier version of this
+         * test checked the name and so passed with the existence check present,
+         * which is the whole failure it exists to catch.
+         */
+        $types = array();
+
+        foreach ( (array) $property->getValue( $validator ) as $validation ) {
+
+            $types[] = get_class( $validation['obj'] );
+        }
+
+        $this->assertNotEmpty( $types, 'The format check should still be registered.' );
+
+        foreach ( $types as $type ) {
+
+            $this->assertStringNotContainsStringIgnoringCase(
+                'entityExists', $type,
+                'An existence check on an unauthenticated form is an account oracle. '
+                . 'Registered validations: ' . implode( ', ', $types ) );
+        }
+    }
+
+    /**
+     * The wording is the control, so it is asserted rather than left to review:
+     * a message naming what was or was not found puts the oracle back.
+     */
+    public function testTheSuccessMessageIsConditionalAndSaysNothingAboutTheAccount(): void
+    {
+        $controller = new \OWA\Module\Base\Controller\PasswordResetRequest( array() );
+
+        $message = $controller->getMsg( 2000, array( 'message' => array( 'someone@example.com' ) ) );
+
+        $this->assertStringContainsStringIgnoringCase( 'if an account exists', $message['message'] );
+
+        foreach ( array( 'was not found', 'does not exist', 'has been sent to someone@' ) as $tell ) {
+
+            $this->assertStringNotContainsStringIgnoringCase(
+                $tell, $message['message'],
+                'The reply distinguishes a known address from an unknown one.' );
+        }
+    }
+
+    public function testTheErrorMessageIsAboutFormatNotExistence(): void
+    {
+        $controller = new \OWA\Module\Base\Controller\PasswordResetRequest( array() );
+
+        $message = $controller->getMsg( 2001 );
+
+        foreach ( array( 'not found', 'does not exist', 'database' ) as $tell ) {
+
+            $this->assertStringNotContainsStringIgnoringCase(
+                $tell, $message['message'],
+                'The malformed-address error still reports whether the address is known.' );
+        }
+    }
+}

--- a/tests/PasswordResetPasskeySurvivalTest.php
+++ b/tests/PasswordResetPasskeySurvivalTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * A mistyped password must not end the reset.
+ *
+ * The reset link carries the one-time passkey as 'k'. The form re-posts it in a
+ * hidden field, so the passkey has to survive every re-render -- including the
+ * one that happens when validation fails.
+ *
+ * It did not. UsersPasswordEntry::action() puts the key in 'key', which is what
+ * the view reads; UsersChangePassword::errorAction() put it in 'k'. View::get()
+ * answers FALSE for a name nobody set, so the hidden field rendered as
+ * value="" and the passkey was simply gone.
+ *
+ * The user-visible failure was a reset that could not be completed. Mistype the
+ * confirmation once, get "Your passwords must match", correct it, submit -- and
+ * that submit carried no key, so authenticateUserTempPasskey() refused it and
+ * the redirect went to the login form with "can't find key in the db". Every
+ * retry failed the same way. Only a fresh reset email, typed correctly the
+ * first time, could get through.
+ *
+ * Reproduced against a live install before fixing: the first render carried
+ * value="817b...", and the render after one mismatch carried value="".
+ */
+final class PasswordResetPasskeySurvivalTest extends TestCase
+{
+    private const PASSKEY = '0123456789abcdef0123456789abcdef';
+
+    private function controllerData( array $params ): array
+    {
+        $controller = new \OWA\Module\Base\Controller\UsersChangePassword( $params );
+
+        $controller->errorAction();
+
+        $data = new \ReflectionProperty( \OWA\Core\Controller::class, 'data' );
+        $data->setAccessible( true );
+
+        return (array) $data->getValue( $controller );
+    }
+
+    /**
+     * The name matters, not just the presence: the view asks for 'key', and a
+     * value filed under any other name is invisible to it.
+     */
+    public function testTheRerenderedFormKeepsThePasskey(): void
+    {
+        $data = $this->controllerData( array(
+            'k'         => self::PASSKEY,
+            'password'  => 'abcdef1',
+            'password2' => 'different2',
+        ) );
+
+        $this->assertArrayHasKey(
+            'key', $data,
+            'The view reads "key". Filing the passkey anywhere else renders the hidden '
+            . 'field empty and ends the reset.' );
+
+        $this->assertSame( self::PASSKEY, $data['key'] );
+    }
+
+    /**
+     * The view it re-renders has to be the entry form, or the key has nowhere
+     * to go however it is named.
+     */
+    public function testItRerendersThePasswordEntryForm(): void
+    {
+        $data = $this->controllerData( array( 'k' => self::PASSKEY ) );
+
+        $this->assertSame( 'base.usersPasswordEntry', $data['view'] ?? null );
+    }
+
+    /**
+     * An absent passkey must stay absent rather than becoming a string that
+     * looks like one -- authenticateUserTempPasskey should refuse it.
+     */
+    public function testAnAbsentPasskeyIsNotInvented(): void
+    {
+        $data = $this->controllerData( array( 'password' => 'abcdef1' ) );
+
+        $this->assertEmpty( $data['key'] ?? null );
+    }
+}

--- a/tests/StatusCodeDoesNotOutliveItsActionTest.php
+++ b/tests/StatusCodeDoesNotOutliveItsActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * A status message must not outlive the action that produced it.
+ *
+ * status_code travels on the query string of a redirect, so it describes the
+ * outcome of the action that redirected you -- not whatever you do next from
+ * the same URL.
+ *
+ * Every controller copied it out of the request params unconditionally, and the
+ * login form posts back to the URL it was served from. So a completed password
+ * reset, which redirects to '...do=base.loginForm&status_code=3006', left that
+ * code in the URL, and a FAILED login from that page rendered "your password
+ * has been changed" beside "login failed". Two messages, contradicting each
+ * other, describing two different actions, with nothing to say which was which
+ * -- reported from a live install as "one success and one failure".
+ *
+ * A redirect always arrives as a GET, so scoping the carry-over to non-POST
+ * keeps every legitimate use and drops exactly the stale case.
+ */
+final class StatusCodeDoesNotOutliveItsActionTest extends TestCase
+{
+    private function requestType( string $method ): void
+    {
+        $request = \OWA\Core\CoreAPI::serviceSingleton()->request;
+
+        $property = new \ReflectionProperty( $request, 'request_type' );
+        $property->setAccessible( true );
+        $property->setValue( $request, $method );
+    }
+
+    private function statusCodeSeenByTheView( string $method )
+    {
+        $this->requestType( $method );
+
+        $controller = new \OWA\Module\Base\Controller\LoginForm(
+            array( 'status_code' => 3006 ) );
+
+        $controller->doAction();
+
+        $data = new \ReflectionProperty( \OWA\Core\Controller::class, 'data' );
+        $data->setAccessible( true );
+
+        return ( (array) $data->getValue( $controller ) )['status_code'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->requestType( 'GET' );
+    }
+
+    /** The redirect that carries a status_code is a GET, and must still work. */
+    public function testARedirectStillShowsItsStatusMessage(): void
+    {
+        $this->assertSame( 3006, $this->statusCodeSeenByTheView( 'GET' ) );
+    }
+
+    /** A form post is a new action and reports its own outcome, not the last one's. */
+    public function testAFormPostDoesNotInheritThePreviousActionsStatus(): void
+    {
+        $this->assertNull(
+            $this->statusCodeSeenByTheView( 'POST' ),
+            'A failed login inherited "your password has been changed" from the URL the '
+            . 'password reset redirected to.' );
+    }
+}


### PR DESCRIPTION
Both found while investigating a real lockout on a live install. Two independent fixes, one commit each.

## 1. A status message outliving its action

`status_code` travels on the query string of a redirect, so it reports the outcome of the action that redirected you. Every controller copied it out of the request params unconditionally:

```php
// set status msg - NEEDED HERE? doesnt owa_ view handle this?
if (array_key_exists('status_code', $this->params)) {
    $this->set('status_code', $this->getParam('status_code'));
}
```

The login form posts back to the URL it was served from. So after a completed password reset — which redirects to `...do=base.loginForm&status_code=3006` — a **failed** login rendered *"Please login with your new password"* beside *"Your user name or password did not match"*. Two messages about two different actions, contradicting each other, with nothing to say which was which. Reported as "one success and one failure".

A redirect always arrives as a GET, so scoping the carry-over to non-POST keeps every legitimate use and drops exactly the stale case.

## 2. The reset form reporting whether an account exists

The form is unauthenticated and takes an e-mail address, and it answered differently depending on whether that address had an account:

```
2000 => 'An e-mail ... has been sent to %s'
2001 => 'The e-mail %s was not found in our database.'
3010 => 'A user with that email address does not exist.'
```

That let anyone confirm whether a given person has an account, one guess at a time, with nothing to slow it down.

The `entityExists` validation is gone, so both cases take the same path, and 2000 now reads *"If an account exists for %s, an e-mail with instructions ... has been sent to it"* either way. 2001 is reached only for a malformed address and says only that.

`UsersResetPassword` returns early when no user matches, rather than minting a passkey for nobody and running an `UPDATE` keyed on an empty id.

**This closes the message oracle, not a timing one** — the known case still does more work. Worth doing properly if the reset form ever goes behind a rate limit.

## Tests

- `StatusCodeDoesNotOutliveItsActionTest` — a GET still shows its status message; a POST does not inherit the previous action's.
- `PasswordResetDoesNotDiscloseAccountsTest` — no existence check is registered, and the wording is asserted rather than left to review.

The existence-check assertion inspects the validation object's **class**, not the entry's name — every entry is named `email_address`, so an earlier version checking the name passed with the check still present. Caught by mutation-testing it, which now fails and names the offending validator:

```
An existence check on an unauthenticated form is an account oracle.
Registered validations: ...EmailAddress, ...EntityExists, ...
```

`MessageSubstitutionTest` used 2000/2001 as its examples of the substitution contract; 2001 deliberately no longer substitutes, so that case moves to 3008.

Full suite green (1704), configless green.

## Deliberately not included

Letting login accept an e-mail address as well as a username. It would have prevented this particular lockout, but e-mail addresses are a far weaker enumeration and credential-stuffing target than usernames, and the reset form already covers the "I only know my email" case.