### PR TITLE
fix: addColumn() has never worked for an indexed column

### DIFF
--- a/Core/Db.php
+++ b/Core/Db.php
@@ -3224,10 +3224,21 @@ class Db extends \OWA\Core\Base {
 
         // Control loop
 
+        // Index clauses are TABLE-level and are collected as we go. They used
+        // to arrive glued onto the end of a column's definition, which is
+        // legal only here -- and made addColumn() emit a syntax error for
+        // every indexed column. See DbColumn::getDefinition().
+        $indexes = array();
+
         foreach ($all_cols as $k => $v){
 
             // get column definition
             $columns .= $v.' '.$entity->getColumnDefinition($v, (bool) $partition_column);
+
+            if ( $entity->isColumnIndexed( $v ) ) {
+
+                $indexes[] = sprintf( 'INDEX (%s)', $v );
+            }
 
             // Add commas to column statement
             if ($i < $count - 1):
@@ -3238,6 +3249,11 @@ class Db extends \OWA\Core\Base {
 
             $i++;
 
+        }
+
+        if ( $indexes ) {
+
+            $columns .= ', ' . implode( ', ', $indexes );
         }
 
         // make table options

--- a/Core/Entity.php
+++ b/Core/Entity.php
@@ -943,6 +943,16 @@ class Entity {
     
     }
     
+    /**
+     * Adds a declared column to the table this entity is already persisted as.
+     *
+     * The index, when the column declares one, is a SECOND statement. MySQL
+     * will not take `ALTER TABLE t ADD col VARCHAR(255), INDEX (col)` -- the
+     * index clause is legal only inside a CREATE TABLE's column list -- and
+     * building it into the column definition meant this method had never
+     * worked for an indexed column on any install that reached it, which is
+     * every upgrade rather than any fresh install.
+     */
     function addColumn($column_name) {
         
         $def = $this->getColumnDefinition($column_name);
@@ -950,12 +960,17 @@ class Entity {
         $db = \OWA\Core\CoreAPI::dbSingleton();
         $status = $db->addColumn($this->getTableName(), $column_name, $def);
         
-        if ($status == true):
-            return true;
-        else:
+        if (! $status) {
             return false;
-        endif;
+        }
         
+        if ($this->isColumnIndexed($column_name)) {
+            // addIndex() is itself a no-op when the index is already there, so
+            // a re-run after a half-finished ALTER finishes the job.
+            return (bool) $db->addIndex($this->getTableName(), $column_name);
+        }
+        
+        return true;
     }
     
     function dropColumn($column_name) {
@@ -1020,11 +1035,31 @@ class Entity {
     
     function getColumnDefinition($column_name, $omit_primary_key = false) {
     
+        return $this->getColumn($column_name)->getDefinition($omit_primary_key);
+    }
+    
+    /**
+     * Whether a column declared an index.
+     *
+     * Separate from its definition because an index is a table-level clause:
+     * createTable() may write it inline, an ALTER may not. See
+     * DbColumn::getDefinition().
+     */
+    function isColumnIndexed($column_name) {
+    
+        return $this->getColumn($column_name)->isIndexed();
+    }
+    
+    /**
+     * The DbColumn object behind a column name.
+     */
+    function getColumn($column_name) {
+    
         if (empty($this->properties)) {
-            return $this->$column_name->getDefinition($omit_primary_key);
-        } else {
-            return $this->properties[$column_name]->getDefinition($omit_primary_key);
+            return $this->$column_name;
         }
+        
+        return $this->properties[$column_name];
     }
     
     /**

--- a/modules/Base/Classes/DbColumn.php
+++ b/modules/Base/Classes/DbColumn.php
@@ -296,6 +296,22 @@ class DbColumn {
     }
 
      /**
+      * THE COLUMN'S OWN DEFINITION, AND NOTHING ELSE.
+      *
+      * An index is a TABLE-level clause, not part of a column definition. This
+      * used to append `, INDEX (col)` here, which reads fine inside a CREATE
+      * TABLE's parenthesised list and is a syntax error everywhere else -- so
+      * `ALTER TABLE t ADD col VARCHAR(255), INDEX (col)` was rejected outright
+      * and addColumn() had never once worked for an indexed column.
+      *
+      * It went unnoticed because a fresh install CREATEs its tables from the
+      * current entity, indexes and all; only an upgrade adding an indexed
+      * column to an existing table takes this path, and that is what stopped a
+      * live upgrade dead at Update026.
+      *
+      * createTable() asks isIndexed() and writes the table-level clause
+      * itself; Entity::addColumn() adds the index as its own statement.
+      *
       * @param bool $omit_primary_key  leave the inline PRIMARY KEY off, for a
       *                                table that declares a composite one
       */
@@ -328,13 +344,19 @@ class DbColumn {
             //$definition .= sprintf(", INDEX (%s)", $this->get('name'));
         endif;
 
-        // check for index
-        if ($this->get('index') == true):
-            $definition .= sprintf(", INDEX (%s)", $this->get('name'));
-        endif;
-
          return $definition;
 
+     }
+
+     /**
+      * Whether this column asked for an index.
+      *
+      * The clause itself belongs to whoever is writing the statement, because
+      * where it may legally go depends on the statement. See getDefinition().
+      */
+     function isIndexed() {
+
+         return (bool) $this->get('index');
      }
 
      function setDataType($type) {

--- a/tests/AddIndexedColumnTest.php
+++ b/tests/AddIndexedColumnTest.php
@@ -1,0 +1,187 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Adding an INDEXED column to a table that already exists.
+ *
+ * THE BUG THIS EXISTS FOR, ALSO FOUND IN PRODUCTION
+ *
+ * DbColumn::getDefinition() used to append `, INDEX (col)` to the column's own
+ * definition. Inside a CREATE TABLE's parenthesised column list that is legal
+ * and does the right thing. Everywhere else it is a syntax error, and every
+ * other caller of getDefinition() is an ALTER:
+ *
+ *     ALTER TABLE owa_custom_report ADD report_type VARCHAR(255), INDEX (report_type)
+ *     ERROR 1064: ... near '(report_type)'
+ *
+ * So Entity::addColumn() had never once worked for an indexed column -- not a
+ * regression, a hole that had always been there. It stayed invisible because a
+ * fresh install CREATEs every table from the current entity definition, index
+ * clauses and all, so the ALTER path is only reached by an UPGRADE of an older
+ * install. That is where it surfaced: a live site at schema 25 stopped dead on
+ * Update026 with the statement above.
+ *
+ * The fix is that a column definition describes a column. Table-level clauses
+ * are written by whoever is composing the statement -- inline by createTable(),
+ * as a separate ALTER by addColumn().
+ *
+ * These tests are in two halves on purpose. The first needs no database, so it
+ * runs in CI's configless job where the ALTER can never be attempted; the
+ * second actually issues the statement, because a scan of the definition string
+ * would not have caught a driver composing the clause back in.
+ */
+final class AddIndexedColumnTest extends TestCase
+{
+    /**
+     * A column definition contains only the column.
+     *
+     * Deliberately built with nothing but a data type and the index flag, so
+     * the assertion needs none of the OWA_DTD_* constants -- those arrive with
+     * a database driver, and this half of the test is here to run without one.
+     */
+    public function testAnIndexedColumnsDefinitionCarriesNoIndexClause(): void
+    {
+        $column = new \OWA\Module\Base\Classes\DbColumn( 'report_type', 'VARCHAR(255)' );
+        $column->setIndex();
+
+        $this->assertSame( 'VARCHAR(255)', $column->getDefinition(),
+            'The index clause is back in the column definition. It makes '
+            . '"ALTER TABLE t ADD col VARCHAR(255), INDEX (col)", which MySQL rejects, '
+            . 'so every upgrade that adds an indexed column dies on the statement.' );
+
+        $this->assertTrue( $column->isIndexed(),
+            'the flag itself has to survive -- createTable() and addColumn() both ask' );
+    }
+
+    /** And a column that asked for no index says so. */
+    public function testAnUnindexedColumnIsNotIndexed(): void
+    {
+        $column = new \OWA\Module\Base\Classes\DbColumn( 'name', 'VARCHAR(255)' );
+
+        $this->assertFalse( $column->isIndexed() );
+        $this->assertSame( 'VARCHAR(255)', $column->getDefinition() );
+    }
+
+    /**
+     * THE STATEMENT, ISSUED.
+     *
+     * A scratch table built from the real CustomReport entity, minus the
+     * indexed column, then asked to add it back -- which is precisely the shape
+     * of an upgrade reaching an older install's table.
+     *
+     * The index is checked as well as the column, because dropping the clause
+     * from the definition without adding it back somewhere else would make this
+     * statement valid and quietly lose the index on every upgraded install.
+     */
+    public function testAddingAnIndexedColumnToAnExistingTable(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+
+        if ( ! owa_test_db_available() ) {
+
+            $this->markTestSkipped( 'the statement has to be issued to a database to be refused by one' );
+        }
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $entity = $this->scratchCustomReport();
+        $table  = $entity->getTableName();
+
+        try {
+
+            $db->createTable( $entity );
+
+            // Back to what an older install's table looks like.
+            $db->query( "ALTER TABLE $table DROP COLUMN report_type" );
+
+            $this->assertEmpty( $this->columns( $db, $table, 'report_type' ),
+                'the fixture did not actually remove the column' );
+
+            $this->assertTrue( $entity->addColumn( 'report_type' ),
+                'addColumn() failed for an indexed column. That is the live failure: the '
+                . 'index clause was glued into the column definition, producing '
+                . '"ALTER TABLE ... ADD report_type VARCHAR(255), INDEX (report_type)".' );
+
+            $this->assertNotEmpty( $this->columns( $db, $table, 'report_type' ),
+                'the column is not there' );
+
+            $this->assertTrue( $db->indexExists( $table, 'report_type' ),
+                'the column arrived without its index. The declaration asked for one, and '
+                . 'an upgraded install would be the only kind missing it -- exactly the '
+                . 'divergence that is never noticed until a report goes slow.' );
+
+            // Idempotent: the guard's job is to make the second run a no-op
+            // rather than an error, so a half-finished upgrade can be re-run.
+            $update = new \OWA\Module\Base\Update\Update026;
+
+            $again = new ReflectionMethod( '\OWA\Core\Update', 'addColumnIfMissing' );
+            $again->setAccessible( true );
+
+            $this->assertTrue( (bool) $again->invoke( $update, $entity, 'report_type' ),
+                'adding an already-present indexed column reported failure' );
+
+        } finally {
+
+            $db->query( "DROP TABLE IF EXISTS $table" );
+        }
+    }
+
+    /**
+     * CREATE TABLE still gets its indexes.
+     *
+     * The clause moved out of the column definition and into createTable(). If
+     * it moved out of one and not into the other, fresh installs would silently
+     * stop indexing -- which no test above would notice, because they all work
+     * on a table the ALTER path fixed up.
+     */
+    public function testCreateTableStillIndexesTheColumnsThatAskedForIt(): void
+    {
+        require_once __DIR__ . '/bootstrap_owa.php';
+
+        if ( ! owa_test_db_available() ) {
+
+            $this->markTestSkipped( 'needs a database' );
+        }
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $entity = $this->scratchCustomReport();
+        $table  = $entity->getTableName();
+
+        try {
+
+            $this->assertTrue( (bool) $db->createTable( $entity ),
+                'the CREATE TABLE was refused' );
+
+            $this->assertTrue( $db->indexExists( $table, 'report_type' ),
+                'a freshly created table has no index on a column that declared one' );
+
+        } finally {
+
+            $db->query( "DROP TABLE IF EXISTS $table" );
+        }
+    }
+
+    /** The real entity, pointed at a table nothing else is using. */
+    private function scratchCustomReport()
+    {
+        $name = 'test_idxcol_' . bin2hex( random_bytes( 4 ) );
+
+        return new class( $name ) extends \OWA\Module\Base\Entity\CustomReport {
+
+            public function __construct( $name ) {
+
+                parent::__construct();
+
+                $this->setTableName( $name );
+            }
+        };
+    }
+
+    /** @return array the SHOW COLUMNS rows for one column, empty if absent */
+    private function columns( $db, $table, $column ): array
+    {
+        return (array) $db->get_results( "SHOW COLUMNS FROM $table LIKE '$column'" );
+    }
+}


### PR DESCRIPTION
## What

`DbColumn::getDefinition()` appended `, INDEX (col)` to the column's own definition. That is legal inside a `CREATE TABLE`'s parenthesised column list and nowhere else — and every other caller of `getDefinition()` is an `ALTER`:

```
ALTER TABLE owa_custom_report ADD report_type VARCHAR(255), INDEX (report_type)
ERROR 1064 ... near '(report_type)'
```

## Not a regression

`addColumn()`, `modifyColumn()` and `renameColumn()` have all been emitting that for as long as a column could declare an index. It stayed invisible because a fresh install `CREATE`s its tables from the current entity definition, index clauses and all — so nothing but an **upgrade of an existing table** reaches the ALTER path.

That is where it surfaced. peteradamsphoto, part-way through 25 → 27, stopped dead on Update026 with the statement above — one update after the one #1065 had just unstuck.

## The fix

A column definition describes a column. The table-level clause is written by whoever composes the statement:

- `Db::createTable()` collects the indexed columns as it walks them and appends the clauses itself, so its SQL is unchanged.
- `Entity::addColumn()` issues the index as its own `ALTER`, through the existing `addIndex()` — which is already a no-op when the index is present, so an upgrade interrupted between the two statements finishes on a re-run.

## Tests

`tests/AddIndexedColumnTest.php`, from both ends:

- the definition string, with **no database**, so CI's configless unit job runs it;
- the statement actually issued against a scratch table built from the real `CustomReport` entity, asserting the column **and its index** arrive;
- and one guarding the move itself — that a freshly `CREATE`d table still gets the index. Dropping the clause from one place without adding it to the other would silently stop indexing new installs while every other test here passed.

Each was mutation-checked by putting the bug back.
