### PR TITLE
test: give the upgrade cycle data to migrate, not just a schema

### DIFF
--- a/modules/Base/Update/Update025.php
+++ b/modules/Base/Update/Update025.php
@@ -208,7 +208,7 @@ class Update025 extends \OWA\Core\Update {
                 'site_id'            => $row['scope_id'],
                 'property_id'        => self::propertyFor( $row['scope_id'] ),
                 'name'               => (string) $goal['goal_name'],
-                'goal_number'        => (int) ( $goal['goal_number'] ?: $number ),
+                'goal_number'        => (int) ( ( $goal['goal_number'] ?? '' ) ?: $number ),
                 'goal_group'         => (string) ( $goal['goal_group'] ?? '' ),
                 'is_active'          => ( ( $goal['goal_status'] ?? '' ) === 'active' ) ? 1 : 0,
                 'value'              => self::valueInCents( $goal ),

--- a/tests/GoalEventStorageTest.php
+++ b/tests/GoalEventStorageTest.php
@@ -128,6 +128,60 @@ final class GoalEventStorageTest extends TestCase
         $this->assertSame( 1, $planned[0]['is_active'] );
     }
 
+    /**
+     * A GOAL WITH NO goal_number AT ALL FALLS BACK TO ITS SLOT KEY.
+     *
+     * The fallback is deliberate -- the slot number is what made a goal unique
+     * within a Profile, so it stands in when the goal carries no number of its
+     * own. But the lookup was written `$goal['goal_number'] ?: $number`, which
+     * reaches the fallback only by way of an "Undefined array key" warning: the
+     * one path the code goes out of its way to support could not be taken
+     * cleanly.
+     *
+     * Every case above sets the key, most of them to ''. An EMPTY value takes
+     * the fallback silently; an ABSENT one warns. That is the whole difference,
+     * and it is why this went unnoticed -- found by seeding a blob without the
+     * key into the upgrade cycle, where PHP printed the warning mid-migration.
+     */
+    public function testAGoalWithNoNumberFallsBackToItsSlotKeyWithoutWarning(): void
+    {
+        $raised = null;
+
+        set_error_handler( static function ( $no, $str ) use ( &$raised ) {
+
+            $raised = $str;
+
+            return true;
+        } );
+
+        try {
+
+            $planned = \OWA\Module\Base\Update\Update025::planForProfile( array(
+                'scope_id' => 'OWA-probe',
+                'value'    => serialize( array( 7 => array(
+                    // No 'goal_number' key at all.
+                    'goal_name'   => 'Newsletter',
+                    'goal_status' => 'active',
+                    'goal_type'   => 'url_destination',
+                    'details'     => array( 'match_type' => 'exact', 'goal_url' => '/news' ),
+                ) ) ),
+            ) );
+
+        } finally {
+
+            restore_error_handler();
+        }
+
+        $this->assertNull( $raised,
+            'Migrating a goal that carries no number raised: ' . (string) $raised );
+
+        $this->assertCount( 1, $planned, 'the goal was dropped rather than numbered' );
+
+        $this->assertSame( 7, $planned[0]['goal_number'],
+            'The slot key is what stands in for a missing goal_number -- it is what made '
+            . 'a goal unique within a Profile.' );
+    }
+
     /** The condition becomes the property/operator/value triple v2 needs. */
     public function testTheConditionIsStoredAsATriple(): void
     {

--- a/tests/tools/upgrade_cycle.php
+++ b/tests/tools/upgrade_cycle.php
@@ -94,6 +94,7 @@ $db     = owa_coreAPI::dbSingleton();
 $dbName = (string) owa_coreAPI::getSetting( 'base', 'db_name' );
 
 require_once __DIR__ . '/scratch_guard.php';
+require_once __DIR__ . '/upgrade_cycle_fixture.php';
 
 owa_upgrade_cycle_guard( $dbName, $force );
 
@@ -129,6 +130,19 @@ if ( $phase === 'down' ) {
         fwrite( STDERR, "refusing: schema $installed leaves nothing to roll back.\n" );
         exit( 2 );
     }
+
+    /*
+     * The legacy DATA, before anything is rewound.
+     *
+     * Without it the cycle round-trips an empty database and every data
+     * migration runs against nothing -- which is how Update025's read path
+     * stayed unexecuted by any test while reporting "Migrated 0 goal(s)"
+     * as though that were a result.
+     */
+    $seeded = owa_upgrade_cycle_seed();
+
+    $note( sprintf( 'seeded 1.x goals on profile %s (property %s)',
+        $seeded['profile'], $seeded['property'] ) );
 
     $before = owa_schema_fingerprint( $db, $dbName );
 
@@ -168,6 +182,7 @@ if ( $phase === 'down' ) {
         'floor'     => $floor,
         'rolled'    => $rolled,
         'before'    => $before,
+        'seeded'    => $seeded,
     ) ) );
 
     if ( ! $rolled ) {
@@ -195,6 +210,7 @@ $installed = (int) $state['installed'];
 $floor     = (int) $state['floor'];
 $rolled    = (array) $state['rolled'];
 $before    = $state['before'];
+$seeded    = (array) ( $state['seeded'] ?? array() );
 
 // Read from a cold boot: this process did not write the version, so a value
 // that only exists in someone's config cache cannot be mistaken for a
@@ -234,6 +250,15 @@ foreach ( owa_fingerprint_diff( $before, $after ) as $problem ) {
     $fail[] = $problem;
 }
 
+/* ---- the DATA has to have come across too ---------------------------------- */
+
+$note( '--- checking what the data migrations produced ---' );
+
+foreach ( owa_upgrade_cycle_expect( $seeded ) as $problem ) {
+
+    $fail[] = "A DATA migration lost or mangled what it was carrying across.\n  " . $problem;
+}
+
 /* ---- and applying them again must not be a failure ------------------------ */
 
 $note( '--- re-applying each rolled update against the schema it just built ---' );
@@ -268,6 +293,19 @@ $final = owa_schema_fingerprint( $db, $dbName );
 foreach ( owa_fingerprint_diff( $after, $final, 're-application' ) as $problem ) {
 
     $fail[] = $problem;
+}
+
+/*
+ * And the DATA is still exactly what it was.
+ *
+ * A migration re-run must UPDATE the rows it made, not make them again --
+ * which is what the content-derived ids in Update025 are for. This is the
+ * assertion that notices when that derivation stops being deterministic:
+ * the count doubles and nothing else changes.
+ */
+foreach ( owa_upgrade_cycle_expect( $seeded ) as $problem ) {
+
+    $fail[] = "Re-running the migrations changed the migrated data.\n  " . $problem;
 }
 
 /* ---- verdict -------------------------------------------------------------- */

--- a/tests/tools/upgrade_cycle_fixture.php
+++ b/tests/tools/upgrade_cycle_fixture.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Legacy-shaped DATA for the upgrade cycle to migrate.
+ *
+ * WHY
+ * ---
+ * upgrade_cycle.php rewinds and rebuilds the SCHEMA, which is what caught the
+ * two ALTER bugs. But it round-trips an EMPTY database: a fresh install has no
+ * 1.x goals, so Update025 -- the one update in the swept range that migrates
+ * DATA rather than adding columns -- ran against nothing and reported
+ * "Migrated 0 goal(s)" every time. Its read path had never been executed by any
+ * test.
+ *
+ * That is the same hole one level down, and it is the more dangerous half: a
+ * broken schema migration stops the upgrade and everybody notices, while a
+ * broken data migration completes, reports success, and silently loses what it
+ * was supposed to carry across.
+ *
+ * WHAT IS SEEDED
+ * --------------
+ * The 1.x goal blob, in the shape a real install holds it: a fixed-length array
+ * of numbered slots, nearly all of them empty stubs, inside one settings row
+ * per Profile. Live installs carry fifteen slots to describe one goal.
+ *
+ * ASYMMETRIC ON PURPOSE. Four real goals among eleven stubs, with four
+ * different values (100, 1250, 500 and 0 cents), two different match types, one
+ * INACTIVE, and one whose value is not a number at all. No assertion here can
+ * pass by landing on a figure that happens to be right for another reason --
+ * which is exactly what "4 goals, all with value 100" would allow.
+ *
+ * ADDING A CASE
+ * -------------
+ * A new data migration gets a seed() clause and an expect() clause here. The
+ * sweep calls both and needs no knowledge of either.
+ */
+
+/** The 1.x goals blob: four real goals and eleven empty slots. */
+function owa_upgrade_cycle_goal_blob() {
+
+    $goals = array();
+
+    // 1. the ordinary case: active, whole-number value, exact match.
+    $goals[1] = array(
+        'goal_name'   => 'Contact',
+        'goal_group'  => 'leads',
+        'goal_status' => 'active',
+        'goal_value'  => '1',
+        'goal_type'   => 'url_destination',
+        'goal_number' => 1,
+        'details'     => array( 'match_type' => 'exact', 'goal_url' => '/contact' ),
+    );
+
+    // 2. a decimal value and a different match type, so neither is assumed.
+    $goals[2] = array(
+        'goal_name'   => 'Signup',
+        'goal_group'  => 'leads',
+        'goal_status' => 'active',
+        'goal_value'  => '12.50',
+        'goal_type'   => 'url_destination',
+        'goal_number' => 2,
+        'details'     => array( 'match_type' => 'regex', 'goal_url' => '/signup.*' ),
+    );
+
+    // 3. NOT active. A migration that copies every goal as enabled would turn
+    //    a goal somebody switched off back on, and report success doing it.
+    $goals[3] = array(
+        'goal_name'   => 'Retired Offer',
+        'goal_group'  => 'sales',
+        'goal_status' => 'deleted',
+        'goal_value'  => '5',
+        'goal_type'   => 'url_destination',
+        'goal_number' => 3,
+        'details'     => array( 'match_type' => 'exact', 'goal_url' => '/offer' ),
+    );
+
+    // 4. a value that is not a number, and NO goal_number -- the slot key has
+    //    to stand in for it. 1.x stored value as free-form text, so this is the
+    //    one field that can fail to convert; it must migrate as 0 rather than
+    //    take the goal down with it.
+    $goals[4] = array(
+        'goal_name'   => 'Newsletter',
+        'goal_group'  => 'leads',
+        'goal_status' => 'active',
+        'goal_value'  => 'free',
+        'goal_type'   => 'url_destination',
+        'details'     => array( 'match_type' => 'exact', 'goal_url' => '/newsletter' ),
+    );
+
+    // 5-15. The stubs. They exist because the blob was a fixed-length array,
+    // not because anybody made them, and they must NOT become rows.
+    for ( $i = 5; $i <= 15; $i++ ) {
+
+        $goals[ $i ] = array( 'goal_number' => '', 'goal_name' => '',
+                              'goal_group'  => '', 'goal_status' => '', 'goal_type' => '' );
+    }
+
+    return $goals;
+}
+
+/** How many of the slots above are real goals, and how many are stubs. */
+function owa_upgrade_cycle_expected_goals() {
+
+    return array(
+        // name => [goal_number, is_active, value in cents, operator, url]
+        'Contact'       => array( 1, 1, 100,  'exact', '/contact' ),
+        'Signup'        => array( 2, 1, 1250, 'regex', '/signup.*' ),
+        'Retired Offer' => array( 3, 0, 500,  'exact', '/offer' ),
+        'Newsletter'    => array( 4, 1, 0,    'exact', '/newsletter' ),
+    );
+}
+
+/**
+ * Writes the legacy data onto the installed schema.
+ *
+ * @return array{profile:string, property:string} what it attached to
+ */
+function owa_upgrade_cycle_seed() {
+
+    $db = \OWA\Core\CoreAPI::dbSingleton();
+
+    /*
+     * A Profile that actually HAS a Property.
+     *
+     * Not simply the first row: the e2e harness adds a tracker fixture site of
+     * its own with property_id 0, and picking that one makes the migration's
+     * site -> property hop untestable while looking like an installer bug. The
+     * installer's own default site is linked correctly.
+     */
+    $sites = (array) $db->get_results(
+        'SELECT site_id, property_id FROM owa_site
+          WHERE property_id IS NOT NULL AND property_id > 0
+          ORDER BY id LIMIT 1' );
+
+    if ( ! $sites ) {
+
+        $all = (array) $db->get_results( 'SELECT COUNT(*) AS n FROM owa_site' );
+
+        fwrite( STDERR, sprintf(
+            "no Profile on this install has a Property (%s site row(s) in total), so the\n"
+          . "migration's site -> property hop cannot be exercised. The installer links one;\n"
+          . "if it has stopped doing so, that is the finding.\n",
+            $all ? ( (array) $all[0] )['n'] : '?' ) );
+
+        exit( 2 );
+    }
+
+    $site = (array) $sites[0];
+
+    $setting = \OWA\Core\CoreAPI::entityFactory( 'base.setting' );
+
+    // makeId( scope_type, scope_id, module, name ) -- four arguments, the same
+    // derivation Update022 uses, so this row is indistinguishable from one an
+    // actual 1.x install carried across.
+    $setting->set( 'id', $setting->makeId( 'profile', $site['site_id'], 'base', 'goals' ) );
+    $setting->set( 'scope_type', 'profile' );
+    $setting->set( 'scope_id', $site['site_id'] );
+    $setting->set( 'module', 'base' );
+    $setting->set( 'name', 'goals' );
+    $setting->set( 'value', serialize( owa_upgrade_cycle_goal_blob() ) );
+    $setting->set( 'creation_date', \OWA\Core\CoreAPI::getRequestTimestamp() );
+
+    if ( ! $setting->create() ) {
+
+        // Already there on a re-run: make sure it holds THIS blob.
+        $db->query( sprintf( "UPDATE owa_setting SET value = '%s'
+                               WHERE scope_type = 'profile' AND scope_id = '%s' AND name = 'goals'",
+            $db->prepare( serialize( owa_upgrade_cycle_goal_blob() ) ), $site['site_id'] ) );
+    }
+
+    return array( 'profile' => $site['site_id'], 'property' => $site['property_id'] );
+}
+
+/**
+ * What the migration must have produced.
+ *
+ * @param array $seeded what owa_upgrade_cycle_seed() attached to
+ * @return array<string> failures, empty when the data came across intact
+ */
+function owa_upgrade_cycle_expect( $seeded ) {
+
+    $db   = \OWA\Core\CoreAPI::dbSingleton();
+    $fail = array();
+
+    $expected = owa_upgrade_cycle_expected_goals();
+
+    $rows = (array) $db->get_results(
+        'SELECT id, property_id, name, goal_number, goal_group, is_active, value,
+                trigger_event_type FROM owa_goal_event' );
+
+    $events = array();
+
+    foreach ( $rows as $r ) {
+
+        $r = (array) $r;
+
+        $events[ $r['name'] ] = $r;
+    }
+
+    /*
+     * THE STUBS. Eleven of the fifteen slots are empty, and carrying them over
+     * would reproduce the exact thing the table exists to stop.
+     */
+    if ( count( $rows ) !== count( $expected ) ) {
+
+        $fail[] = sprintf(
+            "The migration produced %d goal event(s) from %d real goals in a %d-slot blob.\n"
+          . "  Got: %s\n"
+          . '  Eleven of those slots are empty stubs and must not become rows.',
+            count( $rows ), count( $expected ), count( owa_upgrade_cycle_goal_blob() ),
+            $rows ? implode( ', ', array_keys( $events ) ) : '(nothing)' );
+    }
+
+    foreach ( $expected as $name => $want ) {
+
+        list( $number, $active, $cents, $operator, $url ) = $want;
+
+        if ( ! isset( $events[ $name ] ) ) {
+
+            $fail[] = sprintf( 'The goal "%s" did not survive the migration at all.', $name );
+
+            continue;
+        }
+
+        $got = $events[ $name ];
+
+        if ( (int) $got['goal_number'] !== $number ) {
+
+            $fail[] = sprintf( '"%s" migrated as goal_number %s, expected %d%s.',
+                $name, var_export( $got['goal_number'], true ), $number,
+                $number === 4 ? ' (the slot key, because the goal carried no number)' : '' );
+        }
+
+        if ( (int) $got['is_active'] !== $active ) {
+
+            $fail[] = sprintf(
+                "\"%s\" migrated as is_active=%s, expected %d.\n"
+              . '  A goal somebody switched off must not come back enabled.',
+                $name, var_export( $got['is_active'], true ), $active );
+        }
+
+        if ( (int) $got['value'] !== $cents ) {
+
+            $fail[] = sprintf(
+                "\"%s\" migrated with value %s, expected %d cents.\n"
+              . '  1.x stored money as free-form text; this is the field that can fail to convert.',
+                $name, var_export( $got['value'], true ), $cents );
+        }
+
+        /*
+         * THE HOP. Goals were per site; goal events are per Property. A
+         * migration that carried site_id across unchanged would look right in
+         * every other respect and attach every goal to nothing.
+         */
+        if ( (string) $got['property_id'] !== (string) $seeded['property'] ) {
+
+            $fail[] = sprintf(
+                "\"%s\" points at property_id %s, expected %s.\n"
+              . '  Goals were per Profile and goal events are per Property; that hop is the migration.',
+                $name, var_export( $got['property_id'], true ), var_export( $seeded['property'], true ) );
+        }
+
+        $conds = (array) $db->get_results( sprintf(
+            "SELECT condition_property, condition_operator, condition_value
+               FROM owa_goal_event_condition WHERE goal_event_id = '%s'",
+            $db->prepare( $got['id'] ) ) );
+
+        if ( count( $conds ) !== 1 ) {
+
+            $fail[] = sprintf(
+                '"%s" has %d condition rows; a 1.x goal had exactly one (one URL, one match type).',
+                $name, count( $conds ) );
+
+            continue;
+        }
+
+        $c = (array) $conds[0];
+
+        if ( $c['condition_operator'] !== $operator || $c['condition_value'] !== $url ) {
+
+            $fail[] = sprintf(
+                "\"%s\" migrated its condition as %s %s %s, expected page_uri %s %s.",
+                $name, $c['condition_property'], $c['condition_operator'],
+                var_export( $c['condition_value'], true ), $operator, var_export( $url, true ) );
+        }
+    }
+
+    /* No blank conditions from the blank slots, by any route. */
+    $empty = (array) $db->get_results(
+        "SELECT COUNT(*) AS n FROM owa_goal_event_condition
+          WHERE condition_value IS NULL OR condition_value = ''
+             OR condition_property IS NULL OR condition_property = ''" );
+
+    if ( $empty && (int) ( (array) $empty[0] )['n'] !== 0 ) {
+
+        $fail[] = sprintf( '%s empty condition row(s) exist. The blank slots became rows.',
+            ( (array) $empty[0] )['n'] );
+    }
+
+    return $fail;
+}


### PR DESCRIPTION
Follow-up to #1067, closing the gap I flagged when it merged.

## The gap

#1067 rewinds and rebuilds the **schema** — that's what caught the two ALTER bugs. But it round-trips an **empty** database. A fresh install has no 1.x goals, so `Update025` — the one update in the swept range that migrates *data* rather than adding columns — ran against nothing and reported `Migrated 0 goal(s)` every time. Its read path had never been executed by any test.

Same hole, one level down, and the more dangerous half: a broken **schema** migration stops the upgrade and everybody notices; a broken **data** migration completes, reports success, and silently loses what it was carrying.

## The fixture

`tests/tools/upgrade_cycle_fixture.php` seeds the 1.x goal blob in the shape a real install holds it — a fixed-length array of numbered slots, nearly all empty stubs, in one settings row per Profile — and states what must come out.

Asymmetric on purpose: **4 real goals among 11 stubs**, four different values (100 / 1250 / 500 / 0 cents), two match types, one **inactive**, one whose value isn't a number. Nothing can pass by landing on a figure that's right for another reason.

Checked after the upgrade **and** after the forced re-apply — a re-run must *update* the rows it made, not make them again, which is what the content-derived ids are for.

## Mutation-checked, against the real cycle

| mutation | what the sweep said |
|---|---|
| `is_active` hard-coded to 1 | *"Retired Offer migrated as is_active=1, expected 0. A goal somebody switched off must not come back enabled."* |
| empty slots not dropped | *"produced 15 goal events from 4 real goals in a 15-slot blob"* |
| site → property hop skipped | *"produced 0 goal events … (nothing)"* — the migration completing and losing everything |

## And it found one immediately

```
PHP Warning: Undefined array key "goal_number" in Update025.php:211
```

`$goal['goal_number'] ?: $number` falls back to the slot key when a goal carries no number of its own — deliberate, since the slot number is what made a goal unique within a Profile. But written without `??`, **the one path the code goes out of its way to support couldn't be taken cleanly.**

Every existing case in `GoalEventStorageTest` sets the key, most of them to `''`. An *empty* value takes the fallback silently; an *absent* one warns. That's the whole difference, and why it went unseen.

Fixed, plus a unit test for it that runs in **every** environment (configless included) rather than only in the upgrade job — mutation-checked by removing the `??` again.

## One more thing

The fixture picks a Profile that actually **has** a Property. Taking the first `owa_site` row gets the e2e harness's own tracker fixture site, whose `property_id` is `0` — which makes the migration's site→property hop untestable while looking like an installer bug. It isn't one; the installer links it correctly via `ensurePropertyFor()`. I checked before believing my own error message.
