### PR TITLE
A custom report is not saveable until it says what it measures

### DIFF
--- a/modules/Base/Classes/CustomReports.php
+++ b/modules/Base/Classes/CustomReports.php
@@ -42,8 +42,10 @@ namespace OWA\Module\Base\Classes;
  * nothing about whether the NAMES inside resolve. So validate() below also
  * requires that:
  *
- *   - there are at most MAX_WIDGETS widgets;
+ *   - there is at least one widget, and at most MAX_WIDGETS of them;
  *   - every widget names one of the types a person can actually build;
+ *   - every widget names at least one metric, unless the report carries a
+ *     metric set for it to inherit -- see validateQuery();
  *   - every metric, dimension and sort name resolves through the registry.
  *
  * That last one is the REST-to-SQL invariant: a name that reaches the query
@@ -398,6 +400,15 @@ class CustomReports {
                 self::MAX_WIDGETS, count( $widgets ) );
         }
 
+        /*
+         * Whether there is a set for a widget to inherit, read once for the
+         * whole loop. Only a report saved before the builder withdrew the
+         * control has one -- see validateQuery(), which is the only thing that
+         * asks.
+         */
+        $has_report_metrics = (bool) self::asNames(
+            isset( $definition['metrics'] ) ? $definition['metrics'] : '' );
+
         foreach ( $widgets as $i => $widget ) {
 
             $where = sprintf( 'widget %d', $i + 1 );
@@ -415,7 +426,7 @@ class CustomReports {
                     $where, $type, implode( ', ', array_keys( self::WIDGET_TYPES ) ) );
             }
 
