### PR TITLE
test: actually run the schema updates, against a database with a past

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,89 @@ jobs:
         if: always()
         run: php tests/e2e/selfhost_harness.php down
 
+  upgrade:
+    name: Schema upgrade cycle (rewind, then upgrade)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # THE ONLY JOB IN WHICH THE UPDATES ACTUALLY RUN.
+    #
+    # Every other environment -- this workflow's unit job, the isolation sweep,
+    # the e2e runner, and a developer's own box -- INSTALLS. Module::install()
+    # builds every table from the current entity definitions and stamps
+    # schema_version at the latest, so applyUpdates() walks a range that is
+    # always empty and modules/*/Update/* is dead code under test.
+    #
+    # Two production failures came out of that hole in one week (Update023 and
+    # Update026, both of which stopped a live upgrade dead), and both are the
+    # same bug: a value that means two things, only distinguishable against a
+    # database that already has a history. This job makes one -- it installs,
+    # rewinds the schema through the rollbacks, and upgrades it forward again
+    # with the real `cli.php cmd=update`.
+    #
+    # See tests/tools/upgrade_cycle.php for what is asserted and why.
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      OWA_E2E_DB_HOST: 127.0.0.1
+      OWA_E2E_DB_PORT: '3306'
+      OWA_E2E_DB_USER: root
+      OWA_E2E_DB_PASSWORD: ''
+      # Must read as a scratch name: the cycle rewinds the schema, which drops
+      # tables and columns, and refuses to run against anything that does not.
+      OWA_E2E_DB_NAME: owa_upgrade_cycle_scratch
+      OWA_E2E_DB_TYPE: mysql
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, intl, json, mysqli, pdo_mysql, gd
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install, rewind, upgrade
+        id: cycle
+        run: |
+          set -o pipefail
+          composer run-script test:upgrade 2>&1 | tee upgrade.log
+
+      # The verdict on the run summary page, so a finding is readable without
+      # opening the log -- the interesting part is the last block, not the
+      # hundred NOTICE lines the updates print on the way past.
+      - name: Report the verdict
+        if: always()
+        run: |
+          {
+            echo "## Schema upgrade cycle"
+            echo
+            if [ "${{ steps.cycle.outcome }}" = "success" ]; then
+              echo "The schema rewinds and rebuilds to something identical."
+            else
+              echo "**The upgrade path is broken.** An install upgrading from an older"
+              echo "schema would hit this; a fresh install would not, which is why"
+              echo "nothing else in CI notices."
+              echo
+              echo '```'
+              sed -n '/the upgrade path is broken/,$p' upgrade.log | head -60
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   e2e:
     name: E2E (self-hosted, php -S + MySQL)
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,8 @@
         "test": "phpunit",
         "test:isolation": "bash tests/tools/isolation_sweep.sh",
         "test:scratch": "bash tests/tools/scratch_db_run.sh",
-        "test:configless": "bash tests/tools/configless_run.sh"
+        "test:configless": "bash tests/tools/configless_run.sh",
+        "test:upgrade": "bash tests/tools/upgrade_cycle_run.sh"
     },
     "extra": {
         "merge-plugin": {

--- a/tests/UpdateAddColumnGuardTest.php
+++ b/tests/UpdateAddColumnGuardTest.php
@@ -117,6 +117,45 @@ final class UpdateAddColumnGuardTest extends TestCase
         }
     }
     /**
+     * THE UPGRADE SWEEP IS WIRED INTO CI.
+     *
+     * Everything above scans source or exercises one update. The thing that
+     * actually runs the migrations end to end is tests/tools/upgrade_cycle.php,
+     * and it only runs because a CI job invokes it -- no other environment
+     * upgrades anything, so if that job is deleted or renamed, the update path
+     * silently goes back to being untested and every test here still passes.
+     *
+     * That is the failure mode this repository has already had twice (see
+     * project_tests_that_never_run): coverage that reports green by not
+     * running. Cheap to assert, so it is asserted.
+     */
+    public function testTheUpgradeCycleIsReachableAndWiredIntoCi(): void
+    {
+        foreach ( array( 'tests/tools/upgrade_cycle.php',
+                         'tests/tools/upgrade_cycle_run.sh',
+                         'tests/tools/scratch_guard.php' ) as $file ) {
+
+            $this->assertFileExists( self::root() . $file,
+                "$file is gone. It is the only thing that runs the schema updates -- "
+                . 'every other environment installs at the current version and never '
+                . 'applies one.' );
+        }
+
+        $composer = json_decode(
+            (string) file_get_contents( self::root() . 'composer.json' ), true );
+
+        $this->assertArrayHasKey( 'test:upgrade', (array) $composer['scripts'],
+            'the composer script the CI job calls is gone' );
+
+        $workflow = (string) file_get_contents( self::root() . '.github/workflows/ci.yml' );
+
+        $this->assertStringContainsString( 'test:upgrade', $workflow,
+            'No CI job runs the upgrade cycle any more. Without it nothing in this '
+            . 'repository ever applies a migration, which is how two of them reached '
+            . 'production broken.' );
+    }
+
+    /**
      * AN UPDATE THAT BUILDS SOMETHING MUST BE ABLE TO UNBUILD IT.
      *
      * `down() { return true; }` is the worst of the three options: it claims

--- a/tests/tools/scratch_guard.php
+++ b/tests/tools/scratch_guard.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * "Is it safe to wreck this database?"
+ *
+ * Two tools here rewind an installed schema so that a migration can be run for
+ * real -- seed_pre_hierarchy.php and upgrade_cycle.php. Both drop tables and
+ * columns, and both are one mistyped command away from doing it to a dev
+ * install or, worse, a production one. The check lives in one place so the two
+ * cannot drift apart, and so a third tool gets it by asking rather than by
+ * remembering.
+ *
+ * The test is a NAME, not a row count: an empty-looking database can still be
+ * the one a site is pointed at, and a scratch database that happens to hold
+ * fixtures is still scratch. The harnesses that provision these all name them
+ * so this passes -- owa_e2e_installcli_scratch, owa_e2e_selfhost, owa_test_*.
+ */
+
+if ( ! function_exists( 'owa_looks_like_scratch_db' ) ) {
+
+    /**
+     * @param string $dbName the database the install is actually connected to
+     */
+    function owa_looks_like_scratch_db( $dbName ) {
+
+        foreach ( array( 'scratch', 'owa_test', 'selfhost', 'tmp' ) as $marker ) {
+
+            if ( stripos( (string) $dbName, $marker ) !== false ) {
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Refuses, loudly and with an exit code, unless the caller insisted.
+     *
+     * --force exists because a maintainer with an install they genuinely do not
+     * care about should not have to rename a database to use these. It is not a
+     * flag to reach for when the refusal is inconvenient: the refusal is the
+     * feature.
+     *
+     * @param string $dbName
+     * @param bool   $force  the caller saw --force on the command line
+     */
+    function owa_upgrade_cycle_guard( $dbName, $force ) {
+
+        if ( owa_looks_like_scratch_db( $dbName ) || $force ) {
+
+            return;
+        }
+
+        fwrite( STDERR,
+            "refusing: '$dbName' does not look like a scratch database.\n"
+          . "This rewinds the schema, which drops tables and columns and the data in\n"
+          . "them. Provision one with tests/tools/upgrade_cycle_run.sh, or pass --force\n"
+          . "if you are certain -- never against an install with data you want.\n" );
+
+        exit( 2 );
+    }
+}

--- a/tests/tools/seed_pre_hierarchy.php
+++ b/tests/tools/seed_pre_hierarchy.php
@@ -28,11 +28,11 @@ $db = owa_coreAPI::dbSingleton();
 
 $dbName = (string) owa_coreAPI::getSetting( 'base', 'db_name' );
 
-$looksScratch = ( stripos( $dbName, 'scratch' ) !== false )
-             || ( stripos( $dbName, 'owa_test' ) !== false )
-             || ( stripos( $dbName, 'tmp' ) !== false );
+// Shared with upgrade_cycle.php, which rewinds the schema the same way. Two
+// copies of a safety check is one copy that gets loosened on its own.
+require_once __DIR__ . '/scratch_guard.php';
 
-if ( ! $looksScratch && ! in_array( '--force', $argv, true ) ) {
+if ( ! owa_looks_like_scratch_db( $dbName ) && ! in_array( '--force', $argv, true ) ) {
 
     fwrite( STDERR,
         "refusing: '$dbName' does not look like a scratch database.\n"

--- a/tests/tools/upgrade_cycle.php
+++ b/tests/tools/upgrade_cycle.php
@@ -1,0 +1,447 @@
+<?php
+/**
+ * Runs the schema updates. Actually runs them, against a database that has a
+ * past.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Nothing else in this repository ever upgrades a database. Module::install()
+ * creates every table from the CURRENT entity definitions and then stamps
+ * schema_version at the latest, and that is how every test environment is
+ * provisioned -- the dev install, the scratch install, the isolation sweep, the
+ * self-hosted e2e harness. applyUpdates() walks `$seq > $current_schema_version`,
+ * which is never true. The update path is dead code under test.
+ *
+ * Two production failures came out of that hole in one week, and they are the
+ * same bug wearing different clothes: a value that means two things, which can
+ * only be told apart against a database that already has some history.
+ *
+ *   - addColumn() answers false for "could not" AND for "already there". On a
+ *     fresh table the column is never already there, so the ambiguity reads as
+ *     success. Update023 stopped a live upgrade dead.
+ *   - DbColumn::getDefinition() returned a string valid inside CREATE TABLE and
+ *     invalid inside ALTER TABLE. createTable() was its only caller in any test,
+ *     so it was only ever used in the context that made it correct. Update026
+ *     stopped the same upgrade one update later.
+ *
+ * A fresh database has no history, so both ambiguities collapse to the harmless
+ * reading. This makes a database with a history.
+ *
+ * HOW
+ * ---
+ * Rather than install an old release and upgrade it -- which needs old code to
+ * run on a modern PHP, and dates badly -- it uses the rollbacks:
+ *
+ *   1. fingerprint the schema as installed
+ *   2. roll DOWN one update at a time, as far as the down()s allow
+ *   3. roll back UP through the real Module::update() path
+ *   4. fingerprint again: it must MATCH
+ *   5. re-apply every update that was rolled, forced, on the schema it already
+ *      built -- which is the "already there" case, and must succeed
+ *
+ * Step 4 is the one that earns its keep. A column can come back without its
+ * index and every other check here still passes; the fingerprint notices,
+ * because an index that only new installs have is exactly the divergence nobody
+ * finds until a report goes slow.
+ *
+ * Coverage grows on its own. The floor is wherever the rollbacks stop being
+ * honest, so every update written under the "idempotent up AND down" rule is
+ * swept the day it lands, with no list here to update.
+ *
+ * DESTRUCTIVE. It rolls the schema back, which drops tables and columns and the
+ * data in them. It refuses to run against a database that does not look like a
+ * scratch one; --force overrides, and should not be used.
+ *
+ * RUN IN PHASES, in separate processes, because the middle one has to be the
+ * REAL command. `php cli.php cmd=update` is what an operator types and what
+ * failed on the live site; reimplementing the walk here would be testing this
+ * file's idea of an upgrade instead of the one that ships. Separate processes
+ * also mean the verify phase reads the schema version off a cold boot rather
+ * than out of the config cache that just wrote it.
+ *
+ * Usage:  bash tests/tools/upgrade_cycle_run.sh      <- provisions, runs all three
+ *
+ *         php tests/tools/upgrade_cycle.php down   [--force] [--verbose]
+ *         php cli.php cmd=update
+ *         php tests/tools/upgrade_cycle.php verify [--force] [--verbose]
+ */
+
+require_once dirname( __DIR__, 2 ) . '/owa.php';
+
+$owa = new owa( array( 'instance_role' => 'cli' ) );
+
+$phase   = isset( $argv[1] ) && $argv[1][0] !== '-' ? $argv[1] : '';
+$force   = in_array( '--force', $argv, true );
+$verbose = in_array( '--verbose', $argv, true );
+
+if ( ! in_array( $phase, array( 'down', 'verify' ), true ) ) {
+
+    fwrite( STDERR, "usage: upgrade_cycle.php down|verify [--force] [--verbose]\n"
+        . "(or run tests/tools/upgrade_cycle_run.sh, which drives all three steps)\n" );
+
+    exit( 2 );
+}
+
+/**
+ * What the down phase hands to the verify phase.
+ *
+ * A file rather than a return value because `php cli.php cmd=update` runs
+ * between them, in its own process, deliberately.
+ */
+define( 'OWA_UPGRADE_CYCLE_STATE', sys_get_temp_dir() . '/owa_upgrade_cycle.json' );
+
+$db     = owa_coreAPI::dbSingleton();
+$dbName = (string) owa_coreAPI::getSetting( 'base', 'db_name' );
+
+require_once __DIR__ . '/scratch_guard.php';
+
+owa_upgrade_cycle_guard( $dbName, $force );
+
+/**
+ * The LOWEST update this is expected to reach.
+ *
+ * Not a target -- the sweep rolls back as far as the down()s allow and this
+ * only fails the run when that gets WORSE. Coverage shrinking is silent
+ * otherwise: a new update written with `down() { return false; }` satisfies the
+ * guard test, raises the floor, and quietly removes every update below it from
+ * this sweep. Update022 and below refuse by design (020 rewrites every site's
+ * name; there is no honest undo), so 22 is the floor today.
+ */
+const OWA_UPGRADE_CYCLE_FLOOR = 22;
+
+$fail = array();
+$note = static function ( $line ) { fwrite( STDOUT, $line . "\n" ); };
+
+$fail = array();
+
+/* ======================================================================
+ * PHASE 1: down
+ * ==================================================================== */
+
+if ( $phase === 'down' ) {
+
+    $installed = (int) owa_coreAPI::getSetting( 'base', 'schema_version' );
+
+    $note( "--- schema as installed: $installed ---" );
+
+    if ( $installed < OWA_UPGRADE_CYCLE_FLOOR + 1 ) {
+
+        fwrite( STDERR, "refusing: schema $installed leaves nothing to roll back.\n" );
+        exit( 2 );
+    }
+
+    $before = owa_schema_fingerprint( $db, $dbName );
+
+    $note( sprintf( 'fingerprint: %d columns, %d indexes over %d tables',
+        count( $before['columns'] ), count( $before['indexes'] ), count( $before['tables'] ) ) );
+
+    $rolled = array();
+
+    for ( $v = $installed; $v >= 1; $v-- ) {
+
+        $update = owa_update_for( $v );
+
+        if ( ! $update ) {
+
+            $note( "  $v: no update class, stopping" );
+            break;
+        }
+
+        if ( ! $update->rollback() ) {
+
+            $note( "  $v: rollback refused or failed -- floor" );
+            break;
+        }
+
+        $rolled[] = $v;
+
+        $note( "  $v: rolled back" );
+    }
+
+    $floor = (int) owa_coreAPI::getSetting( 'base', 'schema_version' );
+
+    $note( sprintf( '--- rolled back %d update(s), down to schema %d ---',
+        count( $rolled ), $floor ) );
+
+    file_put_contents( OWA_UPGRADE_CYCLE_STATE, json_encode( array(
+        'installed' => $installed,
+        'floor'     => $floor,
+        'rolled'    => $rolled,
+        'before'    => $before,
+    ) ) );
+
+    if ( ! $rolled ) {
+
+        fwrite( STDERR, "\nNothing rolled back at all, so nothing below was exercised.\n" );
+        exit( 1 );
+    }
+
+    exit( 0 );
+}
+
+/* ======================================================================
+ * PHASE 2: verify -- `php cli.php cmd=update` has run in between
+ * ==================================================================== */
+
+$state = @json_decode( (string) @file_get_contents( OWA_UPGRADE_CYCLE_STATE ), true );
+
+if ( ! is_array( $state ) || ! isset( $state['before'] ) ) {
+
+    fwrite( STDERR, "no state from the down phase -- run `upgrade_cycle.php down` first.\n" );
+    exit( 2 );
+}
+
+$installed = (int) $state['installed'];
+$floor     = (int) $state['floor'];
+$rolled    = (array) $state['rolled'];
+$before    = $state['before'];
+
+// Read from a cold boot: this process did not write the version, so a value
+// that only exists in someone's config cache cannot be mistaken for a
+// persisted one.
+$reached = (int) owa_coreAPI::getSetting( 'base', 'schema_version' );
+
+$note( sprintf( '--- rolled to %d, upgrade reached %d, installed at %d ---',
+    $floor, $reached, $installed ) );
+
+if ( $floor > OWA_UPGRADE_CYCLE_FLOOR ) {
+
+    $fail[] = sprintf(
+        "The sweep now stops at schema %d; it used to reach %d.\n"
+      . "  An update between %d and %d has a down() that refuses or fails, which removes\n"
+      . "  every update below it from this sweep -- silently, because a refusal is a legal\n"
+      . "  answer. Either give it a real rollback, or lower OWA_UPGRADE_CYCLE_FLOOR here\n"
+      . "  and say in the commit what stopped being covered.",
+        $floor, OWA_UPGRADE_CYCLE_FLOOR, OWA_UPGRADE_CYCLE_FLOOR, $floor );
+}
+
+if ( $reached !== $installed ) {
+
+    $fail[] = sprintf(
+        "The upgrade stopped at schema %d instead of %d.\n"
+      . "  THIS IS THE LIVE FAILURE, REPRODUCED. Read the `cli.php cmd=update` output\n"
+      . "  above for the update that stopped and the statement it was refused on. An\n"
+      . "  install left here refuses every request with \"OWA Updates required\".",
+        $reached, $installed );
+}
+
+/* ---- the schema has to be the one we started with ------------------------- */
+
+$after = owa_schema_fingerprint( $db, $dbName );
+
+foreach ( owa_fingerprint_diff( $before, $after ) as $problem ) {
+
+    $fail[] = $problem;
+}
+
+/* ---- and applying them again must not be a failure ------------------------ */
+
+$note( '--- re-applying each rolled update against the schema it just built ---' );
+
+foreach ( array_reverse( $rolled ) as $v ) {
+
+    $update = owa_update_for( $v );
+
+    if ( ! $update ) {
+
+        continue;
+    }
+
+    // force=true skips the "already applied" abort so up() actually runs. Every
+    // column it adds is now present, every table it creates exists: the exact
+    // shape that stopped the live upgrade, and it must report success.
+    if ( ! $update->apply( true ) ) {
+
+        $fail[] = sprintf(
+            "Update %d failed when re-applied to a schema that already has its changes.\n"
+          . "  Not hypothetical: an install jumping several versions gets its tables built\n"
+          . "  from the CURRENT entity definitions, so later updates routinely find their\n"
+          . "  columns already there. Use addColumnIfMissing() rather than reading\n"
+          . '  addColumn() === false as a failure.', $v );
+    }
+}
+
+$note( '--- and once more, to prove that run changed nothing ---' );
+
+$final = owa_schema_fingerprint( $db, $dbName );
+
+foreach ( owa_fingerprint_diff( $after, $final, 're-application' ) as $problem ) {
+
+    $fail[] = $problem;
+}
+
+/* ---- verdict -------------------------------------------------------------- */
+
+@unlink( OWA_UPGRADE_CYCLE_STATE );
+
+if ( $verbose ) {
+
+    $note( "\nrolled and re-applied: " . implode( ', ', $rolled ) );
+}
+
+if ( $fail ) {
+
+    fwrite( STDERR, "\n=== the upgrade path is broken ===\n\n" );
+
+    foreach ( $fail as $i => $f ) {
+
+        fwrite( STDERR, sprintf( "%d. %s\n\n", $i + 1, $f ) );
+    }
+
+    exit( 1 );
+}
+
+$note( sprintf( "\nOK: %d update(s) rolled back, re-applied by cli.php cmd=update, and\n"
+    . 'applied again on top of themselves. The schema is identical to the install.',
+    count( $rolled ) ) );
+
+exit( 0 );
+
+
+/* ---- helpers -------------------------------------------------------------- */
+
+/**
+ * The update object for a sequence number, with its version set.
+ *
+ * Module::update() sets schema_version off the FILENAME rather than trusting
+ * the class, and apply()/rollback() both refuse without it.
+ */
+function owa_update_for( $v ) {
+
+    $class = 'Update' . str_pad( (string) $v, 3, '0', STR_PAD_LEFT );
+
+    if ( ! class_exists( '\\OWA\\Module\\Base\\Update\\' . $class ) ) {
+
+        return null;
+    }
+
+    $update = owa_coreAPI::updateFactory( 'base', $class );
+
+    $update->schema_version = (int) $v;
+
+    return $update;
+}
+
+/**
+ * What the schema IS, in the terms that matter.
+ *
+ * Deliberately NOT a SHOW CREATE TABLE diff. Two things legitimately differ
+ * between a table that was CREATEd complete and one an ALTER filled in, and
+ * neither means anything:
+ *
+ *   - COLUMN ORDER. ALTER ... ADD puts the column last; CREATE TABLE puts it in
+ *     declaration order. Same schema, different ordinal positions.
+ *   - INDEX NAMES. createTable() writes `INDEX (col)`, which MySQL names after
+ *     the column; addIndex() names it idx_col so a re-run is recognisable. An
+ *     index's identity here is the columns it covers, not what it is called.
+ *
+ * Everything else is compared: which columns exist, their types, their
+ * nullability, and which column sets are indexed.
+ */
+function owa_schema_fingerprint( $db, $dbName ) {
+
+    $columns = array();
+    $tables  = array();
+
+    $rows = (array) $db->get_results( sprintf(
+        "SELECT TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE
+           FROM information_schema.COLUMNS
+          WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME LIKE 'owa\\_%%'", $dbName ) );
+
+    foreach ( $rows as $r ) {
+
+        $r = (array) $r;
+
+        $tables[ $r['TABLE_NAME'] ] = true;
+
+        $columns[] = sprintf( '%s.%s %s %s', $r['TABLE_NAME'], $r['COLUMN_NAME'],
+            $r['COLUMN_TYPE'], $r['IS_NULLABLE'] === 'YES' ? 'NULL' : 'NOT NULL' );
+    }
+
+    $byIndex = array();
+
+    $rows = (array) $db->get_results( sprintf(
+        "SELECT TABLE_NAME, INDEX_NAME, NON_UNIQUE, SEQ_IN_INDEX, COLUMN_NAME
+           FROM information_schema.STATISTICS
+          WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME LIKE 'owa\\_%%'
+          ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX", $dbName ) );
+
+    foreach ( $rows as $r ) {
+
+        $r = (array) $r;
+
+        $key = $r['TABLE_NAME'] . '|' . $r['INDEX_NAME'];
+
+        if ( ! isset( $byIndex[ $key ] ) ) {
+
+            $byIndex[ $key ] = array(
+                'table'  => $r['TABLE_NAME'],
+                'unique' => ! (int) $r['NON_UNIQUE'],
+                'cols'   => array(),
+            );
+        }
+
+        $byIndex[ $key ]['cols'][] = $r['COLUMN_NAME'];
+    }
+
+    // Named by their column set, so the same index found under two names is one
+    // index -- and a DUPLICATE of an existing one collapses onto it rather than
+    // reading as a difference.
+    $indexes = array();
+
+    foreach ( $byIndex as $ix ) {
+
+        $indexes[] = sprintf( '%s (%s)%s', $ix['table'],
+            implode( ', ', $ix['cols'] ), $ix['unique'] ? ' UNIQUE' : '' );
+    }
+
+    sort( $columns );
+
+    $indexes = array_values( array_unique( $indexes ) );
+
+    sort( $indexes );
+
+    ksort( $tables );
+
+    return array( 'columns' => $columns, 'indexes' => $indexes,
+                  'tables'  => array_keys( $tables ) );
+}
+
+/** @return array<string> human-readable differences, empty when identical */
+function owa_fingerprint_diff( $before, $after, $what = 'a down-and-up cycle' ) {
+
+    $out = array();
+
+    $pairs = array(
+        'table'  => array( $before['tables'],  $after['tables'] ),
+        'column' => array( $before['columns'], $after['columns'] ),
+        'index'  => array( $before['indexes'], $after['indexes'] ),
+    );
+
+    foreach ( $pairs as $kind => $pair ) {
+
+        list( $was, $is ) = $pair;
+
+        $lost   = array_values( array_diff( $was, $is ) );
+        $gained = array_values( array_diff( $is, $was ) );
+
+        if ( $lost ) {
+
+            $out[] = sprintf(
+                "%d %s(s) did not survive %s:\n    %s\n"
+              . "  The update that rebuilt this does not put back everything it took away.%s",
+                count( $lost ), $kind, $what, implode( "\n    ", array_slice( $lost, 0, 20 ) ),
+                $kind === 'index'
+                    ? "\n  An index only fresh installs have is the divergence nobody finds\n"
+                    . '  until a report goes slow.' : '' );
+        }
+
+        if ( $gained ) {
+
+            $out[] = sprintf( "%d %s(s) appeared that the install did not have:\n    %s",
+                count( $gained ), $kind, implode( "\n    ", array_slice( $gained, 0, 20 ) ) );
+        }
+    }
+
+    return $out;
+}

--- a/tests/tools/upgrade_cycle_run.sh
+++ b/tests/tools/upgrade_cycle_run.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Install a schema, rewind it, and upgrade it forward again.
+#
+# WHY: nothing else here ever upgrades a database. Every environment installs at
+# the current version and stamps schema_version at the latest, so the updates
+# never run -- see the long note in upgrade_cycle.php. Two production failures
+# in one week lived in that hole.
+#
+# This provisions a scratch install through tests/e2e/selfhost_harness.php -- the
+# same harness the isolation sweep uses, so CI is already known to provision this
+# way -- and then hands it to upgrade_cycle.php to be rewound and rebuilt.
+#
+# The live config is restored on failure, error and ctrl-c. A dead run must not
+# leave the box without its config.
+#
+#   bash tests/tools/upgrade_cycle_run.sh
+#   bash tests/tools/upgrade_cycle_run.sh --verbose
+#
+# In CI this runs as its own job, because it is the only configuration in which
+# the update path executes at all.
+#
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+HARNESS=tests/e2e/selfhost_harness.php
+
+teardown() {
+    local rc=$?
+    echo
+    echo "--- dropping the scratch database, restoring the live config ---"
+    php "$HARNESS" down >/dev/null 2>&1 || php "$HARNESS" doctor >/dev/null 2>&1
+    exit $rc
+}
+
+echo "--- stashing the live config, creating a scratch database, installing ---"
+php "$HARNESS" up >/dev/null || {
+    echo "provisioning failed; run: php $HARNESS doctor" >&2
+    exit 1
+}
+trap teardown EXIT INT TERM
+
+echo
+echo "--- rewinding the schema ---"
+php tests/tools/upgrade_cycle.php down "$@" || exit 1
+
+echo
+echo "--- upgrading it again: cli.php cmd=update, the real command ---"
+# NOT checked here. A failure is the finding, and the verify phase reports it
+# with the schema version it actually reached -- which is more use than a bare
+# non-zero exit from a command whose own output is already above.
+php cli.php cmd=update 2>&1 | sed 's/^/    /'
+
+echo
+echo "--- verifying ---"
+php tests/tools/upgrade_cycle.php verify "$@"


### PR DESCRIPTION
## The hole

**Nothing in this repository has ever upgraded a database.**

`Module::install()` (`Core/Module.php:669`) creates every table from the **current** entity definitions and then stamps `schema_version` at the latest — and that is how every environment is provisioned: the dev install, the scratch install, the isolation sweep, the self-hosted e2e harness. `applyUpdates()` walks `$seq > $current_schema_version`, which is never true.

`modules/*/Update/*` is dead code under test. Before this PR, exactly one test called an update's `up()`, and it was a settings repair that touches no schema. Zero tests called `addColumn()`, `modifyColumn()` or `renameColumn()` — the only three callers of `getDefinition()` outside `createTable()`.

Two production failures came out of that hole in one week, and they're the same bug wearing different clothes — a value that means two things, distinguishable only against a database that already has a history:

| | ambiguity | collapses to the harmless reading when… |
|---|---|---|
| `addColumn()` (#1065) | `false` = "couldn't" **and** "already there" | the column is never already there — a fresh table |
| `getDefinition()` (#1066) | valid in `CREATE TABLE`, invalid in `ALTER` | the only caller is `CREATE TABLE` — a fresh table |

A fresh database has no history, so both read as success. This makes one with a history.

## How

Not "install an old release and upgrade it" — that needs old code to run on a modern PHP, and dates badly. It uses the rollbacks:

1. fingerprint the installed schema
2. roll **down** as far as the `down()`s are honest
3. upgrade with the **real `php cli.php cmd=update`**, in its own process — the command an operator types, and the one that failed on the live site
4. then check:
   - the upgrade reached the version it started at
   - **the schema fingerprint matches the install**
   - every rolled update re-applies, forced, on the schema it just built
   - and that changed nothing either

The fingerprint is the one that earns its keep: a column can come back **without its index** and every other check still passes. Column order and index *names* are excluded — `ALTER` appends the column and names the index `idx_col`; `CREATE TABLE` puts it in declaration order and lets MySQL name it after the column. Neither difference means anything; the column set does.

Coverage grows on its own. The floor is wherever the rollbacks stop being honest (22 today — 020–022 refuse by design, there's no honest undo for a migration that rewrites every site's name), so every update written under the *idempotent up AND down* rule is swept the day it lands. The floor is **asserted**, so it can't rise silently: a new update with `down() { return false; }` is legal and would quietly drop everything below it out of the sweep.

## Mutation-checked

All three against the real cycle, not a mock:

| mutation | what caught it |
|---|---|
| the ALTER-syntax bug | *"upgrade stopped at schema 25 instead of 27"* + 3 lost columns + 1 lost index |
| `addColumn() === false` as failure | upgrade **reaches 27** (a clean rollback really did remove the columns) — caught only by re-application, which is the production shape |
| `addColumn()` skipping the index | upgrade reaches 27, all columns present, re-application clean — caught **only** by the fingerprint |

## Also

- Runs as its own CI job (`Schema upgrade cycle`), because it's the only configuration in which the update path executes at all. `composer test:upgrade` locally.
- `UpdateAddColumnGuardTest` now asserts that job still exists — coverage that reports green by not running is a failure mode this repo has had before.
- The scratch-database guard is shared with `seed_pre_hierarchy.php`, which rewinds the schema the same way. Two copies of a safety check is one copy that gets loosened on its own.
