### PR TITLE
Restore the published REST entity shape

### DIFF
--- a/Core/View/RestApi.php
+++ b/Core/View/RestApi.php
@@ -127,7 +127,7 @@ class RestApi extends \OWA\Core\View {
 
 	    if ( $data instanceof \OWA\Core\Entity ) {
 
-		    return $data->getPublicProperties();
+		    return self::toPropertyBag( $data );
 	    }
 
 	    if ( is_array( $data ) ) {
@@ -143,6 +143,39 @@ class RestApi extends \OWA\Core\View {
 	    }
 
 	    return $data;
+    }
+
+    /**
+     * An entity as { properties: { <column>: { value: ... } } }.
+     *
+     * This is the shape the REST API has always published, and #977 retired it
+     * without a deprecation path. It was right about the leak it found -- an
+     * entity handed to json_encode() emitted _tableProperties, wasPersisted,
+     * cache and dirty alongside the property bag -- but it fixed that by
+     * flattening the bag to bare values, which removed the leak AND the
+     * contract. Every deployed consumer reading properties.<col>.value broke,
+     * including the WordPress plugin, whose site picker collapses to a single
+     * empty option because the lookup yields null.
+     *
+     * Built FROM getPublicProperties() rather than from the raw property bag,
+     * so everything #977 was actually protecting still holds by construction:
+     * internals never enter, and a private column -- a user's password -- is
+     * dropped before this sees it. The nesting is restored; the leak is not.
+     *
+     * Only 'value' is emitted per column. The old shape carried whatever public
+     * members DbColumn happened to have, which meant schema details rode along
+     * in a public payload; consumers read .value, and that is what is promised.
+     */
+    protected static function toPropertyBag( \OWA\Core\Entity $entity ) {
+
+	    $properties = array();
+
+	    foreach ( (array) $entity->getPublicProperties() as $column => $value ) {
+
+		    $properties[ $column ] = array( 'value' => $value );
+	    }
+
+	    return array( 'properties' => $properties );
     }
     
     /**

--- a/tests/RestResponseDtoTest.php
+++ b/tests/RestResponseDtoTest.php
@@ -53,8 +53,18 @@ final class RestResponseDtoTest extends TestCase
         $out = $this->reduce($site);
 
         $this->assertIsArray($out, 'an entity must reduce to an array');
-        $this->assertSame('https://dto.example.test', $out['domain']);
-        $this->assertSame('DTO Test Site', $out['name']);
+
+        /*
+         * The PUBLISHED shape: properties.<column>.value.
+         *
+         * Asserted explicitly because retiring it is what broke every deployed
+         * consumer -- the WordPress plugin reads
+         * $site['properties']['site_id']['value'] and got null for a month.
+         * A change here needs a deprecation path, not a flip.
+         */
+        $this->assertArrayHasKey('properties', $out);
+        $this->assertSame('https://dto.example.test', $out['properties']['domain']['value']);
+        $this->assertSame('DTO Test Site', $out['properties']['name']['value']);
     }
 
     /**
@@ -68,7 +78,12 @@ final class RestResponseDtoTest extends TestCase
 
         $out = $this->reduce($site);
 
-        foreach (['_tableProperties', 'wasPersisted', 'dirty', 'cache', 'properties'] as $internal) {
+        /*
+         * 'properties' is NOT on this list any more, and that was the mistake.
+         * The bag is the resource; the bookkeeping around it is the leak. #977
+         * removed both, which fixed the leak and retired the contract with it.
+         */
+        foreach (['_tableProperties', 'wasPersisted', 'dirty', 'cache'] as $internal) {
             $this->assertArrayNotHasKey(
                 $internal,
                 $out,
@@ -85,14 +100,14 @@ final class RestResponseDtoTest extends TestCase
         foreach (['password', 'temp_passkey', 'api_key'] as $secret) {
             $this->assertArrayNotHasKey(
                 $secret,
-                $out,
+                $out['properties'],
                 sprintf('%s must never appear in a response', $secret)
             );
         }
 
         // Still a usable representation of the user.
-        $this->assertSame('dto-test@example.test', $out['user_id']);
-        $this->assertSame('DTO Test', $out['real_name']);
+        $this->assertSame('dto-test@example.test', $out['properties']['user_id']['value']);
+        $this->assertSame('DTO Test', $out['properties']['real_name']['value']);
     }
 
     /** Collections are the common case -- every element has to be reduced. */
@@ -102,8 +117,8 @@ final class RestResponseDtoTest extends TestCase
 
         foreach (['a', 'b'] as $k) {
             $this->assertIsArray($out[$k]);
-            $this->assertArrayNotHasKey('password', $out[$k]);
-            $this->assertSame('dto-test@example.test', $out[$k]['user_id']);
+            $this->assertArrayNotHasKey('password', $out[$k]['properties']);
+            $this->assertSame('dto-test@example.test', $out[$k]['properties']['user_id']['value']);
         }
     }
 


### PR DESCRIPTION
Fixes a live regression: **every deployed OWA REST consumer has been broken since 2026-08-02.**

## What happened

#977 changed every entity in a REST response from

```json
{ "properties": { "site_id": { "value": "abc" } } }
```

to

```json
{ "site_id": "abc" }
```

It was right about what it found — an entity handed to `json_encode()` emitted `_tableProperties`, `wasPersisted`, `cache` and `dirty` alongside the property bag, and none of those are API surface. But it removed the leak by *flattening the bag*, which removed the contract with it, and shipped with no deprecation path.

## The impact

The WordPress plugin builds its site picker from:

```php
sprintf('%s (%s)', $site['properties']['site_id']['value'],
                   $site['properties']['domain']['value'])
```

On current OWA that lookup yields `null`, so every entry collapses to one option labelled `" ()"` keyed by the empty string. It doesn't degrade — it stops working, and it is live on any install that has updated.

Verified against the actual plugin and SDK on a deployed install; the SDK passes the response through untransformed, so nothing adapts it.

## The fix

The shape is restored, built **from `getPublicProperties()`** rather than from the raw property bag — so everything #977 was protecting still holds by construction:

```
plugin lookup works: 'abc'
internals withheld:  yes
password withheld:   yes
```

Internals can't enter, and a private column (`password`, `temp_passkey`, `api_key`) is dropped before this code sees it. Only `value` is emitted per column: the old shape carried whatever public members `DbColumn` happened to have, which put schema details in a public payload.

## The test that should have caught it

`RestResponseDtoTest` asserted `properties` must be **absent**, listed among the ORM internals. That's the mistake in one line — the bag is the resource; the bookkeeping around it is the leak. It now asserts the nested shape explicitly, so retiring it again means deleting an assertion that says why it exists.

Worth noting how it escaped: `SitesRestControllerTest` checked `assertIsArray($resp['data'])` and `assertArrayHasKey($site['site_id'], $resp['data'])`. The outer keying is identical under both shapes, and **no assertion ever looked inside an entry** — so every entry's structure could change without touching anything the tests examined.

## Why a month passed

Nothing inside OWA consumes this endpoint. The site selector reads entities directly through `getSitesAllowedForCurrentUser()`, so the API can break without any OWA screen or test noticing.

Full suite green (1704), configless green.