-            $error = self::validateQuery( $widget, $where );
+            $error = self::validateQuery( $widget, $where, $has_report_metrics );
 
             if ( $error !== '' ) {
 
@@ -462,9 +473,12 @@ class CustomReports {
      *
      * @param array  $widget
      * @param string $where human-readable position, for the message
+     * @param bool   $has_report_metrics whether the REPORT declares a metric
+     *               set. Only a report that has one may carry a widget naming
+     *               no metrics of its own; see the rule below.
      * @return string
      */
-    private static function validateQuery( array $widget, $where ) {
+    private static function validateQuery( array $widget, $where, $has_report_metrics = false ) {
 
         $query = isset( $widget['query'] ) ? (array) $widget['query'] : array();
 
@@ -562,22 +576,43 @@ class CustomReports {
         }
 
         /*
-         * A type that may not inherit a set has to have named some.
+         * EVERY WIDGET NAMES ITS OWN METRICS.
+         *
+         * A widget that named none used to inherit the report metric set, and
+         * the builder asked for that set beside the report's name. It no longer
+         * does -- see the note in custom_report_edit.php -- so a widget with an
+         * empty list has nothing to inherit and would draw an empty panel. That
+         * is not something an author can have meant, and it is not something
+         * they would see until after saving, so it is refused here.
+         *
+         * The exception is a report that ALREADY HAS a set. Those were built
+         * while the control existed, they render correctly, and this check runs
+         * at render time as well as at save time -- refusing them would take
+         * down reports that are working, and leave their authors no way to fix
+         * it, because the field they would have to fill is gone. So the
+         * fallback stays legal exactly where there is something to fall back to.
          *
          * AFTER the single-field check, which says the same thing more
          * precisely for a card or a pie: "draws one metric, this one names 0"
-         * names the count as well as the rule. What is left for this to catch
-         * is the type that takes SEVERAL of its own -- a trend card -- where
-         * nothing else would notice an empty list, because an empty list is
-         * legal on every type that CAN inherit.
+         * names the count as well as the rule.
          */
-        if ( in_array( $type, self::OWN_METRIC_TYPES, true )
-             && ! self::asNames( $query['metrics'] ?? '' ) ) {
+        if ( ! self::asNames( $query['metrics'] ?? '' ) ) {
 
-            return sprintf(
-                '%s is a %s, which names its own metrics -- it does not take the '
-              . 'report metric set. This one names none.',
-                $where, self::WIDGET_TYPES[ $type ] ?? $type );
+            if ( in_array( $type, self::OWN_METRIC_TYPES, true ) ) {
+
+                return sprintf(
+                    '%s is a %s, which names its own metrics -- it does not take the '
+                  . 'report metric set. This one names none.',
+                    $where, self::WIDGET_TYPES[ $type ] ?? $type );
+            }
+
+            if ( ! $has_report_metrics ) {
+
+                return sprintf(
+                    '%s names no metrics, so it would draw nothing. Every widget has '
+                  . 'to say what it measures.',
+                    $where );
+            }
         }
 
         $error = self::validateFieldCount(
@@ -609,6 +644,21 @@ class CustomReports {
 
                 return $error;
             }
+        }
+
+        /*
+         * EACH CONSTRAINT, CLAUSE BY CLAUSE.
+         *
+         * Before the combination check below, which folds the constraints'
+         * dimensions into the same reduction: constraintDimensions() keeps only
+         * the names that resolve, so a misspelled one reaches that check as
+         * nothing at all and the combination looks fine.
+         */
+        $error = self::validateConstraints( $widget, $where );
+
+        if ( $error !== '' ) {
+
+            return $error;
         }
 
         /*
@@ -1357,6 +1407,170 @@ class CustomReports {
         $names = is_array( $value ) ? $value : explode( ',', (string) $value );
 
         return array_values( array_filter( array_map( 'trim', $names ) ) );
+    }
+
+    /**
+     * The operators a constraint may use.
+     *
+     * READ FROM THE ENGINE, not listed here. ResultSetManager is what actually
+     * parses these strings, and a list of our own would eventually accept a
+     * clause it then drops -- which is the exact failure this validation
+     * exists to stop.
+     *
+     * Deliberately the FULL set rather than the five the builder offers. The
+     * builder's list is a choice about what is worth putting in a picker; this
+     * is a question about what the engine can run, and a definition written by
+     * hand or carried over from an older report may legitimately use the rest.
+     *
+     * @return array
+     */
+    private static function constraintOperators() {
+
+        $rsm = new \OWA\Module\Base\Classes\ResultSetManager;
+
+        $operators = (array) $rsm->constraint_operators;
+
+        /*
+         * LONGEST FIRST. '>=' contains '>' and '=@' contains '=', so testing in
+         * any other order splits `medium=@news` at the wrong character and
+         * reports a name of `medium=`. The builder's splitConstraint() sorts
+         * for the same reason.
+         */
+        usort( $operators, static function ( $a, $b ) {
+
+            return strlen( $b ) - strlen( $a );
+        } );
+
+        return $operators;
+    }
+
+    /**
+     * Every clause of a widget's constraints, checked the way every other name
+     * in a definition is checked.
+     *
+     * WHY THIS IS HERE AT ALL
+     *
+     * Constraints were the one thing in a definition that reached the query
+     * builder without resolving through the registry at save time. Metrics,
+     * dimensions, sorts, chart metrics and link targets are all checked; a
+     * constraint was not, and the consequences split two ways.
+     *
+     * A clause the engine CAN parse but not resolve -- `notADimension==direct`,
+     * or `medium==` with no value -- is refused by ResultSetManager at QUERY
+     * time. That is the right answer at the wrong moment: the author is told
+     * long after they could easily fix it, and everyone who opens the report is
+     * told as well, every time.
+     *
+     * A clause the engine cannot parse at all is worse. `medium` with no
+     * operator, `==direct` with no name, and `medium~~x` with an operator that
+     * does not exist all parse to NOTHING -- parseConstraintsString() finds no
+     * operator and contributes no constraint -- so the query runs completely
+     * unfiltered, with no error raised anywhere. A widget meant to show organic
+     * search shows the site total, and nothing says so.
+     *
+     * Both are refused here, where the author is looking at the row.
+     *
+     * @param array  $widget
+     * @param string $where human-readable position, for the message
+     * @return string
+     */
+    private static function validateConstraints( array $widget, $where ) {
+
+        $constraints = isset( $widget['constraints'] ) ? $widget['constraints'] : '';
+
+        if ( ! is_string( $constraints ) || trim( $constraints ) === '' ) {
+
+            return '';
+        }
+
+        $operators = self::constraintOperators();
+
+        foreach ( explode( ',', $constraints ) as $clause ) {
+
+            $clause = trim( $clause );
+
+            if ( $clause === '' ) {
+
+                continue;
+            }
+
+            $name     = '';
+            $value    = '';
+            $operator = '';
+
+            foreach ( $operators as $candidate ) {
+
+                $at = strpos( $clause, $candidate );
+
+                /*
+                 * `> 0`, not `!== false`: an operator at position 0 leaves no
+                 * name in front of it. That is a clause the engine drops
+                 * silently -- its own parser uses a truthy strpos and skips it
+                 * -- so it has to be caught as "names nothing" below rather
+                 * than accepted as a clause.
+                 */
+                if ( $at > 0 ) {
+
+                    $name     = trim( substr( $clause, 0, $at ) );
+                    $operator = $candidate;
+                    $value    = trim( substr( $clause, $at + strlen( $candidate ) ) );
+                    break;
+                }
+            }
+
+            if ( $operator === '' ) {
+
+                /*
+                 * An operator at position 0 is a different mistake from no
+                 * operator at all -- "==direct" has a comparison and nothing to
+                 * compare, "medium" has neither -- and telling an author to add
+                 * an operator to a clause that already has one sends them to
+                 * fix the wrong half. Both are dropped identically by the
+                 * engine, which is why both have to be caught, but they do not
+                 * get the same sentence.
+                 */
+                foreach ( $operators as $candidate ) {
+
+                    if ( strpos( $clause, $candidate ) === 0 ) {
+
+                        return sprintf(
+                            '%s has the constraint "%s", which names nothing to constrain '
+                          . 'on. A constraint reads name, operator, value -- for example '
+                          . 'medium==organic-search.',
+                            $where, $clause );
+                    }
+                }
+
+                return sprintf(
+                    '%s has the constraint "%s", which names no comparison. A constraint '
+                  . 'reads name, operator, value -- for example medium==organic-search. '
+                  . 'One the engine cannot read is dropped, and the widget shows '
+                  . 'everything instead of saying so. Operators: %s.',
+                    $where, $clause, implode( ' ', $operators ) );
+            }
+
+            if ( ! self::isKnownName( $name ) ) {
+
+                return sprintf(
+                    '%s constrains on "%s", which is not a dimension or a metric.',
+                    $where, $name );
+            }
+
+            if ( $value === '' ) {
+
+                /*
+                 * The same rule ResultSetManager states at query time: a
+                 * missing value is not a request for everything. Said here so
+                 * that a half-filled row is caught before it is stored.
+                 */
+                return sprintf(
+                    '%s constrains on "%s" but gives no value to compare it with. An '
+                  . 'empty value is not a request for everything.',
+                    $where, $name );
+            }
+        }
+
+        return '';
     }
 
     /**

--- a/modules/Base/Classes/CustomReports.php
+++ b/modules/Base/Classes/CustomReports.php
@@ -578,19 +578,15 @@ class CustomReports {
         /*
          * EVERY WIDGET NAMES ITS OWN METRICS.
          *
-         * A widget that named none used to inherit the report metric set, and
-         * the builder asked for that set beside the report's name. It no longer
-         * does -- see the note in custom_report_edit.php -- so a widget with an
-         * empty list has nothing to inherit and would draw an empty panel. That
-         * is not something an author can have meant, and it is not something
-         * they would see until after saving, so it is refused here.
+         * A widget naming none used to inherit the report metric set. The
+         * builder no longer asks for that set (see custom_report_edit.php), so
+         * an empty list now has nothing to inherit and the widget draws an
+         * empty panel.
          *
-         * The exception is a report that ALREADY HAS a set. Those were built
-         * while the control existed, they render correctly, and this check runs
-         * at render time as well as at save time -- refusing them would take
-         * down reports that are working, and leave their authors no way to fix
-         * it, because the field they would have to fill is gone. So the
-         * fallback stays legal exactly where there is something to fall back to.
+         * A report that already HAS a set is exempt. validate() runs at render
+         * time as well as at save time, so refusing those would break reports
+         * that work today, and their authors have no field left to fix them
+         * with.
          *
          * AFTER the single-field check, which says the same thing more
          * precisely for a card or a pie: "draws one metric, this one names 0"
@@ -598,7 +594,13 @@ class CustomReports {
          */
         if ( ! self::asNames( $query['metrics'] ?? '' ) ) {
 
-            if ( in_array( $type, self::OWN_METRIC_TYPES, true ) ) {
+            /*
+             * The metric-set wording only where there IS a set. The builder no
+             * longer offers one, so telling an author of a report that has none
+             * that this type "does not take the report metric set" names
+             * something they cannot see.
+             */
+            if ( $has_report_metrics && in_array( $type, self::OWN_METRIC_TYPES, true ) ) {
 
                 return sprintf(
                     '%s is a %s, which names its own metrics -- it does not take the '
@@ -608,10 +610,7 @@ class CustomReports {
 
             if ( ! $has_report_metrics ) {
 
-                return sprintf(
-                    '%s names no metrics, so it would draw nothing. Every widget has '
-                  . 'to say what it measures.',
-                    $where );
+                return sprintf( '%s names no metrics.', $where );
             }
         }
 
@@ -1412,15 +1411,12 @@ class CustomReports {
     /**
      * The operators a constraint may use.
      *
-     * READ FROM THE ENGINE, not listed here. ResultSetManager is what actually
-     * parses these strings, and a list of our own would eventually accept a
-     * clause it then drops -- which is the exact failure this validation
-     * exists to stop.
+     * Read from ResultSetManager, which parses these strings. A copy here
+     * would drift and start accepting clauses the engine drops.
      *
-     * Deliberately the FULL set rather than the five the builder offers. The
-     * builder's list is a choice about what is worth putting in a picker; this
-     * is a question about what the engine can run, and a definition written by
-     * hand or carried over from an older report may legitimately use the rest.
+     * The full set, not the five the builder's picker offers: a definition
+     * written by hand or carried over from an older report may use any operator
+     * the engine can run.
      *
      * @return array
      */
@@ -1448,27 +1444,16 @@ class CustomReports {
      * Every clause of a widget's constraints, checked the way every other name
      * in a definition is checked.
      *
-     * WHY THIS IS HERE AT ALL
+     * Constraints were not checked at save time, unlike metrics, dimensions,
+     * sorts, chart metrics and link targets. Two different failures followed.
      *
-     * Constraints were the one thing in a definition that reached the query
-     * builder without resolving through the registry at save time. Metrics,
-     * dimensions, sorts, chart metrics and link targets are all checked; a
-     * constraint was not, and the consequences split two ways.
+     * `notADimension==direct` and `medium==` parse, but do not resolve.
+     * ResultSetManager refuses them at query time, so the report fails for
+     * every reader every time it is opened, rather than for the author once.
      *
-     * A clause the engine CAN parse but not resolve -- `notADimension==direct`,
-     * or `medium==` with no value -- is refused by ResultSetManager at QUERY
-     * time. That is the right answer at the wrong moment: the author is told
-     * long after they could easily fix it, and everyone who opens the report is
-     * told as well, every time.
-     *
-     * A clause the engine cannot parse at all is worse. `medium` with no
-     * operator, `==direct` with no name, and `medium~~x` with an operator that
-     * does not exist all parse to NOTHING -- parseConstraintsString() finds no
-     * operator and contributes no constraint -- so the query runs completely
-     * unfiltered, with no error raised anywhere. A widget meant to show organic
-     * search shows the site total, and nothing says so.
-     *
-     * Both are refused here, where the author is looking at the row.
+     * `medium`, `==direct` and `medium~~x` do not parse at all.
+     * parseConstraintsString() finds no operator and contributes no constraint,
+     * so the query runs unfiltered and raises nothing.
      *
      * @param array  $widget
      * @param string $where human-readable position, for the message
@@ -1504,10 +1489,9 @@ class CustomReports {
 
                 /*
                  * `> 0`, not `!== false`: an operator at position 0 leaves no
-                 * name in front of it. That is a clause the engine drops
-                 * silently -- its own parser uses a truthy strpos and skips it
-                 * -- so it has to be caught as "names nothing" below rather
-                 * than accepted as a clause.
+                 * name in front of it. parseConstraintsString() uses a truthy
+                 * strpos and skips such a clause, so it is caught below as
+                 * naming nothing rather than accepted here.
                  */
                 if ( $at > 0 ) {
 
@@ -1521,31 +1505,24 @@ class CustomReports {
             if ( $operator === '' ) {
 
                 /*
-                 * An operator at position 0 is a different mistake from no
-                 * operator at all -- "==direct" has a comparison and nothing to
-                 * compare, "medium" has neither -- and telling an author to add
-                 * an operator to a clause that already has one sends them to
-                 * fix the wrong half. Both are dropped identically by the
-                 * engine, which is why both have to be caught, but they do not
-                 * get the same sentence.
+                 * "==direct" has an operator and no name; "medium" has
+                 * neither. The engine drops both, but they need different
+                 * messages: telling someone to add an operator to a clause
+                 * that has one points at the wrong half.
                  */
                 foreach ( $operators as $candidate ) {
 
                     if ( strpos( $clause, $candidate ) === 0 ) {
 
                         return sprintf(
-                            '%s has the constraint "%s", which names nothing to constrain '
-                          . 'on. A constraint reads name, operator, value -- for example '
-                          . 'medium==organic-search.',
+                            '%s has the constraint "%s", which names nothing to '
+                          . 'constrain on.',
                             $where, $clause );
                     }
                 }
 
                 return sprintf(
-                    '%s has the constraint "%s", which names no comparison. A constraint '
-                  . 'reads name, operator, value -- for example medium==organic-search. '
-                  . 'One the engine cannot read is dropped, and the widget shows '
-                  . 'everything instead of saying so. Operators: %s.',
+                    '%s has the constraint "%s", which names no operator. Use one of: %s.',
                     $where, $clause, implode( ' ', $operators ) );
             }
 
@@ -1558,15 +1535,10 @@ class CustomReports {
 
             if ( $value === '' ) {
 
-                /*
-                 * The same rule ResultSetManager states at query time: a
-                 * missing value is not a request for everything. Said here so
-                 * that a half-filled row is caught before it is stored.
-                 */
+                // ResultSetManager refuses this at query time; checked here so
+                // a half-filled row is caught before it is stored.
                 return sprintf(
-                    '%s constrains on "%s" but gives no value to compare it with. An '
-                  . 'empty value is not a request for everything.',
-                    $where, $name );
+                    '%s constrains on "%s" but gives no value.', $where, $name );
             }
         }
 

--- a/modules/Base/Controller/CustomReportEdit.php
+++ b/modules/Base/Controller/CustomReportEdit.php
@@ -105,10 +105,11 @@ class CustomReportEdit extends \OWA\Core\ReportController {
         $this->set( 'custom_report_id', $report ? $report['id'] : '' );
 
         /*
-         * The definition the form starts from. A NEW report starts from one
-         * empty widget rather than none, because a report with no widgets
-         * cannot be saved and an empty form gives the author nothing to react
-         * to.
+         * The definition the form starts from. A NEW report starts from NONE --
+         * no widgets and no report metric set -- so the first thing an author
+         * does is choose what to build. It used to be seeded with one table
+         * widget, which meant a report could be saved without a single choice
+         * having been made, and what came out was a table of nothing.
          */
         $definition = $report ? (array) $report['definition'] : array();
 
@@ -182,7 +183,6 @@ class CustomReportEdit extends \OWA\Core\ReportController {
         $this->set( 'full_width_types',   \OWA\Module\Base\Classes\CustomReports::FULL_WIDTH_TYPES );
         $this->set( 'single_field_types', \OWA\Module\Base\Classes\CustomReports::SINGLE_FIELD_TYPES );
         $this->set( 'single_metric_types', \OWA\Module\Base\Classes\CustomReports::SINGLE_METRIC_TYPES );
-        $this->set( 'own_metric_types',   \OWA\Module\Base\Classes\CustomReports::OWN_METRIC_TYPES );
         $this->set( 'chart_types',        \OWA\Module\Base\Classes\CustomReports::CHART_TYPES );
         $this->set( 'fixed_dimensions', \OWA\Module\Base\Classes\CustomReports::FIXED_DIMENSIONS );
         $this->set( 'fixed_dimension_extra', \OWA\Module\Base\Classes\CustomReports::FIXED_DIMENSION_EXTRA );

--- a/modules/Base/Controller/CustomReportSave.php
+++ b/modules/Base/Controller/CustomReportSave.php
@@ -133,6 +133,21 @@ class CustomReportSave extends \OWA\Core\AdminController {
      *
      * The submitted definition rides along in the params, so the builder
      * redraws what the author had rather than what was last stored.
+     *
+     * ASSIGNED TO $this->data AS WELL AS RETURNED, and that is not belt and
+     * braces -- it is the only half that works from errorAction().
+     *
+     * doAction() honours what action() returns (finishActionCall passes it
+     * straight back), and DISCARDS what errorAction() returns: it calls
+     * errorAction() for its side effects and then returns $this->data
+     * regardless -- see Core/Controller.php, the branch that runs when
+     * validate() fails. So a refusal raised by validate() rather than by
+     * action() rendered THIS controller's data, which names no view at all,
+     * and the author got a blank page. Saving with the name left empty did it
+     * every time.
+     *
+     * Assigning makes the two paths agree without changing the dispatcher,
+     * which every other controller's error path depends on.
      */
     private function refuse( $message ) {
 
@@ -143,7 +158,9 @@ class CustomReportSave extends \OWA\Core\AdminController {
 
         $target = new CustomReportEdit( $params );
 
-        return $target->doAction();
+        $this->data = $target->doAction();
+
+        return $this->data;
     }
 
     function errorAction() {

--- a/modules/Base/Controller/VisualizationEdit.php
+++ b/modules/Base/Controller/VisualizationEdit.php
@@ -125,6 +125,12 @@ class VisualizationEdit extends \OWA\Core\ReportController {
         $this->set( 'siteId', $siteId );
 
         $this->set( 'goalEvents', \OWA\Module\Base\Controller\GoalEvents::listFor( $siteId ) );
+
+        /*
+         * The step cap, read from the controller that enforces it so the form
+         * cannot offer a step the save then refuses.
+         */
+        $this->set( 'maxSteps', \OWA\Module\Base\Controller\VisualizationSave::MAX_STEPS );
     }
 
     /**

--- a/modules/Base/View/CustomReportEdit.php
+++ b/modules/Base/View/CustomReportEdit.php
@@ -37,7 +37,6 @@ class CustomReportEdit extends \OWA\Core\View {
         $this->body->set( 'full_width_types', $this->get( 'full_width_types' ) );
         $this->body->set( 'single_field_types', $this->get( 'single_field_types' ) );
         $this->body->set( 'single_metric_types', $this->get( 'single_metric_types' ) );
-        $this->body->set( 'own_metric_types', $this->get( 'own_metric_types' ) );
         $this->body->set( 'chart_types', $this->get( 'chart_types' ) );
         $this->body->set( 'fixed_dimensions', $this->get( 'fixed_dimensions' ) );
         $this->body->set( 'fixed_dimension_extra', $this->get( 'fixed_dimension_extra' ) );

--- a/modules/Base/View/VisualizationEdit.php
+++ b/modules/Base/View/VisualizationEdit.php
@@ -14,6 +14,7 @@ class VisualizationEdit extends \OWA\Core\View {
         $this->body->set( 'visualizationTypeHint', $this->get( 'visualizationTypeHint' ) );
         $this->body->set( 'visualizationTypeIcon', $this->get( 'visualizationTypeIcon' ) );
         $this->body->set( 'goalEvents', (array) $this->get( 'goalEvents' ) );
+        $this->body->set( 'maxSteps', $this->get( 'maxSteps' ) );
         $this->body->set( 'siteId', $this->get( 'siteId' ) );
         $this->body->set( 'validation_errors', $this->get( 'validation_errors' ) ?? array() );
     }

--- a/modules/Base/css/owa.report.css
+++ b/modules/Base/css/owa.report.css
@@ -1341,10 +1341,41 @@ li.constraintRow {
     margin-bottom: 14px;
 }
 
-.owa .owa_builderField > label {
+/* The label, whether it sits alone or in a row beside a "Required" mark. A
+   child selector was enough until the mark needed a row of its own. */
+.owa .owa_builderField label {
     font-size: 12px;
     font-weight: bold;
     color: #505050;
+}
+
+.owa .owa_builderFieldLabel {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+/* Why the dialog will not close: a constraint row that was started and not
+   finished. Sits directly under the rows it is about. */
+.owa .owa_builderRowError {
+    font-size: 12px;
+    color: #99321f;
+    margin-top: 6px;
+}
+
+/* WHICH FIELDS HAVE TO BE ANSWERED, said on the field rather than discovered
+ * on save.
+ *
+ * Small, and in the muted red the refusal text uses, so it reads as the same
+ * voice pointing at the same rule -- but it is not an error: nothing has gone
+ * wrong yet, it is a fact about the field. Hence the weight of a caption
+ * rather than of a warning. */
+.owa .owa_builderRequired {
+    font-size: 10px;
+    font-weight: normal;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #99321f;
 }
 
 .owa .owa_builderField input[type=text],
@@ -1851,12 +1882,103 @@ li.constraintRow {
     line-height: 1;
 }
 
+/* What an EMPTY canvas says.
+ *
+ * A new report starts with no widgets, so this is the first thing on the
+ * screen. The plus alone is a control rather than an instruction -- on a blank
+ * page it reads as one option among others -- so the words say what a report is
+ * made of, and the plus below them is then the obvious thing to press.
+ *
+ * The gap under it is the point of the block. Without it the sentence sat
+ * directly on the top edge of the plus tile and read as a label ON the tile
+ * rather than as a line above it. */
+.owa .owa_builderEmpty {
+    display: block;
+    margin: 0 0 18px 0;
+    padding: 16px 0 0 0;
+}
+
+.owa .owa_builderEmptyTitle {
+    display: block;
+    font-size: 13px;
+    font-weight: bold;
+    color: #505050;
+    margin-bottom: 4px;
+}
+
+.owa .owa_builderEmptyBody {
+    display: block;
+    font-size: 12px;
+    line-height: 1.55;
+    color: #808080;
+    max-width: 560px;
+}
+
+/* ...and the plus keeps clear of the words above it whether or not the empty
+   block is drawn, so the canvas does not shift when the first widget lands. */
+.owa .owa_builderCanvasEmpty {
+    padding-top: 2px;
+}
+
 .owa .owa_builderActions {
     display: flex;
     align-items: center;
     gap: 15px;
     padding-top: 15px;
     border-top: 1px solid #e0e0e0;
+}
+
+/* .owa-button carries `margin: 25px 0 0 0` for the admin forms it was written
+   for, where it is the last thing on a page. Here it sits in a centred flex row
+   under its own rule, and that margin pushes it off the line. Overridden the
+   same way the confirmation dialog's buttons override it, rather than by
+   introducing a second button class. */
+.owa .owa_builderActions .owa-button {
+    margin: 0;
+}
+
+/* Save with nothing to save.
+ *
+ * A report needs at least one widget, and the button says so by being
+ * unavailable rather than by being absent -- a control that vanishes reads as a
+ * page that has not finished loading. The empty-canvas sentence above says
+ * why. */
+.owa .owa_builderActions .owa-button:disabled {
+    background-color: #f0f0f0;
+    color: #a0a0a0;
+    border-color: #dddddd;
+    cursor: default;
+}
+
+/* The reason Save will not go, beside the button that will not go. A disabled
+   control with no explanation says something is wrong and not what. */
+.owa .owa_builderBlocker {
+    font-size: 12px;
+    color: #99321f;
+}
+
+/* A block that has not been told what it measures.
+ *
+ * Marked on the CANVAS as well as in the sentence under the button, because the
+ * canvas is where the author is looking -- "Widget 3 does not say what it
+ * measures" is only useful if Widget 3 can be picked out of a row of blocks.
+ *
+ * A left edge rather than a full border: the block is unfinished, not invalid,
+ * and a red box around it would read as an error the author has made. */
+.owa .owa_builderBlockIncomplete {
+    border-left: 3px solid #d9a441;
+}
+
+.owa .owa_builderBlockIncomplete .owa_builderBlockSummary {
+    color: #99321f;
+}
+
+.owa .owa_builderActions .owa-button:disabled:hover {
+    color: #a0a0a0;
+    border-color: #dddddd;
+    box-shadow: none;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none;
 }
 
 .owa .owa_builderDelete {

--- a/modules/Base/templates/custom_report_edit.php
+++ b/modules/Base/templates/custom_report_edit.php
@@ -120,8 +120,8 @@ $owa_max        = (int) $view->get('max_widgets');
     ?>
     <div id="customReportEmpty" class="owa_builderEmpty" style="display:none;">
         <span class="owa_builderEmptyTitle">Nothing in this report yet.</span>
-        <span class="owa_builderEmptyBody">A report is its widgets &mdash; a table,
-            a chart, a row of totals. Add at least one; it cannot be saved empty.</span>
+        <span class="owa_builderEmptyBody">Add a table, a chart, or a row of totals.
+            A report cannot be saved empty.</span>
     </div>
 
     <div id="customReportCanvas" class="owa_builderCanvas"></div>
@@ -450,12 +450,8 @@ $owa_max        = (int) $view->get('max_widgets');
 
     <?php
         /*
-         * WHY DONE WILL NOT CLOSE.
-         *
-         * One message for the whole dialog rather than one per field. It names
-         * the field it is about -- "Choose at least one metric", "Constraint 1
-         * ... gives no value" -- and it sits at the foot, next to the button
-         * that just refused, which is where the eye is at that moment.
+         * One message for the whole dialog rather than one per field, at the
+         * foot next to the button that refused.
          */
     ?>
     <div id="dlgError" class="owa_builderRowError" style="display:none;" role="alert"></div>
@@ -701,15 +697,10 @@ $owa_max        = (int) $view->get('max_widgets');
     var editing = null;   // index of the widget the dialog is open on
 
     /*
-     * The widget the type chooser just added, which has never been applied.
+     * Index of a widget the type chooser added that has not been applied yet.
      *
-     * The chooser pushes a widget and draws it BEFORE the dialog opens, so
-     * backing out of that dialog has to undo the add -- otherwise Cancel is the
-     * way to create exactly the unconfigured block Done refuses to make, and
-     * the rule is decoration.
-     *
-     * Held here rather than as a flag ON the widget, because a flag would be
-     * copied into the posted definition by the submit handler and stored.
+     * Held here rather than as a flag on the widget: the submit handler copies
+     * the widget object into the posted definition, so a flag would be stored.
      */
     var pendingNew = null;
 
@@ -1078,17 +1069,9 @@ $owa_max        = (int) $view->get('max_widgets');
         }
 
         /*
-         * WHAT AN EMPTY CANVAS SAYS.
-         *
-         * The plus alone is a control, not an instruction: on a blank screen it
-         * reads as one option among others rather than as the only thing there
-         * is to do. So an empty canvas says what a report is made of and that
-         * it needs at least one, beside a plus that is now the obvious target.
-         *
-         * Drawn as a sibling of the plus rather than replacing it, because the
-         * plus is where the widget will appear -- moving it for the empty case
-         * would make the first widget land somewhere other than where it was
-         * added.
+         * An empty canvas gets a line of text above the plus saying what to
+         * add. The text is a sibling of the plus rather than a replacement for
+         * it, so the first widget lands where the plus is.
          */
         $canvas.toggleClass( 'owa_builderCanvasEmpty', ! widgets.length );
 
@@ -1102,14 +1085,12 @@ $owa_max        = (int) $view->get('max_widgets');
     /**
      * Why this report cannot be saved yet, or '' if it can.
      *
-     * THE SAME RULES THE SERVER APPLIES, asked before the round trip rather
-     * than instead of it. Every one of these is refused by
-     * CustomReports::validate() or by the save controller's own validate(); the
-     * point of asking here is that the author is told while the thing they have
-     * to fix is still in front of them.
+     * The same rules the server applies, checked before the round trip rather
+     * than instead of it: CustomReports::validate() and the save controller's
+     * validate() still refuse all of these.
      *
-     * In the order an author would fix them: something to save, a name for it,
-     * then whether each widget says what it measures.
+     * Ordered as an author would fix them: a widget, a name, then each widget's
+     * metrics.
      */
     function saveBlocker() {
 
@@ -1118,10 +1099,8 @@ $owa_max        = (int) $view->get('max_widgets');
         }
 
         /*
-         * The NAME. Required by CustomReportSave::validate(), and the field
-         * carries a placeholder -- "Untitled report" -- which reads as a value
-         * that is already there. Leaving it empty was the one refusal an author
-         * could hit without having done anything they would recognise as wrong.
+         * Required by CustomReportSave::validate(). The field's "Untitled
+         * report" placeholder makes an empty one look filled in.
          */
         if ( ! jQuery.trim( jQuery( '#customReportName' ).val() || '' ) ) {
             return 'Give the report a name before saving.';
@@ -1142,7 +1121,7 @@ $owa_max        = (int) $view->get('max_widgets');
                 if ( ! widgetMetrics( widgets[ i ] ).length ) {
 
                     return ( widgets[ i ].title || ( 'Widget ' + ( i + 1 ) ) )
-                         + ' does not say what it measures. Open it and choose a metric.';
+                         + ' has no metrics.';
                 }
             }
         }
@@ -1157,11 +1136,8 @@ $owa_max        = (int) $view->get('max_widgets');
     }
 
     /**
-     * Save is available exactly when the report could actually be stored.
-     *
-     * Disabled rather than hidden: the button is where an author expects it,
-     * and the sentence beside it says why it will not go yet. A control that
-     * vanishes reads as a page that has not finished loading.
+     * Save is enabled exactly when the report could be stored. Disabled
+     * rather than hidden, with the reason beside it.
      */
     function refreshSaveState() {
 
@@ -1295,7 +1271,7 @@ $owa_max        = (int) $view->get('max_widgets');
          * would be refused on save -- so both halves go and the field says the
          * one thing that is now true of every type: it has to be answered.
          */
-        var required = ' Required: a widget draws what it names, and nothing else.';
+        var required = ' Required.';
 
         /*
          * ...and the mark beside the label says the same thing at a glance.
@@ -1371,6 +1347,7 @@ $owa_max        = (int) $view->get('max_widgets');
 
         refreshLinkControl();
         refreshMoreControl();
+        refreshDialogState();
     }
 
     /**
@@ -1665,19 +1642,12 @@ $owa_max        = (int) $view->get('max_widgets');
     /**
      * What is wrong with the constraint rows, or '' if nothing is.
      *
-     * A HALF-FILLED ROW USED TO VANISH.
-     *
      * readConstraintRows() keeps a row only when it has both a dimension and a
-     * value, and dropped anything else without a word. So an author who chose
-     * `medium`, chose an operator and then tabbed past the value -- or typed a
-     * value and never picked the dimension -- got a widget with no filter on
-     * it, no message, and no way to tell it apart from one they had never
-     * filtered. The query engine treats exactly this as an error worth refusing
-     * ("a missing value is not a request for everything"); the builder treated
-     * it as nothing.
+     * value, and used to drop anything else silently -- so a row with a
+     * dimension and no value produced an unfiltered widget with no message.
+     * ResultSetManager refuses the same thing at query time.
      *
-     * An entirely blank row is still nothing, because there is always one on
-     * the form and it does not mean the author left something out.
+     * An entirely blank row is still ignored: the form always carries one.
      */
     function constraintRowProblem() {
 
@@ -1697,15 +1667,13 @@ $owa_max        = (int) $view->get('max_widgets');
             }
 
             if ( ! part.name ) {
-                problem = 'Constraint ' + ( i + 1 ) + ' has a value but no dimension. '
-                        + 'Choose what to constrain on, or clear the value.';
+                problem = 'Constraint ' + ( i + 1 ) + ' has a value but no dimension.';
                 return;
             }
 
             if ( ! part.value ) {
-                problem = 'Constraint ' + ( i + 1 ) + ' constrains on ' + part.name
-                        + ' but gives no value. An empty value is not a request for '
-                        + 'everything -- fill it in, or remove the row.';
+                problem = 'Constraint ' + ( i + 1 ) + ' on ' + part.name
+                        + ' has no value.';
             }
         } );
 
@@ -1730,15 +1698,13 @@ $owa_max        = (int) $view->get('max_widgets');
     /**
      * What is wrong with the SORT, or '' if nothing is.
      *
-     * The one field in this dialog an author types into freely, and so the one
-     * that could still reach the server as a name that does not resolve -- a
-     * refusal two steps later, on a page about a widget rather than showing
-     * them one. The registry is already in the page for the pickers, so the
-     * same answer is available here.
+     * The only free-text field here, so the only one that could reach the
+     * server with a name that does not resolve. METRICS and DIMENSIONS are
+     * already in the page for the pickers.
      *
-     * A trailing '-' is the DIRECTION, not part of the name, and is stripped
-     * before the lookup: without that, every descending sort would be reported
-     * as unresolvable. Empty is fine -- a widget need not name a sort.
+     * A trailing '-' is the direction and is stripped before the lookup;
+     * without that every descending sort would be reported as unresolvable.
+     * An empty sort is allowed.
      */
     function sortProblem() {
 
@@ -1751,12 +1717,11 @@ $owa_max        = (int) $view->get('max_widgets');
         var name = sort.replace( /-$/, '' );
 
         if ( ! name ) {
-            return 'The sort is only a direction. Name the metric or dimension to sort by.';
+            return 'The sort names no field.';
         }
 
         if ( ! isKnownName( name ) ) {
-            return '"' + name + '" is not a metric or a dimension, so the widget cannot '
-                 + 'be sorted by it. Use a name from the pickers above.';
+            return '"' + name + '" is not a metric or a dimension.';
         }
 
         return '';
@@ -1765,21 +1730,15 @@ $owa_max        = (int) $view->get('max_widgets');
     /**
      * EVERYTHING WRONG WITH THIS WIDGET, or '' if it is ready.
      *
-     * WHY THE MODAL ENFORCES THIS AND NOT JUST THE CANVAS
+     * Done used to close on anything: the block landed on the canvas marked
+     * unfinished and Save reported it, which meant finding the widget again
+     * two screens later. Checked here, the fields are still open.
      *
-     * A widget used to be able to leave this dialog unconfigured: Done closed
-     * on anything, the block landed on the canvas marked unfinished, and Save
-     * explained it. That is a correct chain and a slow one -- the author is
-     * told about a widget two steps after the screen that was about that
-     * widget, and has to find it again to fix it.
+     * The canvas marking and the Save gate remain for definitions that arrive
+     * already broken, from a report stored before these rules or from a
+     * refusal round-trip.
      *
-     * Asked here, the answer arrives while the fields are still open. The
-     * canvas marking and the Save gate stay, because a definition can also
-     * arrive already broken -- from a report saved before these rules, or from
-     * a refusal round-trip -- and those have to say so too.
-     *
-     * In the order the fields appear, so the message points DOWN the form the
-     * way the author reads it.
+     * Ordered as the fields appear in the form.
      *
      * @return string
      */
@@ -1793,11 +1752,8 @@ $owa_max        = (int) $view->get('max_widgets');
          */
         if ( ! reportMetrics && ! ( jQuery( '#dlgMetrics' ).val() || [] ).length ) {
 
-            return isSingleMetric( type )
-                ? 'Choose the metric this ' + ( TYPES[ type ] || type ).toLowerCase()
-                  + ' draws.'
-                : 'Choose at least one metric. A widget draws what it names, and '
-                  + 'nothing else.';
+            return isSingleMetric( type ) ? 'Choose a metric.'
+                                          : 'Choose at least one metric.';
         }
 
         /*
@@ -1808,9 +1764,7 @@ $owa_max        = (int) $view->get('max_widgets');
         if ( isSingleField( type ) && picksDimensions( type )
              && ! ( jQuery( '#dlgDimensions' ).val() || [] ).length ) {
 
-            return 'Choose the dimension its rows are grouped by. A '
-                 + ( TYPES[ type ] || type ).toLowerCase() + ' draws one, and draws '
-                 + 'nothing without it.';
+            return 'Choose a dimension.';
         }
 
         return sortProblem() || constraintRowProblem();
@@ -1990,13 +1944,24 @@ $owa_max        = (int) $view->get('max_widgets');
         narrowDimensions();
         refreshLinkControl();
         refreshMoreControl();
+        refreshDialogState();
     } );
     jQuery( '#dlgDimensions' ).on( 'change', function () {
         narrowDimensions();
         // Both link lists are per dimension, so they change with it.
         refreshLinkControl();
         refreshMoreControl();
+        refreshDialogState();
     } );
+
+    /*
+     * The sort is free text and the constraint rows are added and removed, so
+     * both are watched by delegation rather than by binding to the controls
+     * that exist right now.
+     */
+    jQuery( '#dlgSort' ).on( 'input', refreshDialogState );
+
+    jQuery( '#dlgConstraintRows' ).on( 'change input click', refreshDialogState );
 
     // Remembered, so rebuilding the select on a dimension change does not lose
     // a choice the author has already made.
@@ -2053,32 +2018,28 @@ $owa_max        = (int) $view->get('max_widgets');
         dialogClass: 'owa_widgetDialogFrame',
         buttons: [
             /*
-             * Closed only if the dialog could be applied. A refused apply
-             * leaves the modal open with the reason on it: the fields that need
-             * filling are in here, and closing would take the author away from
-             * the controls the message is about.
+             * Disabled while the widget is unfinished -- refreshDialogState()
+             * keeps it in step with the fields, and #dlgError says what is
+             * missing. applyDialog() re-checks anyway, so a programmatic click
+             * cannot get past it.
              */
-            { text: 'Done', click: function () {
+            { text: 'Save', click: function () {
                 if ( applyDialog() ) { jQuery( this ).dialog( 'close' ); }
             } },
             { text: 'Cancel', click: function () { editing = null; jQuery( this ).dialog( 'close' ); } }
         ],
 
         /*
-         * BACKING OUT OF A NEW WIDGET UNDOES THE ADD.
+         * Backing out of a newly added widget removes it.
          *
          * The type chooser pushes the widget before this dialog opens, so
-         * without this Cancel leaves an unconfigured block on the canvas -- the
-         * very thing Done now refuses to produce, reachable by pressing the
-         * other button. At the moment it is offered, Cancel means "I did not
-         * mean to add this".
+         * without this Cancel leaves the unconfigured block Done refuses to
+         * produce.
          *
          * On `close` rather than in the Cancel handler, so the titlebar X and
-         * the Escape key do the same thing. A successful Done has already
-         * cleared pendingNew by the time it closes, so this cannot undo a
-         * widget that was actually configured -- and re-opening a widget that
-         * WAS configured never sets pendingNew, so Cancel there reverts the
-         * edit and keeps the widget, which is what Cancel means then.
+         * Escape behave the same. A successful Done clears pendingNew before
+         * closing, and re-opening an existing widget never sets it, so this
+         * only ever removes a widget that was just added and never applied.
          */
         close: function () {
 
@@ -2094,6 +2055,29 @@ $owa_max        = (int) $view->get('max_widgets');
             draw();
         }
     } );
+
+    /*
+     * The dialog's Save button, captured after jQuery UI builds the button
+     * pane. .dialog('widget') is the frame, which is where the pane lives.
+     */
+    var $dlgSaveButton = jQuery( '#widgetDialog' ).dialog( 'widget' )
+        .find( '.ui-dialog-buttonpane button' ).first();
+
+    /** Keep the dialog's Save button and message in step with its fields. */
+    function refreshDialogState() {
+
+        if ( editing === null ) {
+            return;
+        }
+
+        var problem = dialogProblem();
+
+        jQuery( '#dlgError' ).text( problem ).toggle( !! problem );
+
+        $dlgSaveButton
+            .prop( 'disabled', !! problem )
+            .toggleClass( 'ui-state-disabled', !! problem );
+    }
 
     // ------------------------------------------------------------------
     // Wiring

--- a/modules/Base/templates/custom_report_edit.php
+++ b/modules/Base/templates/custom_report_edit.php
@@ -56,32 +56,46 @@ $owa_max        = (int) $view->get('max_widgets');
 
     <div class="owa_builderHeader">
         <div class="owa_builderField">
-            <label for="customReportName">Report name</label>
+            <?php
+                /*
+                 * MARKED REQUIRED, because the placeholder makes an empty one
+                 * look filled in.
+                 *
+                 * "Untitled report" sits in the field greyed out, which reads
+                 * as a default that has already been supplied rather than as an
+                 * example of what to type -- so pressing Save with it untouched
+                 * was the most ordinary mistake there is, and the refusal it
+                 * produced was the least informative page in the application.
+                 */
+            ?>
+            <div class="owa_builderFieldLabel">
+                <label for="customReportName">Report name</label>
+                <span class="owa_builderRequired">Required</span>
+            </div>
             <input type="text" id="customReportName" name="customReportName"
                    placeholder="Untitled report"
                    value="<?php $view->out( $owa_name ); ?>" />
         </div>
 
-        <div class="owa_builderField">
-            <label for="reportMetricSet">Report metric set</label>
-            <?php
-                /*
-                 * Enhanced by CHOSEN, the same control the grid's secondary
-                 * dimension picker uses: type to filter a long list, and each
-                 * thing you pick becomes a pill with its own remove.
-                 *
-                 * The same control rather than one of our own, because a second
-                 * searchable multi-select that behaved almost the same would be
-                 * the kind of difference nobody can justify later.
-                 */
-            ?>
-            <select id="reportMetricSet" class="owa_builderChosen" multiple="multiple"></select>
-            <div class="owa_builderHelp">
-                The metrics this report offers as a whole, independent of any one widget.
-                At most <?php $view->out( (int) $view->get('max_metrics') ); ?>, and they
-                have to be measured in the same place &mdash; the list narrows as you choose.
-            </div>
-        </div>
+        <?php
+            /*
+             * THE REPORT METRIC SET IS NOT ASKED FOR HERE ANY MORE.
+             *
+             * It was a second place to answer "what does this report measure",
+             * beside the one inside every widget, and the two did not compose:
+             * a widget that named nothing inherited the set, so the same
+             * report drew different things depending on a field further up the
+             * page that said nothing about which widget it would land in. An
+             * author reading a widget could not tell what it would show.
+             *
+             * So a widget names its own metrics, always -- see
+             * CustomReports::validateQuery(), which now refuses one that names
+             * none. The key is still READ: a report saved while the control
+             * existed keeps its set, keeps rendering, and keeps validating, and
+             * the script below carries the stored value back out untouched
+             * rather than dropping it on the next save.
+             */
+        ?>
     </div>
 
     <div class="owa_builderSectionHeader">
@@ -96,6 +110,20 @@ $owa_max        = (int) $view->get('max_widgets');
          * being that the layout is legible here rather than only after saving.
          */
     ?>
+    <?php
+        /*
+         * Shown only while the canvas is empty, which for a NEW report is what
+         * it opens as. Server-rendered and hidden rather than built in script,
+         * so it is in the page for a reader whose stylesheet or script is slow
+         * -- and so its words live in the template with the rest of them.
+         */
+    ?>
+    <div id="customReportEmpty" class="owa_builderEmpty" style="display:none;">
+        <span class="owa_builderEmptyTitle">Nothing in this report yet.</span>
+        <span class="owa_builderEmptyBody">A report is its widgets &mdash; a table,
+            a chart, a row of totals. Add at least one; it cannot be saved empty.</span>
+    </div>
+
     <div id="customReportCanvas" class="owa_builderCanvas"></div>
 
     <div class="owa_builderActions">
@@ -106,10 +134,48 @@ $owa_max        = (int) $view->get('max_widgets');
              * site filter brings a form of its own.
              */
         ?>
-        <input type="submit" id="customReportSubmit" class="owa_button" value="Save report" />
+        <?php
+            /*
+             * owa-button, the class every other save form on the installation
+             * uses -- the sibling visualization builder included.
+             *
+             * This said `owa_button`, with an underscore, and NOTHING defines
+             * that: not owa.css, not owa.report.css, not the combined bundle.
+             * So the one affirmative control on the screen rendered as a bare
+             * browser submit while Save Visualization two screens over was the
+             * orange primary, and the difference was invisible in review
+             * because a class name reads as styling whether or not a rule
+             * exists for it.
+             */
+        ?>
+        <?php
+            /*
+             * Disabled in the MARKUP, not only by draw().
+             *
+             * draw() sets this on every canvas change and is the thing that
+             * keeps it right, but it does not run until the script at the foot
+             * of the page does -- so a new report drew an enabled Save for as
+             * long as that took, and pressing it in that window posted an empty
+             * definition. Rendered from the same fact the canvas is rendered
+             * from, there is no window.
+             */
+        ?>
+        <input type="submit" id="customReportSubmit" class="owa-button" value="Save report"
+               <?php echo empty( $owa_definition['widgets'] ) ? 'disabled="disabled"' : ''; ?> />
+
+        <?php
+            /*
+             * WHY Save will not go, next to the button that will not go.
+             *
+             * A disabled control with no explanation is the worst of both: it
+             * says something is wrong and not what. The text is written by
+             * refreshSaveState() from the same rules the server applies.
+             */
+        ?>
+        <span id="customReportBlocker" class="owa_builderBlocker" style="display:none;"></span>
 
         <?php if ( $owa_id ): ?>
-        <a class="owa_button owa_buttonQuiet" href="<?php echo $view->makeLink( array(
+        <a class="owa-button owa-button-quiet" href="<?php echo $view->makeLink( array(
             'do'       => 'base.report',
             'reportId' => 'custom-' . $owa_id,
         ), true ); ?>">View</a>
@@ -271,14 +337,35 @@ $owa_max        = (int) $view->get('max_widgets');
              * widget has no way to draw.
              */
         ?>
+        <?php
+            /*
+             * The "Required" marks are TOGGLED, not written once.
+             *
+             * Which of these must be answered depends on the widget's type --
+             * a card and a pie draw exactly one dimension and are refused
+             * without it, while a grid may name none -- so a mark painted into
+             * the markup would be wrong on half the types. applyTypeRules()
+             * sets them from the same lists the server validates against.
+             *
+             * Kept in a row beside the label rather than inside it, because
+             * that label's text is rewritten per type and would take the mark
+             * with it.
+             */
+        ?>
         <div class="owa_builderField" id="dlgMetricsField">
-            <label for="dlgMetrics" id="dlgMetricsLabel">Metrics</label>
+            <div class="owa_builderFieldLabel">
+                <label for="dlgMetrics" id="dlgMetricsLabel">Metrics</label>
+                <span class="owa_builderRequired" id="dlgMetricsRequired">Required</span>
+            </div>
             <select id="dlgMetrics" class="owa_builderChosen" multiple="multiple"></select>
             <div class="owa_builderHelp" id="dlgMetricsHelp"></div>
         </div>
 
         <div class="owa_builderField" id="dlgDimensionsField">
-            <label for="dlgDimensions" id="dlgDimensionsLabel">Dimensions</label>
+            <div class="owa_builderFieldLabel">
+                <label for="dlgDimensions" id="dlgDimensionsLabel">Dimensions</label>
+                <span class="owa_builderRequired" id="dlgDimensionsRequired">Required</span>
+            </div>
             <select id="dlgDimensions" class="owa_builderChosen" multiple="multiple"></select>
             <div class="owa_builderHelp" id="dlgDimensionsHelp"></div>
         </div>
@@ -355,6 +442,14 @@ $owa_max        = (int) $view->get('max_widgets');
              */
         ?>
         <div id="dlgConstraintRows" class="owa_builderConstraints"><ul></ul></div>
+        <?php
+            /*
+             * Why Done will not close. A half-filled row used to be dropped
+             * silently on the way out, which produced a widget with no filter
+             * and nothing to say one had been asked for.
+             */
+        ?>
+        <div id="dlgConstraintError" class="owa_builderRowError" style="display:none;"></div>
         <div class="owa_builderHelp">
             Rows are combined, e.g. <code>medium</code> is <code>organic-search</code>
             <em>and</em> <code>browserType</code> contains <code>Chrome</code>.
@@ -494,16 +589,13 @@ $owa_max        = (int) $view->get('max_widgets');
     var CHART_TYPES = <?php echo json_encode( array_values( (array) $view->get('chart_types') ) ); ?>;
 
     /*
-     * Types that name their own metrics and cannot fall back to the report
-     * metric set. Used to say so on the form -- an author who leaves the
-     * metrics of a card empty is not going to inherit anything, they are going
-     * to be refused on save.
+     * OWN_METRIC_TYPES used to be read here, to say on the form which types
+     * could not fall back to the report metric set. Nothing falls back any
+     * more -- every widget names its own -- so the distinction has nothing left
+     * to tell an author, and the list is not sent. The constant still exists
+     * server-side, where it is what makes the refusal for those types say the
+     * more precise thing.
      */
-    var OWN_METRIC_TYPES = <?php echo json_encode( array_values( (array) $view->get('own_metric_types') ) ); ?>;
-
-    function needsOwnMetrics( type ) {
-        return OWN_METRIC_TYPES.indexOf( type ) !== -1;
-    }
 
     /*
      * The grid the report is drawn on. These mirror Core\ReportGrid, which
@@ -578,11 +670,29 @@ $owa_max        = (int) $view->get('max_widgets');
      */
     var widgets = ( definition && definition.widgets ) ? definition.widgets.slice() : [];
 
-    // A new report starts from one block. A report with no widgets cannot be
-    // saved, and an empty canvas gives the author nothing to press.
-    if ( ! widgets.length ) {
-        widgets = [ newWidget( 0, 'grid' ) ];
-    }
+    /*
+     * A NEW REPORT STARTS EMPTY.
+     *
+     * It used to start from one table block, so the canvas was never blank --
+     * and the cost of that was a report you could save without having decided
+     * anything. The block was already named, already a table, already the right
+     * width; pressing Save produced a report with a table of nothing in it, and
+     * the author had answered no question to get there.
+     *
+     * Empty, the first thing on the screen is the choice that actually starts a
+     * report: what kind of widget. Save is refused until one exists, here and
+     * on the server both.
+     */
+
+    /*
+     * The report-level metric set, as it was stored.
+     *
+     * Not editable any more -- see the note where the control used to be -- but
+     * carried so that saving a report built before it was withdrawn does not
+     * silently strip it. Read once, written back on submit, never looked at in
+     * between.
+     */
+    var reportMetrics = ( definition && definition.metrics ) ? definition.metrics : '';
 
     var editing = null;   // index of the widget the dialog is open on
 
@@ -812,12 +922,15 @@ $owa_max        = (int) $view->get('max_widgets');
      * list from the select and only re-reads it on chosen:updated. An option
      * left in place but unusable would still appear in the search results.
      */
-    function narrowMetrics( selector ) {
+    function narrowMetrics() {
 
-        var $select  = jQuery( selector );
+        var $select  = jQuery( '#dlgMetrics' );
         var selected = $select.val() || [];
 
-        var full = selected.length >= ( selector === '#dlgMetrics' ? maxMetrics() : MAX_METRICS );
+        // The widget's own cap, which depends on its type. It used to also
+        // serve the report metric set, whose cap was MAX_METRICS flat; that
+        // control is gone, so there is one caller and one cap.
+        var full = selected.length >= maxMetrics();
 
         var allowed = METRICS.filter( function ( choice ) {
 
@@ -836,7 +949,7 @@ $owa_max        = (int) $view->get('max_widgets');
 
         fillChoices( $select, allowed, selected );
 
-        chosenSync( selector );
+        chosenSync( '#dlgMetrics' );
     }
 
     /**
@@ -913,11 +1026,26 @@ $owa_max        = (int) $view->get('max_widgets');
                 .append( jQuery( '<span class="owa_builderBlockSpan">' )
                     .text( colspan + ' × ' + rowspan ) ) );
 
-            var summary = names( widget.query && widget.query.metrics )
+            var summary = widgetMetrics( widget )
                 .concat( names( widget.query && widget.query.dimensions ) );
 
+            /*
+             * A block that names no metrics is marked ON THE CANVAS, not only
+             * in the sentence under the Save button. The canvas is where an
+             * author is looking, and "Widget 3 does not say what it measures"
+             * is only useful if Widget 3 can be picked out of a row of blocks.
+             *
+             * Not marked at all where a report metric set exists, because there
+             * the widget is inheriting rather than unfinished -- the same
+             * exception the server makes.
+             */
+            if ( ! reportMetrics && ! widgetMetrics( widget ).length ) {
+
+                $block.addClass( 'owa_builderBlockIncomplete' );
+            }
+
             $block.append( jQuery( '<div class="owa_builderBlockSummary">' )
-                .text( summary.length ? summary.join( ', ' ) : 'Nothing configured yet' ) );
+                .text( summary.length ? summary.join( ', ' ) : 'No metrics chosen yet' ) );
 
             $block.append( jQuery( '<a href="#" class="owa_builderEdit">' ).text( 'Edit' ) );
 
@@ -932,7 +1060,101 @@ $owa_max        = (int) $view->get('max_widgets');
                     .append( jQuery( '<span>' ).text( 'Add widget' ) ) );
         }
 
+        /*
+         * WHAT AN EMPTY CANVAS SAYS.
+         *
+         * The plus alone is a control, not an instruction: on a blank screen it
+         * reads as one option among others rather than as the only thing there
+         * is to do. So an empty canvas says what a report is made of and that
+         * it needs at least one, beside a plus that is now the obvious target.
+         *
+         * Drawn as a sibling of the plus rather than replacing it, because the
+         * plus is where the widget will appear -- moving it for the empty case
+         * would make the first widget land somewhere other than where it was
+         * added.
+         */
+        $canvas.toggleClass( 'owa_builderCanvasEmpty', ! widgets.length );
+
+        jQuery( '#customReportEmpty' ).toggle( ! widgets.length );
+
         jQuery( '#widgetBudget' ).text( widgets.length + ' of ' + MAX + ' widgets' );
+
+        refreshSaveState();
+    }
+
+    /**
+     * Why this report cannot be saved yet, or '' if it can.
+     *
+     * THE SAME RULES THE SERVER APPLIES, asked before the round trip rather
+     * than instead of it. Every one of these is refused by
+     * CustomReports::validate() or by the save controller's own validate(); the
+     * point of asking here is that the author is told while the thing they have
+     * to fix is still in front of them.
+     *
+     * In the order an author would fix them: something to save, a name for it,
+     * then whether each widget says what it measures.
+     */
+    function saveBlocker() {
+
+        if ( ! widgets.length ) {
+            return 'Add at least one widget before saving.';
+        }
+
+        /*
+         * The NAME. Required by CustomReportSave::validate(), and the field
+         * carries a placeholder -- "Untitled report" -- which reads as a value
+         * that is already there. Leaving it empty was the one refusal an author
+         * could hit without having done anything they would recognise as wrong.
+         */
+        if ( ! jQuery.trim( jQuery( '#customReportName' ).val() || '' ) ) {
+            return 'Give the report a name before saving.';
+        }
+
+        /*
+         * ...and every widget names its own metrics.
+         *
+         * Unless the report carries a metric set from before that control was
+         * withdrawn, which is the one case the server still lets inherit -- the
+         * builder has to allow exactly what the server allows, or it refuses an
+         * old report its author cannot fix.
+         */
+        if ( ! reportMetrics ) {
+
+            for ( var i = 0; i < widgets.length; i++ ) {
+
+                if ( ! widgetMetrics( widgets[ i ] ).length ) {
+
+                    return ( widgets[ i ].title || ( 'Widget ' + ( i + 1 ) ) )
+                         + ' does not say what it measures. Open it and choose a metric.';
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /** The metric names one widget asks for. */
+    function widgetMetrics( widget ) {
+
+        return names( widget && widget.query && widget.query.metrics );
+    }
+
+    /**
+     * Save is available exactly when the report could actually be stored.
+     *
+     * Disabled rather than hidden: the button is where an author expects it,
+     * and the sentence beside it says why it will not go yet. A control that
+     * vanishes reads as a page that has not finished loading.
+     */
+    function refreshSaveState() {
+
+        var blocker = saveBlocker();
+
+        jQuery( '#customReportSubmit' )
+            .prop( 'disabled', !! blocker )
+            .attr( 'title', blocker );
+
+        jQuery( '#customReportBlocker' ).text( blocker ).toggle( !! blocker );
     }
 
     // ------------------------------------------------------------------
@@ -942,6 +1164,9 @@ $owa_max        = (int) $view->get('max_widgets');
     function openDialog( index ) {
 
         editing = index;
+
+        // A refusal from last time is not about this widget.
+        jQuery( '#dlgConstraintError' ).text( '' ).hide();
 
         var widget = widgets[ index ];
         var query  = widget.query || {};
@@ -1044,26 +1269,49 @@ $owa_max        = (int) $view->get('max_widgets');
         jQuery( '#dlgMetricsLabel' ).text( oneMetric ? 'Metric' : 'Metrics' );
 
         /*
-         * "Leave empty to use the report metric set" is only true where it IS
-         * an option. A type that names its own metrics has no fallback -- an
-         * author who left the field empty on the strength of that sentence
-         * would be refused on save, by the rule the sentence contradicted.
+         * THERE IS NO LONGER ANYTHING TO LEAVE THIS EMPTY FOR.
+         *
+         * The sentence here used to be "Leave empty to use the report metric
+         * set" on every type that could inherit one, and a contradiction of it
+         * on the types that could not. With the set withdrawn from the builder
+         * the first half is an offer nothing fulfils -- an author who took it
+         * would be refused on save -- so both halves go and the field says the
+         * one thing that is now true of every type: it has to be answered.
          */
-        var setFallback = needsOwnMetrics( type )
-            ? ' A ' + name.toLowerCase() + ' names its own; it does not take the report metric set.'
-            : ' Leave empty to use the report metric set.';
+        var required = ' Required: a widget draws what it names, and nothing else.';
+
+        /*
+         * ...and the mark beside the label says the same thing at a glance.
+         *
+         * Metrics are required on every type UNLESS the report carries a metric
+         * set from before that control was withdrawn -- the one case the server
+         * still lets a widget inherit. Marking it required there would be
+         * telling an author to fill a field they can legitimately leave alone.
+         */
+        jQuery( '#dlgMetricsRequired' ).toggle( ! reportMetrics );
 
         jQuery( '#dlgMetricsHelp' ).text( oneMetric
-            ? 'The one metric this ' + name.toLowerCase() + ' draws.'
+            ? 'The one metric this ' + name.toLowerCase() + ' draws.' + required
             : ( type === 'trend' || type === 'trend-card'
                 ? 'Up to ' + MAX_METRICS + '. The first is charted; all of them are '
                   + 'drawn as boxes ' + ( type === 'trend-card' ? 'above' : 'under' ) + ' it.'
-                  + setFallback
-                : 'Up to ' + MAX_METRICS + '.' + setFallback ) );
+                  + required
+                : 'Up to ' + MAX_METRICS + '.' + required ) );
 
         var fixed = fixedDimension( type );
 
         jQuery( '#dlgDimensionsField' ).toggle( picksDimensions( type ) );
+
+        /*
+         * A dimension is REQUIRED exactly where the type draws exactly one --
+         * a card ranks rows by it, a pie divides by it, and neither renders
+         * without it. SINGLE_FIELD_TYPES is the server's own list, so the mark
+         * cannot come to disagree with the rule that enforces it.
+         *
+         * Everywhere else it is optional: a grid may be a row of totals, and a
+         * trend's breakdown is an addition to a chart that draws without one.
+         */
+        jQuery( '#dlgDimensionsRequired' ).toggle( single );
 
         if ( fixed !== null ) {
 
@@ -1098,7 +1346,7 @@ $owa_max        = (int) $view->get('max_widgets');
         // A sort orders rows, and these types have none to order.
         jQuery( '#dlgSortField' ).toggle( picksDimensions( type ) );
 
-        narrowMetrics( '#dlgMetrics' );
+        narrowMetrics();
 
         if ( picksDimensions( type ) ) {
             narrowDimensions();
@@ -1363,13 +1611,23 @@ $owa_max        = (int) $view->get('max_widgets');
         } );
     }
 
+    /** One constraint row read off its controls. */
+    function readConstraintRow( row ) {
+
+        return {
+            name:  jQuery( row ).find( 'select.dim-list' ).val() || '',
+            op:    jQuery( row ).find( 'select.operator-list' ).val() || '==',
+            value: jQuery.trim( jQuery( row ).children( '.constraintValueField' ).val() || '' )
+        };
+    }
+
     /**
      * The rows, back as the stored string.
      *
-     * A row with no dimension or no value contributes NOTHING -- it filters
-     * nothing, and writing `==` into the definition would be a clause the
-     * server then has to reject. That is also what lets the form always carry
-     * one empty row without it meaning anything.
+     * A COMPLETELY empty row contributes nothing, which is what lets the form
+     * always carry a blank one without it meaning anything. A HALF-filled row
+     * is a different thing and is not silently dropped -- see
+     * constraintRowProblem(), which stops the dialog closing on one.
      */
     function readConstraintRows() {
 
@@ -1377,22 +1635,87 @@ $owa_max        = (int) $view->get('max_widgets');
 
         jQuery( '#dlgConstraintRows > ul > li' ).each( function () {
 
-            var name  = jQuery( this ).find( 'select.dim-list' ).val();
-            var op    = jQuery( this ).find( 'select.operator-list' ).val();
-            var value = jQuery.trim( jQuery( this ).children( '.constraintValueField' ).val() || '' );
+            var part = readConstraintRow( this );
 
-            if ( name && value ) {
-                out.push( name + ( op || '==' ) + value );
+            if ( part.name && part.value ) {
+                out.push( part.name + part.op + part.value );
             }
         } );
 
         return out.join( ',' );
     }
 
+    /**
+     * What is wrong with the constraint rows, or '' if nothing is.
+     *
+     * A HALF-FILLED ROW USED TO VANISH.
+     *
+     * readConstraintRows() keeps a row only when it has both a dimension and a
+     * value, and dropped anything else without a word. So an author who chose
+     * `medium`, chose an operator and then tabbed past the value -- or typed a
+     * value and never picked the dimension -- got a widget with no filter on
+     * it, no message, and no way to tell it apart from one they had never
+     * filtered. The query engine treats exactly this as an error worth refusing
+     * ("a missing value is not a request for everything"); the builder treated
+     * it as nothing.
+     *
+     * An entirely blank row is still nothing, because there is always one on
+     * the form and it does not mean the author left something out.
+     */
+    function constraintRowProblem() {
+
+        var problem = '';
+
+        jQuery( '#dlgConstraintRows > ul > li' ).each( function ( i ) {
+
+            if ( problem ) {
+                return;
+            }
+
+            var part = readConstraintRow( this );
+
+            // Untouched. There is always one of these.
+            if ( ! part.name && ! part.value ) {
+                return;
+            }
+
+            if ( ! part.name ) {
+                problem = 'Constraint ' + ( i + 1 ) + ' has a value but no dimension. '
+                        + 'Choose what to constrain on, or clear the value.';
+                return;
+            }
+
+            if ( ! part.value ) {
+                problem = 'Constraint ' + ( i + 1 ) + ' constrains on ' + part.name
+                        + ' but gives no value. An empty value is not a request for '
+                        + 'everything -- fill it in, or remove the row.';
+            }
+        } );
+
+        return problem;
+    }
+
+    /**
+     * Write the dialog back onto the widget.
+     *
+     * Returns FALSE when it refused to, which is what stops Done closing on a
+     * half-filled constraint row -- the row is the thing that needs fixing and
+     * it is inside this dialog, so closing would hide it.
+     *
+     * @return bool
+     */
     function applyDialog() {
 
         if ( editing === null ) {
-            return;
+            return true;
+        }
+
+        var problem = constraintRowProblem();
+
+        jQuery( '#dlgConstraintError' ).text( problem ).toggle( !! problem );
+
+        if ( problem ) {
+            return false;
         }
 
         var widget = widgets[ editing ];
@@ -1531,6 +1854,8 @@ $owa_max        = (int) $view->get('max_widgets');
         editing = null;
 
         draw();
+
+        return true;
     }
 
     chosenify( '#dlgMetrics' );
@@ -1538,7 +1863,7 @@ $owa_max        = (int) $view->get('max_widgets');
 
     // Choosing a metric changes what else is askable alongside it.
     jQuery( '#dlgMetrics' ).on( 'change', function () {
-        narrowMetrics( '#dlgMetrics' );
+        narrowMetrics();
         // Choosing a metric can rule dimensions out, so both are redrawn.
         narrowDimensions();
         refreshLinkControl();
@@ -1560,8 +1885,6 @@ $owa_max        = (int) $view->get('max_widgets');
     jQuery( '#dlgMoreReport' ).on( 'change', function () {
         dialogMore = jQuery( this ).val() || '';
     } );
-
-    jQuery( '#reportMetricSet' ).on( 'change', function () { narrowMetrics( '#reportMetricSet' ); } );
 
     jQuery( '#typeDialog' ).dialog( {
         autoOpen: false,
@@ -1607,7 +1930,15 @@ $owa_max        = (int) $view->get('max_widgets');
         // dialog chrome cannot be styled through #widgetDialog alone.
         dialogClass: 'owa_widgetDialogFrame',
         buttons: [
-            { text: 'Done', click: function () { applyDialog(); jQuery( this ).dialog( 'close' ); } },
+            /*
+             * Closed only if the dialog could be applied. A refused apply
+             * leaves the modal open with the reason on it: the row that needs
+             * fixing is in here, and closing would take the author away from
+             * the one control the message is about.
+             */
+            { text: 'Done', click: function () {
+                if ( applyDialog() ) { jQuery( this ).dialog( 'close' ); }
+            } },
             { text: 'Cancel', click: function () { editing = null; jQuery( this ).dialog( 'close' ); } }
         ]
     } );
@@ -1628,12 +1959,16 @@ $owa_max        = (int) $view->get('max_widgets');
 
             widgets.splice( index, 1 );
 
-            // A report with no widgets cannot be saved, so removing the last
-            // one leaves a fresh block rather than an empty canvas.
-            if ( ! widgets.length ) {
-                widgets = [ newWidget( 0 ) ];
-            }
-
+            /*
+             * Removing the last one leaves the canvas EMPTY.
+             *
+             * It used to put a fresh block back, on the reasoning that a report
+             * with no widgets cannot be saved and so an empty canvas is a dead
+             * end. It is not a dead end -- the plus is right there -- and the
+             * replacement was worse than the emptiness: an author who removed a
+             * widget got another one, of a type they had not chosen, which then
+             * had to be removed as well.
+             */
             draw();
         } )
         .on( 'click', '#addWidget', function ( e ) {
@@ -1667,22 +2002,42 @@ $owa_max        = (int) $view->get('max_widgets');
         openDialog( widgets.length - 1 );
     } );
 
-    fillChoices( jQuery( '#reportMetricSet' ), METRICS, names( definition.metrics ) );
-
-    chosenify( '#reportMetricSet' );
-
-    narrowMetrics( '#reportMetricSet' );
+    /*
+     * The name is one of the things Save waits for, so it is re-checked as it
+     * is typed rather than only when a widget changes.
+     */
+    jQuery( '#customReportName' ).on( 'input', refreshSaveState );
 
     // The definition is assembled at submit rather than kept in step with every
     // keystroke: one place it is built means one place it can be wrong.
-    jQuery( '#customReportForm' ).on( 'submit', function () {
+    jQuery( '#customReportForm' ).on( 'submit', function ( e ) {
+
+        /*
+         * A disabled Save is not the whole guard.
+         *
+         * Pressing Enter in a text field submits the form whether or not there
+         * is a submit button to press, so an unsaveable report could still be
+         * posted. Stopped here, the reason stays on the screen beside the
+         * button instead of the author being sent to a refusal page.
+         */
+        if ( saveBlocker() ) {
+
+            e.preventDefault();
+
+            refreshSaveState();
+
+            return false;
+        }
 
         var built = { title: jQuery( '#customReportName' ).val(), widgets: [] };
 
-        var metricSet = jQuery( '#reportMetricSet' ).val() || [];
-
-        if ( metricSet.length ) {
-            built.metrics = metricSet.join( ',' );
+        /*
+         * Whatever set the report already had, unchanged. There is no control
+         * for it, so there is nothing to read -- the stored value is simply
+         * passed through, which is what stops a rename from stripping it.
+         */
+        if ( reportMetrics ) {
+            built.metrics = reportMetrics;
         }
 
         widgets.forEach( function ( widget, i ) {

--- a/modules/Base/templates/custom_report_edit.php
+++ b/modules/Base/templates/custom_report_edit.php
@@ -442,19 +442,23 @@ $owa_max        = (int) $view->get('max_widgets');
              */
         ?>
         <div id="dlgConstraintRows" class="owa_builderConstraints"><ul></ul></div>
-        <?php
-            /*
-             * Why Done will not close. A half-filled row used to be dropped
-             * silently on the way out, which produced a widget with no filter
-             * and nothing to say one had been asked for.
-             */
-        ?>
-        <div id="dlgConstraintError" class="owa_builderRowError" style="display:none;"></div>
         <div class="owa_builderHelp">
             Rows are combined, e.g. <code>medium</code> is <code>organic-search</code>
             <em>and</em> <code>browserType</code> contains <code>Chrome</code>.
         </div>
     </div>
+
+    <?php
+        /*
+         * WHY DONE WILL NOT CLOSE.
+         *
+         * One message for the whole dialog rather than one per field. It names
+         * the field it is about -- "Choose at least one metric", "Constraint 1
+         * ... gives no value" -- and it sits at the foot, next to the button
+         * that just refused, which is where the eye is at that moment.
+         */
+    ?>
+    <div id="dlgError" class="owa_builderRowError" style="display:none;" role="alert"></div>
 </div>
 
 <script>
@@ -695,6 +699,19 @@ $owa_max        = (int) $view->get('max_widgets');
     var reportMetrics = ( definition && definition.metrics ) ? definition.metrics : '';
 
     var editing = null;   // index of the widget the dialog is open on
+
+    /*
+     * The widget the type chooser just added, which has never been applied.
+     *
+     * The chooser pushes a widget and draws it BEFORE the dialog opens, so
+     * backing out of that dialog has to undo the add -- otherwise Cancel is the
+     * way to create exactly the unconfigured block Done refuses to make, and
+     * the rule is decoration.
+     *
+     * Held here rather than as a flag ON the widget, because a flag would be
+     * copied into the posted definition by the submit handler and stored.
+     */
+    var pendingNew = null;
 
     /*
      * The report the widget's rows link to, as the dialog was opened.
@@ -1166,7 +1183,7 @@ $owa_max        = (int) $view->get('max_widgets');
         editing = index;
 
         // A refusal from last time is not about this widget.
-        jQuery( '#dlgConstraintError' ).text( '' ).hide();
+        jQuery( '#dlgError' ).text( '' ).hide();
 
         var widget = widgets[ index ];
         var query  = widget.query || {};
@@ -1695,12 +1712,116 @@ $owa_max        = (int) $view->get('max_widgets');
         return problem;
     }
 
+    /** Whether a name is one the reporting registry knows. */
+    function isKnownName( name ) {
+
+        var all = METRICS.concat( DIMENSIONS );
+
+        for ( var i = 0; i < all.length; i++ ) {
+
+            if ( all[ i ].name === name ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * What is wrong with the SORT, or '' if nothing is.
+     *
+     * The one field in this dialog an author types into freely, and so the one
+     * that could still reach the server as a name that does not resolve -- a
+     * refusal two steps later, on a page about a widget rather than showing
+     * them one. The registry is already in the page for the pickers, so the
+     * same answer is available here.
+     *
+     * A trailing '-' is the DIRECTION, not part of the name, and is stripped
+     * before the lookup: without that, every descending sort would be reported
+     * as unresolvable. Empty is fine -- a widget need not name a sort.
+     */
+    function sortProblem() {
+
+        var sort = jQuery.trim( jQuery( '#dlgSort' ).val() || '' );
+
+        if ( ! sort || ! picksDimensions( editingType() ) ) {
+            return '';
+        }
+
+        var name = sort.replace( /-$/, '' );
+
+        if ( ! name ) {
+            return 'The sort is only a direction. Name the metric or dimension to sort by.';
+        }
+
+        if ( ! isKnownName( name ) ) {
+            return '"' + name + '" is not a metric or a dimension, so the widget cannot '
+                 + 'be sorted by it. Use a name from the pickers above.';
+        }
+
+        return '';
+    }
+
+    /**
+     * EVERYTHING WRONG WITH THIS WIDGET, or '' if it is ready.
+     *
+     * WHY THE MODAL ENFORCES THIS AND NOT JUST THE CANVAS
+     *
+     * A widget used to be able to leave this dialog unconfigured: Done closed
+     * on anything, the block landed on the canvas marked unfinished, and Save
+     * explained it. That is a correct chain and a slow one -- the author is
+     * told about a widget two steps after the screen that was about that
+     * widget, and has to find it again to fix it.
+     *
+     * Asked here, the answer arrives while the fields are still open. The
+     * canvas marking and the Save gate stay, because a definition can also
+     * arrive already broken -- from a report saved before these rules, or from
+     * a refusal round-trip -- and those have to say so too.
+     *
+     * In the order the fields appear, so the message points DOWN the form the
+     * way the author reads it.
+     *
+     * @return string
+     */
+    function dialogProblem() {
+
+        var type = editingType();
+
+        /*
+         * Metrics, unless the report carries a set from before that control was
+         * withdrawn -- the one case the server still lets a widget inherit.
+         */
+        if ( ! reportMetrics && ! ( jQuery( '#dlgMetrics' ).val() || [] ).length ) {
+
+            return isSingleMetric( type )
+                ? 'Choose the metric this ' + ( TYPES[ type ] || type ).toLowerCase()
+                  + ' draws.'
+                : 'Choose at least one metric. A widget draws what it names, and '
+                  + 'nothing else.';
+        }
+
+        /*
+         * A dimension, on the types that draw exactly one and render nothing
+         * without it. SINGLE_FIELD_TYPES is the server's list, so this cannot
+         * come to disagree with the rule that enforces it.
+         */
+        if ( isSingleField( type ) && picksDimensions( type )
+             && ! ( jQuery( '#dlgDimensions' ).val() || [] ).length ) {
+
+            return 'Choose the dimension its rows are grouped by. A '
+                 + ( TYPES[ type ] || type ).toLowerCase() + ' draws one, and draws '
+                 + 'nothing without it.';
+        }
+
+        return sortProblem() || constraintRowProblem();
+    }
+
     /**
      * Write the dialog back onto the widget.
      *
      * Returns FALSE when it refused to, which is what stops Done closing on a
-     * half-filled constraint row -- the row is the thing that needs fixing and
-     * it is inside this dialog, so closing would hide it.
+     * widget that is not finished -- the fields that need filling are in this
+     * dialog, so closing would hide them.
      *
      * @return bool
      */
@@ -1710,9 +1831,9 @@ $owa_max        = (int) $view->get('max_widgets');
             return true;
         }
 
-        var problem = constraintRowProblem();
+        var problem = dialogProblem();
 
-        jQuery( '#dlgConstraintError' ).text( problem ).toggle( !! problem );
+        jQuery( '#dlgError' ).text( problem ).toggle( !! problem );
 
         if ( problem ) {
             return false;
@@ -1851,7 +1972,8 @@ $owa_max        = (int) $view->get('max_widgets');
             delete widget.more;
         }
 
-        editing = null;
+        editing    = null;
+        pendingNew = null;
 
         draw();
 
@@ -1932,15 +2054,45 @@ $owa_max        = (int) $view->get('max_widgets');
         buttons: [
             /*
              * Closed only if the dialog could be applied. A refused apply
-             * leaves the modal open with the reason on it: the row that needs
-             * fixing is in here, and closing would take the author away from
-             * the one control the message is about.
+             * leaves the modal open with the reason on it: the fields that need
+             * filling are in here, and closing would take the author away from
+             * the controls the message is about.
              */
             { text: 'Done', click: function () {
                 if ( applyDialog() ) { jQuery( this ).dialog( 'close' ); }
             } },
             { text: 'Cancel', click: function () { editing = null; jQuery( this ).dialog( 'close' ); } }
-        ]
+        ],
+
+        /*
+         * BACKING OUT OF A NEW WIDGET UNDOES THE ADD.
+         *
+         * The type chooser pushes the widget before this dialog opens, so
+         * without this Cancel leaves an unconfigured block on the canvas -- the
+         * very thing Done now refuses to produce, reachable by pressing the
+         * other button. At the moment it is offered, Cancel means "I did not
+         * mean to add this".
+         *
+         * On `close` rather than in the Cancel handler, so the titlebar X and
+         * the Escape key do the same thing. A successful Done has already
+         * cleared pendingNew by the time it closes, so this cannot undo a
+         * widget that was actually configured -- and re-opening a widget that
+         * WAS configured never sets pendingNew, so Cancel there reverts the
+         * edit and keeps the widget, which is what Cancel means then.
+         */
+        close: function () {
+
+            if ( pendingNew === null ) {
+                return;
+            }
+
+            widgets.splice( pendingNew, 1 );
+
+            pendingNew = null;
+            editing    = null;
+
+            draw();
+        }
     } );
 
     // ------------------------------------------------------------------
@@ -1998,7 +2150,11 @@ $owa_max        = (int) $view->get('max_widgets');
         jQuery( '#typeDialog' ).dialog( 'close' );
 
         // Straight into configuring it: the type was a question about what to
-        // build, not a step of its own.
+        // build, not a step of its own. Recorded as pending, so backing out of
+        // that dialog undoes the add rather than leaving a block nobody chose
+        // to make.
+        pendingNew = widgets.length - 1;
+
         openDialog( widgets.length - 1 );
     } );
 

--- a/modules/Base/templates/visualization_edit.php
+++ b/modules/Base/templates/visualization_edit.php
@@ -33,7 +33,7 @@ and where they left.</div>
       action="<?php echo $view->makeLink( array( 'do' => 'base.visualizationSave' ) );?>">
 
     <div class="setting">
-        <div class="title">Name</div>
+        <div class="title">Name <span class="owa_builderRequired">Required</span></div>
         <div class="description">What this is called in the Visualizations list and its own
         heading.</div>
         <div class="field">
@@ -73,7 +73,7 @@ and where they left.</div>
     </div>
 
     <div class="setting">
-        <div class="title">Steps</div>
+        <div class="title">Steps <span class="owa_builderRequired">Required</span></div>
         <div class="description">In order, first to last. A step is either a page &mdash; matched
         on its path &mdash; or one of this Property's goal events, which counts a step exactly
         where that goal event would have counted a conversion. A step with nothing chosen is
@@ -84,8 +84,36 @@ and where they left.</div>
             /* Always one row, or there is nowhere to type the first step. */
             $owa_steps = $view->steps ?: array( array( 'name' => '', 'path' => '' ) );
             ?>
-            <?php foreach ( $owa_steps as $owa_step ):?>
-            <?php $owa_stepGoal = (string) ( $owa_step['goal_event_id'] ?? '' );?>
+            <?php
+                /*
+                 * Which error keys have been shown, so the catch-all below can
+                 * show anything left over.
+                 */
+                $owa_shownErrors = array( 'name' => true );
+            ?>
+            <?php foreach ( $owa_steps as $owa_stepIndex => $owa_step ):?>
+            <?php
+                $owa_stepGoal = (string) ( $owa_step['goal_event_id'] ?? '' );
+                $owa_stepNo   = (int) $owa_stepIndex + 1;
+
+                /*
+                 * This step's messages, keyed the way VisualizationSave::validate()
+                 * writes them.
+                 */
+                $owa_stepErrors = array();
+
+                foreach ( array( 'stepName', 'stepPath', 'stepGoalEvent' ) as $owa_key ) {
+
+                    $owa_field = $owa_key . $owa_stepNo;
+
+                    $owa_shownErrors[ $owa_field ] = true;
+
+                    if ( ! empty( $view->validation_errors[ $owa_field ] ) ) {
+
+                        $owa_stepErrors[] = $view->validation_errors[ $owa_field ];
+                    }
+                }
+            ?>
                 <li class="constraintRow owa_funnelStep">
                     <input class="constraintValueField owa_funnelStepName" type="text"
                            placeholder="Step name"
@@ -132,12 +160,31 @@ and where they left.</div>
                           title="Add another step" aria-label="Add another step">+</span>
                     <span class="constraintRemoveButton" role="button" tabindex="0"
                           title="Remove this step" aria-label="Remove this step">X</span>
+                    <?php foreach ( $owa_stepErrors as $owa_stepError ):?>
+                    <span class="validation_error owa_funnelStepError"><?php
+                        $view->out( $owa_stepError );?></span>
+                    <?php endforeach;?>
                 </li>
             <?php endforeach;?>
             </ul>
-            <span class="validation_error"><?php $view->out( $view->validation_errors['stepPath1'] ?? '' );?></span>
-            <span class="validation_error"><?php $view->out( $view->validation_errors['stepName1'] ?? '' );?></span>
-            <span class="validation_error"><?php $view->out( $view->validation_errors['stepGoalEvent1'] ?? '' );?></span>
+            <?php
+                /*
+                 * Anything the rows did not show.
+                 *
+                 * This used to be three hardcoded keys -- stepPath1, stepName1,
+                 * stepGoalEvent1 -- so a message about step 2 or later was
+                 * written by validate(), refused the save, and then appeared
+                 * nowhere. The author got the form back with no reason on it.
+                 *
+                 * Driven off the errors themselves now, so a key added to
+                 * validate() cannot go unrendered.
+                 */
+                $owa_otherErrors = array_diff_key(
+                    (array) $view->validation_errors, $owa_shownErrors );
+            ?>
+            <?php foreach ( $owa_otherErrors as $owa_otherError ):?>
+            <span class="validation_error"><?php $view->out( $owa_otherError );?></span>
+            <?php endforeach;?>
         </div>
     </div>
 
@@ -157,7 +204,17 @@ and where they left.</div>
          */
     ?>
     <input type="hidden" name="siteId" value="<?php $view->out( $view->get('siteId') );?>">
-    <input class="owa-button" type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Save Visualization">
+    <input class="owa-button" type="submit" id="owa_visualizationSubmit"
+           name="<?php echo $view->getNs();?>submit_btn" value="Save Visualization">
+
+    <?php
+        /*
+         * Why Save is unavailable. Written by the script below; the server
+         * validates the same rules either way, so a browser running none of
+         * this still saves and is still refused with a reason.
+         */
+    ?>
+    <span id="owa_visualizationBlocker" class="owa_builderBlocker" style="display:none;"></span>
 </form>
 
 <?php if ( ! empty( $owa_v['id'] ) ):?>
@@ -228,5 +285,118 @@ jQuery( function () {
 
         syncStep( this );
     } );
+
+    /*
+     * The same rules VisualizationSave::validate() applies, checked before the
+     * round trip rather than instead of it.
+     *
+     * A row left entirely blank is ignored, here and there -- the form always
+     * carries one, and the description says so. A row with anything in it has
+     * to be complete.
+     */
+    var MAX_STEPS = <?php echo (int) ( $view->maxSteps ?: 10 ); ?>;
+
+    /** One step row read off its controls. */
+    function readStep( row ) {
+
+        var $row = jQuery( row );
+
+        return {
+            name: jQuery.trim( $row.find( '.owa_funnelStepName' ).val() || '' ),
+            kind: $row.find( '.owa_funnelStepKind' ).val() || 'path',
+            path: jQuery.trim( $row.find( '.owa_funnelStepPath' ).val() || '' ),
+            goal: $row.find( '.owa_funnelStepGoal' ).val() || ''
+        };
+    }
+
+    /** Why this funnel cannot be saved yet, or '' if it can. */
+    function visualizationBlocker() {
+
+        if ( ! jQuery.trim( jQuery( 'input[name$="name"]' ).not( '[type=hidden]' ).first().val() || '' ) ) {
+            return 'Give the visualization a name.';
+        }
+
+        var rows    = jQuery( '#owa_goalEventFunnel .constraintRow' );
+        var problem = '';
+        var kept    = 0;
+
+        rows.each( function ( i ) {
+
+            var step  = readStep( this );
+            var value = step.kind === 'goal_event' ? step.goal : step.path;
+
+            // Untouched, so not a mistake.
+            if ( ! step.name && ! value ) {
+                return;
+            }
+
+            kept++;
+
+            if ( problem ) {
+                return;
+            }
+
+            if ( ! step.name ) {
+                problem = 'Step ' + ( i + 1 ) + ' has no name.';
+
+            } else if ( ! value ) {
+                problem = step.kind === 'goal_event'
+                    ? 'Step ' + ( i + 1 ) + ' has no goal event.'
+                    : 'Step ' + ( i + 1 ) + ' has no path.';
+
+            } else if ( step.kind !== 'goal_event' && /^[a-z][a-z0-9+.\-]*:\/\//i.test( step.path ) ) {
+                // Matched on the path alone, so a full address matches nothing.
+                problem = 'Step ' + ( i + 1 ) + ' needs a path, such as /basket, not a full '
+                        + 'web address.';
+            }
+        } );
+
+        if ( problem ) {
+            return problem;
+        }
+
+        if ( ! kept ) {
+            return 'Add at least one step.';
+        }
+
+        if ( kept > MAX_STEPS ) {
+            return 'A funnel can have at most ' + MAX_STEPS + ' steps; this one has ' + kept + '.';
+        }
+
+        return '';
+    }
+
+    function refreshVisualizationState() {
+
+        var blocker = visualizationBlocker();
+
+        jQuery( '#owa_visualizationSubmit' )
+            .prop( 'disabled', !! blocker )
+            .attr( 'title', blocker );
+
+        jQuery( '#owa_visualizationBlocker' ).text( blocker ).toggle( !! blocker );
+    }
+
+    /*
+     * Delegated: the + button clones rows at runtime, so binding to the rows
+     * that exist now would miss every one added afterwards.
+     */
+    jQuery( document ).on( 'input change click',
+        '#owa_goalEventFunnel, input[name$="name"]', refreshVisualizationState );
+
+    jQuery( 'form[name=owa_visualization]' ).on( 'submit', function ( e ) {
+
+        // Enter in a text field submits whether or not there is a button to
+        // press, so the disabled button is not the whole guard.
+        if ( visualizationBlocker() ) {
+
+            e.preventDefault();
+            refreshVisualizationState();
+
+            return false;
+        }
+    } );
+
+    refreshVisualizationState();
 } );
 </script>

--- a/tests/CustomReportsTest.php
+++ b/tests/CustomReportsTest.php
@@ -821,20 +821,20 @@ final class CustomReportsTest extends TestCase
             // Parseable, but no value. "A missing value is not a request for
             // everything" -- ResultSetManager's own words.
             'no value' => array(
-                'medium==', 'no value to compare it with'),
+                'medium==', 'gives no value'),
 
             /*
              * NOT PARSEABLE AT ALL. Each of these contributes no constraint and
              * raises no error, so the widget silently answers unfiltered.
              */
             'no operator' => array(
-                'medium', 'names no comparison'),
+                'medium', 'names no operator'),
 
             'operator but no name' => array(
                 '==direct', 'names nothing to constrain on'),
 
             'an operator that does not exist' => array(
-                'medium~~x', 'names no comparison'),
+                'medium~~x', 'names no operator'),
         );
     }
 

--- a/tests/CustomReportsTest.php
+++ b/tests/CustomReportsTest.php
@@ -768,6 +768,218 @@ final class CustomReportsTest extends TestCase
     }
 
     // ------------------------------------------------------------------
+    // Constraints, clause by clause
+    // ------------------------------------------------------------------
+
+    /**
+     * A constraint resolves through the registry, like every other name.
+     *
+     * It was the ONE thing in a definition that did not. Metrics, dimensions,
+     * sorts, chart metrics and link targets were all checked at save time and a
+     * constraint was not, and it failed two different ways depending on whether
+     * the engine could parse the clause at all.
+     *
+     * A clause it CAN parse but not resolve is refused by ResultSetManager at
+     * QUERY time -- the right answer at the wrong moment, told to every reader
+     * who opens the report rather than to the author who can fix it.
+     *
+     * A clause it cannot parse is worse: parseConstraintsString() finds no
+     * operator, contributes nothing, and the widget runs completely unfiltered
+     * with no error raised anywhere. A widget meant to show organic search
+     * shows the site total and nothing says so. Those are the last three cases
+     * below, and they are the reason this validation exists rather than being
+     * left to the query layer.
+     *
+     * @dataProvider badConstraintProvider
+     */
+    public function testAMalformedConstraintIsRefused(string $constraint, string $expected): void
+    {
+        $definition = $this->definition();
+
+        $definition['widgets'][1]['constraints'] = $constraint;
+
+        $error = CustomReports::validate($definition);
+
+        $this->assertNotSame('', $error,
+            sprintf('"%s" must be refused at save time', $constraint));
+        $this->assertStringContainsString('widget 2', $error,
+            'the message has to say which widget');
+        $this->assertStringContainsString($expected, $error);
+    }
+
+    public static function badConstraintProvider(): array
+    {
+        return array(
+            // Parseable, but the name resolves to nothing. Refused at query
+            // time already; refused here so the author hears it first.
+            'unknown name' => array(
+                'notADimension==direct', 'not a dimension or a metric'),
+
+            'unknown name beside a good one' => array(
+                'medium==organic-search,notADimension==x', 'notADimension'),
+
+            // Parseable, but no value. "A missing value is not a request for
+            // everything" -- ResultSetManager's own words.
+            'no value' => array(
+                'medium==', 'no value to compare it with'),
+
+            /*
+             * NOT PARSEABLE AT ALL. Each of these contributes no constraint and
+             * raises no error, so the widget silently answers unfiltered.
+             */
+            'no operator' => array(
+                'medium', 'names no comparison'),
+
+            'operator but no name' => array(
+                '==direct', 'names nothing to constrain on'),
+
+            'an operator that does not exist' => array(
+                'medium~~x', 'names no comparison'),
+        );
+    }
+
+    /**
+     * ...and everything legitimate still passes.
+     *
+     * Including the operators the BUILDER does not offer. Its picker carries
+     * five; the engine runs ten, and a definition written by hand or carried
+     * over from an older report may use any of them. Validating against the
+     * picker's list rather than the engine's would refuse a report that runs
+     * perfectly well.
+     *
+     * @dataProvider goodConstraintProvider
+     */
+    public function testALegitimateConstraintIsAccepted(string $constraint): void
+    {
+        $definition = $this->definition();
+
+        $definition['widgets'][1]['constraints'] = $constraint;
+
+        $this->assertSame('', CustomReports::validate($definition),
+            sprintf('"%s" is a constraint the engine can run', $constraint));
+    }
+
+    public static function goodConstraintProvider(): array
+    {
+        return array(
+            'equality'                 => array('medium==organic-search'),
+            'a metric'                 => array('pageViews>5'),
+            'contains, not in the UI'  => array('medium=@news'),
+            'gte, not in the UI'       => array('pageViews>=5'),
+            'two of them'              => array('medium==organic-search,browserType=@Chrome'),
+            'a trailing comma'         => array('medium==organic-search,'),
+        );
+    }
+
+    /**
+     * The operator list comes from the ENGINE, not from a copy.
+     *
+     * ResultSetManager is what actually parses these strings. A list of our own
+     * would drift, and the symptom of drift is precisely the bug this checks
+     * for: a clause accepted here and then dropped there.
+     */
+    public function testTheOperatorsCheckedAreTheOnesTheEngineParses(): void
+    {
+        $rsm = new \OWA\Module\Base\Classes\ResultSetManager;
+
+        foreach ((array) $rsm->constraint_operators as $operator) {
+
+            $definition = $this->definition();
+
+            $definition['widgets'][1]['constraints'] = 'medium' . $operator . 'organic-search';
+
+            $this->assertSame('', CustomReports::validate($definition),
+                sprintf('the engine parses "%s", so validation must accept it', $operator));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Every widget names its own metrics
+    // ------------------------------------------------------------------
+
+    /**
+     * A widget that names no metrics is refused, because there is no longer
+     * anything for it to inherit.
+     *
+     * The builder used to ask for a report metric set beside the report's name,
+     * and a widget that named none fell back to it. That is gone: a widget
+     * declares what it measures or it draws an empty panel, and an empty panel
+     * is not something an author can have meant.
+     *
+     * Asserted on a GRID, deliberately. A card, a pie and a trend card were
+     * always refused for this by rules of their own; the grid is the type that
+     * used to be legal with an empty list, so it is the one that shows the new
+     * rule is doing something.
+     */
+    public function testAWidgetThatNamesNoMetricsIsRefused(): void
+    {
+        $definition = $this->definition();
+
+        unset($definition['metrics']);
+
+        $definition['widgets'][0]['query']['metrics'] = 'visits';
+        $definition['widgets'][1]['query']['metrics'] = '';
+
+        $says = CustomReports::validate($definition);
+
+        $this->assertStringContainsString('widget 2', $says,
+            'the message has to say WHICH widget, or the author cannot find it');
+        $this->assertStringContainsString('names no metrics', $says);
+
+        $definition['widgets'][1]['query']['metrics'] = 'pageViews';
+
+        $this->assertSame('', CustomReports::validate($definition),
+            'naming one is all it takes');
+    }
+
+    /** A metrics key that is absent entirely reads the same as an empty one. */
+    public function testAWidgetWithNoMetricsKeyAtAllIsRefused(): void
+    {
+        $definition = $this->definition();
+
+        unset($definition['metrics']);
+
+        $definition['widgets'][0]['query']['metrics'] = 'visits';
+
+        unset($definition['widgets'][1]['query']['metrics']);
+
+        $this->assertStringContainsString('names no metrics',
+            CustomReports::validate($definition));
+    }
+
+    /**
+     * ...UNLESS the report carries a metric set, which is the case this rule
+     * deliberately does not break.
+     *
+     * validate() runs when a report is RENDERED as well as when it is saved, so
+     * a rule applied unconditionally would take down every report built while
+     * the builder still offered a set -- and leave the author no way to fix it,
+     * because the field they would have to fill no longer exists. The fallback
+     * therefore stays legal exactly where there is something to fall back to.
+     *
+     * The fixture definition is that shape already: a report metric set, and a
+     * trend that names nothing of its own.
+     */
+    public function testAWidgetMayStillInheritAReportMetricSetThatExists(): void
+    {
+        $definition = $this->definition();
+
+        $this->assertSame('visits,uniqueVisitors', $definition['metrics'],
+            'the fixture has to carry a set for this test to be about anything');
+        $this->assertArrayNotHasKey('metrics', $definition['widgets'][0]['query'],
+            '...and a widget that names none of its own');
+
+        $this->assertSame('', CustomReports::validate($definition));
+
+        // ...and the SAME definition without the set is refused, which is what
+        // makes the assertion above about the set rather than about the widget.
+        unset($definition['metrics']);
+
+        $this->assertStringContainsString('names no metrics',
+            CustomReports::validate($definition));
+    }
+
+    // ------------------------------------------------------------------
     // A widget that draws one metric must name it
     // ------------------------------------------------------------------
 

--- a/tests/TemplateLatentVarTest.php
+++ b/tests/TemplateLatentVarTest.php
@@ -314,6 +314,9 @@ final class TemplateLatentVarTest extends TestCase
                     'goalEvents' => [],
                     'siteId' => 'owa-e2e',
                     'validation_errors' => [],
+                    // The step cap, read from VisualizationSave so the form
+                    // cannot offer a step the save then refuses.
+                    'maxSteps' => 10,
                 ],
                 ['name="name"', 'name="stepPath[]"', 'name="visualizationType"'],
             ],

--- a/tests/e2e/custom-reports.spec.js
+++ b/tests/e2e/custom-reports.spec.js
@@ -181,14 +181,6 @@ async function onlyWidget(page, type, opts = {}) {
     await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
 }
 
-/** Open the FIRST block's modal, set some fields, and close it with Done. */
-async function configureFirstWidget(page, opts) {
-    await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
-    await expect(page.locator('#widgetDialog')).toBeVisible();
-
-    await fillWidget(page, opts);
-}
-
 /** Fill the widget modal that is already open, and close it with Done. */
 async function fillWidget(page, opts) {
     if (opts.title !== undefined) { await page.fill('#dlgTitle', opts.title); }
@@ -555,7 +547,7 @@ test.describe('custom reports', () => {
             await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
 
             await expect(page.locator('#widgetDialog')).toBeVisible();
-            await expect(page.locator('#dlgConstraintError'))
+            await expect(page.locator('#dlgError'))
                 .toContainText('gives no value');
 
             // Filling it in lets the dialog close, and the constraint reaches
@@ -619,28 +611,148 @@ test.describe('custom reports', () => {
             await expect(page.locator('#customReportBlocker'))
                 .toContainText('Add at least one widget');
 
-            await startWidget(page, 'grid');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            // A configured widget -- the modal will not let an unconfigured one
+            // onto the canvas -- so the only rule left is the name.
+            await addWidget(page, 'grid', { metrics: ['pageViews'] });
 
-            // A widget, still no name.
             await expect(page.locator('#customReportSubmit')).toBeDisabled();
             await expect(page.locator('#customReportBlocker')).toContainText('name');
 
             await page.fill('#customReportName', reportName('Gate'));
 
-            // Named, but the widget still measures nothing -- and it is marked
-            // ON THE CANVAS, because that is where the author is looking.
-            await expect(page.locator('#customReportSubmit')).toBeDisabled();
-            await expect(page.locator('#customReportBlocker'))
-                .toContainText('does not say what it measures');
-            await expect(page.locator('.owa_builderBlockIncomplete')).toHaveCount(1);
-
-            await configureFirstWidget(page, { metrics: ['pageViews'] });
-
             // ...and now it can go.
             await expect(page.locator('#customReportSubmit')).toBeEnabled();
             await expect(page.locator('#customReportBlocker')).toBeHidden();
             await expect(page.locator('.owa_builderBlockIncomplete')).toHaveCount(0);
+        });
+
+        /*
+         * ------------------------------------------------------------------
+         * THE MODAL IS WHERE A WIDGET IS FINISHED
+         * ------------------------------------------------------------------
+         *
+         * Done used to close on anything. The block landed on the canvas marked
+         * unfinished and Save explained it -- a correct chain, and a slow one:
+         * the author was told about a widget two steps after the screen that
+         * was about that widget, and had to find it again to fix it.
+         *
+         * The canvas marking and the Save gate STAY, because a definition can
+         * arrive already broken from a report saved before these rules or from
+         * a refusal round-trip. They are the backstop, not the first line.
+         */
+        test('done will not close on a widget that is not finished', async ({ page }) => {
+            await openBuilder(page);
+
+            await startWidget(page, 'grid');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await expect(page.locator('#dlgError')).toContainText('at least one metric');
+
+            await chooseInChosen(page, 'dlgMetrics', 'pageViews');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            await expect(page.locator('#widgetDialog')).toBeHidden();
+        });
+
+        /**
+         * ...and a type that draws exactly one dimension is not finished
+         * without it either. SINGLE_FIELD_TYPES, the server's own list.
+         */
+        test('a pie is not finished until it has a dimension too', async ({ page }) => {
+            await openBuilder(page);
+
+            await startWidget(page, 'pie');
+            await chooseInChosen(page, 'dlgMetrics', 'pageViews');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await expect(page.locator('#dlgError')).toContainText('dimension');
+
+            await chooseInChosen(page, 'dlgDimensions', 'pagePath');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            await expect(page.locator('#widgetDialog')).toBeHidden();
+        });
+
+        /**
+         * THE SORT IS THE ONE FIELD AN AUTHOR TYPES INTO FREELY.
+         *
+         * Everything else in this dialog is a picker fed from the registry, so
+         * the sort was the only way to reach the server with a name that does
+         * not resolve -- and the answer came back as a refusal two steps later,
+         * on a page about a widget rather than showing them one. The registry
+         * is already in the page for the pickers.
+         *
+         * A trailing '-' is the DIRECTION and is stripped before the lookup;
+         * without that every descending sort would be reported as unresolvable,
+         * which is the bug this check would otherwise introduce.
+         */
+        test('an unresolvable sort is caught in the modal, and a descending one is not',
+            async ({ page }) => {
+
+            await openBuilder(page);
+
+            await startWidget(page, 'grid');
+            await chooseInChosen(page, 'dlgMetrics', 'pageViews');
+
+            await page.fill('#dlgSort', 'notARealMetric-');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await expect(page.locator('#dlgError')).toContainText('notARealMetric');
+
+            // A real metric, descending, is fine -- the '-' is not part of it.
+            await page.fill('#dlgSort', 'pageViews-');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            await expect(page.locator('#widgetDialog')).toBeHidden();
+        });
+
+        /**
+         * BACKING OUT OF A NEW WIDGET UNDOES THE ADD.
+         *
+         * The type chooser pushes the widget onto the canvas before the modal
+         * opens, so without this Cancel leaves exactly the unconfigured block
+         * Done refuses to produce -- the rule would be reachable around, and so
+         * would be decoration.
+         *
+         * Asserted through the titlebar X as well, because that is the same
+         * decision made with a different control and it is the one that gets
+         * missed.
+         */
+        test('cancelling a widget that was never configured removes it', async ({ page }) => {
+            await openBuilder(page);
+
+            await startWidget(page, 'grid');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
+
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(0);
+            await expect(page.locator('#customReportEmpty')).toBeVisible();
+
+            // The same, closed with the X rather than the button.
+            await startWidget(page, 'grid');
+            await page.locator('.owa_widgetDialogFrame .ui-dialog-titlebar-close').click();
+
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(0);
+        });
+
+        /**
+         * ...but cancelling an EDIT keeps the widget.
+         *
+         * Cancel means "I did not mean to add this" only at the moment a widget
+         * is being added. On one that already exists it means "leave it as it
+         * was", and dropping it there would delete work on a keystroke.
+         */
+        test('cancelling an edit of a configured widget keeps it', async ({ page }) => {
+            await openBuilder(page);
+
+            await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+
+            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await page.fill('#dlgTitle', 'Should not stick');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
+
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+            await expect(page.locator('.owa_builderBlockName').first()).toHaveText('Widget 1');
         });
 
         /**
@@ -667,14 +779,37 @@ test.describe('custom reports', () => {
                 metrics: ['pageViews'], dimensions: ['pagePath'],
             });
 
-            // A sort the registry cannot resolve, on the SECOND widget, so the
-            // refusal is about one block and the other is untouched.
             await addWidget(page, 'grid-card', {
-                metrics: ['pageViews'], dimensions: ['pagePath'], sort: 'notARealMetric-',
+                metrics: ['pageViews'], dimensions: ['pagePath'],
             });
 
-            await page.click('#customReportSubmit');
-            await page.waitForLoadState('networkidle');
+            /*
+             * A sort the registry cannot resolve, on the SECOND widget -- put
+             * there by POSTING it, not by typing it.
+             *
+             * The modal now resolves the sort against the registry, so this
+             * cannot be built in the builder any more; a save-time refusal is
+             * not reachable through the UI at all. It is still reachable from a
+             * stale tab, a direct post, or a report stored before these rules,
+             * which is exactly why the refusal page still has to work.
+             */
+            await Promise.all([
+                page.waitForNavigation({ waitUntil: 'load' }),
+                page.evaluate(() => {
+                    const form = document.getElementById('customReportForm');
+                    form.dispatchEvent(new Event('submit'));
+
+                    const built = JSON.parse(
+                        document.getElementById('customReportDefinition').value);
+
+                    built.widgets[1].query.sort = 'notARealMetric-';
+
+                    document.getElementById('customReportDefinition').value =
+                        JSON.stringify(built);
+
+                    HTMLFormElement.prototype.submit.call(form);
+                }),
+            ]);
 
             await expect(page.locator('.notice')).toContainText('notARealMetric');
 
@@ -728,8 +863,11 @@ test.describe('custom reports', () => {
 
             await openBuilder(page);
 
+            // The widget is added but deliberately NOT finished -- the modal
+            // would refuse to close on it, which is the point: this test is
+            // about what the SERVER does with a post the builder would never
+            // make, the way a stale tab or a direct post can.
             await startWidget(page, 'grid');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
 
             await Promise.all([
                 page.waitForNavigation({ waitUntil: 'load' }),
@@ -794,8 +932,9 @@ test.describe('custom reports', () => {
 
             await openBuilder(page);
 
+            // Left unfinished on purpose; the modal would refuse to close on
+            // it. What is under test is the SERVER's answer to that shape.
             await startWidget(page, 'trend');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
 
             await Promise.all([
                 page.waitForNavigation({ waitUntil: 'load' }),
@@ -1017,7 +1156,7 @@ test.describe('custom reports', () => {
             // a click -- and the chooser is modal, so the next plus is behind
             // its overlay until it closes.
             for (let i = 0; i < 10; i++) {
-                await addWidget(page, 'grid');
+                await addWidget(page, 'grid', { metrics: ['pageViews'] });
             }
 
             await expect(page.locator('.owa_builderBlock')).toHaveCount(10);
@@ -1046,7 +1185,7 @@ test.describe('custom reports', () => {
             await openBuilder(page);
 
             // A block to look at: the canvas starts empty now.
-            await addWidget(page, 'grid');
+            await addWidget(page, 'grid', { metrics: ['pageViews'] });
 
             const canvas = page.locator('#customReportCanvas');
 
@@ -1156,7 +1295,7 @@ test.describe('custom reports', () => {
         test('an added block has a default name and its type', async ({ page }) => {
             await openBuilder(page);
 
-            await addWidget(page, 'grid');
+            await addWidget(page, 'grid', { metrics: ['pageViews'] });
 
             const block = page.locator('.owa_builderBlock').first();
 
@@ -1929,15 +2068,14 @@ test.describe('custom reports', () => {
             expect(after.total).toBe(after.parts.reduce((a, b) => a + b, 0));
         });
 
-        /** Cancel leaves the widget as it was. */
-        test('cancelling the modal changes nothing', async ({ page }) => {
-            await openBuilderOnGrid(page);
-
-            await page.fill('#dlgTitle', 'Should not stick');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
-
-            await expect(page.locator('.owa_builderBlockName').first()).toHaveText('Widget 1');
-        });
+        /*
+         * The test that used to sit here asserted that cancelling the modal
+         * left the widget as it was. It opened a BARE grid to do it, which now
+         * means something different: Cancel on a widget that was never
+         * configured removes it. Both halves of that distinction are covered
+         * above, by 'cancelling a widget that was never configured removes it'
+         * and 'cancelling an edit of a configured widget keeps it'.
+         */
 
         /**
          * A block can be removed, and removing the LAST one leaves the canvas
@@ -2245,15 +2383,38 @@ test.describe('custom reports', () => {
             await openBuilder(page);
             await page.fill('#customReportName', name);
 
-            // Reach past the pickers: a sort is free text, which is the field
-            // an author can put an unresolvable name into.
-            await addWidget(page, 'grid', {
-                metrics: ['pageViews'],
-                sort: 'notARealMetric-',
-            });
+            await addWidget(page, 'grid', { metrics: ['pageViews'] });
 
-            await page.click('#customReportSubmit');
-            await page.waitForLoadState('networkidle');
+            /*
+             * POSTED, not typed.
+             *
+             * The sort used to be the way in: free text, so an author could put
+             * an unresolvable name in it and find out on save. The modal
+             * resolves it against the registry now, so that route is closed and
+             * a refusal cannot be built through the UI at all.
+             *
+             * The refusal still has to work, because a definition can arrive
+             * from a stale tab, a direct post, or a report stored before these
+             * rules -- and what it has to do is name the thing that did not
+             * resolve and keep the author's work.
+             */
+            await Promise.all([
+                page.waitForNavigation({ waitUntil: 'load' }),
+                page.evaluate(() => {
+                    const form = document.getElementById('customReportForm');
+                    form.dispatchEvent(new Event('submit'));
+
+                    const built = JSON.parse(
+                        document.getElementById('customReportDefinition').value);
+
+                    built.widgets[0].query.sort = 'notARealMetric-';
+
+                    document.getElementById('customReportDefinition').value =
+                        JSON.stringify(built);
+
+                    HTMLFormElement.prototype.submit.call(form);
+                }),
+            ]);
 
             await expect(page.locator('.notice')).toContainText('notARealMetric');
 

--- a/tests/e2e/custom-reports.spec.js
+++ b/tests/e2e/custom-reports.spec.js
@@ -35,6 +35,19 @@ async function openBuilder(page) {
     await page.waitForSelector('#customReportForm', { timeout: 20_000 });
 }
 
+/**
+ * The builder, with one grid block added and its modal OPEN.
+ *
+ * A new report starts empty now -- there is no default block to press Edit on
+ * -- so a test about what the widget modal contains has to put a widget there
+ * first. A grid, because that is what the default block used to be, so the
+ * tests below are asking the same question they were.
+ */
+async function openBuilderOnGrid(page) {
+    await openBuilder(page);
+    await startWidget(page, 'grid');
+}
+
 async function openRoster(page) {
     await page.goto('?owa_do=base.customReports', { waitUntil: 'networkidle' });
 }
@@ -71,9 +84,9 @@ async function buildOne(page, label) {
     await openBuilder(page);
     await page.fill('#customReportName', name);
 
-    // One block is drawn for a new report, so there is always something to
-    // configure without pressing the plus first.
-    await configureWidget(page, 0, { metrics: ['pageViews'], dimensions: ['pagePath'] });
+    // A new report starts EMPTY, so the widget has to be added. There is
+    // nothing to configure until one is.
+    await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
 
     await page.click('#customReportSubmit');
     await page.waitForLoadState('networkidle');
@@ -132,10 +145,13 @@ function chosenPills(page, selectId) {
  * Add a widget of a given type, through the plus.
  *
  * The type is chosen BEFORE the widget modal opens -- the modal is built for a
- * type, so there has to be one first. That is also why configureWidget() below
- * takes no type: by the time a block exists, its type is settled.
+ * type, so there has to be one first, which is why every caller names one.
+ *
+ * startWidget() is the same thing stopping one step earlier, with the modal
+ * left OPEN: a test about what the modal CONTAINS needs a widget there and
+ * needs it not filled in.
  */
-async function addWidget(page, type, opts = {}) {
+async function startWidget(page, type) {
     await page.click('#addWidget');
 
     await expect(page.locator('#typeDialog')).toBeVisible();
@@ -143,6 +159,10 @@ async function addWidget(page, type, opts = {}) {
 
     // Choosing lands straight in the widget modal, on the block just added.
     await expect(page.locator('#widgetDialog')).toBeVisible();
+}
+
+async function addWidget(page, type, opts = {}) {
+    await startWidget(page, type);
 
     await fillWidget(page, opts);
 }
@@ -150,20 +170,20 @@ async function addWidget(page, type, opts = {}) {
 /**
  * One widget of a given type, and nothing else.
  *
- * A new report starts with one grid block so the canvas is never empty. A test
- * that wants a single widget of some OTHER type adds one and drops that
- * default, rather than asserting past it.
+ * This used to add one and then remove the grid block a new report started
+ * with. A new report starts EMPTY, so there is nothing to drop -- but the
+ * assertion is kept, because it is what makes every caller's later
+ * `.first()` unambiguous.
  */
 async function onlyWidget(page, type, opts = {}) {
     await addWidget(page, type, opts);
 
-    await page.locator('.owa_builderBlock').first().locator('.owa_builderRemove').click();
     await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
 }
 
-/** Open a block's modal, set some fields, and close it with Done. */
-async function configureWidget(page, index, opts) {
-    await page.locator('.owa_builderBlock').nth(index).locator('.owa_builderEdit').click();
+/** Open the FIRST block's modal, set some fields, and close it with Done. */
+async function configureFirstWidget(page, opts) {
+    await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
     await expect(page.locator('#widgetDialog')).toBeVisible();
 
     await fillWidget(page, opts);
@@ -290,10 +310,7 @@ test.describe('custom reports', () => {
          * dimension to pick; a card takes one metric where a table takes four.
          */
         test('the widget modal does not offer the type again', async ({ page }) => {
-            await openBuilder(page);
-
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await openBuilderOnGrid(page);
 
             await expect(page.locator('#dlgType')).toHaveCount(0);
         });
@@ -305,10 +322,7 @@ test.describe('custom reports', () => {
          * author could not see.
          */
         test('the pickers are populated from the registry', async ({ page }) => {
-            await openBuilder(page);
-
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await openBuilderOnGrid(page);
 
             expect(await page.locator('#dlgMetrics option').count()).toBeGreaterThan(10);
             expect(await page.locator('#dlgDimensions option').count()).toBeGreaterThan(10);
@@ -332,9 +346,7 @@ test.describe('custom reports', () => {
          * -- the pickers enhance to a couple of pixels and cannot be used.
          */
         test('the metric picker is a searchable pill control, not a multi-select', async ({ page }) => {
-            await openBuilder(page);
-
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await openBuilderOnGrid(page);
 
             const chosen = page.locator('#dlgMetrics_chosen');
 
@@ -348,9 +360,7 @@ test.describe('custom reports', () => {
 
         /** Typing filters the list, and choosing turns the value into a pill. */
         test('choosing a metric turns it into a pill that can be removed', async ({ page }) => {
-            await openBuilder(page);
-
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await openBuilderOnGrid(page);
 
             await expect(chosenPills(page, 'dlgMetrics')).toHaveCount(0);
 
@@ -366,15 +376,391 @@ test.describe('custom reports', () => {
             await expect(chosenPills(page, 'dlgMetrics')).toHaveCount(1);
         });
 
-        /** The report metric set is the same control. */
-        test('the report metric set is a pill control too', async ({ page }) => {
+        /**
+         * THE REPORT METRIC SET IS NOT ASKED FOR ANY MORE.
+         *
+         * It was a second answer to "what does this report measure", beside the
+         * one inside every widget, and the two did not compose: a widget naming
+         * nothing inherited the set, so what a widget drew depended on a field
+         * further up the page that said nothing about which widget it landed
+         * in. Every widget names its own now.
+         *
+         * Asserted on the CONTROL rather than on the label, because the label
+         * could be renamed and the picker left behind -- and the picker is the
+         * half that would still be posting a set.
+         */
+        test('the builder does not ask for a report metric set', async ({ page }) => {
             await openBuilder(page);
 
-            await expect(page.locator('#reportMetricSet_chosen')).toBeVisible();
+            await expect(page.locator('#reportMetricSet')).toHaveCount(0);
+            await expect(page.locator('#reportMetricSet_chosen')).toHaveCount(0);
 
-            await chooseInChosen(page, 'reportMetricSet', 'visits');
+            // The report's name is still the only thing asked for up here.
+            await expect(page.locator('#customReportName')).toBeVisible();
+        });
 
-            await expect(chosenPills(page, 'reportMetricSet')).toHaveCount(1);
+        /*
+         * ------------------------------------------------------------------
+         * A NEW REPORT STARTS EMPTY
+         * ------------------------------------------------------------------
+         *
+         * It used to start from one table block: already named, already the
+         * right width, already a type. So Save worked on a report the author
+         * had made no decision about, and what came out was a table of nothing.
+         *
+         * Empty, the first thing on the screen is the choice that actually
+         * starts a report, and Save is unavailable until it has been made.
+         */
+        test('a new report starts with no widgets and cannot be saved', async ({ page }) => {
+            await openBuilder(page);
+
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(0);
+
+            // The plus is there, and it is the only thing to press.
+            await expect(page.locator('#addWidget')).toBeVisible();
+
+            // ...beside a sentence saying what is missing. The plus alone is a
+            // control, not an instruction.
+            await expect(page.locator('#customReportEmpty')).toBeVisible();
+            await expect(page.locator('#customReportEmpty')).toContainText('at least one');
+
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+
+            // The budget counts from nought, rather than from the block that
+            // used to be there.
+            await expect(page.locator('#widgetBudget')).toContainText('0 of');
+        });
+
+        /**
+         * ...and a named report with a configured widget is saveable.
+         *
+         * Both halves, because Save waits for every rule: the widget makes the
+         * canvas non-empty, and the name is the other thing the server
+         * requires.
+         */
+        test('adding a widget and a name enables the save button', async ({ page }) => {
+            await openBuilder(page);
+
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+
+            await page.fill('#customReportName', reportName('Enables'));
+            await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
+
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+            await expect(page.locator('#customReportEmpty')).toBeHidden();
+            await expect(page.locator('#customReportSubmit')).toBeEnabled();
+        });
+
+        /**
+         * The disabled Save is not the whole guard.
+         *
+         * Enter in a text field submits a form whether or not there is a submit
+         * button to press, so an empty report could still be posted -- and the
+         * refusal would come back as a message about a definition the author
+         * never assembled.
+         */
+        test('pressing enter on an empty report does not post it', async ({ page }) => {
+            await openBuilder(page);
+
+            await page.fill('#customReportName', reportName('EnterKey'));
+            await page.locator('#customReportName').press('Enter');
+
+            // Still on the builder, with the sentence still saying why.
+            await expect(page.locator('#customReportForm')).toBeVisible();
+            await expect(page.locator('#customReportEmpty')).toBeVisible();
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(0);
+        });
+
+        /**
+         * WHICH FIELDS HAVE TO BE ANSWERED IS SAID ON THE FIELD.
+         *
+         * Every one of these was discoverable only by pressing Save and reading
+         * the refusal. The report name is the worst of them: it carries an
+         * "Untitled report" placeholder, which reads as a value already
+         * supplied rather than as an example, so an empty one does not look
+         * empty.
+         *
+         * The marks are asserted PER TYPE, because that is the half that can
+         * rot. Metrics are required on every widget; a dimension is required
+         * only where the type draws exactly one -- a card and a pie -- and
+         * marking it everywhere would be telling an author to fill a field a
+         * grid may legitimately leave alone.
+         */
+        test('the required fields say so', async ({ page }) => {
+            await openBuilder(page);
+
+            const nameField = page.locator('.owa_builderField', {
+                has: page.locator('#customReportName'),
+            });
+
+            await expect(nameField.locator('.owa_builderRequired')).toBeVisible();
+            await expect(nameField.locator('.owa_builderRequired')).toHaveText(/required/i);
+
+            // A grid: metrics have to be named, dimensions need not be.
+            await startWidget(page, 'grid');
+            await expect(page.locator('#dlgMetricsRequired')).toBeVisible();
+            await expect(page.locator('#dlgDimensionsRequired')).toBeHidden();
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
+
+            // A card and a pie draw exactly one of each, and are refused
+            // without either -- see CustomReports::SINGLE_FIELD_TYPES.
+            for (const type of ['grid-card', 'pie']) {
+                await startWidget(page, type);
+                await expect(page.locator('#dlgMetricsRequired')).toBeVisible();
+                await expect(page.locator('#dlgDimensionsRequired')).toBeVisible();
+                await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
+            }
+
+            // A trend's breakdown is an addition to a chart that draws without
+            // one, so it is optional -- but its metrics are not.
+            await startWidget(page, 'trend');
+            await expect(page.locator('#dlgMetricsRequired')).toBeVisible();
+            await expect(page.locator('#dlgDimensionsRequired')).toBeHidden();
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
+
+            // Info boxes have no dimension field at all, so there is nothing to
+            // mark -- the mark must not be showing beside a hidden control.
+            await startWidget(page, 'metric-boxes');
+            await expect(page.locator('#dlgMetricsRequired')).toBeVisible();
+            await expect(page.locator('#dlgDimensionsField')).toBeHidden();
+            await expect(page.locator('#dlgDimensionsRequired')).toBeHidden();
+        });
+
+        /**
+         * A HALF-FILLED CONSTRAINT ROW USED TO VANISH.
+         *
+         * readConstraintRows() keeps a row only when it has both a dimension
+         * and a value, and dropped anything else without a word. So an author
+         * who chose a dimension and tabbed past the value got a widget with no
+         * filter on it, no message, and nothing to distinguish it from one they
+         * had never filtered -- the same failure the query engine refuses to
+         * run ("a missing value is not a request for everything"), except that
+         * here it happened before anything reached the engine.
+         *
+         * Done does not close on one. The row is inside this dialog, so closing
+         * would take the author away from the control the message is about.
+         */
+        test('a constraint row started and not finished stops the dialog closing',
+            async ({ page }) => {
+
+            await openBuilder(page);
+            await page.fill('#customReportName', reportName('Constraint'));
+
+            await startWidget(page, 'grid');
+            await chooseInChosen(page, 'dlgMetrics', 'pageViews');
+
+            // A dimension, and deliberately no value.
+            await fillConstraintRow(page, { dimension: '(medium)' });
+
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await expect(page.locator('#dlgConstraintError'))
+                .toContainText('gives no value');
+
+            // Filling it in lets the dialog close, and the constraint reaches
+            // the definition rather than being dropped on the way out.
+            await fillConstraintRow(page, { value: 'organic-search' });
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            await expect(page.locator('#widgetDialog')).toBeHidden();
+
+            const definition = await page.evaluate(() => {
+                document.getElementById('customReportForm')
+                    .dispatchEvent(new Event('submit'));
+                return document.getElementById('customReportDefinition').value;
+            });
+
+            expect(JSON.parse(definition).widgets[0].constraints)
+                .toBe('medium==organic-search');
+        });
+
+        /**
+         * A blank row is still nothing.
+         *
+         * The form always carries one, and it does not mean the author left
+         * something out -- so it must not be what stops them saving.
+         */
+        test('the always-present empty constraint row is not an error', async ({ page }) => {
+            await openBuilder(page);
+            await page.fill('#customReportName', reportName('BlankRow'));
+
+            await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
+
+            await expect(page.locator('#customReportSubmit')).toBeEnabled();
+
+            const definition = await page.evaluate(() => {
+                document.getElementById('customReportForm')
+                    .dispatchEvent(new Event('submit'));
+                return document.getElementById('customReportDefinition').value;
+            });
+
+            expect(JSON.parse(definition).widgets[0]).not.toHaveProperty('constraints');
+        });
+
+        /**
+         * SAVE WAITS FOR EVERY RULE THE SERVER APPLIES, and says which one.
+         *
+         * A widget could be added and left with no metrics, and Save was
+         * bright orange over it. The report was then refused -- correctly, it
+         * would have drawn an empty panel -- but the author found that out
+         * after a round trip, on a page that had to tell them about a widget
+         * rather than showing it to them.
+         *
+         * Each rule asserted with the ONE reason it should give: a disabled
+         * button that does not say what is missing is the worst of both, and a
+         * message that named the wrong rule would send an author to fix
+         * something that was already right.
+         */
+        test('save says which rule it is waiting for, one at a time', async ({ page }) => {
+            await openBuilder(page);
+
+            // Nothing at all: the widget is the first thing to fix.
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+            await expect(page.locator('#customReportBlocker'))
+                .toContainText('Add at least one widget');
+
+            await startWidget(page, 'grid');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            // A widget, still no name.
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+            await expect(page.locator('#customReportBlocker')).toContainText('name');
+
+            await page.fill('#customReportName', reportName('Gate'));
+
+            // Named, but the widget still measures nothing -- and it is marked
+            // ON THE CANVAS, because that is where the author is looking.
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+            await expect(page.locator('#customReportBlocker'))
+                .toContainText('does not say what it measures');
+            await expect(page.locator('.owa_builderBlockIncomplete')).toHaveCount(1);
+
+            await configureFirstWidget(page, { metrics: ['pageViews'] });
+
+            // ...and now it can go.
+            await expect(page.locator('#customReportSubmit')).toBeEnabled();
+            await expect(page.locator('#customReportBlocker')).toBeHidden();
+            await expect(page.locator('.owa_builderBlockIncomplete')).toHaveCount(0);
+        });
+
+        /**
+         * A REFUSED REPORT IS STILL EDITABLE, block by block.
+         *
+         * The refusal page is rebuilt by CustomReportSave::refuse(), which
+         * delegates to the builder rather than rendering a page of its own --
+         * so everything the canvas does has to survive that hand-off: the
+         * blocks come back from the SUBMITTED definition, the dialog is
+         * initialised, and Edit opens the widget the message is about.
+         *
+         * Asserted REPEATEDLY, on both blocks and through both ways of closing,
+         * because the failure this guards against is a canvas that draws and
+         * then does nothing -- which looks identical to a working one in a
+         * screenshot.
+         */
+        test('every block stays editable after a refusal, and the fix saves',
+            async ({ page }) => {
+
+            await openBuilder(page);
+            await page.fill('#customReportName', reportName('Refused'));
+
+            await addWidget(page, 'grid', {
+                metrics: ['pageViews'], dimensions: ['pagePath'],
+            });
+
+            // A sort the registry cannot resolve, on the SECOND widget, so the
+            // refusal is about one block and the other is untouched.
+            await addWidget(page, 'grid-card', {
+                metrics: ['pageViews'], dimensions: ['pagePath'], sort: 'notARealMetric-',
+            });
+
+            await page.click('#customReportSubmit');
+            await page.waitForLoadState('networkidle');
+
+            await expect(page.locator('.notice')).toContainText('notARealMetric');
+
+            // Both blocks came back, from the definition that was posted.
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(2);
+
+            for (const index of [1, 0, 1]) {
+                await page.locator('.owa_builderBlock').nth(index)
+                    .locator('.owa_builderEdit').click();
+
+                await expect(page.locator('#widgetDialog')).toBeVisible();
+
+                await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
+                await expect(page.locator('#widgetDialog')).toBeHidden();
+            }
+
+            // ...and the widget the message named can actually be fixed here,
+            // which is the whole point of coming back to the builder.
+            await page.locator('.owa_builderBlock').nth(1).locator('.owa_builderEdit').click();
+            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await page.fill('#dlgSort', 'pageViews-');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await page.click('#customReportSubmit');
+            await page.waitForLoadState('networkidle');
+
+            // Saved: on the report, with no refusal on the page.
+            await expect(page.locator('.owa_reportTitle')).toBeVisible();
+            await expect(page.locator('.notice')).toHaveCount(0);
+        });
+
+        /**
+         * A REFUSAL RAISED BY validate() RENDERS A PAGE.
+         *
+         * It did not. Core/Controller.php calls errorAction() for its side
+         * effects and then returns $this->data regardless -- it only honours
+         * what action() returns -- so CustomReportSave::refuse() built the
+         * whole builder screen and had it thrown away. The author got a blank
+         * white page, every time, for the most ordinary mistake there is:
+         * pressing Save with the name left empty. The field carries a
+         * placeholder, so an empty one does not look empty.
+         *
+         * Driven PAST the client-side gate on purpose. The gate stops this in a
+         * browser, which is why the server half went unnoticed for so long --
+         * but a stale tab, a second window, or anything posting the form
+         * directly still reaches it, and a blank page is the one response that
+         * tells nobody anything.
+         */
+        test('a save refused for a missing name renders the builder, not a blank page',
+            async ({ page }) => {
+
+            await openBuilder(page);
+
+            await startWidget(page, 'grid');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await Promise.all([
+                page.waitForNavigation({ waitUntil: 'load' }),
+                page.evaluate(() => {
+                    // Bypass the submit handler AND the disabled button, the
+                    // way a direct post does.
+                    document.getElementById('customReportDefinition').value = JSON.stringify({
+                        title: '',
+                        widgets: [{
+                            type: 'grid', id: 'w1', container: 'w1',
+                            query: { metrics: 'pageViews', dimensions: 'pagePath' },
+                        }],
+                    });
+                    document.getElementById('customReportName').value = '';
+
+                    HTMLFormElement.prototype.submit.call(
+                        document.getElementById('customReportForm'));
+                }),
+            ]);
+
+            // A PAGE, with the reporting chrome on it -- the blank one had none
+            // of this. Asserted on rendered text rather than on the response
+            // body, because the body was never the empty part.
+            const body = page.locator('body');
+
+            await expect(body).not.toHaveText('');
+            await expect(body).toContainText('Custom Report');
+            await expect(page.locator('.notice')).toContainText('needs a name');
+
+            // ...and the builder is back, so the author can fix it here.
+            await expect(page.locator('#customReportForm')).toBeVisible();
         });
 
         /**
@@ -396,8 +782,7 @@ test.describe('custom reports', () => {
             await openBuilder(page);
             await page.fill('#customReportName', name);
 
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'grid');
 
             await chooseInChosen(page, 'dlgMetrics', 'visits');
             await chooseInChosen(page, 'dlgDimensions', 'browserType');
@@ -559,12 +944,13 @@ test.describe('custom reports', () => {
         test('the plus adds blocks, and stops at ten', async ({ page }) => {
             await openBuilder(page);
 
-            await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+            // From NOUGHT: a new report no longer starts with a block.
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(0);
 
             // The plus asks what KIND now, so each one is a choice as well as
             // a click -- and the chooser is modal, so the next plus is behind
             // its overlay until it closes.
-            for (let i = 1; i < 10; i++) {
+            for (let i = 0; i < 10; i++) {
                 await addWidget(page, 'grid');
             }
 
@@ -593,6 +979,9 @@ test.describe('custom reports', () => {
         test('the builder is actually styled', async ({ page }) => {
             await openBuilder(page);
 
+            // A block to look at: the canvas starts empty now.
+            await addWidget(page, 'grid');
+
             const canvas = page.locator('#customReportCanvas');
 
             // The canvas is a CSS grid. Unstyled it would be a plain block.
@@ -618,9 +1007,7 @@ test.describe('custom reports', () => {
          * unstyled block in the middle of the document.
          */
         test('the widget modal is a styled dialog', async ({ page }) => {
-            await openBuilder(page);
-
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await openBuilderOnGrid(page);
 
             const dialog = page.locator('.owa_widgetDialogFrame').first();
 
@@ -644,9 +1031,7 @@ test.describe('custom reports', () => {
          * theme leaves it so faint the page looks live underneath.
          */
         test('the modal dims the page behind it', async ({ page }) => {
-            await openBuilder(page);
-
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await openBuilderOnGrid(page);
 
             const overlay = page.locator('.ui-widget-overlay');
 
@@ -667,8 +1052,7 @@ test.describe('custom reports', () => {
          * selection that the save then refuses.
          */
         test('the metric picker stops offering incompatible metrics', async ({ page }) => {
-            await openBuilder(page);
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await openBuilderOnGrid(page);
 
             // Both are on offer to begin with.
             await expect(page.locator('#dlgMetrics option[value="visits"]')).toHaveCount(1);
@@ -683,8 +1067,7 @@ test.describe('custom reports', () => {
 
         /** The same narrowing reaches dimensions, and the caps are enforced. */
         test('the pickers stop at four', async ({ page }) => {
-            await openBuilder(page);
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await openBuilderOnGrid(page);
 
             for (const m of ['visits', 'uniqueVisitors', 'pageViews', 'uniquePageViews']) {
                 await chooseInChosen(page, 'dlgMetrics', m);
@@ -701,11 +1084,13 @@ test.describe('custom reports', () => {
         });
 
         /**
-         * A block carries a default name, so a new report is never a row of
-         * unlabelled boxes.
+         * A block carries a default name, so a report under construction is
+         * never a row of unlabelled boxes.
          */
-        test('a new block has a default name and a type', async ({ page }) => {
+        test('an added block has a default name and its type', async ({ page }) => {
             await openBuilder(page);
+
+            await addWidget(page, 'grid');
 
             const block = page.locator('.owa_builderBlock').first();
 
@@ -754,11 +1139,7 @@ test.describe('custom reports', () => {
          * no controls at all.
          */
         test('a grid has no column span to set, and says why', async ({ page }) => {
-            await openBuilder(page);
-
-            // The block a new report starts with is a grid.
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await openBuilderOnGrid(page);
 
             await expect(page.locator('#dlgColspanField')).toBeHidden();
             await expect(page.locator('#dlgWidthNote')).toContainText('always full width');
@@ -769,9 +1150,7 @@ test.describe('custom reports', () => {
             await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
 
             // ...and a card has a width to choose.
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="grid-card"]').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'grid-card');
 
             await expect(page.locator('#dlgColspanField')).toBeVisible();
             await expect(page.locator('#dlgWidthNote')).toBeHidden();
@@ -793,9 +1172,7 @@ test.describe('custom reports', () => {
         test('metric boxes ask for no dimension, because they are totals', async ({ page }) => {
             await openBuilder(page);
 
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="metric-boxes"]').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'metric-boxes');
 
             await expect(page.locator('#dlgDimensionsField')).toBeHidden();
             await expect(page.locator('#dlgDimensionNote')).toContainText('totals for the period');
@@ -804,30 +1181,28 @@ test.describe('custom reports', () => {
         /**
          * A trend card names its own metrics and has nothing to group by.
          *
-         * Both follow from the width. Half a row has no room for a legend of
-         * six lines, so it cannot be broken out -- and a report metric set
-         * would replace the figures its author chose with three to six whose
-         * boxes do not fit that width, so it does not take one.
+         * Both follow from the width: half a row has no room for a legend of
+         * six lines, so it cannot be broken out.
          *
-         * The form has to SAY the second one. "Leave empty to use the report
-         * metric set" is the sentence every other multi-metric type carries,
-         * and an author who acted on it here would be refused on save by the
-         * rule that sentence contradicted.
+         * The metrics half used to be the interesting one -- every other
+         * multi-metric type carried "Leave empty to use the report metric set",
+         * and an author who acted on that sentence HERE would be refused on
+         * save by the rule it contradicted. There is no set to leave it empty
+         * for any more, on any type, so the sentence is gone from all of them
+         * and what is asserted is that it has not come back.
          */
         test('a trend card names its own metrics and is not broken out', async ({ page }) => {
             await openBuilder(page);
 
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="trend-card"]').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'trend-card');
 
             // Several metrics, so the field is plural -- unlike a card or a pie.
             await expect(page.locator('#dlgMetricsLabel')).toHaveText('Metrics');
 
-            // ...and it says the set is not on offer, rather than offering it.
-            await expect(page.locator('#dlgMetricsHelp'))
-                .toContainText('does not take the report metric set');
+            // Nothing offers an inheritance that no longer exists.
             await expect(page.locator('#dlgMetricsHelp')).not.toContainText('Leave empty');
+            await expect(page.locator('#dlgMetricsHelp')).not.toContainText('report metric set');
+            await expect(page.locator('#dlgMetricsHelp')).toContainText('Required');
 
             // The boxes are above the chart, and the form says which.
             await expect(page.locator('#dlgMetricsHelp')).toContainText('above');
@@ -1048,26 +1423,27 @@ test.describe('custom reports', () => {
         });
 
         /**
-         * A card draws one metric, so it is offered a METRIC, not a metric set.
+         * A card draws ONE metric, a table several -- and the field says which
+         * by being singular or plural.
          *
-         * The report metric set is several metrics, and a card ranks its rows
-         * by one -- so calling the field "Metrics" there would be offering a
-         * set the widget has no way to draw.
+         * Both are required now: neither can be left empty, because there is no
+         * report metric set for either to fall back to. What separates them is
+         * the count, which is what these labels are for.
          */
-        test('a card asks for one metric, a table for a set', async ({ page }) => {
-            await openBuilder(page);
+        test('a card asks for one metric, a table for several', async ({ page }) => {
+            await openBuilderOnGrid(page);
 
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
             await expect(page.locator('#dlgMetricsLabel')).toHaveText('Metrics');
-            await expect(page.locator('#dlgMetricsHelp')).toContainText('report metric set');
+            await expect(page.locator('#dlgMetricsHelp')).toContainText('Up to');
+            await expect(page.locator('#dlgMetricsHelp')).toContainText('Required');
             await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
 
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="grid-card"]').click();
+            await startWidget(page, 'grid-card');
 
             await expect(page.locator('#dlgMetricsLabel')).toHaveText('Metric');
             await expect(page.locator('#dlgDimensionsLabel')).toHaveText('Dimension');
-            await expect(page.locator('#dlgMetricsHelp')).not.toContainText('report metric set');
+            await expect(page.locator('#dlgMetricsHelp')).toContainText('The one metric');
+            await expect(page.locator('#dlgMetricsHelp')).toContainText('Required');
         });
 
         test('a card takes one metric and one dimension and then offers no more',
@@ -1075,9 +1451,7 @@ test.describe('custom reports', () => {
 
             await openBuilder(page);
 
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="grid-card"]').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'grid-card');
 
             await chooseInChosen(page, 'dlgMetrics', 'pageViews');
             await chooseInChosen(page, 'dlgDimensions', 'pagePath');
@@ -1125,9 +1499,7 @@ test.describe('custom reports', () => {
         test('a card is offered only the reports its dimension can reach', async ({ page }) => {
             await openBuilder(page);
 
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="grid-card"]').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'grid-card');
 
             // Nothing to link from yet.
             await expect(page.locator('#dlgLinkField')).toBeHidden();
@@ -1155,9 +1527,7 @@ test.describe('custom reports', () => {
         test('the full-report link is scoped to the dimension too', async ({ page }) => {
             await openBuilder(page);
 
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="grid-card"]').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'grid-card');
 
             // Nothing shown yet, so there is no "more of the same thing".
             await expect(page.locator('#dlgMoreField')).toBeHidden();
@@ -1288,9 +1658,7 @@ test.describe('custom reports', () => {
 
             await openBuilder(page);
 
-            await page.click('#addWidget');
-            await page.locator('.owa_typeChoice[data-type="trend"]').click();
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await startWidget(page, 'trend');
 
             // The axis is settled; what is offered is the breakdown.
             await expect(page.locator('#dlgDimensionsField')).toBeVisible();
@@ -1497,29 +1865,50 @@ test.describe('custom reports', () => {
 
         /** Cancel leaves the widget as it was. */
         test('cancelling the modal changes nothing', async ({ page }) => {
-            await openBuilder(page);
+            await openBuilderOnGrid(page);
 
-            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
             await page.fill('#dlgTitle', 'Should not stick');
             await page.locator('.ui-dialog-buttonpane button', { hasText: 'Cancel' }).click();
 
             await expect(page.locator('.owa_builderBlockName').first()).toHaveText('Widget 1');
         });
 
-        /** A block can be removed, and the last one leaves a fresh block. */
-        test('removing blocks never empties the canvas', async ({ page }) => {
+        /**
+         * A block can be removed, and removing the LAST one leaves the canvas
+         * empty rather than putting another block back.
+         *
+         * It used to put a fresh one back, on the reasoning that a report with
+         * no widgets cannot be saved and so an empty canvas is a dead end. It
+         * is not a dead end -- the plus is right there -- and the replacement
+         * was worse than the emptiness: an author who removed a widget got
+         * another one, of a type they had not chosen, which then had to be
+         * removed as well.
+         */
+        test('removing the last block empties the canvas and disables save',
+            async ({ page }) => {
+
             await openBuilder(page);
 
-            await addWidget(page, 'grid');
+            // Named and configured, so that the ONLY thing Save is waiting for
+            // by the end of this test is the emptiness of the canvas.
+            await page.fill('#customReportName', reportName('Removing'));
+            await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
+            await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
             await expect(page.locator('.owa_builderBlock')).toHaveCount(2);
 
             await page.locator('.owa_builderBlock').first().locator('.owa_builderRemove').click();
             await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+            await expect(page.locator('#customReportSubmit')).toBeEnabled();
 
-            // Removing the last leaves a fresh one: a report with no widgets
-            // cannot be saved, so an empty canvas is a dead end.
             await page.locator('.owa_builderBlock').first().locator('.owa_builderRemove').click();
-            await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(0);
+            await expect(page.locator('#customReportEmpty')).toBeVisible();
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+
+            // ...and the plus is still there, which is why the emptiness is not
+            // a dead end.
+            await expect(page.locator('#addWidget')).toBeVisible();
         });
 
         /**
@@ -1590,8 +1979,8 @@ test.describe('custom reports', () => {
             await openBuilder(page);
             await page.fill('#customReportName', name);
 
-            // A grid -- the block a new report starts with...
-            await configureWidget(page, 0, {
+            // A grid...
+            await addWidget(page, 'grid', {
                 title: 'Pages',
                 metrics: ['pageViews'],
                 dimensions: ['pagePath'],
@@ -1645,7 +2034,7 @@ test.describe('custom reports', () => {
             await openBuilder(page);
             await page.fill('#customReportName', name);
 
-            await configureWidget(page, 0, {
+            await addWidget(page, 'grid', {
                 title: 'Pages',
                 metrics: ['pageViews'],
                 dimensions: ['pagePath'],
@@ -1792,7 +2181,7 @@ test.describe('custom reports', () => {
 
             // Reach past the pickers: a sort is free text, which is the field
             // an author can put an unresolvable name into.
-            await configureWidget(page, 0, {
+            await addWidget(page, 'grid', {
                 metrics: ['pageViews'],
                 sort: 'notARealMetric-',
             });

--- a/tests/e2e/custom-reports.spec.js
+++ b/tests/e2e/custom-reports.spec.js
@@ -136,6 +136,17 @@ async function chooseInChosen(page, selectId, name) {
         .toHaveJSProperty('selected', true);
 }
 
+/**
+ * The widget dialog's Save button.
+ *
+ * Built by jQuery UI in the frame outside #widgetDialog, so it cannot be
+ * reached through that id.
+ */
+function dialogSave(page) {
+    return page.locator('.owa_widgetDialogFrame .ui-dialog-buttonpane button',
+        { hasText: 'Save' });
+}
+
 /** The pills currently shown by a Chosen control. */
 function chosenPills(page, selectId) {
     return page.locator(`#${selectId}_chosen .search-choice`);
@@ -181,7 +192,7 @@ async function onlyWidget(page, type, opts = {}) {
     await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
 }
 
-/** Fill the widget modal that is already open, and close it with Done. */
+/** Fill the widget modal that is already open, and close it with Save. */
 async function fillWidget(page, opts) {
     if (opts.title !== undefined) { await page.fill('#dlgTitle', opts.title); }
     if (opts.colspan)             { await page.selectOption('#dlgColspan', String(opts.colspan)); }
@@ -198,7 +209,7 @@ async function fillWidget(page, opts) {
 
     if (opts.sort !== undefined)  { await page.fill('#dlgSort', opts.sort); }
 
-    await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+    await page.locator('.ui-dialog-buttonpane button', { hasText: 'Save' }).click();
     await expect(page.locator('#widgetDialog')).toBeHidden();
 }
 
@@ -414,7 +425,8 @@ test.describe('custom reports', () => {
             // ...beside a sentence saying what is missing. The plus alone is a
             // control, not an instruction.
             await expect(page.locator('#customReportEmpty')).toBeVisible();
-            await expect(page.locator('#customReportEmpty')).toContainText('at least one');
+            await expect(page.locator('#customReportEmpty'))
+                .toContainText('cannot be saved empty');
 
             await expect(page.locator('#customReportSubmit')).toBeDisabled();
 
@@ -544,16 +556,15 @@ test.describe('custom reports', () => {
             // A dimension, and deliberately no value.
             await fillConstraintRow(page, { dimension: '(medium)' });
 
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            await expect(dialogSave(page)).toBeDisabled();
+            await expect(page.locator('#dlgError')).toContainText('has no value');
 
-            await expect(page.locator('#widgetDialog')).toBeVisible();
-            await expect(page.locator('#dlgError'))
-                .toContainText('gives no value');
-
-            // Filling it in lets the dialog close, and the constraint reaches
-            // the definition rather than being dropped on the way out.
+            // Filling it in lets the widget be saved, and the constraint
+            // reaches the definition rather than being dropped on the way out.
             await fillConstraintRow(page, { value: 'organic-search' });
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(dialogSave(page)).toBeEnabled();
+            await dialogSave(page).click();
             await expect(page.locator('#widgetDialog')).toBeHidden();
 
             const definition = await page.evaluate(() => {
@@ -644,13 +655,18 @@ test.describe('custom reports', () => {
             await openBuilder(page);
 
             await startWidget(page, 'grid');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
 
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            // Not refused on click -- never clickable. The reason is on the
+            // dialog beside it.
+            await expect(dialogSave(page)).toBeDisabled();
             await expect(page.locator('#dlgError')).toContainText('at least one metric');
 
             await chooseInChosen(page, 'dlgMetrics', 'pageViews');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(dialogSave(page)).toBeEnabled();
+            await expect(page.locator('#dlgError')).toBeHidden();
+
+            await dialogSave(page).click();
             await expect(page.locator('#widgetDialog')).toBeHidden();
         });
 
@@ -663,13 +679,14 @@ test.describe('custom reports', () => {
 
             await startWidget(page, 'pie');
             await chooseInChosen(page, 'dlgMetrics', 'pageViews');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
 
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await expect(dialogSave(page)).toBeDisabled();
             await expect(page.locator('#dlgError')).toContainText('dimension');
 
             await chooseInChosen(page, 'dlgDimensions', 'pagePath');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(dialogSave(page)).toBeEnabled();
+            await dialogSave(page).click();
             await expect(page.locator('#widgetDialog')).toBeHidden();
         });
 
@@ -695,14 +712,15 @@ test.describe('custom reports', () => {
             await chooseInChosen(page, 'dlgMetrics', 'pageViews');
 
             await page.fill('#dlgSort', 'notARealMetric-');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
 
-            await expect(page.locator('#widgetDialog')).toBeVisible();
+            await expect(dialogSave(page)).toBeDisabled();
             await expect(page.locator('#dlgError')).toContainText('notARealMetric');
 
             // A real metric, descending, is fine -- the '-' is not part of it.
             await page.fill('#dlgSort', 'pageViews-');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await expect(dialogSave(page)).toBeEnabled();
+            await dialogSave(page).click();
             await expect(page.locator('#widgetDialog')).toBeHidden();
         });
 
@@ -831,7 +849,7 @@ test.describe('custom reports', () => {
             await page.locator('.owa_builderBlock').nth(1).locator('.owa_builderEdit').click();
             await expect(page.locator('#widgetDialog')).toBeVisible();
             await page.fill('#dlgSort', 'pageViews-');
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Save' }).click();
 
             await page.click('#customReportSubmit');
             await page.waitForLoadState('networkidle');
@@ -995,7 +1013,7 @@ test.describe('custom reports', () => {
             await fillConstraintRow(page,
                 { dimension: '(medium)', operator: 'Contains', value: 'organic' });
 
-            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Save' }).click();
             await expect(page.locator('#widgetDialog')).toBeHidden();
 
             await page.click('#customReportSubmit');

--- a/tests/e2e/custom-reports.spec.js
+++ b/tests/e2e/custom-reports.spec.js
@@ -757,10 +757,76 @@ test.describe('custom reports', () => {
 
             await expect(body).not.toHaveText('');
             await expect(body).toContainText('Custom Report');
+
+            // A MESSAGE, and a specific one. "A broken error page with no msg"
+            // is the whole symptom, so an empty notice is as much a failure
+            // here as no page at all.
             await expect(page.locator('.notice')).toContainText('needs a name');
+            await expect(page.locator('.notice')).not.toHaveText('');
 
             // ...and the builder is back, so the author can fix it here.
             await expect(page.locator('#customReportForm')).toBeVisible();
+
+            // THE WORK IS STILL THERE. The blocks come back from the submitted
+            // definition, not from the stored row -- there is no stored row --
+            // so a refusal that redrew an empty canvas would have thrown away
+            // everything the author had built.
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+
+            // ...and the screen is correctly gated on arrival, saying which
+            // rule is unmet rather than offering a Save that will fail again.
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+            await expect(page.locator('#customReportBlocker')).toContainText('name');
+        });
+
+        /**
+         * The same refusal, driven with a BARE TREND.
+         *
+         * A trend is the one type whose query is non-empty before the author
+         * has chosen anything -- newWidget() fills in the fixed date dimension
+         * and its sort -- so it is the type most likely to look configured to
+         * code that only checks whether `query` has anything in it. It reaches
+         * the refusal with no metrics and no report name, which is the shape
+         * that has to come back legible.
+         */
+        test('a bare trend refused for a missing name comes back with its block',
+            async ({ page }) => {
+
+            await openBuilder(page);
+
+            await startWidget(page, 'trend');
+            await page.locator('.ui-dialog-buttonpane button', { hasText: 'Done' }).click();
+
+            await Promise.all([
+                page.waitForNavigation({ waitUntil: 'load' }),
+                page.evaluate(() => {
+                    document.getElementById('customReportDefinition').value = JSON.stringify({
+                        title: '',
+                        widgets: [{
+                            type: 'trend', title: 'Widget 1', rowspan: 1, colspan: 6,
+                            query: { dimensions: 'date', sort: 'date' },
+                            id: 'w1', container: 'w1',
+                        }],
+                    });
+                    document.getElementById('customReportName').value = '';
+
+                    HTMLFormElement.prototype.submit.call(
+                        document.getElementById('customReportForm'));
+                }),
+            ]);
+
+            await expect(page.locator('.notice')).toContainText('needs a name');
+            await expect(page.locator('.owa_builderBlock')).toHaveCount(1);
+            await expect(page.locator('.owa_builderBlockType')).toHaveText('Trend chart');
+
+            // The trend names no metrics, so it is marked as unfinished too --
+            // the canvas says which block, not just that something is wrong.
+            await expect(page.locator('.owa_builderBlockIncomplete')).toHaveCount(1);
+            await expect(page.locator('#customReportSubmit')).toBeDisabled();
+
+            // ...and it can be opened and fixed from here.
+            await page.locator('.owa_builderBlock').first().locator('.owa_builderEdit').click();
+            await expect(page.locator('#widgetDialog')).toBeVisible();
         });
 
         /**

--- a/tests/e2e/visualizations.spec.js
+++ b/tests/e2e/visualizations.spec.js
@@ -142,18 +142,31 @@ test.describe('visualizations', () => {
         await expect(page.locator('input[name="stepName[]"]').first()).toBeVisible();
     });
 
-    /** A funnel is nothing but its steps, so one with none describes no path. */
-    test('a visualization with no steps is refused', async ({ page }) => {
+    /**
+     * A funnel is nothing but its steps, so one with none describes no path.
+     *
+     * Stopped in the form now: Save is unavailable until the rules are met, so
+     * the button cannot post this. The server still refuses it -- the second
+     * half below posts past the button the way a stale tab would -- and keeps
+     * what was typed.
+     */
+    test('a visualization with no steps cannot be saved', async ({ page }) => {
         await gotoAction(page, 'base.visualizationEdit', `&owa_siteId=${FIXTURE.siteId}`);
 
         await page.fill('input[name="name"]', 'E2E Empty Viz');
 
+        await expect(page.locator('#owa_visualizationSubmit')).toBeDisabled();
+        await expect(page.locator('#owa_visualizationBlocker')).toContainText('at least one step');
+
         await Promise.all([
             page.waitForNavigation({ waitUntil: 'networkidle' }),
-            page.locator('input[value="Save Visualization"]').click(),
+            page.evaluate(() => HTMLFormElement.prototype.submit.call(
+                document.forms.owa_visualization)),
         ]);
 
         await expect(page.locator('input[name="name"]')).toHaveValue('E2E Empty Viz');
+        await expect(page.locator('.validation_error').filter({ hasText: 'at least one step' }))
+            .toHaveCount(1);
     });
 
     /**
@@ -168,12 +181,86 @@ test.describe('visualizations', () => {
         await page.locator('input[name="stepName[]"]').first().fill('Basket');
         await page.locator('input[name="stepPath[]"]').first().fill('https://example.test/basket');
 
+        // Caught in the form, on the same rule the save applies.
+        await expect(page.locator('#owa_visualizationSubmit')).toBeDisabled();
+        await expect(page.locator('#owa_visualizationBlocker'))
+            .toContainText('not a full web address');
+
         await Promise.all([
             page.waitForNavigation({ waitUntil: 'networkidle' }),
-            page.locator('input[value="Save Visualization"]').click(),
+            page.evaluate(() => HTMLFormElement.prototype.submit.call(
+                document.forms.owa_visualization)),
         ]);
 
         await expect(page.locator('input[name="name"]')).toHaveValue('E2E Bad Step');
+        await expect(page.locator('.validation_error').filter({ hasText: 'page PATH' }))
+            .toHaveCount(1);
+    });
+
+    /**
+     * AN ERROR ABOUT STEP 2 WAS WRITTEN AND NEVER SHOWN.
+     *
+     * The template rendered three hardcoded keys -- stepPath1, stepName1,
+     * stepGoalEvent1 -- and validate() writes one per step number. So a problem
+     * with any step but the first refused the save and then appeared nowhere:
+     * the author got the form back, unchanged, with no reason on it.
+     *
+     * Driven past the button, because the form now stops this before it is
+     * posted; what is under test is the server's answer and where it is shown.
+     */
+    test('an error about a later step is shown, not swallowed', async ({ page }) => {
+        await gotoAction(page, 'base.visualizationEdit', `&owa_siteId=${FIXTURE.siteId}`);
+
+        await page.fill('input[name="name"]', 'E2E Second Step');
+        await page.locator('input[name="stepName[]"]').first().fill('One');
+        await page.locator('input[name="stepPath[]"]').first().fill('/one');
+
+        await page.locator('#owa_goalEventFunnel .constraintAddButton').first().click();
+
+        // A second step with a name and no path.
+        await page.locator('input[name="stepName[]"]').nth(1).fill('Two');
+
+        await expect(page.locator('#owa_visualizationSubmit')).toBeDisabled();
+        await expect(page.locator('#owa_visualizationBlocker')).toContainText('Step 2');
+
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'networkidle' }),
+            page.evaluate(() => HTMLFormElement.prototype.submit.call(
+                document.forms.owa_visualization)),
+        ]);
+
+        // The message names the step it is about, and the work is still there.
+        await expect(page.locator('.validation_error').filter({ hasText: 'Step 2 needs a path' }))
+            .toHaveCount(1);
+        await expect(page.locator('input[name="stepName[]"]').nth(1)).toHaveValue('Two');
+    });
+
+    /**
+     * Save waits for the same rules the server applies, and says which one.
+     *
+     * The form used to offer Save from the moment it opened, so the first
+     * answer to an empty funnel was a round trip.
+     */
+    test('save waits for a name and a complete step', async ({ page }) => {
+        await gotoAction(page, 'base.visualizationEdit', `&owa_siteId=${FIXTURE.siteId}`);
+
+        // Name and Steps both say they are required, rather than the author
+        // finding out on save.
+        await expect(page.locator('.owa_builderRequired')).toHaveCount(2);
+
+        await expect(page.locator('#owa_visualizationSubmit')).toBeDisabled();
+        await expect(page.locator('#owa_visualizationBlocker')).toContainText('name');
+
+        await page.fill('input[name="name"]', 'E2E Gate ' + Date.now());
+        await expect(page.locator('#owa_visualizationBlocker')).toContainText('at least one step');
+
+        await page.locator('input[name="stepName[]"]').first().fill('Basket');
+        await expect(page.locator('#owa_visualizationBlocker')).toContainText('no path');
+
+        await page.locator('input[name="stepPath[]"]').first().fill('/basket');
+
+        await expect(page.locator('#owa_visualizationSubmit')).toBeEnabled();
+        await expect(page.locator('#owa_visualizationBlocker')).toBeHidden();
     });
 
     /**


### PR DESCRIPTION
The add screen opened with a **report metric set** and a **defaulted table widget**, so a report could be saved without a single decision having been made — and what came out was a table of nothing. Both are gone, and nothing saves until the report is actually complete.

## The screen

A new report starts empty. The first thing on it is the choice that starts a report: what kind of widget.

Save is refused until there is a widget, a name, and a metric on every widget. It is disabled with the reason next to it, one rule at a time, and the offending block is marked on the canvas — "Widget 3 does not say what it measures" is only useful if Widget 3 can be picked out of a row of blocks. Removing the last block now leaves the canvas empty rather than putting a fresh block back, which used to hand the author a widget of a type they had not chosen.

Every one of those rules is the server's. Asking here only means the author is told while the thing to fix is still in front of them; the Enter key goes through the same gate.

Required fields say so, toggled per widget type from the server's own lists — the report name always, metrics on every widget, and a dimension only on `grid-card` and `pie`, the types that draw exactly one.

## Why the metric set went

It was a second answer to "what does this report measure", beside the one inside every widget, and the two did not compose: a widget naming nothing inherited the set, so what a widget drew depended on a field further up the page that said nothing about which widget it would land in.

Every widget names its own now — enforced in `CustomReports::validateQuery()`.

**The stored key is still read and still validated.** A report saved while the control existed keeps its set, keeps rendering, and round-trips through an edit untouched. That exemption is deliberate and load-bearing: `validate()` runs at *render* time as well as at save time, so applying the new rule unconditionally would 500 every report built under the old builder and leave its author no field to fix it with.

## Two bugs found on the way, both older than this change

**A refusal raised by `validate()` rendered a blank page.** `Core/Controller.php` calls `errorAction()` for its side effects and returns `$this->data` regardless — only `action()`'s return value is honoured — so `CustomReportSave::refuse()` built the entire builder screen and had it thrown away. Pressing Save with the name left empty did it every time, and the field carries an "Untitled report" placeholder, so an empty one does not look empty. Reproduced at `LEN=0`.

Fixed locally, by assigning as well as returning. The dispatcher is left alone on purpose: `finishActionCall()` also runs `success()` and `post()`, which 26 other controllers' error paths currently do not get. Worth fixing properly one day; not here.

**A constraint was the one name in a definition never resolved through the registry at save time.** Metrics, dimensions, sorts, chart metrics and link targets were all checked. Measured before changing anything — every one of these saved clean:

| clause | before | consequence |
|---|---|---|
| `notADimension==direct` | accepted | refused at *query* time — told to every reader, forever |
| `medium==` | accepted | same |
| `medium` | accepted | **parses to nothing** — widget answers unfiltered, nothing raised |
| `==direct` | accepted | same (`parseConstraintsString` uses a truthy `strpos`) |
| `medium~~x` | accepted | same |

The last three are the serious ones: no operator is found, no constraint is contributed, and the query runs completely unfiltered. A widget meant to show organic search shows the site total and nothing says so.

Each clause is now checked for an operator, a name that resolves as a dimension or metric, and a non-empty value — reading the operator list from `ResultSetManager::$constraint_operators` rather than copying it, and accepting the full ten the engine runs rather than the five the picker offers, so a hand-written definition is not refused for working. `==direct` and `medium` get different messages, because "add an operator" is wrong advice for a clause that already has one.

The builder half of the same hole: a half-filled constraint row was dropped silently on the way out of the dialog — pick a dimension, tab past the value, and you got an unfiltered widget with no indication you had asked for a filter. That is exactly what the query engine refuses to run ("a missing value is not a request for everything"). Done no longer closes on one.

## Also

The Save button carried `class="owa_button"`, and nothing defines that — not `owa.css`, not `owa.report.css`, not the bundle. So the one affirmative control on the screen rendered as a bare browser submit while *Save Visualization*, one screen over in the sibling builder, was the orange primary. Now `owa-button`, like every other save form.

## Testing

- `CustomReportsTest`: the per-widget metric rule, the metric-set exemption, and constraints — six malformed shapes refused, six legitimate ones accepted, plus a test asserting the operators checked are the ones the engine parses, so the two lists cannot drift.
- `custom-reports.spec.js`: the empty canvas, the save gate rule by rule, the required marks per type, the half-filled constraint row, and the blank page — driven *past* the client gate, because the gate is why the server half went unnoticed.
- One test pins that every block stays editable after a refusal and the fix then saves.

1970 PHP unit, 562 jest, 61 custom-report e2e, 6 visualization e2e — all green.
