### PR TITLE
Schema updates are idempotent in both directions

### DIFF
--- a/Core/Update.php
+++ b/Core/Update.php
@@ -208,6 +208,80 @@ class Update extends \OWA\Core\Base {
      *
      * @return boolean
      */
+    /**
+     * Add a column, treating "it is already there" as success.
+     *
+     * addColumn() answers FALSE both for "could not" and for "already exists",
+     * so a migration that stops on the second never writes its schema version --
+     * and every request afterwards refuses with "OWA Updates required" while
+     * the database is in fact correct.
+     *
+     * THIS IS NOT A RE-RUN GUARD. It is the ordinary case for any install that
+     * jumps several versions at once. A table CREATED by an earlier migration is
+     * built from the CURRENT entity definition, which already carries every
+     * column that LATER migrations add -- so the column exists before the
+     * migration that adds it ever runs.
+     *
+     * Found on a live deploy: an installation at schema 20 ran Update021, which
+     * created owa_property complete with the archived_date that Update023 then
+     * tried to add. The upgrade stopped dead at 23, on a database that was
+     * already correct.
+     *
+     * Interpolated, not bound: SHOW COLUMNS takes no parameters, and both values
+     * come from the migration's own code rather than from a request.
+     *
+     * @param  object $entity a table entity
+     * @param  string $column
+     * @return bool   false only when the column is genuinely missing and could
+     *                not be added
+     */
+    protected function addColumnIfMissing( $entity, $column ) {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $existing = (array) $db->get_results( sprintf(
+            "SHOW COLUMNS FROM %s LIKE '%s'",
+            $entity->getTableName(),
+            $column ) );
+
+        if ( $existing ) {
+
+            return true;
+        }
+
+        return $entity->addColumn( $column ) !== false;
+    }
+
+    /**
+     * Drop a column, treating "it is already gone" as success.
+     *
+     * The mirror of addColumnIfMissing(), and it exists for the mirror reason:
+     * a down() has to be runnable twice. MySQL has no DROP COLUMN IF EXISTS, so
+     * the check is explicit -- and without it a rollback that got half way
+     * through cannot be finished, which is the worst moment to be unable to
+     * repeat a step.
+     *
+     * @param  object $entity
+     * @param  string $column
+     * @return bool   false only when the column is there and could not be dropped
+     */
+    protected function dropColumnIfPresent( $entity, $column ) {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $existing = (array) $db->get_results( sprintf(
+            "SHOW COLUMNS FROM %s LIKE '%s'",
+            $entity->getTableName(),
+            $column ) );
+
+        if ( ! $existing ) {
+
+            return true;
+        }
+
+        return $entity->dropColumn( $column ) !== false;
+    }
+
     function up() {
 
         return false;

--- a/modules/Base/Update/Update020.php
+++ b/modules/Base/Update/Update020.php
@@ -31,7 +31,10 @@ class Update020 extends \OWA\Core\Update {
 
         foreach ( array( 'billing_country', 'billing_state', 'billing_city' ) as $column ) {
 
-            if ( $entity->addColumn( $column ) === false ) {
+            // Skipped when already present -- see Update::addColumnIfMissing().
+            // Found latent here by the guard test rather than by an upgrade
+            // failing: this one has already run everywhere it was going to.
+            if ( ! $this->addColumnIfMissing( $entity, $column ) ) {
 
                 $this->e->notice( "Adding $column to commerce_transaction_fact failed" );
 

--- a/modules/Base/Update/Update023.php
+++ b/modules/Base/Update/Update023.php
@@ -39,7 +39,14 @@ class Update023 extends \OWA\Core\Update {
 
             $entity = \OWA\Core\CoreAPI::entityFactory( $entityName );
 
-            if ( $entity->addColumn( 'archived_date' ) === false ) {
+            /*
+             * Skipped when it is already there. Update021 CREATES owa_property
+             * from the current entity definition, which already declares
+             * archived_date -- so on an install jumping from below 21 the
+             * column exists before this runs, and treating that as a failure
+             * stopped a live upgrade dead on a correct database.
+             */
+            if ( ! $this->addColumnIfMissing( $entity, 'archived_date' ) ) {
 
                 $this->e->notice( "Adding archived_date to $table failed" );
 
@@ -50,7 +57,35 @@ class Update023 extends \OWA\Core\Update {
         return true;
     }
 
+    /**
+     * Take archived_date back off both tables.
+     *
+     * Idempotent, like the up: dropColumnIfPresent() treats an already-absent
+     * column as done, so a rollback that got half way through can be finished
+     * rather than being stuck needing hand surgery.
+     *
+     * Archiving state is LOST by this, and that is the honest outcome -- the
+     * column is where it lived. Rolling back to a schema with no notion of
+     * archiving cannot keep a record of what was archived.
+     */
     function down() {
+
+        $targets = array(
+            'base.site'     => 'owa_site',
+            'base.property' => 'owa_property',
+        );
+
+        foreach ( $targets as $entityName => $table ) {
+
+            $entity = \OWA\Core\CoreAPI::entityFactory( $entityName );
+
+            if ( ! $this->dropColumnIfPresent( $entity, 'archived_date' ) ) {
+
+                $this->e->notice( "Dropping archived_date from $table failed" );
+
+                return false;
+            }
+        }
 
         return true;
     }

--- a/modules/Base/Update/Update024.php
+++ b/modules/Base/Update/Update024.php
@@ -40,7 +40,8 @@ class Update024 extends \OWA\Core\Update {
 
         foreach ( array( 'stream_type', 'app_id' ) as $column ) {
 
-            if ( $entity->addColumn( $column ) === false ) {
+            // Skipped when already present -- see Update::addColumnIfMissing().
+            if ( ! $this->addColumnIfMissing( $entity, $column ) ) {
 
                 $this->e->notice( "Adding $column to owa_site failed" );
 
@@ -51,7 +52,27 @@ class Update024 extends \OWA\Core\Update {
         return true;
     }
 
+    /**
+     * Take the stream type and app id back off the Profile.
+     *
+     * Idempotent: an already-absent column counts as dropped.
+     *
+     * Every Profile becomes a web Profile again by implication, which is what
+     * the schema meant before this update -- there was no other kind.
+     */
     function down() {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.site' );
+
+        foreach ( array( 'stream_type', 'app_id' ) as $column ) {
+
+            if ( ! $this->dropColumnIfPresent( $entity, $column ) ) {
+
+                $this->e->notice( "Dropping $column from owa_site failed" );
+
+                return false;
+            }
+        }
 
         return true;
     }

--- a/modules/Base/Update/Update025.php
+++ b/modules/Base/Update/Update025.php
@@ -267,7 +267,25 @@ class Update025 extends \OWA\Core\Update {
         return $cents;
     }
 
+    /**
+     * Drop the goal event tables.
+     *
+     * Safe BECAUSE the up() copied rather than moved: the goals it read are
+     * still in the settings blob, untouched, so dropping these tables returns
+     * the installation to reading them from there. If the up had emptied the
+     * blob this down would be destroying the only copy.
+     *
+     * Idempotent: DROP TABLE IF EXISTS, so a half-finished rollback finishes.
+     */
     function down() {
+
+        foreach ( array( 'base.goal_event_condition', 'base.goal_event' ) as $name ) {
+
+            // Conditions first. Nothing enforces the reference in SQL, but
+            // dropping the parent first would leave rows pointing at a table
+            // that is gone if the second drop then failed.
+            \OWA\Core\CoreAPI::entityFactory( $name )->dropTable();
+        }
 
         return true;
     }

--- a/modules/Base/Update/Update026.php
+++ b/modules/Base/Update/Update026.php
@@ -31,37 +31,14 @@ class Update026 extends \OWA\Core\Update {
 
         $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report' );
 
-        $db = \OWA\Core\CoreAPI::dbSingleton();
-
         foreach ( array( 'report_type', 'visualization_type' ) as $column ) {
 
             /*
              * Skipped when it is already there, rather than treated as a
-             * failure.
-             *
-             * addColumn() answers false both for "could not" and for "already
-             * exists", and a migration that stops on the second never completes
-             * -- so the schema version is never written, and every subsequent
-             * request refuses with "OWA Updates required" while the database is
-             * in fact correct. Measured here, on this install.
+             * failure -- see Update::addColumnIfMissing() for why that is the
+             * ordinary case and not a re-run guard.
              */
-            /*
-             * Interpolated, not bound: SHOW COLUMNS takes no parameters, and
-             * both values here are hardcoded -- the table from the entity and
-             * the column from the literal list above. Nothing from a request
-             * reaches this.
-             */
-            $existing = (array) $db->get_results( sprintf(
-                "SHOW COLUMNS FROM %s LIKE '%s'",
-                $entity->getTableName(),
-                $column ) );
-
-            if ( $existing ) {
-
-                continue;
-            }
-
-            if ( $entity->addColumn( $column ) === false ) {
+            if ( ! $this->addColumnIfMissing( $entity, $column ) ) {
 
                 $this->e->notice( "Adding $column to owa_custom_report failed" );
 
@@ -72,7 +49,31 @@ class Update026 extends \OWA\Core\Update {
         return true;
     }
 
+    /**
+     * Take the type columns back off owa_custom_report.
+     *
+     * Idempotent. VISUALIZATIONS BECOME REPORTS by doing this -- a row whose
+     * report_type said "visualization" loses the only thing distinguishing it,
+     * and the roster will list it as an ordinary custom report whose definition
+     * holds steps no widget renderer understands.
+     *
+     * Stated rather than guarded against: a rollback to a schema that has no
+     * visualizations cannot keep them, and the alternative is refusing to roll
+     * back at all.
+     */
     function down() {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report' );
+
+        foreach ( array( 'visualization_type', 'report_type' ) as $column ) {
+
+            if ( ! $this->dropColumnIfPresent( $entity, $column ) ) {
+
+                $this->e->notice( "Dropping $column from owa_custom_report failed" );
+
+                return false;
+            }
+        }
 
         return true;
     }

--- a/modules/Base/Update/Update027.php
+++ b/modules/Base/Update/Update027.php
@@ -30,32 +30,8 @@ class Update027 extends \OWA\Core\Update {
 
         $entity = \OWA\Core\CoreAPI::entityFactory( 'base.property' );
 
-        $db = \OWA\Core\CoreAPI::dbSingleton();
-
-        /*
-         * Skipped when it is already there, rather than treated as a failure.
-         *
-         * addColumn() answers false both for "could not" and for "already
-         * exists", and a migration that stops on the second never completes --
-         * so the schema version is never written and every subsequent request
-         * refuses with "OWA Updates required" while the database is in fact
-         * correct. Measured on this install, on Update026.
-         *
-         * Interpolated, not bound: SHOW COLUMNS takes no parameters, and both
-         * values are hardcoded -- the table from the entity, the column from
-         * the literal below. Nothing from a request reaches this.
-         */
-        $existing = (array) $db->get_results( sprintf(
-            "SHOW COLUMNS FROM %s LIKE '%s'",
-            $entity->getTableName(),
-            'property_type' ) );
-
-        if ( $existing ) {
-
-            return true;
-        }
-
-        if ( $entity->addColumn( 'property_type' ) === false ) {
+        // Skipped when already present -- see Update::addColumnIfMissing().
+        if ( ! $this->addColumnIfMissing( $entity, 'property_type' ) ) {
 
             $this->e->notice( 'Adding property_type to owa_property failed' );
 
@@ -65,7 +41,23 @@ class Update027 extends \OWA\Core\Update {
         return true;
     }
 
+    /**
+     * Take property_type back off the Property.
+     *
+     * Idempotent. Every Property reads as a website again, which is what falsy
+     * already means -- see Property::getPropertyType() -- so nothing downstream
+     * changes behaviour beyond losing the ability to say otherwise.
+     */
     function down() {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.property' );
+
+        if ( ! $this->dropColumnIfPresent( $entity, 'property_type' ) ) {
+
+            $this->e->notice( 'Dropping property_type from owa_property failed' );
+
+            return false;
+        }
 
         return true;
     }

--- a/tests/UpdateAddColumnGuardTest.php
+++ b/tests/UpdateAddColumnGuardTest.php
@@ -197,4 +197,107 @@ final class UpdateAddColumnGuardTest extends TestCase
 
         return substr( $code, $open );
     }
+    /**
+     * THE PRODUCTION FAILURE, REPRODUCED.
+     *
+     * The scans above prove the SHAPE of the code. This proves the behaviour:
+     * running an update whose column is already present must SUCCEED.
+     *
+     * That is exactly what killed the live upgrade -- Update023 asked for a
+     * column Update021 had already created, got false, and reported failure on
+     * a correct database. The source scan alone would pass against a helper
+     * that was subtly wrong; this runs the real thing against a real table.
+     *
+     * Update023's own targets are used because that is the update that failed.
+     * The column is already there on any install at schema 23 or above, which
+     * is every install this suite runs against -- so the test needs no fixture,
+     * only a database.
+     */
+    public function testAnUpdateSucceedsWhenItsColumnIsAlreadyThere(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+
+        if ( ! owa_test_db_available() ) {
+
+            $this->markTestSkipped( 'the behaviour needs a database to be idempotent against' );
+        }
+
+        $property = \OWA\Core\CoreAPI::entityFactory( 'base.property' );
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $present = (array) $db->get_results(
+            "SHOW COLUMNS FROM " . $property->getTableName() . " LIKE 'archived_date'" );
+
+        $this->assertNotEmpty( $present,
+            'this install is below schema 23, so the already-present case cannot be exercised' );
+
+        $update = new \OWA\Module\Base\Update\Update023;
+
+        $this->assertTrue( $update->up(),
+            'Update023 reported failure for a column that is already there. That is what '
+            . 'stopped a live upgrade at schema 22: addColumn() answers false for "already '
+            . 'exists", and reading that as a failure halts an install whose database is '
+            . 'already correct.' );
+
+        // And again, because idempotent means repeatable rather than merely
+        // survivable once.
+        $this->assertTrue( $update->up(), 'the second run reported failure' );
+    }
+
+    /**
+     * And the down is repeatable too.
+     *
+     * Run against a scratch table so nothing real loses a column: a rollback
+     * that got half way through has to be finishable, and dropColumnIfPresent()
+     * is what makes the second attempt a no-op rather than an error.
+     */
+    public function testDroppingAColumnTwiceIsNotAFailure(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+
+        if ( ! owa_test_db_available() ) {
+
+            $this->markTestSkipped( 'the behaviour needs a database' );
+        }
+
+        $db    = \OWA\Core\CoreAPI::dbSingleton();
+        $table = 'owa_test_drop_' . bin2hex( random_bytes( 4 ) );
+
+        $db->query( "CREATE TABLE $table (id BIGINT NOT NULL, archived_date BIGINT, PRIMARY KEY (id))" );
+
+        try {
+
+            $entity = new class( $table ) extends \OWA\Core\Entity {
+
+                private $t;
+
+                public function __construct( $t ) { $this->t = $t; }
+
+                public function getTableName() { return $this->t; }
+
+                public function dropColumn( $column ) {
+
+                    return \OWA\Core\CoreAPI::dbSingleton()->query(
+                        'ALTER TABLE ' . $this->t . ' DROP COLUMN ' . $column );
+                }
+            };
+
+            $update = new \OWA\Module\Base\Update\Update023;
+
+            $drop = new ReflectionMethod( '\OWA\Core\Update', 'dropColumnIfPresent' );
+            $drop->setAccessible( true );
+
+            $this->assertTrue( (bool) $drop->invoke( $update, $entity, 'archived_date' ),
+                'the first drop failed' );
+
+            $this->assertTrue( (bool) $drop->invoke( $update, $entity, 'archived_date' ),
+                'dropping an already-absent column reported failure, so a rollback that got '
+                . 'half way through cannot be finished' );
+
+        } finally {
+
+            $db->query( "DROP TABLE IF EXISTS $table" );
+        }
+    }
 }

--- a/tests/UpdateAddColumnGuardTest.php
+++ b/tests/UpdateAddColumnGuardTest.php
@@ -1,0 +1,200 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A migration must not treat "the column is already there" as a failure.
+ *
+ * THE BUG THIS EXISTS FOR, WHICH WAS FOUND IN PRODUCTION
+ *
+ * addColumn() answers FALSE both for "could not" and for "already exists". A
+ * migration that stops on the second never writes its schema version, so every
+ * request afterwards refuses with "OWA Updates required" -- on a database that
+ * is already correct.
+ *
+ * That is not a re-run guard and it is not hypothetical. It is the ORDINARY
+ * case for an install jumping several versions at once: a table created by an
+ * earlier migration is built from the CURRENT entity definition, which already
+ * carries every column later migrations add. An installation at schema 20 ran
+ * Update021, which created owa_property complete with the archived_date that
+ * Update023 then tried to add -- and the upgrade stopped dead at 23, mid-way,
+ * on a live site.
+ *
+ * Update::addColumnIfMissing() is the one place that gets this right. This test
+ * makes sure the next migration uses it rather than rediscovering the trap.
+ */
+final class UpdateAddColumnGuardTest extends TestCase
+{
+    /**
+     * The install root, resolved from this file rather than from OWA_DIR.
+     *
+     * A data provider runs BEFORE any bootstrap, so the constant does not exist
+     * yet -- and a provider that throws reports as "the data provider is
+     * invalid", which says nothing about what is wrong.
+     */
+    private static function root(): string
+    {
+        return dirname( __DIR__ ) . '/';
+    }
+
+    /** @return array<string, array{0:string,1:string}> path => [path, source] */
+    public static function updateFiles(): array
+    {
+        $cases = array();
+
+        foreach ( (array) glob( self::root() . 'modules/*/Update/Update*.php' ) as $file ) {
+
+            $cases[ basename( dirname( $file, 2 ) ) . '/' . basename( $file ) ]
+                = array( $file, (string) file_get_contents( $file ) );
+        }
+
+        return $cases;
+    }
+
+    /**
+     * No migration calls addColumn() and reads the result as a failure.
+     *
+     * The call itself is fine -- addColumnIfMissing() makes it. What must not
+     * appear is a migration deciding for itself what a false answer means,
+     * because false does not mean what it looks like it means.
+     *
+     * @dataProvider updateFiles
+     */
+    public function testNoUpdateTreatsAddColumnFalseAsFailure( string $file, string $source ): void
+    {
+        $relative = str_replace( self::root(), '', $file );
+
+        /*
+         * Comments stripped first. Several of these files EXPLAIN the trap in
+         * prose, and a naive scan reads the explanation as the offence -- which
+         * would make the fix undoable without deleting the reasoning for it.
+         */
+        $code = preg_replace( '~/\*.*?\*/~s', '', $source );
+        $code = preg_replace( '~//[^\n]*~', '', (string) $code );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/addColumn\s*\([^)]*\)\s*===?\s*false/', (string) $code,
+            "$relative reads addColumn() === false as a failure. It answers false for "
+            . '"already exists" too, so this stops the upgrade on a database that is '
+            . 'already correct. Use $this->addColumnIfMissing( $entity, $column ).' );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/!\s*\$\w+->addColumn\s*\(/', (string) $code,
+            "$relative negates addColumn() directly, which reads \"already exists\" as a "
+            . 'failure. Use $this->addColumnIfMissing( $entity, $column ).' );
+    }
+
+    /** The helper exists, and is reachable from a migration. */
+    public function testTheHelperExistsOnTheUpdateBaseClass(): void
+    {
+        $this->assertTrue( method_exists( '\OWA\Core\Update', 'addColumnIfMissing' ),
+            'Update::addColumnIfMissing() is gone, so every migration that adds a column '
+            . 'has to rediscover why addColumn() answering false is not a failure.' );
+
+        $method = new ReflectionMethod( '\OWA\Core\Update', 'addColumnIfMissing' );
+
+        $this->assertTrue( $method->isProtected(),
+            'the helper must be callable from a migration subclass' );
+    }
+
+    /**
+     * And the migrations that add columns actually use it.
+     *
+     * Named rather than discovered: these are the four that were adding columns
+     * when the trap was found, and a fifth appearing without the guard is
+     * exactly what the scan above is for.
+     */
+    public function testTheColumnAddingUpdatesUseTheHelper(): void
+    {
+        foreach ( array( 'Update023', 'Update024', 'Update026', 'Update027' ) as $name ) {
+
+            $source = (string) file_get_contents(
+                self::root() . 'modules/Base/Update/' . $name . '.php' );
+
+            $this->assertStringContainsString( 'addColumnIfMissing', $source,
+                "$name adds a column without the guard, so an install that jumps versions "
+                . 'stops there.' );
+        }
+    }
+    /**
+     * AN UPDATE THAT BUILDS SOMETHING MUST BE ABLE TO UNBUILD IT.
+     *
+     * `down() { return true; }` is the worst of the three options: it claims
+     * the rollback succeeded and leaves the schema exactly as it was, so an
+     * operator who rolls back gets a success message and a database still
+     * carrying the change. Either undo it, or say plainly that you will not.
+     *
+     * Both honest answers are allowed:
+     *   - drop what the up() created (dropTable / dropColumn / dropIndex)
+     *   - `return false` -- a refusal, which the runner reports as a failed
+     *     rollback rather than a silent no-op
+     *
+     * What is banned is the third: a bare success that did nothing. This test
+     * exists because five migrations were written that way in a row, which is a
+     * habit rather than an oversight and needed a mechanism rather than a
+     * resolution.
+     *
+     * @dataProvider updateFiles
+     */
+    public function testAnUpdateThatBuildsSomethingCanUnbuildIt( string $file, string $source ): void
+    {
+        $relative = str_replace( self::root(), '', $file );
+
+        $code = preg_replace( '~/\*.*?\*/~s', '', $source );
+        $code = preg_replace( '~//[^\n]*~', '', (string) $code );
+
+        // What the up() actually builds.
+        if ( ! preg_match( '/(createTable|addColumn|addColumnIfMissing|addIndex)/', (string) $code ) ) {
+
+            $this->assertTrue( true, 'nothing structural to undo' );
+
+            return;
+        }
+
+        $down = $this->downBody( (string) $code );
+
+        $this->assertNotSame( '', $down, "$relative declares no down() at all" );
+
+        $undoes  = (bool) preg_match( '/(dropTable|dropColumn|dropColumnIfPresent|dropIndex)/', $down );
+        $refuses = (bool) preg_match( '/return\s+false/', $down );
+
+        $this->assertTrue( $undoes || $refuses,
+            "$relative builds schema in up() but its down() neither undoes it nor refuses.\n"
+            . "A bare `return true` reports a rollback that did not happen. Either drop what "
+            . "was created -- there are dropColumnIfPresent()/dropTable() helpers for doing it "
+            . "idempotently -- or `return false` to say the rollback is not supported." );
+    }
+
+    /** The body of down(), brace-matched so a nested block does not end it early. */
+    private function downBody( string $code ): string
+    {
+        $at = strpos( $code, 'function down' );
+
+        if ( $at === false ) {
+
+            return '';
+        }
+
+        $open = strpos( $code, '{', $at );
+
+        if ( $open === false ) {
+
+            return '';
+        }
+
+        $depth = 0;
+
+        for ( $i = $open; $i < strlen( $code ); $i++ ) {
+
+            if ( $code[ $i ] === '{' ) { $depth++; }
+            if ( $code[ $i ] === '}' ) { $depth--; }
+
+            if ( $depth === 0 ) {
+
+                return substr( $code, $open, $i - $open + 1 );
+            }
+        }
+
+        return substr( $code, $open );
+    }
+}


### PR DESCRIPTION
A live upgrade stopped dead, which is how this was found.

`peteradamsphoto` at schema 20 ran **Update021**, which *creates* `owa_property` — from the current entity definition, which already declares the `archived_date` that **Update023** then tried to add. `addColumn()` answered false, Update023 read that as a failure, and the install stopped at 22 on a database that was already correct.

## The trap

`addColumn()` answers **FALSE both for "could not" and for "already exists"**. That is not a re-run guard problem — it is the ordinary case for any install jumping several versions at once, because a table created by an earlier migration carries every column the later ones add. Tables were already safe (`CREATE TABLE IF NOT EXISTS`); columns were not.

`Core\Update` gains `addColumnIfMissing()` and `dropColumnIfPresent()` — one place that gets this right. Updates 020 and 023–027 use them.

**Update020 was found by the new test, not by an upgrade failing.** It has already run everywhere it was going to, and was carrying the same trap for anyone still below it.

## The downs are real now

Updates 023–027 shipped with `down() { return true; }` — five in a row. That is the worst of the three options: it reports a rollback that did not happen, so an operator gets a success message and a database still carrying the change.

Each now drops what its `up()` created, idempotently, and each states in its docblock **what is lost** by rolling back — archiving state, stream types, visualization types — rather than pretending nothing is.

## Enforced, not promised

`UpdateAddColumnGuardTest` checks every module's updates:

- no update may read `addColumn() === false` as a failure
- an update whose `up()` builds schema must either undo it in `down()` **or** `return false` to refuse — a bare `return true` fails

Both mutation-checked: reverting 027's `down()` to a bare success, and its `up()` to a bare `addColumn`, each fail with the message that names the fix.

## Verification

1946 PHP tests green, phpstan clean, configless run green, and the new file green in isolation.
