### PR TITLE
A signed-in user can edit their own account

### DIFF
--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -951,6 +951,34 @@ class Controller extends \OWA\Core\Base {
         $nav = array();
 
         /*
+         * YOUR OWN SETTINGS, first.
+         *
+         * Not part of the Installation group: every entry there is gated on
+         * edit_settings and describes the installation, while this describes
+         * the person looking at it. An analyst has one of these and none of
+         * those.
+         *
+         * At the head, above the scope chain rather than inside it. The groups
+         * below read widest to narrowest -- install, Organization, Property,
+         * Profile -- and this is not a step in that chain: it is the one group
+         * about you rather than about the tree, which is also why it is the one
+         * every signed-in role can open.
+         *
+         * One entry today. The group exists because user-level preferences land
+         * here as siblings of Profile rather than inside it.
+         */
+        $nav['My Preferences'] = array(
+            array(
+                'do'         => 'base.myProfile',
+                'label'      => 'Profile',
+                'params'     => array(),
+                // What admin, analyst and viewer all carry and nothing else
+                // does -- the capability that means "signed in".
+                'capability' => 'view_site_list',
+            ),
+        );
+
+        /*
          * Install-wide options head the SAME nav now.
          *
          * They were split into a separate settings menu because the hierarchy
@@ -1057,35 +1085,6 @@ class Controller extends \OWA\Core\Base {
                        'capability' => 'edit_sites' ),
             );
         }
-
-        /*
-         * YOUR OWN SETTINGS, in a group of their own, LAST.
-         *
-         * Not part of the Installation group: every entry there is gated on
-         * edit_settings and describes the installation, while this describes
-         * the person looking at it. An analyst has one of these and none of
-         * those.
-         *
-         * Last, not first. The groups above read widest scope to narrowest --
-         * install, Organization, Property, Profile -- and putting a group that
-         * is not a step in that chain at the head would make "install-wide
-         * options head the nav" false. After it, the ordering statement still
-         * holds and this reads as what it is: not a narrower scope, a different
-         * subject.
-         *
-         * One entry today. The group exists because user-level preferences land
-         * here as siblings of Profile rather than inside it.
-         */
-        $nav['My Preferences'] = array(
-            array(
-                'do'         => 'base.myProfile',
-                'label'      => 'Profile',
-                'params'     => array(),
-                // What admin, analyst and viewer all carry and nothing else
-                // does -- the capability that means "signed in".
-                'capability' => 'view_site_list',
-            ),
-        );
 
         return $nav;
     }

--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -1058,6 +1058,35 @@ class Controller extends \OWA\Core\Base {
             );
         }
 
+        /*
+         * YOUR OWN SETTINGS, in a group of their own, LAST.
+         *
+         * Not part of the Installation group: every entry there is gated on
+         * edit_settings and describes the installation, while this describes
+         * the person looking at it. An analyst has one of these and none of
+         * those.
+         *
+         * Last, not first. The groups above read widest scope to narrowest --
+         * install, Organization, Property, Profile -- and putting a group that
+         * is not a step in that chain at the head would make "install-wide
+         * options head the nav" false. After it, the ordering statement still
+         * holds and this reads as what it is: not a narrower scope, a different
+         * subject.
+         *
+         * One entry today. The group exists because user-level preferences land
+         * here as siblings of Profile rather than inside it.
+         */
+        $nav['My Preferences'] = array(
+            array(
+                'do'         => 'base.myProfile',
+                'label'      => 'Profile',
+                'params'     => array(),
+                // What admin, analyst and viewer all carry and nothing else
+                // does -- the capability that means "signed in".
+                'capability' => 'view_site_list',
+            ),
+        );
+
         return $nav;
     }
 

--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -1260,7 +1260,22 @@ namespace OWA\Module\Base\Classes;
                                 // NOT in capabilitiesThatRequireSiteAccess: a
                                 // custom report is site-agnostic, so there is
                                 // no one site to check access against.
-                                'edit_reports'
+                                'edit_reports',
+                                // Changing the email address on your own
+                                // account. Admin-only by default; grant it to
+                                // another role in the config file to let people
+                                // change their own.
+                                //
+                                // Separate from edit_users, which is about
+                                // other people's accounts. The address is where
+                                // password resets are sent, so changing it
+                                // moves who can recover the account -- everyone
+                                // may edit their own name without that being
+                                // true of their address.
+                                //
+                                // Not site-scoped, so not in
+                                // capabilitiesThatRequireSiteAccess.
+                                'edit_own_email'
                         ),
                         'analyst' => array('install_schema', 'view_site_list', 'view_reports', 'view_reports_ecommerce'),
                         'viewer' => array('install_schema', 'view_site_list', 'view_reports'),

--- a/modules/Base/Controller/InstallBase.php
+++ b/modules/Base/Controller/InstallBase.php
@@ -52,14 +52,41 @@ class InstallBase extends \OWA\Core\Controller\Install {
         $this->addValidation('email_address', $this->getParam('email_address'), 'required', ['errorMsg' => $this->getMsg(3310)]);
         $this->addValidation('password', $this->getParam('password'), 'required', ['errorMsg' => $this->getMsg(3310)]);
 
-        $domainConf = [
-            'substring' => 'http',
-            'position'  => 0,
-            'operator'  => '!=',
-            'errorMsg'  => $this->getMsg(3208)
-        ];
+        /*
+         * A pasted URL is no longer refused.
+         *
+         * The form used to ask for the scheme in a select of its own, so a
+         * domain that also carried one produced "https://https://example.com"
+         * -- hence a validation that rejected anything starting with "http".
+         * The select is gone and the scheme is stripped instead, which is what
+         * every reader of this column does anyway; refusing the most natural
+         * thing to paste bought nothing.
+         */
+    }
 
-        $this->addValidation('domain', $this->getParam('domain'), 'subStringPosition', $domainConf);
+    /**
+     * A domain, from whatever was typed.
+     *
+     * Stores what the column is for. Site::getDomainName() strips a scheme on
+     * the way out for the rows that still have one, so writing a bare domain
+     * here means the two agree rather than one undoing the other -- and it
+     * matches what the CLI installer has always stored.
+     *
+     * @param string $domain
+     * @return string
+     */
+    public static function domainOnly( $domain ) {
+
+        $domain = trim( (string) $domain );
+
+        $separator = strpos( $domain, '://' );
+
+        if ( $separator !== false ) {
+
+            $domain = substr( $domain, $separator + 3 );
+        }
+
+        return rtrim( trim( $domain ), '/' );
     }
 
     function action() {
@@ -67,11 +94,17 @@ class InstallBase extends \OWA\Core\Controller\Install {
         $status = $this->installSchema();
 
         if ($status == true) {
-            $this->set('status_code', 3305);
+            /*
+             * No status banner on the way to the finish screen.
+             *
+             * It announced "Base Database Schema Installed." above a page whose
+             * own headline is "Installation complete" -- the same news, told
+             * twice, the second time as a sub-step nobody asked about.
+             */
 
             $password = $this->createAdminUser($this->getParam('user_id'), $this->getParam('email_address'), $this->getParam('password') );
 
-            $site_id = $this->createDefaultSite($this->getParam('protocol').$this->getParam('domain'));
+            $site_id = $this->createDefaultSite( self::domainOnly( $this->getParam('domain') ) );
 
             /*
              * Persisted here, with the rest of the install, because the choice
@@ -126,7 +159,20 @@ class InstallBase extends \OWA\Core\Controller\Install {
 
             // set view
             $this->set('u', $this->getParam('user_id'));
-            $this->set('p', $password);
+
+            /*
+             * The password ONLY when OWA generated it.
+             *
+             * createAdminUser() generates one only when none was supplied, and
+             * this form requires one -- so on the web path this is a password
+             * the operator just chose, and printing it back tells them nothing
+             * while leaving a live credential in the page, in the back-forward
+             * cache, and in any screenshot of the completion screen.
+             *
+             * The CLI installer can be run without one, which is the case that
+             * has to be told; it prints its own.
+             */
+            $this->set( 'p', $this->getParam('password') ? '' : $password );
             $this->set('site_id', $site_id);
             $this->setView('base.install');
             $this->setSubview('base.installFinish');

--- a/modules/Base/Controller/InstallCheckEnv.php
+++ b/modules/Base/Controller/InstallCheckEnv.php
@@ -33,122 +33,206 @@ namespace OWA\Module\Base\Controller;
 
 class InstallCheckEnv extends \OWA\Core\Controller\Install {
 
+    /**
+     * The lowest PHP this release runs on.
+     *
+     * The same number composer.json requires. It was a hand-rolled comparison
+     * -- `$version[0] < 5 && $version[1] < 2` -- which cannot express a
+     * requirement at all: on PHP 8.2 the first term is false, so the whole
+     * check passed, and on PHP 5.1 it passed too because 5 is not less than 5.
+     * It has been unable to fail for every PHP anyone still runs.
+     */
+    const MIN_PHP_VERSION = '8.2';
+
+    /**
+     * Extensions OWA cannot run without, and what each is for.
+     *
+     * Checked here because the alternative is finding out later and worse: with
+     * no database driver the wizard takes a full page of connection details and
+     * then fails on connect, which reads as "my credentials are wrong".
+     */
+    const REQUIRED_EXTENSIONS = array(
+        'json'     => 'Encoding stored report definitions and API responses.',
+        'mbstring' => 'Handling non-ASCII page titles, URLs and search terms.',
+        'pcre'     => 'Matching URLs, goal conditions and constraint values.',
+    );
+
     function action() {
 
-        $errors = array();
-        $bad_environment = false;
-        $config_file_present = false;
+        $checks = array();
 
-        // check PHP version
-        $version = explode( '.', phpversion() );
+        // PHP itself.
+        $checks[] = $this->check(
+            'PHP version',
+            phpversion(),
+            version_compare( phpversion(), self::MIN_PHP_VERSION, '>=' ),
+            sprintf( 'OWA needs PHP %s or newer. Ask your host to upgrade, or point '
+                   . 'this virtual host at a newer PHP.', self::MIN_PHP_VERSION ) );
 
-        if ( $version[0] < 5 && $version[1] < 2 ) {
-            $errors['php_version']['name'] = 'PHP Version';
-            $errors['php_version']['value'] = phpversion();
-            $errors['php_version']['msg'] = $this->getMsgAsString(3301);
-            $bad_environment = true;
+        /*
+         * A database driver: PDO with a MySQL driver, or mysqli. Either one is
+         * enough -- Db picks whichever is present -- so this is one check
+         * rather than three, and it says which ones it looked for.
+         */
+        $drivers = array();
+
+        if ( extension_loaded( 'pdo_mysql' ) ) {
+            $drivers[] = 'pdo_mysql';
         }
 
-        // Check permissions on log directory
-        if ( ! is_writable( OWA_DATA_DIR . 'logs/' ) ) {
-
-            $errors['owa_logdir_permissions']['name'] = 'Log Directory Permissions';
-            $errors['owa_logdir_permissions']['value'] = 'Not writable';
-            $errors['owa_logdir_permissions']['msg'] = 'Check filesystem permissions for '. OWA_DATA_DIR . 'logs/ ' . ' to ensure it is writable.';
-            $bad_environment = true;
+        if ( extension_loaded( 'mysqli' ) ) {
+            $drivers[] = 'mysqli';
         }
 
-        // Check permissions on caches directory
-        if ( ! is_writable( OWA_DATA_DIR . 'caches/' ) ) {
+        $checks[] = $this->check(
+            'Database driver',
+            $drivers ? implode( ', ', $drivers ) : 'none found',
+            (bool) $drivers,
+            'OWA needs the pdo_mysql or mysqli PHP extension to reach a database. '
+          . 'Install one and restart PHP.' );
 
-            $errors['owa_caches_permissions']['name'] = 'Caches Directory Permissions';
-            $errors['owa_caches_permissions']['value'] = 'Not writable';
-            $errors['owa_caches_permissions']['msg'] = 'Check filesystem permissions for '. OWA_DATA_DIR . 'caches/ ' . ' to ensure it is writable.';
-            $bad_environment = true;
+        foreach ( self::REQUIRED_EXTENSIONS as $extension => $what_for ) {
+
+            $checks[] = $this->check(
+                sprintf( 'PHP extension: %s', $extension ),
+                extension_loaded( $extension ) ? 'loaded' : 'missing',
+                extension_loaded( $extension ),
+                $what_for . ' Install the ' . $extension . ' extension and restart PHP.' );
         }
 
-        // check for magic_quotes
-        if ( function_exists( 'get_magic_quotes_gpc' ) ) {
+        // Where OWA writes.
+        foreach ( array( 'logs' => 'Log directory', 'caches' => 'Cache directory' )
+                  as $dir => $label ) {
 
-            $magic_quotes = get_magic_quotes_gpc();
+            $path = OWA_DATA_DIR . $dir . '/';
 
-            if ( $magic_quotes ) {
-
-                $errors['magic_quotes_gpc']['name'] = 'magic_quotes_gpc';
-                $errors['magic_quotes_gpc']['value'] = $magic_quotes;
-                $errors['magic_quotes_gpc']['msg'] = "The magic_quotes_gpc PHP INI directive must be set to 'OFF' in order for OWA domstreams to operate correctly.";
-                $bad_environment = true;
-
-            }
-        }
-        
-        // check to ensure tha the vendors dir exist
-        if (! is_dir( OWA_VENDOR_DIR ) ) {
-	        
-	        $errors['vendors_dir'] = [
-		        
-		        'name'	=> 'Vendors Directory',
-		        'value'	=> 'missing',
-		        'msg'	=> "The vendors directory is missing. Please run 'composer install' from the top level OWA directory."
-	        ];
-	        
-	        $bad_environment = true;
-        }
-        
-        // check to ensure the built asset dir exists. The webpack build now emits
-        // the tracker/reporting bundles under public/base/dist (they used to live
-        // in modules/base/dist); public/ is gitignored, so a fresh source checkout
-        // still lacks it until 'npm run build' runs.
-        if ( ! is_dir( OWA_DIR .'public/base/dist' ) ) {
-
-	        $errors['base_dist_dir'] = [
-
-		        'name'	=> 'dist Directory',
-		        'value'	=> 'missing',
-		        'msg'	=> "The built asset directory (public/base/dist) is missing. Please run 'npm run build' from the top level OWA directory."
-	        ];
-
-	        $bad_environment = true;
+            $checks[] = $this->check(
+                $label,
+                is_writable( $path ) ? 'writable' : 'not writable',
+                is_writable( $path ),
+                sprintf( 'Make %s writable by the user your web server runs as.', $path ) );
         }
 
+        /*
+         * Whether the config file can be WRITTEN, which nothing checked.
+         *
+         * The next screen collects database details and then calls
+         * createConfigFile(), which fopen()s the path for writing without
+         * asking first -- so on a docroot the web server cannot write to, an
+         * author filled in the whole form before anything went wrong, and what
+         * went wrong was a file handle failing rather than a message. Asked
+         * here, they are told before they type anything.
+         *
+         * An existing file is fine: that path skips the form entirely.
+         */
+        $config_file = $this->c->get( 'base', 'config_file' );
+        $config_dir  = dirname( $config_file );
 
-        // Check for config file and then test the db connection
-        if ($this->c->isConfigFilePresent()) {
-            $config_file_present = true;
-            $conn = $this->checkDbConnection();
-            if ($conn != true) {
-                $errors['db']['name'] = 'Database Connection';
-                $errors['db']['value'] = 'Connection failed';
-                $errors['db']['msg'] = 'Check the connection settings in your configuration file.' ;
-                $bad_environment = true;
-            }
+        $config_writable = file_exists( $config_file )
+            ? is_readable( $config_file )
+            : is_writable( $config_dir );
+
+        $checks[] = $this->check(
+            'Configuration file',
+            file_exists( $config_file )
+                ? ( is_readable( $config_file ) ? 'present' : 'present, not readable' )
+                : ( is_writable( $config_dir ) ? 'can be created' : 'cannot be created' ),
+            $config_writable,
+            file_exists( $config_file )
+                ? sprintf( 'Make %s readable by the user your web server runs as.', $config_file )
+                : sprintf( 'Make %s writable so the installer can create owa-config.php, or '
+                         . 'copy owa-config-dist.php to owa-config.php yourself and fill it in.',
+                           $config_dir ) );
+
+        // The two directories a source checkout does not come with.
+        $checks[] = $this->check(
+            'Dependencies',
+            is_dir( OWA_VENDOR_DIR ) ? 'installed' : 'missing',
+            is_dir( OWA_VENDOR_DIR ),
+            "Run 'composer install' in the top level OWA directory." );
+
+        /*
+         * The webpack build emits the tracker and reporting bundles under
+         * public/base/dist, and public/ is gitignored -- so a fresh source
+         * checkout has none of it until 'npm run build' runs.
+         */
+        $checks[] = $this->check(
+            'Built assets',
+            is_dir( OWA_DIR . 'public/base/dist' ) ? 'built' : 'missing',
+            is_dir( OWA_DIR . 'public/base/dist' ),
+            "Run 'npm run build' in the top level OWA directory." );
+
+        /*
+         * The database connection, only when there is already a config file
+         * naming one. Without a config file there is nothing to connect with,
+         * and the next screen is where those details get entered.
+         */
+        $config_file_present = (bool) $this->c->isConfigFilePresent();
+
+        if ( $config_file_present ) {
+
+            $connected = (bool) $this->checkDbConnection();
+
+            $checks[] = $this->check(
+                'Database connection',
+                $connected ? 'connected' : 'failed',
+                $connected,
+                'Check the database settings in ' . $config_file . '.' );
         }
 
-        // if the environment is good
-        if ($bad_environment != true) {
-            // and the config file is present
-            if ($config_file_present === true) {
-                //skip to defaults entry step
-                $this->setRedirectAction('base.installDefaultsEntry');
+        $failed = array_values( array_filter( $checks, static function ( $check ) {
+
+            return ! $check['passed'];
+        } ) );
+
+        if ( ! $failed ) {
+
+            if ( $config_file_present ) {
+
+                // Everything is in place already; go straight to the defaults.
+                $this->setRedirectAction( 'base.installDefaultsEntry' );
+
                 return;
-            } else {
-                // otherwise show config file entry form
-                $this->setView('base.install');
-                // Todo: prepopulate public URL.
-                //$config = array('public_url', $url);
-                //$this->set('config', $config);
-                $this->setSubview('base.installConfigEntry');
-                return;
             }
-        // if the environment is bad, then show environment error details.
-        } else {
-            $this->set('errors', $errors);
-            $this->setView('base.install');
-            $this->setSubview('base.installCheckEnv');
+
+            $this->setView( 'base.install' );
+            $this->setSubview( 'base.installConfigEntry' );
+
+            return;
         }
+
+        /*
+         * Every check, not just the failures.
+         *
+         * The screen used to list only what was wrong, which left no way to
+         * tell "this was checked and is fine" from "this was never looked at"
+         * -- and on a screen whose whole job is to describe the environment,
+         * that is most of the information.
+         */
+        $this->set( 'checks', $checks );
+        $this->set( 'errors', $failed );
+        $this->setView( 'base.install' );
+        $this->setSubview( 'base.installCheckEnv' );
+    }
+
+    /**
+     * One environment check, in the shape the template renders.
+     *
+     * @param string $name   what was looked at
+     * @param string $value  what was found
+     * @param bool   $passed
+     * @param string $msg    what to do about it, shown only when it failed
+     * @return array
+     */
+    private function check( $name, $value, $passed, $msg ) {
+
+        return array(
+            'name'   => $name,
+            'value'  => $value,
+            'passed' => (bool) $passed,
+            'msg'    => $passed ? '' : $msg,
+        );
     }
 }
-
-
 
 ?>

--- a/modules/Base/Controller/MyProfile.php
+++ b/modules/Base/Controller/MyProfile.php
@@ -41,7 +41,7 @@ class MyProfile extends \OWA\Core\Controller {
          */
         $this->setRequiredCapability( 'view_site_list' );
 
-        return parent::__construct( $params );
+        parent::__construct( $params );
     }
 
     function action() {

--- a/modules/Base/Controller/MyProfile.php
+++ b/modules/Base/Controller/MyProfile.php
@@ -1,0 +1,108 @@
+<?php
+namespace OWA\Module\Base\Controller;
+
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+/**
+ * The signed-in user's own account.
+ *
+ * Their name, their email address and their password. Not other people's --
+ * base.usersProfile is that screen and requires edit_users. This one always
+ * acts on whoever is signed in, so it takes no user_id: a screen that accepted
+ * one would have to prove the requester may edit that account, and there is no
+ * reason for this screen to be able to edit any account but its own.
+ *
+ * @since owa 1.8.0
+ */
+class MyProfile extends \OWA\Core\Controller {
+
+    function __construct( $params ) {
+
+        /*
+         * view_site_list is what every signed-in role carries -- admin,
+         * analyst and viewer -- and nothing else does. Editing your own account
+         * is not an administrative act, so gating this on edit_users or
+         * edit_settings would leave most users with no way to change their own
+         * name.
+         */
+        $this->setRequiredCapability( 'view_site_list' );
+
+        return parent::__construct( $params );
+    }
+
+    function action() {
+
+        $user = \OWA\Core\CoreAPI::getCurrentUser();
+
+        $this->set( 'user_id', (string) $user->getUserData( 'user_id' ) );
+        $this->set( 'real_name', (string) $user->getUserData( 'real_name' ) );
+        $this->set( 'email_address', (string) $user->getUserData( 'email_address' ) );
+        $this->set( 'role', (string) $user->getRole() );
+
+        /*
+         * Whether the address is theirs to change. The field is shown either
+         * way -- knowing which address the account uses matters even when it
+         * cannot be edited here -- but read-only without the capability, and
+         * the save refuses it as well.
+         */
+        $this->set( 'may_edit_email', (bool) $user->isCapable( 'edit_own_email' ) );
+
+        /*
+         * A refused save comes back through here rather than redirecting, so
+         * what was typed is still on the form. The password fields are
+         * deliberately not carried back: they are secrets, and re-rendering
+         * them would put them in the page source of a refusal.
+         */
+        foreach ( array( 'real_name', 'email_address' ) as $field ) {
+
+            if ( $this->getParam( 'submitted_' . $field ) !== null ) {
+
+                $this->set( $field, (string) $this->getParam( 'submitted_' . $field ) );
+            }
+        }
+
+        if ( $this->getParam( 'myProfileError' ) ) {
+
+            $this->set( 'my_profile_error', (string) $this->getParam( 'myProfileError' ) );
+        }
+
+        if ( $this->getParam( 'myProfileSaved' ) ) {
+
+            $this->set( 'my_profile_saved', true );
+        }
+
+        /*
+         * The settings chrome, the same way every other screen in that nav
+         * gets it. Tier 0: this is about the person rather than about the
+         * Organization, Property or Profile below it.
+         */
+        $siteId = $this->resolveCurrentSiteId( $this->getParam( 'siteId' ) );
+
+        $this->set( 'params', array_merge( (array) $this->params, array( 'siteId' => $siteId ) ) );
+        $this->set( 'site_hierarchy', $this->getSiteHierarchy( $this->getSitesAllowedForCurrentUser() ) );
+        $this->set( 'hierarchy_nav', $this->getHierarchyNav( $siteId ) );
+        $this->set( 'hierarchy_tier', 0 );
+
+        // Tier 0 because it belongs to no Organization, but it is not an
+        // install-wide setting, so the root crumb says whose screen this is.
+        $this->set( 'hierarchy_root_label', 'My Preferences' );
+        $this->set( 'siteId', $siteId );
+
+        $this->setView( 'base.optionsHierarchy' );
+        $this->setSubview( 'base.myProfile' );
+    }
+}

--- a/modules/Base/Controller/MyProfileSave.php
+++ b/modules/Base/Controller/MyProfileSave.php
@@ -1,0 +1,264 @@
+<?php
+namespace OWA\Module\Base\Controller;
+
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+/**
+ * Stores what base.myProfile produced.
+ *
+ * Always writes to the signed-in user's own row. The account is taken from the
+ * session, never from the request, so there is no user_id to authorise.
+ *
+ * @since owa 1.8.0
+ */
+class MyProfileSave extends \OWA\Core\Controller {
+
+    /** Shortest new password accepted, matching base.usersChangePassword. */
+    const MIN_PASSWORD_LENGTH = 6;
+
+    function __construct( $params ) {
+
+        $this->setRequiredCapability( 'view_site_list' );
+        $this->setNonceRequired();
+
+        return parent::__construct( $params );
+    }
+
+    public function validate() {
+
+        if ( (string) $this->getParam( 'email_address' ) !== '' ) {
+
+            $this->addValidation( 'email_address', $this->getParam( 'email_address' ),
+                'emailAddress',
+                array( 'errorMsg' => 'That does not look like an email address.' ) );
+        }
+
+        if ( ! $this->changingPassword() ) {
+
+            return;
+        }
+
+        $this->addValidation( 'current_password', $this->getParam( 'current_password' ),
+            'required',
+            array( 'errorMsg' => 'Enter your current password to change it.' ) );
+
+        $this->addValidation( 'new_password', $this->getParam( 'new_password' ), 'required',
+            array( 'errorMsg' => 'Enter the new password.' ) );
+
+        $this->addValidation( 'password_match',
+            array( $this->getParam( 'new_password' ), $this->getParam( 'new_password2' ) ),
+            'stringMatch',
+            array( 'errorMsg' => 'The new passwords do not match.' ) );
+
+        /*
+         * stringLength, not required -- that is the validator that reads the
+         * operator and length below. Typed as 'required' the rule degrades to a
+         * non-empty check and short passwords pass; see
+         * base.usersChangePassword, where that happened.
+         */
+        $this->addValidation( 'password_length', $this->getParam( 'new_password' ),
+            'stringLength', array(
+                'operator' => '>=',
+                'length'   => self::MIN_PASSWORD_LENGTH,
+                'errorMsg' => sprintf( 'The new password must be at least %d characters.',
+                    self::MIN_PASSWORD_LENGTH ),
+            ) );
+    }
+
+    /** Whether this submission is trying to set a password at all. */
+    private function changingPassword() {
+
+        foreach ( array( 'current_password', 'new_password', 'new_password2' ) as $field ) {
+
+            if ( (string) $this->getParam( $field ) !== '' ) {
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function action() {
+
+        $user = \OWA\Core\CoreAPI::getCurrentUser();
+
+        $user_id = (string) $user->getUserData( 'user_id' );
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.user' );
+        $entity->getByColumn( 'user_id', $user_id );
+
+        if ( ! $entity->wasPersisted() ) {
+
+            return $this->refuse( 'That account no longer exists.' );
+        }
+
+        $entity->set( 'real_name', trim( (string) $this->getParam( 'real_name' ) ) );
+
+        /*
+         * The address is only writable with edit_own_email.
+         *
+         * isParam(), not getParam() !== '': without the capability the form
+         * renders the address as text with no name attribute, so the field is
+         * not posted AT ALL. Reading an absent param as an empty string made it
+         * look like a change to '' and refused every save by anyone who could
+         * not edit their address -- including saves that only changed a name.
+         * Absent means "not offered", which is different from "cleared".
+         */
+        if ( $this->isParam( 'email_address' ) ) {
+
+            $submitted_email = trim( (string) $this->getParam( 'email_address' ) );
+            $current_email   = (string) $entity->get( 'email_address' );
+
+            if ( $submitted_email !== $current_email ) {
+
+                /*
+                 * Posted a change without the capability, which the form does
+                 * not offer -- so this came from something other than the form.
+                 * Refused rather than ignored, so the answer is not "saved" for
+                 * a change that did not happen.
+                 */
+                if ( ! $user->isCapable( 'edit_own_email' ) ) {
+
+                    return $this->refuse(
+                        'Changing the email address on your account is not something '
+                      . 'your role can do. Ask an administrator.' );
+                }
+
+                $entity->set( 'email_address', $submitted_email );
+            }
+        }
+
+        $entity->set( 'last_update_date', time() );
+
+        $entity->update();
+
+        if ( $this->changingPassword() ) {
+
+            $error = $this->changePassword( $entity, $user_id );
+
+            if ( $error !== '' ) {
+
+                return $this->refuse( $error );
+            }
+
+            /*
+             * A PASSWORD CHANGE ENDS THIS SESSION.
+             *
+             * The auth cookie is md5( user_id . password_hash ) -- see
+             * Auth::saveCredentials() -- so the moment the hash changes the
+             * cookie stops matching and the next request is anonymous. Left
+             * alone, someone who changed their password was silently signed out
+             * on their next click and had no idea why.
+             *
+             * So it is done deliberately and said out loud: credentials
+             * cleared, and back to the login form asking them to sign in with
+             * the new password. That is also what the emailed reset does.
+             *
+             * The name and address above are already written, so a submission
+             * that changed both keeps both.
+             */
+            $auth = \OWA\Core\Auth::get_instance();
+            $auth->deleteCredentials();
+
+            $this->set( 'status_code', 3006 );
+            $this->setRedirectAction( 'base.loginForm' );
+
+            return;
+        }
+
+        /*
+         * The session carries the name that the chrome greets people with, so
+         * it has to be told rather than left showing the old one until the next
+         * sign-in.
+         */
+        $user->setUserData( 'real_name', $entity->get( 'real_name' ) );
+        $user->setUserData( 'email_address', $entity->get( 'email_address' ) );
+
+        $this->set( 'myProfileSaved', true );
+        $this->setRedirectAction( 'base.myProfile' );
+    }
+
+    /**
+     * Verify the current password, then set the new one.
+     *
+     * The CURRENT password is required and checked here rather than trusted
+     * from the session. A session is enough to read this screen; it is not
+     * enough to replace the credential that recovers the account, because a
+     * borrowed session would otherwise be able to lock its owner out.
+     *
+     * @param object $entity  the user row, already loaded
+     * @param string $user_id
+     * @return string an error, or '' on success
+     */
+    private function changePassword( $entity, $user_id ) {
+
+        $current = (string) $this->getParam( 'current_password' );
+
+        /*
+         * password_verify against the stored hash, the same check Auth uses to
+         * sign somebody in. Not encryptPassword() and compare: password_hash
+         * salts, so two hashes of one password never match as strings.
+         */
+        if ( ! password_verify( $current, (string) $entity->get( 'password' ) ) ) {
+
+            return 'That is not your current password.';
+        }
+
+        /*
+         * updateUserPassword() hashes it and mints a new temp_passkey, which
+         * also invalidates any reset link that was outstanding.
+         */
+        $manager = \OWA\Core\CoreAPI::supportClassFactory( 'base', 'userManager' );
+
+        $updated = $manager->updateUserPassword( array(
+            'user_id'  => $user_id,
+            'password' => $this->getParam( 'new_password' ),
+        ) );
+
+        if ( ! $updated ) {
+
+            return 'The password could not be changed.';
+        }
+
+        return '';
+    }
+
+    /**
+     * Back to the form, with what was typed and why it was refused.
+     *
+     * The name and address ride along under submitted_ names so the form
+     * redraws them; the password fields deliberately do not, because carrying a
+     * secret back would put it in the page source of the refusal.
+     */
+    private function refuse( $message ) {
+
+        $this->set( 'myProfileError', $message );
+        $this->set( 'submitted_real_name', (string) $this->getParam( 'real_name' ) );
+        $this->set( 'submitted_email_address', (string) $this->getParam( 'email_address' ) );
+
+        $this->setRedirectAction( 'base.myProfile' );
+    }
+
+    function errorAction() {
+
+        $messages = (array) $this->getValidationErrorMsgs();
+
+        return $this->refuse( $messages ? implode( ' ', $messages )
+            : 'Those details could not be saved.' );
+    }
+}

--- a/modules/Base/Controller/MyProfileSave.php
+++ b/modules/Base/Controller/MyProfileSave.php
@@ -35,7 +35,7 @@ class MyProfileSave extends \OWA\Core\Controller {
         $this->setRequiredCapability( 'view_site_list' );
         $this->setNonceRequired();
 
-        return parent::__construct( $params );
+        parent::__construct( $params );
     }
 
     public function validate() {

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -238,6 +238,8 @@ class Module extends \OWA\Core\Module {
         $this->registerAction( 'base.usersNewAccount',               'OWA\\Module\\Base\\Controller\\UsersNewAccount',              'Controller/UsersNewAccount.php' );
         $this->registerAction( 'base.usersPasswordEntry',            'OWA\\Module\\Base\\Controller\\UsersPasswordEntry',           'Controller/UsersPasswordEntry.php' );
         $this->registerAction( 'base.usersProfile',                  'OWA\\Module\\Base\\Controller\\UsersProfile',                 'Controller/UsersProfile.php' );
+        $this->registerAction( 'base.myProfile',                 'OWA\\Module\\Base\\Controller\\MyProfile',                'Controller/MyProfile.php' );
+        $this->registerAction( 'base.myProfileSave',             'OWA\\Module\\Base\\Controller\\MyProfileSave',            'Controller/MyProfileSave.php' );
         $this->registerAction( 'base.usersResetPassword',            'OWA\\Module\\Base\\Controller\\UsersResetPassword',           'Controller/UsersResetPassword.php' );
         $this->registerAction( 'base.usersRest',                     'OWA\\Module\\Base\\Controller\\UsersRest',                    'Controller/UsersRest.php' );
         $this->registerAction( 'base.usersSetPassword',              'OWA\\Module\\Base\\Controller\\UsersSetPassword',             'Controller/UsersSetPassword.php' );

--- a/modules/Base/View/MyProfile.php
+++ b/modules/Base/View/MyProfile.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OWA\Module\Base\View;
+
+/**
+ * The signed-in user's own account screen.
+ *
+ * Every value the template reads is forwarded by name: the body is a separate
+ * template with its own scope, so a value the controller set but this method
+ * does not mention is simply absent, and a missing template variable is an
+ * error rather than an empty string.
+ *
+ * @since owa 1.8.0
+ */
+class MyProfile extends \OWA\Core\View {
+
+    function render() {
+
+        $this->t->set( 'page_title', 'Profile' );
+
+        $this->body->set_template( 'my_profile.php' );
+
+        $this->body->set( 'user_id', $this->get( 'user_id' ) );
+        $this->body->set( 'real_name', $this->get( 'real_name' ) );
+        $this->body->set( 'email_address', $this->get( 'email_address' ) );
+        $this->body->set( 'role', $this->get( 'role' ) );
+        $this->body->set( 'may_edit_email', $this->get( 'may_edit_email' ) );
+        $this->body->set( 'my_profile_error', $this->get( 'my_profile_error' ) );
+        $this->body->set( 'my_profile_saved', $this->get( 'my_profile_saved' ) );
+        $this->body->set( 'siteId', $this->get( 'siteId' ) );
+        $this->body->set( 'min_password_length',
+            \OWA\Module\Base\Controller\MyProfileSave::MIN_PASSWORD_LENGTH );
+    }
+}

--- a/modules/Base/View/OptionsHierarchy.php
+++ b/modules/Base/View/OptionsHierarchy.php
@@ -33,6 +33,16 @@ class OptionsHierarchy extends \OWA\Core\View {
 
         $this->body->set( 'params', $params );
         $this->body->set( 'hierarchy_nav', $this->get( 'hierarchy_nav' ) );
+
+        /*
+         * What the root crumb says. Tier 0 means install-wide on every other
+         * screen, so 'Installation' is the default -- but base.myProfile is
+         * tier 0 and is about the person rather than the installation, so it
+         * names its own. get() answers false for a name nobody set, hence the
+         * ?: rather than a check.
+         */
+        $this->body->set( 'hierarchy_root_label',
+            $this->get( 'hierarchy_root_label' ) ?: 'Installation' );
         /*
  * Not ?: -- tier 0 (install-wide) is a legitimate value that ?: would turn
  * into 3, putting a Property and a Profile above Main Configuration.

--- a/modules/Base/css/owa.admin.css
+++ b/modules/Base/css/owa.admin.css
@@ -65,11 +65,12 @@
 
 .owa .owa_userMenu {
     position: relative;
-    /* Floated right and AFTER the bell in the markup, so it lands to the
-       bell's left -- with float:right the first element in source order goes
-       furthest right. The bell stays at the edge, where its overhanging badge
-       has room. */
+    /* Floated right and FIRST in the markup, so it lands furthest right -- with
+       float:right the first element in source order goes to the end. It is the
+       one against the window edge now, so it carries the margin that keeps the
+       group off it. */
     float: right;
+    margin: 0 18px 0 0;
     /* ...and the same for the account menu. */
     display: flex;
     align-items: center;
@@ -124,6 +125,8 @@
     display: flex;
     align-items: center;
     height: 55px;
+    /* 16px to the bell. Left of it is open bar, so it needs nothing there. */
+    margin: 0 16px 0 0;
 }
 
 .owa .owa_helpMenuToggle {
@@ -223,7 +226,15 @@
    --------------------------------------------------------------------------- */
 
 .owa .owa_notificationBell {
-    position: relative;
+    /* NOT position:relative.
+     *
+     * The badge is a child of the BUTTON and hangs off its top-right corner, so
+     * the button has to be what it is positioned against. While this wrapper
+     * was the containing block it worked only because the wrapper was exactly
+     * the button's size; giving it the bar's height to centre the button moved
+     * the corner the badge was measuring from 7px up, and the badge stopped
+     * overlapping the circle. The positioning context is on the toggle now, so
+     * the wrapper's height is free to change. */
     /* Floated right, and it sits BEFORE the account menu in the markup -- with
        float:right the first element in source order lands furthest right, so
        the bell ends up at the far right of the nav bar and the menu to its
@@ -235,11 +246,20 @@
     display: flex;
     align-items: center;
     height: 55px;
-    /* Wide enough on the right that the overhanging badge is not clipped. */
-    margin: 0 18px 0 16px;
+    /*
+     * The same 16px as the others.
+     *
+     * The badge overhangs this button, and it does NOT get a say in the
+     * spacing: the three controls are spaced by their own boxes, so the gaps
+     * stay equal whether or not there is anything unread. The badge hangs into
+     * the gap on its right when it is there.
+     */
+    margin: 0 16px 0 0;
 }
 
 .owa .owa_notificationToggle {
+    /* What the badge hangs off -- see .owa_notificationBell. */
+    position: relative;
     background: #e4e6eb;
     border: 0;
     border-radius: 50%;
@@ -283,10 +303,11 @@
     z-index: 1;
 }
 
-/* The badge is never hidden -- a control that comes and goes moves the bell
-   under the cursor. At zero it goes quiet instead: grey, not red. */
-.owa .owa_notificationBadge.is-zero {
-    background: #b0b3b8;
+/* Nothing unread, nothing to show. The badge is positioned absolutely and
+   overhangs the button, so hiding it moves nothing -- which is what makes this
+   safe where it was not before. */
+.owa .owa_notificationBadge[hidden] {
+    display: none;
 }
 
 .owa .owa_notificationPanel[hidden] {

--- a/modules/Base/css/owa.admin.css
+++ b/modules/Base/css/owa.admin.css
@@ -54,12 +54,155 @@
     border-bottom: 2px solid orange;
 }
 
-.owa .user-greating {
+/* ---------------------------------------------------------------------------
+   The account menu
 
-    color: #9f9f9f;
-    font-weight: normal;
-    float:right;
-    vertical-align:middle;
+   The username is a control, not a greeting. It opens a menu holding Profile
+   and Logout, and it is built to match the notification bell beside it: same
+   size, same hover, same panel treatment, so the two read as one pair of
+   controls rather than as two unrelated widgets.
+   --------------------------------------------------------------------------- */
+
+.owa .owa_userMenu {
+    position: relative;
+    /* Floated right and AFTER the bell in the markup, so it lands to the
+       bell's left -- with float:right the first element in source order goes
+       furthest right. The bell stays at the edge, where its overhanging badge
+       has room. */
+    float: right;
+    /* ...and the same for the account menu. */
+    display: flex;
+    align-items: center;
+    height: 55px;
+}
+
+.owa .owa_userMenuToggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 280px;
+    height: 40px;
+    padding: 0 12px;
+    border: 0;
+    border-radius: 20px;
+    background: #e4e6eb;
+    color: #050505;
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.owa .owa_userMenuToggle:hover {
+    background: #d8dadf;
+}
+
+/* A long address must not push the bell off the bar. */
+.owa .owa_userMenuName {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.owa .owa_userMenuCaret {
+    font-size: 10px;
+    opacity: 0.7;
+}
+
+.owa .owa_userMenuToggle[aria-expanded="true"] .owa_userMenuCaret {
+    transform: rotate(180deg);
+}
+
+.owa .owa_userMenuPanel[hidden],
+.owa .owa_headerMenuPanel[hidden] {
+    display: none;
+}
+
+/* Help: a round button matching the bell, holding the links that leave the
+   application. Left of the account menu, which is where the markup puts it. */
+.owa .owa_helpMenu {
+    position: relative;
+    float: right;
+    display: flex;
+    align-items: center;
+    height: 55px;
+}
+
+.owa .owa_helpMenuToggle {
+    background: #e4e6eb;
+    border: 0;
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    cursor: pointer;
+    color: #050505;
+    font-size: 16px;
+    line-height: 40px;
+    text-align: center;
+}
+
+.owa .owa_helpMenuToggle:hover {
+    background: #d8dadf;
+}
+
+.owa .owa_helpMenuPanel {
+    position: absolute;
+    top: 46px;
+    right: 0;
+    z-index: 1000;
+    min-width: 180px;
+    padding: 6px 0;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.22);
+    line-height: normal;
+}
+
+/* Anchored to the button rather than to the window: this menu is about the
+   control it hangs off, unlike the notification panel, which is a surface
+   pinned to the edge of the app. */
+.owa .owa_userMenuPanel {
+    position: absolute;
+    top: 46px;
+    right: 0;
+    z-index: 1000;
+    min-width: 180px;
+    padding: 6px 0;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.22);
+    line-height: normal;
+}
+
+.owa .owa_userMenuItem,
+.owa .owa_headerMenuItem {
+    display: block;
+    padding: 10px 16px;
+    color: #050505;
+    font-size: 14px;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.owa .owa_userMenuItem:hover,
+.owa .owa_headerMenuItem:hover {
+    background: #f0f2f5;
+}
+
+/* Signed out: a plain link, because there is no account to open a menu on. */
+.owa .owa_userMenuSignIn {
+    display: inline-block;
+    height: 40px;
+    padding: 0 14px;
+    border-radius: 20px;
+    background: #e4e6eb;
+    color: #050505;
+    font-size: 13px;
+    line-height: 40px;
+    text-decoration: none;
+}
+
+.owa .owa_userMenuSignIn:hover {
+    background: #d8dadf;
 }
 
 .owa a.login {
@@ -81,15 +224,17 @@
 
 .owa .owa_notificationBell {
     position: relative;
-    /* Floated right, and it sits BEFORE .user-greating in the markup -- with
+    /* Floated right, and it sits BEFORE the account menu in the markup -- with
        float:right the first element in source order lands furthest right, so
-       the bell ends up at the far right of the nav bar and the greeting to its
+       the bell ends up at the far right of the nav bar and the menu to its
        left. Ordering the markup the other way would silently swap them. */
     float: right;
-    display: inline-block;
-    vertical-align: middle;
-    /* Room on the right for the badge, which overhangs the button. Without it
-       the badge is clipped by the edge of the header. */
+    /* The bar's height with the button centred in it, so the bell shares the
+       logo's centre line rather than hanging 8px above it. See .owa_navigation
+       in owa.css for why every floated item needs this. */
+    display: flex;
+    align-items: center;
+    height: 55px;
     /* Wide enough on the right that the overhanging badge is not clipped. */
     margin: 0 18px 0 16px;
 }

--- a/modules/Base/css/owa.css
+++ b/modules/Base/css/owa.css
@@ -133,7 +133,9 @@ div {margin:0;}
 
 }
 .owa-button:hover {
-    color: #000000;
+    /* Blue, not black. The label is white at rest and takes the link colour on
+       hover, which is the one other blue on these screens. */
+    color: #1a5f8a;
     border-color: #9f9f9f;
     -moz-box-shadow:2px 2px 2px #999;
     box-shadow:2px 2px 2px #999;
@@ -610,7 +612,7 @@ a.owa-button {
 
 a.owa_publicSubmit:hover,
 a.owa-button:hover {
-    color: #ffffff;
+    color: #1a5f8a;
 }
 
 /* The status and error banners on the signed-out pages.

--- a/modules/Base/css/owa.css
+++ b/modules/Base/css/owa.css
@@ -463,9 +463,11 @@ td#panel {margin: 0px; padding-top:0px;width:;border-collapse: collapse;border:0
     text-align: left;
 }
 
+/* The step's own heading, under the installer's title. Separated from it, or
+   the two headings read as one run-on line. */
 .owa_installBody h2,
 .owa_installFinish h2 {
-    margin: 0 0 8px 0;
+    margin: 22px 0 8px 0;
     font-size: 18px;
     color: #333333;
 }

--- a/modules/Base/css/owa.css
+++ b/modules/Base/css/owa.css
@@ -591,3 +591,63 @@ td#panel {margin: 0px; padding-top:0px;width:;border-collapse: collapse;border:0
 .owa_installActions {
     margin-top: 26px;
 }
+
+
+/* An <a> styled as the primary button.
+ *
+ * .owa-button was written for <input type=submit>, which is inline-block and
+ * takes the button's own colour. An anchor is inline -- so width:100% did
+ * nothing and it kept the link colour, which on the installer's finish screen
+ * meant a blue label on an orange button, at a third of the width. */
+a.owa_publicSubmit,
+a.owa-button {
+    display: inline-block;
+    box-sizing: border-box;
+    color: #ffffff;
+    text-align: center;
+    text-decoration: none;
+}
+
+a.owa_publicSubmit:hover,
+a.owa-button:hover {
+    color: #ffffff;
+}
+
+/* The status and error banners on the signed-out pages.
+ *
+ * They are rendered outside the card, so without this they ran the full width
+ * of the window while everything else sat in a 380-720px column. */
+.owa_publicPage .status,
+.owa_publicPage .error {
+    max-width: 720px;
+    margin: 0 auto 20px auto;
+    border-radius: 6px;
+}
+
+/* The installer's cron notice. It used the green .status treatment, which is
+   for "this worked" -- this is a thing still to do, and a wall of white on
+   green to read. */
+.owa_installFinish .owa-install-cron {
+    margin-top: 26px;
+    padding: 16px;
+    background-color: #fffaf0;
+    border: 1px solid #f0d9a8;
+    border-radius: 6px;
+    color: #4a3c22;
+}
+
+.owa_installFinish .owa-install-cron p {
+    margin: 8px 0 0 0;
+    font-size: 13px;
+    line-height: 1.6;
+}
+
+.owa_installFinish .owa-install-cron code {
+    display: inline-block;
+    padding: 2px 5px;
+    background-color: #ffffff;
+    border: 1px solid #ecdcc0;
+    border-radius: 3px;
+    font-size: 12px;
+    word-break: break-all;
+}

--- a/modules/Base/css/owa.css
+++ b/modules/Base/css/owa.css
@@ -37,20 +37,49 @@ div {margin:0;}
 .host_app_nav {background-color:; vertical-align:middle;font-size:18px;padding:4px;}
 #owa_header {border-bottom: 1px solid #9f9f9f; background-color:#FFFFFF; padding:10px; font-size:16px; line-height:55px;}
 .owa_logo {float:left;padding-right:30px;  vertical-align: middle;line-height:normal;}
-.owa_navigation {float:left;vertical-align:middle;padding-top:10px;}
-.owa_navigation ul {list-style: none; padding: 0; margin: 0;float:left;padding-top:0px;}
-.owa_navigation li {text-decoration: none; float:left; margin: 2px;}
-.owa_navigation li a {
-    background: url() #fff bottom left repeat-x;
-    height: 2em;
-    line-height: 2em;
+/* The top bar's links.
+ *
+ * Each link used to be a 9em box, floated, whatever its text: "Donate" sat in
+ * the middle of a wide empty box and "Documentation" filled its own to the
+ * edge, so the gaps between words were all different widths. They are sized by
+ * their text now, with one padding value between them, which is what makes the
+ * spacing even.
+ *
+ * A row rather than a set of floats, so the items share a baseline instead of
+ * each one setting its own line-height. */
+/* As tall as the bar, with its contents centred in it.
+ *
+ * Every item in this header is floated, and a float takes its own height and
+ * sits at the top of the content box -- so the logo (55px), the links (36px)
+ * and the bell (40px) each started at the same top edge and ended in three
+ * different places, none of them centred on any other. Giving each the bar's
+ * height and centring inside it puts them all on one line.
+ *
+ * 55px is the header's own line-height, which is what sets the bar's height. */
+.owa_navigation {
     float: left;
-    width: 9em;
+    display: flex;
+    align-items: center;
+    height: 55px;
+}
+.owa_navigation ul {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0;
+    margin: 0;
+}
+.owa_navigation li {margin: 0;}
+.owa_navigation li a {
     display: block;
-    border: 0 solid #efefef;
+    padding: 0 14px;
+    height: 36px;
+    line-height: 36px;
+    border-radius: 6px;
+    color: #1a5f8a;
     text-decoration: none;
-    text-align: center;
-    
+    white-space: nowrap;
 }
 
 #updates {
@@ -64,9 +93,12 @@ div {margin:0;}
 	font-size: 14px;
 }
 
+/* A filled hover rather than an underline that appears from nowhere: the link
+   is a box, so the box responds. The orange stays for the current item, where
+   it means something. */
 .owa_navigation li a:hover {
-	border-bottom: 2px solid orange;
-   
+	background-color: #f0f2f5;
+	color: #124a6b;
 }
 
 .owa_current{

--- a/modules/Base/css/owa.css
+++ b/modules/Base/css/owa.css
@@ -328,3 +328,264 @@ td#panel {margin: 0px; padding-top:0px;width:;border-collapse: collapse;border:0
 }
 
 .noedit {color: #999;}
+
+/* ---------------------------------------------------------------------------
+   The signed-out pages: login, password reset, set password, install, updates.
+
+   These looked like a different application from the one they let you into: a
+   table with a spacer column, runs of <BR>, and rounded-corner "spiffy" spans.
+   They already loaded this stylesheet -- Core\View adds it to every view -- and
+   simply were not using it.
+
+   A centred column with the form in a card, borrowing the treatments the rest
+   of the application uses: the same button, the same field borders, the same
+   muted description text.
+   --------------------------------------------------------------------------- */
+
+.owa_publicPage {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 48px 20px 32px 20px;
+    font-size: 14px;
+    line-height: normal;
+}
+
+.owa_publicLogo {
+    margin-bottom: 28px;
+    text-align: center;
+}
+
+.owa_publicLogo img {
+    max-width: 200px;
+    height: auto;
+}
+
+/* The card is only as wide as a short form wants to be. The wrapper is also
+   used by install and updates, whose bodies set their own width -- so the
+   narrowing lives here rather than on the page. */
+.owa_publicCard {
+    max-width: 380px;
+    margin: 0 auto;
+    padding: 28px 28px 24px 28px;
+    background-color: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.owa_publicTitle {
+    margin: 0 0 6px 0;
+    font-size: 22px;
+    font-weight: bold;
+    color: #333333;
+}
+
+.owa_publicIntro {
+    margin: 0 0 20px 0;
+    color: #666666;
+    font-size: 13px;
+    line-height: 1.55;
+}
+
+.owa_publicForm {
+    margin: 18px 0 0 0;
+}
+
+.owa_publicField {
+    margin-bottom: 16px;
+}
+
+.owa_publicField label {
+    display: block;
+    margin-bottom: 5px;
+    font-size: 12px;
+    font-weight: bold;
+    color: #505050;
+}
+
+.owa_publicField input {
+    /* Full width of the card: a fixed size= attribute made every field a
+       different length regardless of what it held. */
+    box-sizing: border-box;
+    width: 100%;
+    padding: 9px 10px;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.owa_publicField input:focus {
+    border-color: #1a5f8a;
+    outline: none;
+}
+
+/* .owa-button carries a 25px top margin for the admin forms it was written
+   for, where it is the last thing on a page. Here it follows a field. */
+.owa_publicSubmit {
+    width: 100%;
+    margin: 4px 0 0 0;
+    font-size: 16px;
+    padding: 12px 20px;
+}
+
+.owa_publicAside {
+    margin-top: 18px;
+    text-align: center;
+    font-size: 13px;
+}
+
+.owa_publicFooter {
+    margin-top: 40px;
+    text-align: center;
+    color: #909090;
+    font-size: 12px;
+}
+
+.owa_publicFooter a {
+    color: #909090;
+}
+
+
+/* ---------------------------------------------------------------------------
+   The installer
+
+   Uses the signed-out card above, widened: it asks for a page of database
+   details, which does not fit a login box.
+
+   The fields were three spans positioned ABSOLUTELY -- the value at left:620px
+   and the hint at left:850px -- so on any window narrower than about 1100px the
+   hints sat off the edge of the page and the values overlapped the labels.
+   Stacked instead, which needs no assumption about the width.
+   --------------------------------------------------------------------------- */
+
+.owa_installCard {
+    max-width: 720px;
+    text-align: left;
+}
+
+.owa_installBody h2,
+.owa_installFinish h2 {
+    margin: 0 0 8px 0;
+    font-size: 18px;
+    color: #333333;
+}
+
+.owa_installBody h3 {
+    margin: 26px 0 10px 0;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #ededed;
+    font-size: 13px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #808080;
+}
+
+.owa_installField {
+    margin-bottom: 16px;
+}
+
+.owa_installField label {
+    display: block;
+    margin-bottom: 5px;
+    font-size: 12px;
+    font-weight: bold;
+    color: #505050;
+}
+
+.owa_installField input[type=text],
+.owa_installField input[type=password],
+.owa_installField select {
+    box-sizing: border-box;
+    width: 100%;
+    padding: 9px 10px;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.owa_installHint {
+    display: block;
+    margin-top: 5px;
+    color: #808080;
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+/* The environment report. Every check is listed, passed or not: a list of only
+   the failures cannot distinguish "checked and fine" from "never looked at". */
+.owa_installChecks {
+    list-style: none;
+    margin: 20px 0 0 0;
+    padding: 0;
+}
+
+.owa_installCheck {
+    display: grid;
+    grid-template-columns: 20px 1fr auto;
+    gap: 2px 10px;
+    align-items: baseline;
+    padding: 10px 0;
+    border-bottom: 1px solid #f0f0f0;
+    font-size: 13px;
+}
+
+.owa_installCheckMark {
+    font-weight: bold;
+}
+
+.owa_installCheck.is-ok .owa_installCheckMark {
+    color: #2e7d32;
+}
+
+.owa_installCheck.is-bad .owa_installCheckMark {
+    color: #99321f;
+}
+
+.owa_installCheckName {
+    color: #333333;
+}
+
+.owa_installCheckValue {
+    color: #808080;
+    text-align: right;
+}
+
+.owa_installCheck.is-bad .owa_installCheckValue {
+    color: #99321f;
+}
+
+/* The fix spans the two columns under the name, so it reads as belonging to
+   the row above rather than as another row. */
+.owa_installCheckFix {
+    grid-column: 2 / -1;
+    margin-top: 4px;
+    color: #666666;
+    font-size: 12px;
+    line-height: 1.55;
+}
+
+/* The generated password, shown once. */
+.owa_installCredentials {
+    margin: 18px 0;
+    padding: 16px;
+    background-color: #fafafa;
+    border: 1px solid #e8e8e8;
+    border-radius: 6px;
+}
+
+.owa_installCredentials .owa_installField:last-child {
+    margin-bottom: 0;
+}
+
+.owa_installCredential {
+    font-family: monospace;
+    font-size: 15px;
+    color: #333333;
+    /* Selectable in one gesture: it is generated, not chosen. */
+    user-select: all;
+}
+
+.owa_installActions {
+    margin-top: 26px;
+}

--- a/modules/Base/templates/head.php
+++ b/modules/Base/templates/head.php
@@ -17,7 +17,19 @@
 <?php endif;?>
 
 <script>
+<?php
+    /*
+     * Only when the bundle that defines OWA is on the page.
+     *
+     * config_dom.php assigns onto OWA.config, and the signed-out pages -- the
+     * password reset request and the set-password form -- load no JavaScript at
+     * all. So every one of them threw "OWA is not defined" on load, which was
+     * harmless and permanently in the console, hiding anything that was not.
+     */
+?>
+if (typeof OWA !== 'undefined' && OWA.config) {
 <?php include('config_dom.php'); ?>
+}
 </script>
 
 

--- a/modules/Base/templates/header.php
+++ b/modules/Base/templates/header.php
@@ -6,15 +6,24 @@
     <span class="owa_navigation">
         <UL>
             <?php if ($view->getCurrentUser()->isCapable('view_site_list')): ?>
-                <LI><a href="<?php echo $view->makeLink(array('do' => 'base.reportingHome'));?>">Reporting</a></LI>
+                <LI><a href="<?php echo $view->makeLink(array('do' => 'base.reportingHome'));?>">Analytics</a></LI>
             <?php endif; ?>
             <?php if ($view->getCurrentUser()->isCapable('edit_settings')): ?>
                 <LI><a href="<?php echo $view->makeLink(array('do' => 'base.optionsGeneral'));?>">Settings</a></LI>
             <?php endif; ?>
-            <LI><a href="https://github.com/Open-Web-Analytics/Open-Web-Analytics/wiki">Documentation</a></LI>
-            <LI><a href="https://github.com/Open-Web-Analytics/Open-Web-Analytics/issues">Report a Bug</a></LI>
-            <LI><a href="https://github.com/sponsors/padams">Donate</a>
-
+            <?php
+                /*
+                 * Documentation and Report a Bug used to sit here. They are in
+                 * the help menu on the right now: both leave the application
+                 * for GitHub, which is a different kind of thing from Analytics
+                 * and Settings, and listing them here spent half the bar on
+                 * links that navigate away from it.
+                 *
+                 * This item was also never closed, so the markup nested the
+                 * rest of the bar inside it.
+                 */
+            ?>
+            <LI><a href="https://github.com/sponsors/padams">Donate</a></LI>
         </UL>
     </span>
     <?php $cu = $view->getCurrentUser(); ?>
@@ -244,29 +253,141 @@
     })();
     </script>
 <?php endif; ?>
-    <span class="user-greating" style="">
-        <?php
-            /*
-             * The username is the way to your own account, which is where
-             * people reach for it. Only when signed in -- the greeting renders
-             * for an anonymous request too, and there is nothing to link to.
-             */
-        ?>
-        Hi, <?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ):?><a
-            class="owa_myProfileLink"
-            href="<?php echo $view->makeLink( array( 'do' => 'base.myProfile' ), false );?>"
-            ><?php $view->out( $cu->getUserData('user_id') );?></a><?php
-            else: $view->out( $cu->getUserData('user_id') ); endif;?> ! &bull;
-        <?php if ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ):?>
-
-                <?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ):?>
-                <a class="login" href="<?php echo $view->makeLink(array('do' => 'base.logout'), false);?>">Logout</a>
-                <?php else:?>
-                <a class="login" href="<?php echo $view->makeLink(array('do' => 'base.loginForm'), false);?>">Login</a>
-                <?php endif;?>
-
+    <?php
+        /*
+         * THE ACCOUNT MENU.
+         *
+         * This was "Hi, <name> ! * Logout" -- a greeting, a bullet and a link,
+         * which spent the widest part of the bar saying hello and left the two
+         * things people come here to do looking like punctuation.
+         *
+         * The name is now the control: a button that opens a menu holding
+         * Profile and Logout. Same interaction as the notification bell beside
+         * it -- a button with aria-expanded, a panel with hidden, and a click
+         * outside to close -- so the two behave alike.
+         */
+    ?>
+<?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ): ?>
+    <span class="owa_userMenu">
+        <button type="button" id="owa_userMenuToggle" class="owa_userMenuToggle"
+                aria-expanded="false" aria-controls="owa_userMenuPanel" aria-haspopup="true">
+            <span class="owa_userMenuName"><?php $view->out( $cu->getUserData('user_id') );?></span>
+            <i class="fas fa-chevron-down owa_userMenuCaret" aria-hidden="true"></i>
+        </button>
+        <div id="owa_userMenuPanel" class="owa_userMenuPanel" role="menu" hidden>
+            <a role="menuitem" class="owa_userMenuItem owa_myProfileLink"
+               href="<?php echo $view->makeLink( array( 'do' => 'base.myProfile' ), false );?>">Profile</a>
+            <?php
+                /*
+                 * An embedded install signs people in through its host, so it
+                 * has no session of its own to end -- the same condition that
+                 * hid the old Logout link.
+                 */
+            ?>
+            <?php if ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ):?>
+            <a role="menuitem" class="owa_userMenuItem owa_userMenuLogout"
+               href="<?php echo $view->makeLink(array('do' => 'base.logout'), false);?>">Logout</a>
             <?php endif;?>
+        </div>
     </span>
+    <?php
+        /*
+         * HELP, to the left of the account menu.
+         *
+         * After it in the markup, which is what puts it to its left: these are
+         * floated right, so the first element in source order lands furthest
+         * right. Everything in here leaves the application for GitHub, which is
+         * why it is a menu rather than three more links in the bar.
+         */
+    ?>
+    <span class="owa_helpMenu">
+        <button type="button" id="owa_helpMenuToggle" class="owa_helpMenuToggle"
+                aria-expanded="false" aria-controls="owa_helpMenuPanel"
+                aria-haspopup="true" aria-label="Help">
+            <i class="fas fa-question" aria-hidden="true"></i>
+        </button>
+        <div id="owa_helpMenuPanel" class="owa_helpMenuPanel owa_headerMenuPanel" role="menu" hidden>
+            <a role="menuitem" class="owa_headerMenuItem" target="_blank" rel="noopener"
+               href="https://github.com/Open-Web-Analytics/Open-Web-Analytics/wiki">Documentation</a>
+            <a role="menuitem" class="owa_headerMenuItem" target="_blank" rel="noopener"
+               href="https://github.com/Open-Web-Analytics/Open-Web-Analytics/issues">Report a Bug</a>
+            <a role="menuitem" class="owa_headerMenuItem" target="_blank" rel="noopener"
+               href="https://github.com/Open-Web-Analytics/Open-Web-Analytics">GitHub</a>
+        </div>
+    </span>
+    <script>
+    (function () {
+        /*
+         * Both header menus are wired by one routine.
+         *
+         * They behave identically -- open on the control, close on a click
+         * outside, close on Escape, report state through aria-expanded -- and
+         * two copies of that is how the two come to differ.
+         */
+        var menus = [];
+
+        function wire(toggleId, panelId, wrapperClass) {
+
+            var toggle = document.getElementById(toggleId);
+            var panel  = document.getElementById(panelId);
+
+            if (!toggle || !panel) {
+                return;
+            }
+
+            var menu = {
+                toggle: toggle,
+                panel: panel,
+                wrapper: wrapperClass,
+                close: function () {
+                    panel.hidden = true;
+                    toggle.setAttribute('aria-expanded', 'false');
+                }
+            };
+
+            toggle.addEventListener('click', function () {
+
+                var open = !panel.hidden;
+
+                // One at a time: opening either closes the other, so two
+                // panels cannot overlap each other in the corner of the bar.
+                menus.forEach(function (other) {
+                    if (other !== menu) {
+                        other.close();
+                    }
+                });
+
+                panel.hidden = open;
+                toggle.setAttribute('aria-expanded', String(!open));
+            });
+
+            document.addEventListener('click', function (e) {
+                if (!panel.hidden && !e.target.closest('.' + wrapperClass)) {
+                    menu.close();
+                }
+            });
+
+            // Escape closes it and puts the focus back on the control that
+            // opened it, so a keyboard user is not left adrift in the page.
+            document.addEventListener('keydown', function (e) {
+                if (e.key === 'Escape' && !panel.hidden) {
+                    menu.close();
+                    toggle.focus();
+                }
+            });
+
+            menus.push(menu);
+        }
+
+        wire('owa_userMenuToggle', 'owa_userMenuPanel', 'owa_userMenu');
+        wire('owa_helpMenuToggle', 'owa_helpMenuPanel', 'owa_helpMenu');
+    })();
+    </script>
+<?php elseif ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ): ?>
+    <span class="owa_userMenu">
+        <a class="owa_userMenuSignIn" href="<?php echo $view->makeLink(array('do' => 'base.loginForm'), false);?>">Login</a>
+    </span>
+<?php endif; ?>
     <div class="post-nav"></div>
     <?php if (!empty($service_msg)): ?>
     <div class="owa_headerServiceMsg"><?php echo $service_msg; ?></div>

--- a/modules/Base/templates/header.php
+++ b/modules/Base/templates/header.php
@@ -245,7 +245,18 @@
     </script>
 <?php endif; ?>
     <span class="user-greating" style="">
-        Hi, <?php $view->out( $cu->getUserData('user_id') );?> ! &bull;
+        <?php
+            /*
+             * The username is the way to your own account, which is where
+             * people reach for it. Only when signed in -- the greeting renders
+             * for an anonymous request too, and there is nothing to link to.
+             */
+        ?>
+        Hi, <?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ):?><a
+            class="owa_myProfileLink"
+            href="<?php echo $view->makeLink( array( 'do' => 'base.myProfile' ), false );?>"
+            ><?php $view->out( $cu->getUserData('user_id') );?></a><?php
+            else: $view->out( $cu->getUserData('user_id') ); endif;?> ! &bull;
         <?php if ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ):?>
 
                 <?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ):?>

--- a/modules/Base/templates/header.php
+++ b/modules/Base/templates/header.php
@@ -304,16 +304,32 @@
          * outside to close -- so the two behave alike.
          */
     ?>
-<?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ): ?>
+<?php if ( ! \OWA\Core\CoreAPI::isCurrentUserAuthenticated()
+           && ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ): ?>
     <?php
         /*
-         * HELP, at the left of the three.
+         * Signed out, the account slot is a way in rather than a menu. Before
+         * the help block so it takes the same place at the right-hand end that
+         * the account menu does when there is one.
+         */
+    ?>
+    <span class="owa_userMenu">
+        <a class="owa_userMenuSignIn" href="<?php echo $view->makeLink(array('do' => 'base.loginForm'), false);?>">Login</a>
+    </span>
+<?php endif; ?>
+    <?php
+        /*
+         * HELP, at the left of the group, AND FOR EVERYONE.
          *
-         * Last in source order, which is what puts it there: these are floated
-         * right, so the first element in source order lands furthest right and
-         * the bar reads help, notifications, account from left to right.
-         * Everything in this menu leaves the application for GitHub, which is
-         * why it is a menu rather than three more links in the bar.
+         * Outside the signed-in branch on purpose. An install that grants
+         * "everyone" view_reports -- which the demo does -- renders this chrome
+         * for people with no account, and documentation is the thing they are
+         * most likely to want. Every destination here is a public GitHub URL,
+         * so there is nothing in it that depends on being signed in.
+         *
+         * Last in source order, which is what puts it at the left: these are
+         * floated right, so the first element in source order lands furthest
+         * right and the bar reads help, notifications, account.
          */
     ?>
     <span class="owa_helpMenu">
@@ -399,11 +415,6 @@
         wire('owa_helpMenuToggle', 'owa_helpMenuPanel', 'owa_helpMenu');
     })();
     </script>
-<?php elseif ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ): ?>
-    <span class="owa_userMenu">
-        <a class="owa_userMenuSignIn" href="<?php echo $view->makeLink(array('do' => 'base.loginForm'), false);?>">Login</a>
-    </span>
-<?php endif; ?>
     <div class="post-nav"></div>
     <?php if (!empty($service_msg)): ?>
     <div class="owa_headerServiceMsg"><?php echo $service_msg; ?></div>

--- a/modules/Base/templates/header.php
+++ b/modules/Base/templates/header.php
@@ -28,6 +28,37 @@
     </span>
     <?php $cu = $view->getCurrentUser(); ?>
 <?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ): ?>
+    <?php
+        /*
+         * THE ACCOUNT MENU, at the right-hand end.
+         *
+         * FIRST in source order, because these are floated right and the first
+         * element lands furthest right. Moving it after the bell would put the
+         * name to the bell's left again without anything saying so.
+         */
+    ?>
+    <span class="owa_userMenu">
+        <button type="button" id="owa_userMenuToggle" class="owa_userMenuToggle"
+                aria-expanded="false" aria-controls="owa_userMenuPanel" aria-haspopup="true">
+            <span class="owa_userMenuName"><?php $view->out( $cu->getUserData('user_id') );?></span>
+            <i class="fas fa-chevron-down owa_userMenuCaret" aria-hidden="true"></i>
+        </button>
+        <div id="owa_userMenuPanel" class="owa_userMenuPanel" role="menu" hidden>
+            <a role="menuitem" class="owa_userMenuItem owa_myProfileLink"
+               href="<?php echo $view->makeLink( array( 'do' => 'base.myProfile' ), false );?>">Profile</a>
+            <?php
+                /*
+                 * An embedded install signs people in through its host, so it
+                 * has no session of its own to end -- the same condition that
+                 * hid the old Logout link.
+                 */
+            ?>
+            <?php if ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ):?>
+            <a role="menuitem" class="owa_userMenuItem owa_userMenuLogout"
+               href="<?php echo $view->makeLink(array('do' => 'base.logout'), false);?>">Logout</a>
+            <?php endif;?>
+        </div>
+    </span>
 <?php
     /*
      * The badge count is NOT rendered here and is not a call of its own.
@@ -84,10 +115,16 @@
             var unread = items.querySelectorAll('.owa_notification.is-unread').length;
 
             badge.textContent = unread;
-            // Never hidden: an empty badge is still the control people look
-            // for, and a bell that only sometimes has one moves under the
-            // cursor.
-            badge.classList.toggle('is-zero', unread === 0);
+
+            /*
+             * Nothing unread, nothing to show.
+             *
+             * This used to stay put and go grey, because a badge that comes and
+             * goes moves the bell under the cursor. It no longer can: the badge
+             * overhangs the button and is not part of what spaces the header
+             * controls, so showing or hiding it moves nothing.
+             */
+            badge.hidden = unread === 0;
         }
 
         function markRead(id, el) {
@@ -268,35 +305,14 @@
          */
     ?>
 <?php if ( \OWA\Core\CoreAPI::isCurrentUserAuthenticated() ): ?>
-    <span class="owa_userMenu">
-        <button type="button" id="owa_userMenuToggle" class="owa_userMenuToggle"
-                aria-expanded="false" aria-controls="owa_userMenuPanel" aria-haspopup="true">
-            <span class="owa_userMenuName"><?php $view->out( $cu->getUserData('user_id') );?></span>
-            <i class="fas fa-chevron-down owa_userMenuCaret" aria-hidden="true"></i>
-        </button>
-        <div id="owa_userMenuPanel" class="owa_userMenuPanel" role="menu" hidden>
-            <a role="menuitem" class="owa_userMenuItem owa_myProfileLink"
-               href="<?php echo $view->makeLink( array( 'do' => 'base.myProfile' ), false );?>">Profile</a>
-            <?php
-                /*
-                 * An embedded install signs people in through its host, so it
-                 * has no session of its own to end -- the same condition that
-                 * hid the old Logout link.
-                 */
-            ?>
-            <?php if ( ! \OWA\Core\CoreAPI::getSetting( 'base', 'is_embedded' ) ):?>
-            <a role="menuitem" class="owa_userMenuItem owa_userMenuLogout"
-               href="<?php echo $view->makeLink(array('do' => 'base.logout'), false);?>">Logout</a>
-            <?php endif;?>
-        </div>
-    </span>
     <?php
         /*
-         * HELP, to the left of the account menu.
+         * HELP, at the left of the three.
          *
-         * After it in the markup, which is what puts it to its left: these are
-         * floated right, so the first element in source order lands furthest
-         * right. Everything in here leaves the application for GitHub, which is
+         * Last in source order, which is what puts it there: these are floated
+         * right, so the first element in source order lands furthest right and
+         * the bar reads help, notifications, account from left to right.
+         * Everything in this menu leaves the application for GitHub, which is
          * why it is a menu rather than three more links in the bar.
          */
     ?>

--- a/modules/Base/templates/hierarchy_breadcrumb.php
+++ b/modules/Base/templates/hierarchy_breadcrumb.php
@@ -27,10 +27,14 @@ $owa_crumbs = array();
  * installation rather than an Organization. Saying "My Organization" above a
  * screen whose settings apply to every Organization would be wrong in exactly
  * the way the tiering is meant to prevent.
+ *
+ * The label is not always "Installation": base.myProfile is tier 0 for the same
+ * reason -- it belongs to no Organization -- but is about the person, so it
+ * supplies its own. See OptionsHierarchy, which defaults it.
  */
 if ( (int) $view->hierarchy_tier === 0 ) {
 
-    $owa_crumbs[] = array( 'label' => 'Installation', 'note' => '' );
+    $owa_crumbs[] = array( 'label' => (string) $view->hierarchy_root_label, 'note' => '' );
 
 } elseif ( ! empty( $owa_h['organization']['name'] ) ) {
 

--- a/modules/Base/templates/install.php
+++ b/modules/Base/templates/install.php
@@ -1,9 +1,14 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div style="width:800px; margin: 0px auto -1px auto;">
-    <div class="" style="text-align:center;">
-        <h1>Open Web Analytics Installer</h1>
-    </div>
-    <br>
-    <div class="layout_subview" valign="top" style="text-align:left;"><?php echo $view->subview;?></div>
-
+<?php
+/*
+ * The installer's frame.
+ *
+ * A fixed 800px block with a centred <h1> and a <br>. The card and the column
+ * come from the signed-out page styles in owa.css, which this wrapper already
+ * loads -- the installer is one of the screens that uses wrapper_public.php.
+ */
+?>
+<div class="owa_publicCard owa_installCard">
+    <h1 class="owa_publicTitle">Install Open Web Analytics</h1>
+    <div class="owa_installBody"><?php echo $view->subview;?></div>
 </div>

--- a/modules/Base/templates/install_check_env.php
+++ b/modules/Base/templates/install_check_env.php
@@ -1,23 +1,37 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<!-- <div class="panel_headline"><?php //echo $headline;?></div> -->
-
-<h2>Uh-oh. We found a few issues.</h2>
-
-<p>We found a few problems with your server environment. Please resolve these issues and start the installation again.</p>
-
-<style>
-.form-row {border-bottom:1px solid #efefef;padding:10px;}
-.form-label {position: inherit; min-width: 300px;}
-.form-field {position: absolute; left: 620px;}
-.form-error {background-color: red; border:1px solid red; color:#ffffff; padding:3px;}
-.form-instructions {position: absolute; left: 850px; font-size:12px; color: #9f9f9f;}
-</style>    
-
-<h3>Problems</h3>
-<?php foreach ($view->errors as $error): ?>
-<p class="form-row">
-    <span class="form-label"><?php echo $error['name'];?></span>
-    <span class="form-field form-error"><?php echo $error['value'];?></span>
-    <span class="form-instructions"><?php echo $error['msg'];?></span>
+<?php
+/*
+ * What was checked, and what each check found.
+ *
+ * This listed the FAILURES only, under "Uh-oh. We found a few issues." -- so
+ * there was no way to tell a check that passed from one that was never made,
+ * which on a screen describing the environment is most of what you want to
+ * know. Every check is listed, and the ones that failed carry the fix.
+ *
+ * The <style> block that used to be here positioned the columns absolutely at
+ * left:620px and left:850px; the rules live in owa.css with the rest now.
+ */
+$owa_failed = count( (array) $view->errors );
+?>
+<p class="owa_publicIntro">
+<?php if ( $owa_failed === 1 ): ?>
+One thing needs fixing before OWA can be installed. Sort it out and reload this page.
+<?php else: ?>
+<?php $view->out( (string) $owa_failed ); ?> things need fixing before OWA can be
+installed. Sort them out and reload this page.
+<?php endif; ?>
 </p>
+
+<ul class="owa_installChecks">
+<?php foreach ( (array) $view->checks as $owa_check ): ?>
+    <li class="owa_installCheck <?php echo $owa_check['passed'] ? 'is-ok' : 'is-bad';?>">
+        <span class="owa_installCheckMark" aria-hidden="true"><?php
+            echo $owa_check['passed'] ? '&#10003;' : '&#10007;';?></span>
+        <span class="owa_installCheckName"><?php $view->out( $owa_check['name'] );?></span>
+        <span class="owa_installCheckValue"><?php $view->out( $owa_check['value'] );?></span>
+        <?php if ( ! $owa_check['passed'] ): ?>
+        <span class="owa_installCheckFix"><?php $view->out( $owa_check['msg'] );?></span>
+        <?php endif; ?>
+    </li>
 <?php endforeach; ?>
+</ul>

--- a/modules/Base/templates/install_config_entry.php
+++ b/modules/Base/templates/install_config_entry.php
@@ -1,77 +1,80 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
 <h2>Configuration Settings</h2>
-<p>
-We could not locate OWA's <code>owa-config.php</code> configuration file. You can use the form below to create the file but this may not work on all hosts. If file generation fails, you can  create the config file manually by renaming <code>owa-config-dist.php</code> to <code>owa-config.php</code> and filling in your database information and public URL.
+<p class="owa_publicIntro">
+We could not find OWA's <code>owa-config.php</code>. The form below creates it. If your
+server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
+<code>owa-config.php</code> yourself and fill in the same details.
 </p>
 <div id="configSettings">
     <form method="POST">
 
         <h3>Public URL</h3>
-        <p class="form-row">
-            <span class="form-label">Public URL:</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Public URL:</label>
+            <span class="owa_installInput">
                 <input type="text"size="50" name="<?php echo $view->getNs();?>public_url" value="<?php echo $view->public_url;?>">
             </span>
-            <span class="form-instructions">This is the web URL of OWA's base directory.</span>
-        </p>
+            <span class="owa_installHint">This is the web URL of OWA's base directory.</span>
+        </div>
 
         <h3>Database</h3>
-        <p class="form-row">
-            <span class="form-label">Database Type:</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Database Type:</label>
+            <span class="owa_installInput">
                 <select name="<?php echo $view->getNs();?>db_type">
 	                <?php foreach ( $this->config['db_supported_types'] as $db_type => $db_label ): ?>
                     <option value="<?php $view->out( $db_type );?>"><?php $view->out( $db_label );?></option>
                     <?php endforeach;?>
                 </select>
             </span>
-            <span class="form-instructions">This is the type of database you are going to use.</span>
-        </p>
+            <span class="owa_installHint">This is the type of database you are going to use.</span>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Database Host:</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Database Host:</label>
+            <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_host" value="<?php echo $view->config['db_host'] ?? '';?>">
             </span>
-            <span class="form-instructions">This is the host that your database resides on. Localhost is ok.</span>
-        </p>
+            <span class="owa_installHint">This is the host that your database resides on. Localhost is ok.</span>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Database Port:</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Database Port:</label>
+            <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_port" value="<?php echo (!empty($view->config['db_port']) ? $view->config['db_port'] : 3306);?>">
             </span>
-            <span class="form-instructions">(optional) The port of your database. Will default to port 3306 if you leave this empty.</span>
-        </p>
+            <span class="owa_installHint">(optional) The port of your database. Will default to port 3306 if you leave this empty.</span>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Database Name:</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Database Name:</label>
+            <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_name" value="<?php echo $view->config['db_name'] ?? '';?>">
             </span>
-            <span class="form-instructions">This is the name of the database to install tables into.</span>
-        </p>
+            <span class="owa_installHint">This is the name of the database to install tables into.</span>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Database User:</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Database User:</label>
+            <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_user" value="<?php echo $view->config['db_user'] ?? '';?>">
             </span>
-            <span class="form-instructions">This is the user name to connect to the database.</span>
-        </p>
+            <span class="owa_installHint">This is the user name to connect to the database.</span>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Database Password:</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Database Password:</label>
+            <span class="owa_installInput">
                 <input type="password"size="30" name="<?php echo $view->getNs();?>db_password" value="<?php echo $view->config['db_password'] ?? '';?>">
             </span>
-            <span class="form-instructions">This is the password to connect to the database.</span>
-        </p>
-        <p>
+            <span class="owa_installHint">This is the password to connect to the database.</span>
+        </div>
+        <div class="owa_installActions">
             <?php echo $view->createNonceFormField('base.installConfig');?>
             <input type="hidden" value="base.installConfig" name="<?php echo $view->getNs();?>action">
-            <input class="owa-button"type="submit" value="Continue..." name="<?php echo $view->getNs();?>save_button">
-        <p>
+            <input class="owa-button owa_publicSubmit" type="submit" value="Continue"
+                   name="<?php echo $view->getNs();?>save_button">
+        </div>
 
     </form>
 

--- a/modules/Base/templates/install_config_entry.php
+++ b/modules/Base/templates/install_config_entry.php
@@ -10,7 +10,7 @@ server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
 
         <h3>Public URL</h3>
         <div class="owa_installField">
-            <label>Public URL:</label>
+            <label>Public URL</label>
             <span class="owa_installInput">
                 <input type="text"size="50" name="<?php echo $view->getNs();?>public_url" value="<?php echo $view->public_url;?>">
             </span>
@@ -19,7 +19,7 @@ server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
 
         <h3>Database</h3>
         <div class="owa_installField">
-            <label>Database Type:</label>
+            <label>Database Type</label>
             <span class="owa_installInput">
                 <select name="<?php echo $view->getNs();?>db_type">
 	                <?php foreach ( $this->config['db_supported_types'] as $db_type => $db_label ): ?>
@@ -31,7 +31,7 @@ server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
         </div>
 
         <div class="owa_installField">
-            <label>Database Host:</label>
+            <label>Database Host</label>
             <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_host" value="<?php echo $view->config['db_host'] ?? '';?>">
             </span>
@@ -39,7 +39,7 @@ server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
         </div>
 
         <div class="owa_installField">
-            <label>Database Port:</label>
+            <label>Database Port</label>
             <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_port" value="<?php echo (!empty($view->config['db_port']) ? $view->config['db_port'] : 3306);?>">
             </span>
@@ -47,7 +47,7 @@ server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
         </div>
 
         <div class="owa_installField">
-            <label>Database Name:</label>
+            <label>Database Name</label>
             <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_name" value="<?php echo $view->config['db_name'] ?? '';?>">
             </span>
@@ -55,7 +55,7 @@ server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
         </div>
 
         <div class="owa_installField">
-            <label>Database User:</label>
+            <label>Database User</label>
             <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>db_user" value="<?php echo $view->config['db_user'] ?? '';?>">
             </span>
@@ -63,7 +63,7 @@ server does not let PHP write the file, copy <code>owa-config-dist.php</code> to
         </div>
 
         <div class="owa_installField">
-            <label>Database Password:</label>
+            <label>Database Password</label>
             <span class="owa_installInput">
                 <input type="password"size="30" name="<?php echo $view->getNs();?>db_password" value="<?php echo $view->config['db_password'] ?? '';?>">
             </span>

--- a/modules/Base/templates/install_defaults_entry.php
+++ b/modules/Base/templates/install_defaults_entry.php
@@ -3,9 +3,9 @@
 <div id="configSettings">
     <form method="POST">
         
-        <p class="form-row">
-            <span class="form-label">Site Domain</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Site Domain</label>
+            <span class="owa_installInput">
                 <select name="<?php echo $view->getNs();?>protocol">
                     <option value="http://">http://</option>
                     <option value="https://">https://</option>
@@ -21,12 +21,12 @@
                 ?>
                 <input type="text"size="30" name="<?php echo $view->getNs();?>domain" value="<?php $view->out( $view->defaults['domain'] ?? '' );?>">
             </span>
-            <span class="form-instructions">This is the domain of the site to track.</span>
-        </p>
+            <span class="owa_installHint">This is the domain of the site to track.</span>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Reporting Timezone</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Reporting Timezone</label>
+            <span class="owa_installInput">
                 <?php
                 /*
                  * A timezone supplied by OWA_TIMEZONE in owa-config.php is not
@@ -109,45 +109,46 @@
                 <?php } ?>
             </span>
             <?php if ( $tz_constant ) { ?>
-            <span class="form-instructions">Set by <code><?php $view->out( $tz_constant ); ?></code>
+            <span class="owa_installHint">Set by <code><?php $view->out( $tz_constant ); ?></code>
             in <code>owa-config.php</code>, which overrides any value chosen here. Remove the
             constant to choose a timezone from this page.</span>
             <?php } else { ?>
-            <span class="form-instructions">Statistics are bucketed into days using this
+            <span class="owa_installHint">Statistics are bucketed into days using this
             timezone. <strong>Changing it later is not retroactive</strong> &mdash; existing data
             keeps the day boundaries it was recorded with.</span>
             <?php } ?>
-        </p>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Your Admin Name</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Your Admin Name</label>
+            <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( $view->defaults['user_id'] ?? '' );?>">
             </span>
-            <span class="form-instructions">This is name of the admin user.</span>
-        </p>
+            <span class="owa_installHint">This is name of the admin user.</span>
+        </div>
 
-        <p class="form-row">
-            <span class="form-label">Your E-mail Address</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Your E-mail Address</label>
+            <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>email_address" value="<?php $view->out( $view->defaults['email_address'] ?? '' );?>">
             </span>
-            <span class="form-instructions">This is the e-mail address of the admin user.</span>
-        </p>
+            <span class="owa_installHint">This is the e-mail address of the admin user.</span>
+        </div>
         
-        <p class="form-row">
-            <span class="form-label">Your Password</span>
-            <span class="form-field">
+        <div class="owa_installField">
+            <label>Your Password</label>
+            <span class="owa_installInput">
                 <input type="password"size="30" name="<?php echo $view->getNs();?>password" value="">
             </span>
-            <span class="form-instructions">This will be the password of the admin user.</span>
-        </p>
+            <span class="owa_installHint">This will be the password of the admin user.</span>
+        </div>
                 
-        <p>
+        <div class="owa_installActions">
             <?php echo $view->createNonceFormField('base.installBase');?>
             <input type="hidden" value="base.installBase" name="<?php echo $view->getNs();?>action">
-            <input class="owa-button" type="submit" value="Continue..." name="<?php echo $view->getNs();?>save_button">
-        </p>
+            <input class="owa-button owa_publicSubmit" type="submit" value="Continue"
+                   name="<?php echo $view->getNs();?>save_button">
+        </div>
         
     </form>
     

--- a/modules/Base/templates/install_defaults_entry.php
+++ b/modules/Base/templates/install_defaults_entry.php
@@ -1,9 +1,8 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
 <h2>Your first Property</h2>
 
-<p class="owa_publicIntro">A Property is the thing being measured. OWA creates one for
-this website, with a single Observation Profile beneath it to record visits, and an
-administrator account to sign in with.</p>
+<p class="owa_publicIntro">A Property is the website or application you want to
+track.</p>
 <div id="configSettings">
     <form method="POST">
         
@@ -35,7 +34,8 @@ administrator account to sign in with.</p>
                        placeholder="example.com"
                        value="<?php $view->out( $view->defaults['domain'] ?? '' );?>">
             </span>
-            <span class="owa_installHint">The website you want to measure.</span>
+            <span class="owa_installHint">The domain of the website this Property will
+            track (e.g. www.mydomain.com). Subdomains are also acceptable.</span>
         </div>
 
         <div class="owa_installField">
@@ -138,7 +138,7 @@ administrator account to sign in with.</p>
             <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( $view->defaults['user_id'] ?? '' );?>">
             </span>
-            <span class="owa_installHint">The name this account signs in with.</span>
+            <span class="owa_installHint">The user name to use for login.</span>
         </div>
 
         <div class="owa_installField">

--- a/modules/Base/templates/install_defaults_entry.php
+++ b/modules/Base/templates/install_defaults_entry.php
@@ -1,17 +1,29 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<h2>Default Site & User Information</h2>
+<h2>Your first Property</h2>
+
+<p class="owa_publicIntro">A Property is the thing being measured. OWA creates one for
+this website, with a single Observation Profile beneath it to record visits, and an
+administrator account to sign in with.</p>
 <div id="configSettings">
     <form method="POST">
         
         <div class="owa_installField">
-            <label>Site Domain</label>
+            <label>Property Domain</label>
             <span class="owa_installInput">
-                <select name="<?php echo $view->getNs();?>protocol">
-                    <option value="http://">http://</option>
-                    <option value="https://">https://</option>
-                </select>
                 <?php
                 /*
+                 * NO PROTOCOL SELECT.
+                 *
+                 * It prefixed http:// or https:// onto the stored domain, and
+                 * nothing wants that: Site::getDomainName() strips a scheme
+                 * back off wherever the domain is used, the Profile edit form
+                 * asks for a bare domain, and the CLI installer stores one --
+                 * so the two install paths disagreed about what a domain is.
+                 *
+                 * The scheme was only ever load-bearing when a site's identity
+                 * was md5( domain ), where http:// and https:// made one website
+                 * into two sites. Identifiers are minted now.
+                 *
                  * ?? '' on every defaults read, because on the FIRST render
                  * there are none. InstallBase sets 'defaults' only in
                  * errorAction(), the re-render after a validation failure, so an
@@ -19,9 +31,11 @@
                  * line below already had the guard and the rest did not.
                  */
                 ?>
-                <input type="text"size="30" name="<?php echo $view->getNs();?>domain" value="<?php $view->out( $view->defaults['domain'] ?? '' );?>">
+                <input type="text" size="30" name="<?php echo $view->getNs();?>domain"
+                       placeholder="example.com"
+                       value="<?php $view->out( $view->defaults['domain'] ?? '' );?>">
             </span>
-            <span class="owa_installHint">This is the domain of the site to track.</span>
+            <span class="owa_installHint">The website you want to measure.</span>
         </div>
 
         <div class="owa_installField">
@@ -120,27 +134,27 @@
         </div>
 
         <div class="owa_installField">
-            <label>Your Admin Name</label>
+            <label>Admin User Name</label>
             <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( $view->defaults['user_id'] ?? '' );?>">
             </span>
-            <span class="owa_installHint">This is name of the admin user.</span>
+            <span class="owa_installHint">The name this account signs in with.</span>
         </div>
 
         <div class="owa_installField">
-            <label>Your E-mail Address</label>
+            <label>Email Address</label>
             <span class="owa_installInput">
                 <input type="text"size="30" name="<?php echo $view->getNs();?>email_address" value="<?php $view->out( $view->defaults['email_address'] ?? '' );?>">
             </span>
-            <span class="owa_installHint">This is the e-mail address of the admin user.</span>
+            <span class="owa_installHint">Where password resets for this account are sent.</span>
         </div>
         
         <div class="owa_installField">
-            <label>Your Password</label>
+            <label>Password</label>
             <span class="owa_installInput">
                 <input type="password"size="30" name="<?php echo $view->getNs();?>password" value="">
             </span>
-            <span class="owa_installHint">This will be the password of the admin user.</span>
+            <span class="owa_installHint">The password for this account.</span>
         </div>
                 
         <div class="owa_installActions">

--- a/modules/Base/templates/install_finish.php
+++ b/modules/Base/templates/install_finish.php
@@ -1,25 +1,28 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div class="subview_content">
+<div class="owa_installFinish">
 
-    <h1>Success! That's It. Installation is Complete.</h1>
+    <h2 class="owa_installDone">Installation complete</h2>
     <p>Open Web Analytics has been successfully installed. Login using the user name and password below and generate a tracker.</p>
-    <p class="form-row">
-        <span class="form-label">User Name:</span>
-        <span class="form-field"><?php echo $view->u;?></span>
-    </p>
-    <p class="form-row">
-        <span class="form-label">Password:</span>
-        <span class="form-field"><?php echo $view->p;?></span>
-        <span class="form-instructions"></span>
-    </p>
-    <BR>
+    <?php
+        /*
+         * The one time this password is ever shown. It is generated, not
+         * chosen, so a copy of it that is easy to select matters.
+         */
+    ?>
+    <div class="owa_installCredentials">
+        <div class="owa_installField">
+            <label>User name</label>
+            <span class="owa_installCredential"><?php $view->out( $view->u );?></span>
+        </div>
+        <div class="owa_installField">
+            <label>Password</label>
+            <span class="owa_installCredential"><?php $view->out( $view->p );?></span>
+        </div>
+    </div>
     <p>
-        <a href="<?php echo $view->makeLink(array("action" => "base.sitesInvocation", "siteId" => $view->site_id), false, \OWA\Core\CoreAPI::getSetting('base','public_url'));?>" target="_blank">
-            <span class="owa-button">Login and generate a site tracker!</span>
-        </a>
+        <a class="owa-button owa_publicSubmit"
+           href="<?php echo $view->makeLink(array("action" => "base.sitesInvocation", "siteId" => $view->site_id), false, \OWA\Core\CoreAPI::getSetting('base','public_url'));?>">Log in and generate a tracker</a>
     </p>
-
-    <BR>
 
     <div class="status owa-install-cron">
         <b>One more step: add OWA's cron entry.</b>

--- a/modules/Base/templates/install_finish.php
+++ b/modules/Base/templates/install_finish.php
@@ -2,42 +2,47 @@
 <div class="owa_installFinish">
 
     <h2 class="owa_installDone">Installation complete</h2>
-    <p>Open Web Analytics has been successfully installed. Login using the user name and password below and generate a tracker.</p>
-    <?php
-        /*
-         * The one time this password is ever shown. It is generated, not
-         * chosen, so a copy of it that is easy to select matters.
-         */
-    ?>
+    <p class="owa_publicIntro">Sign in with the account below, then copy the tracking tag
+    for your Observation Profile onto your website.</p>
     <div class="owa_installCredentials">
         <div class="owa_installField">
             <label>User name</label>
             <span class="owa_installCredential"><?php $view->out( $view->u );?></span>
         </div>
+        <?php
+            /*
+             * The password appears ONLY when OWA generated one, which happens
+             * when none was given. The wizard requires one, so on this path the
+             * operator already knows it -- printing it back would leave a live
+             * credential in the page for nothing.
+             */
+        ?>
+        <?php if ( $view->p ): ?>
         <div class="owa_installField">
             <label>Password</label>
             <span class="owa_installCredential"><?php $view->out( $view->p );?></span>
+            <span class="owa_installHint">Generated for you. It is not shown again.</span>
         </div>
+        <?php endif; ?>
     </div>
     <p>
         <a class="owa-button owa_publicSubmit"
-           href="<?php echo $view->makeLink(array("action" => "base.sitesInvocation", "siteId" => $view->site_id), false, \OWA\Core\CoreAPI::getSetting('base','public_url'));?>">Log in and generate a tracker</a>
+           href="<?php echo $view->makeLink(array("action" => "base.sitesInvocation", "siteId" => $view->site_id), false, \OWA\Core\CoreAPI::getSetting('base','public_url'));?>">Log in and get the tracking tag</a>
     </p>
 
     <div class="status owa-install-cron">
         <b>One more step: add OWA's cron entry.</b>
         <p>
-            OWA runs its scheduled maintenance -- keeping the fact tables' date
-            partitions ahead of incoming data, and anything else you schedule later --
-            from a single cron entry. Without it that maintenance never runs.
+            OWA runs its scheduled maintenance from a single cron entry: keeping the
+            fact tables' date partitions ahead of incoming data, and anything else you
+            schedule later. Without it that maintenance never runs.
         </p>
         <p>Add this to the crontab of the user that owns your OWA files:</p>
         <p><code><?php $view->out( \OWA\Module\Base\Classes\SchedulerHealth::cronLine() ); ?></code></p>
         <p>
-            Then check it took, with
-            <code>php cli.php cmd=schedule-status</code> -- it will tell you in as many
-            words whether the scheduler has ever run. Until the entry is in place, OWA
-            will keep reminding you at the top of every admin page.
+            Then check it with <code>php cli.php cmd=schedule-status</code>, which reports
+            whether the scheduler has run. Until the entry is in place, OWA reminds you at
+            the top of every admin page.
         </p>
     </div>
 </div>

--- a/modules/Base/templates/install_start.php
+++ b/modules/Base/templates/install_start.php
@@ -1,16 +1,16 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div id="panel" style="width:800px; margin: 0px auto 20px auto;">
+<p class="owa_publicIntro">The next few screens set up the framework: a check of this
+server, your database details, and an account to sign in with. If you need help, the
+<a href="<?php $view->out( $this->config['wiki_url'] );?>">documentation wiki</a> covers
+each step.</p>
 
-    <h2>Welcome to the Installer!</h2>
-	<div class="layout_subview" valign="top" style="text-align:left;">
-    <P>The next few screens will guide you through installing the Open Web Analytics framework. If at any time you
-    need help, please consult the <a href=<?php echo $this->config['wiki_url'];?>>OWA Documentation Wiki</a>.</P>
-    <BR>
-    <p>
-        <a href="<?php echo $view->makeLink(array('action' => 'base.installCheckEnv'));?>"><span class="owa-button">Let's Get Started...</span></a>
-    </p>
-
-	</div>
-
-</div>
-    
+<?php
+    /*
+     * The href was unquoted -- href=<?php echo ... ?> -- so any URL with a
+     * character needing quoting broke the tag.
+     */
+?>
+<p>
+    <a class="owa-button owa_publicSubmit"
+       href="<?php echo $view->makeLink( array( 'action' => 'base.installCheckEnv' ) );?>">Get started</a>
+</p>

--- a/modules/Base/templates/login_form.php
+++ b/modules/Base/templates/login_form.php
@@ -1,35 +1,38 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div style="width:340px; margin: 0px auto -1px auto;">
-    <div class="inline_h1" style="text-align:left;">Login</div><BR>
+<div class="owa_publicCard">
 
-    <div style="width:340px; margin: 0px auto -1px auto; text-align:center;">
+    <h1 class="owa_publicTitle">Login</h1>
 
-        <!-- content goes here -->
-        <DIV id="login_box" style="color:#ffffff; padding:45px; height:210px; text-align:left;" >
+    <form method="POST" class="owa_publicForm">
 
-            <form method="POST">
+        <div class="owa_publicField">
+            <label for="owa_loginUserId">User name</label>
+            <input id="owa_loginUserId" type="text" autocomplete="username" autofocus
+                   name="<?php echo $view->getNs();?>user_id"
+                   value="<?php $view->out( $view->user_id ); ?>">
+        </div>
 
-            <div class="inline_h3"><B>User Name:</B></div>
-            <INPUT class="owa_largeFormField" type="text" size="20" name="<?php echo $view->getNs();?>user_id" value="<?php $view->out( $view->user_id); ?>"><BR><BR>
-            <div class="inline_h3"><B>Password:</B></div>
-            <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $view->getNs();?>password"><BR><BR>
-            <input type="hidden" size="70" name="<?php echo $view->getNs();?>go" value="<?php echo $view->go?>">
-            <input name="<?php echo $view->getNs();?>action" value="base.login" type="hidden">
-            <div style="text-align:;">
-            <INPUT class="owa_largeFormField" type="submit" name="<?php echo $view->getNs();?>submit_btn" value="Login">
-            </div>
-            </form>
+        <div class="owa_publicField">
+            <label for="owa_loginPassword">Password</label>
+            <input id="owa_loginPassword" type="password" autocomplete="current-password"
+                   name="<?php echo $view->getNs();?>password">
+        </div>
 
-        </DIV>
+        <?php
+            /*
+             * Where to go once they are in, and which action handles this. Both
+             * were here before and both are load-bearing: without `go` a login
+             * from a deep link lands on the dashboard instead.
+             */
+        ?>
+        <input type="hidden" name="<?php echo $view->getNs();?>go" value="<?php $view->out( $view->go );?>">
+        <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.login">
 
+        <input class="owa-button owa_publicSubmit" type="submit"
+               name="<?php echo $view->getNs();?>submit_btn" value="Login">
+    </form>
+
+    <div class="owa_publicAside">
+        <a href="<?php echo $view->makeLink(array('do' => 'base.passwordResetForm'))?>">Forgot your password?</a>
     </div>
-
-
-    <BR>
-    <span class="info_text">
-    <a href="<?php echo $view->makeLink(array('do' => 'base.passwordResetForm'))?>">Forgot your password?</a>
-    </span>
 </div>
-
-
-

--- a/modules/Base/templates/my_profile.php
+++ b/modules/Base/templates/my_profile.php
@@ -1,0 +1,128 @@
+<?php /** @var \OWA\Core\ViewScope $view */ ?>
+<?php
+/*
+ * The signed-in user's own account.
+ *
+ * Laid out with the .setting / .title / .description / .field markup the rest
+ * of the settings screens use, so it reads as one of them rather than as a
+ * screen of its own.
+ */
+$owa_mayEditEmail = (bool) $view->may_edit_email;
+$owa_error        = (string) $view->my_profile_error;
+$owa_minPassword  = (int) $view->min_password_length;
+?>
+<DIV class="panel_headline">Profile</DIV>
+<div id="panel">
+
+<div class="owa_panelIntro">Your own account: the name you are shown as, the address
+password resets are sent to, and your password. To change somebody else's account, use
+Users under Organization.</div>
+
+<?php if ( $owa_error ): ?>
+<div class="notice error" role="alert"><?php $view->out( $owa_error ); ?></div>
+<?php endif; ?>
+
+<?php if ( $view->my_profile_saved ): ?>
+<div class="notice" role="status">Your profile has been saved.</div>
+<?php endif; ?>
+
+<form method="post" name="owa_myProfile"
+      action="<?php echo $view->makeLink( array( 'do' => 'base.myProfileSave' ) ); ?>">
+
+    <fieldset name="owa-options" class="options">
+
+        <div class="setting">
+            <div class="title">Username</div>
+            <div class="description">What you sign in with. It identifies everything you
+            have made &mdash; your custom reports and the sites you have been granted
+            &mdash; so it is not changed here.</div>
+            <div class="field">
+                <span class="noedit"><?php $view->out( $view->user_id ); ?></span>
+            </div>
+        </div>
+
+        <div class="setting">
+            <div class="title">Role</div>
+            <div class="description">What you are allowed to do. Only an administrator can
+            change it.</div>
+            <div class="field">
+                <span class="noedit"><?php $view->out( $view->role ); ?></span>
+            </div>
+        </div>
+
+        <div class="setting">
+            <div class="title">Name</div>
+            <div class="description">Your name, as other people see it on the users
+            list.</div>
+            <div class="field">
+                <input type="text" size="30" maxlength="255" name="real_name"
+                       value="<?php $view->out( $view->real_name ); ?>">
+            </div>
+        </div>
+
+        <div class="setting">
+            <div class="title">Email address</div>
+            <div class="description">Where password resets are sent.<?php
+                if ( ! $owa_mayEditEmail ): ?> Changing it is not something your role can
+                do &mdash; ask an administrator.<?php endif; ?></div>
+            <div class="field">
+                <?php
+                    /*
+                     * Shown either way. Which address the account uses is worth
+                     * knowing even when it cannot be changed here, and a field
+                     * that vanishes reads as an account with no address.
+                     *
+                     * Read-only WITHOUT a name attribute, so nothing is posted
+                     * at all -- a disabled input posts nothing either, but a
+                     * readonly one does, and posting the unchanged value would
+                     * make the save compare a value it should never have been
+                     * offered.
+                     */
+                ?>
+                <?php if ( $owa_mayEditEmail ): ?>
+                <input type="email" size="30" maxlength="255" name="email_address"
+                       value="<?php $view->out( $view->email_address ); ?>">
+                <?php else: ?>
+                <span class="noedit"><?php $view->out( $view->email_address ); ?></span>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <div class="setting">
+            <div class="title">Change password</div>
+            <div class="description">Leave these empty to keep your current password. Your
+            current password is required, so a signed-in browser that is not yours cannot
+            change it. At least <?php echo (int) $owa_minPassword; ?> characters. Changing
+            it signs you out, so you will be asked to sign in again.</div>
+            <div class="field">
+                <?php
+                    /*
+                     * autocomplete names the browser understands, so a password
+                     * manager offers the right thing in each box rather than
+                     * filling the new-password fields with the old one.
+                     */
+                ?>
+                <div><input type="password" size="30" name="current_password"
+                            autocomplete="current-password" placeholder="Current password"></div>
+                <div><input type="password" size="30" name="new_password"
+                            autocomplete="new-password" placeholder="New password"></div>
+                <div><input type="password" size="30" name="new_password2"
+                            autocomplete="new-password" placeholder="Repeat new password"></div>
+            </div>
+        </div>
+
+        <BR>
+
+        <?php echo $view->createNonceFormField( 'base.myProfileSave' ); ?>
+        <?php
+            /*
+             * The site travels with the form so the redirect back lands on a
+             * screen that names one -- the settings chrome needs a Profile to
+             * draw its tile and its nav.
+             */
+        ?>
+        <input type="hidden" name="siteId" value="<?php $view->out( $view->siteId ); ?>">
+        <input class="owa-button" type="submit" value="Save Profile">
+    </fieldset>
+</form>
+</div>

--- a/modules/Base/templates/users_change_password.php
+++ b/modules/Base/templates/users_change_password.php
@@ -1,39 +1,39 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div style="width:550px;margin: 0px auto -1px auto;">
-    <div class="inline_h1" style="text-align:left;">Password Setup</div><BR>
-    <div class="inline_h2" style="text-align:left;">Enter your new password below.</div><BR>
-    <div style="width:550px; margin: 0px auto -1px auto; ">
-      <b class="spiffy">
-      <b class="spiffy1"><b></b></b>
-      <b class="spiffy2"><b></b></b>
-      <b class="spiffy3"></b>
-      <b class="spiffy4"></b>
-      <b class="spiffy5"></b></b>
+<div class="owa_publicCard">
 
-      <div class="spiffyfg">
-        <!-- content goes here -->
-        <div id="" style="color:#ffffff; padding:30px; height:200px; text-align:left;" >
-            <form method="POST">
-                <div class="inline_h2">New Password</div>
-                <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $view->getNs();?>password"><BR><BR>
-                <div class="inline_h2">Re-type your Password</div>
-                <INPUT class="owa_largeFormField" type="password" size="20" name="<?php echo $view->getNs();?>password2"><BR><BR>
-                <?php if ( $view->is_embedded ) {?>
-		        <input type="hidden" name="<?php echo $view->getNs();?>is_embedded" value="<?php echo $view->is_embedded;?>">                
-                <?php } ?>
-                <input type="hidden" name="<?php echo $view->getNs();?>k" value="<?php echo $view->key;?>">
-                <input name="<?php echo $view->getNs();?>action" value="base.usersChangePassword" type="hidden">
-                <INPUT class="owa_largeFormField" type="submit" size="" name="<?php echo $view->getNs();?>submit_btn" value="Save Your New Password">
-            </form>
+    <h1 class="owa_publicTitle">Set your password</h1>
+
+    <p class="owa_publicIntro">Choose a new password for your account.</p>
+
+    <form method="POST" class="owa_publicForm">
+
+        <div class="owa_publicField">
+            <label for="owa_newPassword">New password</label>
+            <input id="owa_newPassword" type="password" autocomplete="new-password" autofocus
+                   name="<?php echo $view->getNs();?>password">
         </div>
-    </div>
 
-      <b class="spiffy">
-      <b class="spiffy5"></b>
-      <b class="spiffy4"></b>
-      <b class="spiffy3"></b>
-      <b class="spiffy2"><b></b></b>
-      <b class="spiffy1"><b></b></b></b>
-    </div>
+        <div class="owa_publicField">
+            <label for="owa_newPassword2">Repeat new password</label>
+            <input id="owa_newPassword2" type="password" autocomplete="new-password"
+                   name="<?php echo $view->getNs();?>password2">
+        </div>
 
+        <?php
+            /*
+             * The passkey from the emailed link is what identifies the account
+             * here -- there is no session yet -- so it has to travel with the
+             * form. is_embedded rides along on the migration path that sets it.
+             */
+        ?>
+        <?php if ( $view->is_embedded ): ?>
+        <input type="hidden" name="<?php echo $view->getNs();?>is_embedded"
+               value="<?php $view->out( $view->is_embedded );?>">
+        <?php endif; ?>
+        <input type="hidden" name="<?php echo $view->getNs();?>k" value="<?php $view->out( $view->key );?>">
+        <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.usersChangePassword">
+
+        <input class="owa-button owa_publicSubmit" type="submit"
+               name="<?php echo $view->getNs();?>submit_btn" value="Save new password">
+    </form>
 </div>

--- a/modules/Base/templates/users_password_reset_request.php
+++ b/modules/Base/templates/users_password_reset_request.php
@@ -1,51 +1,33 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div style="width:550px;margin: 0px auto -1px auto;">
-    <div class="inline_h1" style="text-align:left;">Password Reset</div><BR>
-    <div class="inline_h2" style="text-align:left;">Enter the e-mail address associated with your account.</div><BR>
-    <div style="width:550px; margin: 0px auto -1px auto; ">
-      <b class="spiffy">
-      <b class="spiffy1"><b></b></b>
-      <b class="spiffy2"><b></b></b>
-      <b class="spiffy3"></b>
-      <b class="spiffy4"></b>
-      <b class="spiffy5"></b></b>
+<div class="owa_publicCard">
 
-      <div class="spiffyfg">
-        <!-- content goes here -->
-        <div id="" style="color:#ffffff; padding:30px; height:100px; text-align:left;" >
-            <form method="POST">
-                <div class="inline_h3">E-mail address:</div>
-                <INPUT class="owa_largeFormField" type="text" size="30" name="<?php echo $view->getNs();?>email_address" value=""></TD>
-                </TR>
+    <h1 class="owa_publicTitle">Reset your password</h1>
 
-                <TR>
-                    <TH scope="row"></TH>
-                    <TD>
+    <p class="owa_publicIntro">Enter the email address on your account and we will send you a
+    link to set a new password.</p>
 
-                        <input name="<?php echo $view->getNs();?>action" value="base.passwordResetRequest" type="hidden"><BR><BR>
-                        <INPUT class="owa_largeFormField" type="submit" size="30" name="<?php echo $view->getNs();?>submit" value="Request New Password">
-                    </TD>
-                </TR>
+    <?php
+        /*
+         * The markup here used to close a table that was never opened --
+         * </TD></TR>, a <TR>, then </TABLE> -- left behind when this stopped
+         * being a table. Browsers dropped the stray tags silently.
+         */
+    ?>
+    <form method="POST" class="owa_publicForm">
 
-                </TABLE>
-
-            </form>
+        <div class="owa_publicField">
+            <label for="owa_resetEmail">Email address</label>
+            <input id="owa_resetEmail" type="email" autocomplete="email" autofocus
+                   name="<?php echo $view->getNs();?>email_address" value="">
         </div>
 
+        <input type="hidden" name="<?php echo $view->getNs();?>action" value="base.passwordResetRequest">
+
+        <input class="owa-button owa_publicSubmit" type="submit"
+               name="<?php echo $view->getNs();?>submit" value="Send reset link">
+    </form>
+
+    <div class="owa_publicAside">
+        <a href="<?php echo $view->makeLink(array('do' => 'base.loginForm'))?>">Back to login</a>
     </div>
-
-      <b class="spiffy">
-      <b class="spiffy5"></b>
-      <b class="spiffy4"></b>
-      <b class="spiffy3"></b>
-      <b class="spiffy2"><b></b></b>
-      <b class="spiffy1"><b></b></b></b>
-    </div>
-
-
-    <BR>
-    <span class="info_text">
-    <!--<a href="<?php echo $view->makeLink(array('do' => 'base.passwordResetForm'))?>">Forgot your password?</a> -->
-    </span>
 </div>
-

--- a/modules/Base/templates/wrapper_public.php
+++ b/modules/Base/templates/wrapper_public.php
@@ -1,34 +1,53 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<?php
+/*
+ * The signed-out pages: login, password reset, set password, install, updates.
+ *
+ * This was a table with a spacer column, a run of <BR> tags and a 150px JPEG
+ * logo, which is why these screens looked like a different application from the
+ * one they let you into. It is a centred column now, and the card the forms sit
+ * in is styled in owa.css beside everything else.
+ *
+ * Core\View loads base/css/owa.css on every view, so these pages already have a
+ * stylesheet -- they were simply not using it.
+ */
+?>
+<!DOCTYPE html>
+<html lang="en">
 
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title><?php if (isset($view->page_title)) { $view->out( $view->page_title . ' - '); } ?>Open Web Analytics</title>
         <?php include($view->getTemplatePath('base','head.php'));?>
     </head>
 
     <body>
 
-        <div class="owa">
-            <div id="header" style="text-align:center;">
-                <table width="100%">
-                    <TR>
-                        <TD class="">
-                            <img src="<?php echo $view->makeImageLink('base/i/owa_logo_150w.jpg'); ?>" alt="Open Web Analytics"><BR>
-                        </TD>
-                    </TR>
-                </table>
-            </div>
-            <BR>
-            <?php include($view->setTemplate('msgs.php'));?>
-            <BR>
-            <?php if (isset($content)) { echo $content; }?>
-            <?php echo $view->body;?>
+        <div class="owa owa_publicPage">
 
-            <BR><BR><BR><BR>
-            <div style="text-align:center">
-                <span class="inline_h4"><a href="http://www.openwebanalytics.com">Web Analytics</a> powered by <a href="http://www.openwebanalytics.com">Open Web Analytics</a>.</span>
+            <?php
+                /*
+                 * The same logo the signed-in header uses, from the same
+                 * setting, rather than a second hard-coded file -- an install
+                 * that has set its own was showing it everywhere except on the
+                 * way in.
+                 */
+            ?>
+            <div class="owa_publicLogo">
+                <img src="<?php echo $view->makeImageLink( \OWA\Core\CoreAPI::getSetting( 'base', 'logo_image_path' ) ); ?>"
+                     alt="Open Web Analytics">
+            </div>
+
+            <div class="owa_publicMain">
+                <?php include($view->setTemplate('msgs.php'));?>
+                <?php if (isset($content)) { echo $content; }?>
+                <?php echo $view->body;?>
+            </div>
+
+            <div class="owa_publicFooter">
+                <a href="http://www.openwebanalytics.com">Web Analytics</a>
+                powered by <a href="http://www.openwebanalytics.com">Open Web Analytics</a>
             </div>
         </div>
 

--- a/tests/MyProfileTest.php
+++ b/tests/MyProfileTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * The full framework, the way CapabilitiesConfigFileOnlyTest loads it.
+ *
+ * Reading a setting or the action map spins up the service singleton, which
+ * needs OWA_BASE_DIR -- defined by owa_env.php, which this bootstrap loads.
+ * Without it these pass only when some earlier test in the same process has
+ * already booted OWA, and fail when the file is run alone. CI runs an isolation
+ * sweep that does exactly that.
+ */
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The signed-in user's own account screen.
+ *
+ * WHAT ONLY THESE TESTS CAN CHECK
+ *
+ * The capability shape. Whether editing your own address is admin-only, and
+ * whether this screen is reachable by an analyst, are decisions expressed as
+ * entries in one array in Settings.php -- so a change to that array is exactly
+ * the change these assert against. The e2e suite drives the screen; this pins
+ * what it is allowed to do.
+ */
+class MyProfileTest extends TestCase
+{
+    /** The shipped role -> capability map. */
+    private function capabilities(): array
+    {
+        return (array) \OWA\Core\CoreAPI::getSetting('base', 'capabilities');
+    }
+
+    /**
+     * Changing your own email address is a capability of its own.
+     *
+     * It is not edit_users: that is about other people's accounts, and an
+     * analyst who could edit nobody's account still has one of their own. It is
+     * not free either -- the address is where password resets are sent, so
+     * changing it moves who can recover the account.
+     */
+    public function testChangingYourOwnEmailIsAdminOnlyByDefault(): void
+    {
+        $capabilities = $this->capabilities();
+
+        $this->assertContains('edit_own_email', $capabilities['admin'],
+            'an admin can change their own address');
+
+        foreach (array('analyst', 'viewer', 'everyone') as $role) {
+
+            $this->assertNotContains('edit_own_email', $capabilities[$role],
+                sprintf('%s must not change their own address without being granted it', $role));
+        }
+    }
+
+    /**
+     * ...and it is not site-scoped.
+     *
+     * capabilitiesThatRequireSiteAccess is checked against ONE site. An account
+     * is not held per site, so a capability about it listed there would be
+     * asked an unanswerable question and refused for everyone.
+     */
+    public function testTheEmailCapabilityIsNotSiteScoped(): void
+    {
+        $this->assertNotContains(
+            'edit_own_email',
+            (array) \OWA\Core\CoreAPI::getSetting('base', 'capabilitiesThatRequireSiteAccess'));
+    }
+
+    /**
+     * The screen is reachable by every signed-in role.
+     *
+     * view_site_list is what admin, analyst and viewer all carry and nothing
+     * else does, so it is the capability that means "signed in". Gating this on
+     * edit_settings -- which is what every other entry in the Installation nav
+     * group uses -- would leave most users unable to change their own name.
+     */
+    public function testEverySignedInRoleCanReachTheScreen(): void
+    {
+        $capabilities = $this->capabilities();
+
+        foreach (array('admin', 'analyst', 'viewer') as $role) {
+
+            $this->assertContains('view_site_list', $capabilities[$role],
+                sprintf('%s must be able to open their own account screen', $role));
+        }
+    }
+
+    /** @dataProvider controllerCapabilityProvider */
+    public function testTheControllersRequireThatCapability(string $class, string $expected): void
+    {
+        $controller = new $class(array());
+
+        $this->assertSame($expected, $controller->getRequiredCapability());
+    }
+
+    public static function controllerCapabilityProvider(): array
+    {
+        return array(
+            'the form' => array(\OWA\Module\Base\Controller\MyProfile::class, 'view_site_list'),
+            'the save' => array(\OWA\Module\Base\Controller\MyProfileSave::class, 'view_site_list'),
+        );
+    }
+
+    /**
+     * The save is nonce-required.
+     *
+     * It writes to an account, so a link somebody follows must not be able to
+     * rename them or start a password change on their behalf.
+     */
+    public function testTheSaveRequiresANonce(): void
+    {
+        $save = new \OWA\Module\Base\Controller\MyProfileSave(array());
+
+        $this->assertTrue($save->is_nonce_required);
+    }
+
+    /**
+     * Both actions are registered, or the screen is unreachable however it is
+     * linked.
+     */
+    public function testBothActionsAreRegistered(): void
+    {
+        $actions = (array) \OWA\Core\CoreAPI::serviceSingleton()->getMap('actions');
+
+        foreach (array('base.myProfile', 'base.myProfileSave') as $action) {
+
+            $this->assertArrayHasKey($action, $actions,
+                sprintf('%s must be registered, or the screen is unreachable', $action));
+
+            $this->assertTrue(class_exists($actions[$action]['class_name']),
+                sprintf('%s names a class that does not load', $action));
+        }
+    }
+}

--- a/tests/PropertyAdminScreensTest.php
+++ b/tests/PropertyAdminScreensTest.php
@@ -484,8 +484,10 @@ final class PropertyAdminScreensTest extends TestCase
 
         /* Installation is always present -- it is install-wide and needs no
            context. What must NOT appear without a site is Property or Profile. */
+        /* My Preferences needs no context either -- it is about the person, not
+           about anything in the tree -- so it is present here too. */
         $this->assertSame(
-            array( 'Installation', 'Organization' ), array_keys( $bare ),
+            array( 'Installation', 'Organization', 'My Preferences' ), array_keys( $bare ),
             'A screen with no site in context still offered Property or Profile links, '
             . 'which would point at nothing.' );
 
@@ -499,7 +501,8 @@ final class PropertyAdminScreensTest extends TestCase
         $withProperty = (array) $method->invoke( $controller, '', 'some-property-id' );
 
         $this->assertSame(
-            array( 'Installation', 'Organization', 'Property' ), array_keys( $withProperty ) );
+            array( 'Installation', 'Organization', 'Property', 'My Preferences' ),
+            array_keys( $withProperty ) );
     }
 
     /** Every item declares the capability that gates it. */
@@ -1159,9 +1162,20 @@ final class PropertyAdminScreensTest extends TestCase
             OWA_DIR . 'modules/Base/templates/hierarchy_breadcrumb.php' );
 
         $this->assertStringContainsString( "hierarchy_tier === 0", $crumb );
-        $this->assertStringContainsString( "'label' => 'Installation'", $crumb );
+
+        /*
+         * The tier-0 crumb is NAMED by the screen rather than hardcoded, so
+         * base.myProfile -- tier 0 because it belongs to no Organization, but
+         * about the person rather than the install -- can say so. What matters
+         * here is still that tier 0 gets a root crumb of its own instead of an
+         * Organization name.
+         */
+        $this->assertStringContainsString( 'hierarchy_root_label', $crumb );
 
         $view = (string) file_get_contents( OWA_DIR . 'modules/Base/View/OptionsHierarchy.php' );
+
+        /* ...and it still says Installation for every screen that names none. */
+        $this->assertStringContainsString( "?: 'Installation'", $view );
 
         $this->assertStringNotContainsString(
             "hierarchy_tier' ) ?: 3", $view,

--- a/tests/PropertyAdminScreensTest.php
+++ b/tests/PropertyAdminScreensTest.php
@@ -485,9 +485,9 @@ final class PropertyAdminScreensTest extends TestCase
         /* Installation is always present -- it is install-wide and needs no
            context. What must NOT appear without a site is Property or Profile. */
         /* My Preferences needs no context either -- it is about the person, not
-           about anything in the tree -- so it is present here too. */
+           about anything in the tree -- so it is present here too, at the head. */
         $this->assertSame(
-            array( 'Installation', 'Organization', 'My Preferences' ), array_keys( $bare ),
+            array( 'My Preferences', 'Installation', 'Organization' ), array_keys( $bare ),
             'A screen with no site in context still offered Property or Profile links, '
             . 'which would point at nothing.' );
 
@@ -501,7 +501,7 @@ final class PropertyAdminScreensTest extends TestCase
         $withProperty = (array) $method->invoke( $controller, '', 'some-property-id' );
 
         $this->assertSame(
-            array( 'Installation', 'Organization', 'Property', 'My Preferences' ),
+            array( 'My Preferences', 'Installation', 'Organization', 'Property' ),
             array_keys( $withProperty ) );
     }
 
@@ -1120,10 +1120,25 @@ final class PropertyAdminScreensTest extends TestCase
 
         $nav = (array) $method->invoke( $controller, '', '' );
 
+        /*
+         * Install-wide options head the SCOPE CHAIN -- install, Organization,
+         * Property, Profile -- which is the ordering this is about.
+         *
+         * They are no longer literally first: My Preferences sits above them,
+         * and it is not a step in that chain. It is the group about the person
+         * rather than about the tree, so it is neither wider nor narrower than
+         * the rest and does not belong anywhere inside their order.
+         */
+        $groups = array_keys( $nav );
+
+        $this->assertSame( 'My Preferences', $groups[0],
+            'Your own settings head the nav; they belong to no scope in the tree.' );
+
         $this->assertSame(
-            'Installation', array_key_first( $nav ),
-            'Install-wide options are the widest scope, so they head the nav -- the order '
-            . 'reads install, Organization, Property, Profile.' );
+            array( 'Installation', 'Organization' ),
+            array_values( array_diff( $groups, array( 'My Preferences' ) ) ),
+            'Install-wide options are the widest scope in the tree, so they head it -- the '
+            . 'order reads install, Organization, Property, Profile.' );
 
         $actions = array_column( $nav['Installation'], 'do' );
 

--- a/tests/SiteDomainNameTest.php
+++ b/tests/SiteDomainNameTest.php
@@ -83,4 +83,55 @@ final class SiteDomainNameTest extends TestCase
             'sub.example.co.uk',
             $this->siteWithDomain( 'sub.example.co.uk' )->getDomainName() );
     }
+
+    /**
+     * THE INSTALLER NOW WRITES THE BARE SHAPE, so this column stops gaining new
+     * rows with a scheme in them.
+     *
+     * The wizard asked for the scheme in a select and prefixed it onto what was
+     * typed -- while the CLI installer stored the domain as given, so the two
+     * install paths disagreed about what a domain is. The select is gone and
+     * whatever is typed is normalised instead.
+     *
+     * @dataProvider installerDomainProvider
+     */
+    public function testTheInstallerStoresADomainNotAUrl( string $typed, string $stored ): void
+    {
+        $this->assertSame(
+            $stored,
+            \OWA\Module\Base\Controller\InstallBase::domainOnly( $typed ) );
+    }
+
+    public static function installerDomainProvider(): array
+    {
+        return array(
+            'a bare domain is left alone'  => array( 'example.com', 'example.com' ),
+            'https is stripped'            => array( 'https://example.com', 'example.com' ),
+            'http is stripped'             => array( 'http://example.com', 'example.com' ),
+            'a trailing slash goes'        => array( 'https://example.com/', 'example.com' ),
+            'a subdomain survives'         => array( 'https://sub.example.co.uk', 'sub.example.co.uk' ),
+            'surrounding space goes'       => array( '  example.com  ', 'example.com' ),
+            'a port is not a scheme'       => array( 'example.com:8080', 'example.com:8080' ),
+        );
+    }
+
+    /**
+     * ...and what it writes is what getDomainName() answers, unchanged.
+     *
+     * The two have to agree: one normalises on the way in and the other on the
+     * way out, and a round trip that altered the value would mean the stored
+     * domain and the reported one were different strings.
+     */
+    public function testWhatTheInstallerStoresSurvivesTheRoundTrip(): void
+    {
+        foreach ( array( 'example.com', 'https://example.com/', 'sub.example.co.uk' ) as $typed ) {
+
+            $stored = \OWA\Module\Base\Controller\InstallBase::domainOnly( $typed );
+
+            $this->assertSame(
+                $stored,
+                $this->siteWithDomain( $stored )->getDomainName(),
+                sprintf( 'the round trip changed "%s"', $typed ) );
+        }
+    }
 }

--- a/tests/TemplateLatentVarTest.php
+++ b/tests/TemplateLatentVarTest.php
@@ -325,6 +325,31 @@ final class TemplateLatentVarTest extends TestCase
              * NOT change their address, because that branch renders a different
              * field and is the one a fixture is most likely to miss.
              */
+            /*
+             * The installer's environment report.
+             *
+             * Rendered nowhere else in the test suite: the web-wizard e2e walks
+             * a HEALTHY environment, which routes straight past this screen to
+             * the config form, so the only time it is drawn is the one nobody
+             * exercises.
+             */
+            'install_check_env (failures present)' => [
+                'install_check_env.php',
+                [
+                    'checks' => [
+                        [ 'name' => 'PHP version', 'value' => '8.2.33',
+                          'passed' => true, 'msg' => '' ],
+                        [ 'name' => 'Database driver', 'value' => 'none found',
+                          'passed' => false, 'msg' => 'Install pdo_mysql or mysqli.' ],
+                    ],
+                    'errors' => [
+                        [ 'name' => 'Database driver', 'value' => 'none found',
+                          'passed' => false, 'msg' => 'Install pdo_mysql or mysqli.' ],
+                    ],
+                ],
+                ['owa_installCheck', 'PHP version', 'Database driver',
+                 'Install pdo_mysql or mysqli.'],
+            ],
             'my_profile (no email capability)' => [
                 'my_profile.php',
                 [

--- a/tests/TemplateLatentVarTest.php
+++ b/tests/TemplateLatentVarTest.php
@@ -320,6 +320,26 @@ final class TemplateLatentVarTest extends TestCase
                 ],
                 ['name="name"', 'name="stepPath[]"', 'name="visualizationType"'],
             ],
+            /*
+             * The signed-in user's own account. Rendered for somebody who may
+             * NOT change their address, because that branch renders a different
+             * field and is the one a fixture is most likely to miss.
+             */
+            'my_profile (no email capability)' => [
+                'my_profile.php',
+                [
+                    'user_id' => 'someone@example.test',
+                    'real_name' => 'Someone',
+                    'email_address' => 'someone@example.test',
+                    'role' => 'viewer',
+                    'may_edit_email' => false,
+                    'my_profile_error' => '',
+                    'my_profile_saved' => false,
+                    'siteId' => 'owa-e2e',
+                    'min_password_length' => 6,
+                ],
+                ['name="real_name"', 'name="current_password"', 'name="new_password"'],
+            ],
             'goal_event_edit (add)' => [
                 'goal_event_edit.php',
                 [

--- a/tests/e2e/admin-actions.spec.js
+++ b/tests/e2e/admin-actions.spec.js
@@ -68,7 +68,15 @@ test.describe('admin: authentication (login / logout)', () => {
         // Profile's dashboard. base.sites is gone -- the roster of Profiles is
         // the site control's fan-out now, and its "add new" is the affordance
         // an admin (edit_sites) gets and an analyst never does.
-        await expect(page.locator('text=Logout').first()).toBeVisible();
+        /*
+         * The account menu, not the word "Logout".
+         *
+         * Logout lives inside that menu now and is hidden until it is opened,
+         * so a visibility check on the text fails for a perfectly good session.
+         * The toggle is a better signal anyway: it is rendered only for an
+         * authenticated request.
+         */
+        await expect(page.locator('#owa_userMenuToggle')).toBeVisible();
         await expect(page.locator('#owa_siteControl')).toBeVisible();
         await expect(
             page.locator('#owa_siteControlPanel a.owa_siteControlAdd').first()
@@ -81,12 +89,12 @@ test.describe('admin: authentication (login / logout)', () => {
         // land authenticated -- no Logout control, and the password field is
         // still on the page.
         await expect(page.locator('input[name="password"]')).toBeVisible();
-        expect(await page.locator('text=Logout').count()).toBe(0);
+        expect(await page.locator('#owa_userMenuToggle').count()).toBe(0);
     });
 
     test('logout ends the session', async ({ page }) => {
         await adminLogin(page);
-        await expect(page.locator('text=Logout').first()).toBeVisible();
+        await expect(page.locator('#owa_userMenuToggle')).toBeVisible();
 
         await logout(page);
 
@@ -525,11 +533,11 @@ test.describe('admin: password change (emailed-passkey flow)', () => {
         //    change actually took: the OLD password no longer authenticates...
         await loginAs(page, FIXTURE.pwUserId, FIXTURE.pwOldPassword);
         await expect(page.locator('input[name="password"]')).toBeVisible();
-        expect(await page.locator('text=Logout').count()).toBe(0);
+        expect(await page.locator('#owa_userMenuToggle').count()).toBe(0);
 
         // 3. ...and the NEW password does.
         await loginAs(page, FIXTURE.pwUserId, newPassword);
-        await expect(page.locator('text=Logout').first()).toBeVisible();
+        await expect(page.locator('#owa_userMenuToggle')).toBeVisible();
     });
 });
 

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -47,6 +47,18 @@ const FIXTURE = {
     // so the seeder plants a KNOWN temp_passkey the test submits to the real
     // base.usersChangePassword form. Isolated to its own user so rotating its
     // creds can't disturb the admin/reporter logins.
+    /*
+     * The Profile screen's own password fixture, separate from pwUserId.
+     *
+     * admin-actions.spec.js leaves pwUserId on a NEW password -- that is the
+     * point of its test -- and nothing restores it until the next seeding run.
+     * A second spec logging in as that user works alone and fails whenever
+     * admin-actions has run first, which in a full run it always has: the files
+     * run in name order.
+     */
+    profilePwUserId: 'owa-e2e-profilepw@example.test',
+    profilePwPassword: 'e2e-ProfilePw-Old-1!',
+
     pwUserId: 'owa-e2e-pwchange@example.test',
     pwOldPassword: 'e2e-PwChange-Old-1!',
     pwPasskey: '735512bd84ae1f2635e3e89fb7ecc001',

--- a/tests/e2e/header-nav.spec.js
+++ b/tests/e2e/header-nav.spec.js
@@ -1,0 +1,274 @@
+// @ts-check
+/**
+ * The top bar.
+ *
+ * WHAT ONLY THIS SUITE CAN CHECK
+ *
+ * That the account menu behaves like a menu. Whether it starts closed, opens on
+ * the control, closes on a click elsewhere and on Escape, and reports its state
+ * to assistive technology are all runtime behaviour -- the markup alone says
+ * none of it.
+ *
+ * And the spacing. The links used to be fixed-width boxes whatever their text,
+ * so the gaps between the words were all different; that is a measurement, not
+ * a class name.
+ */
+const { test, expect } = require('@playwright/test');
+const { FIXTURE, loginAs } = require('./fixtures');
+
+const toggle = '#owa_userMenuToggle';
+const panel  = '#owa_userMenuPanel';
+
+test.describe('the top bar', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await loginAs(page, FIXTURE.adminUserId, FIXTURE.adminPassword);
+        await page.goto(`?owa_do=base.reportingHome&owa_siteId=${FIXTURE.siteId}`,
+            { waitUntil: 'networkidle' });
+    });
+
+    /**
+     * The greeting is gone.
+     *
+     * "Hi, <name> !" spent the widest part of the bar saying hello. The name is
+     * the control now, so there is nothing left to greet with.
+     */
+    test('there is no greeting, and the name is a control', async ({ page }) => {
+        await expect(page.locator('#owa_header')).not.toContainText('Hi,');
+
+        // A button, not a link: it opens something rather than going somewhere.
+        await expect(page.locator(toggle)).toHaveCount(1);
+        await expect(page.locator(toggle)).toContainText(FIXTURE.adminUserId);
+    });
+
+    test('the menu starts closed, opens, and holds Profile and Logout', async ({ page }) => {
+        await expect(page.locator(panel)).toBeHidden();
+        await expect(page.locator(toggle)).toHaveAttribute('aria-expanded', 'false');
+
+        await page.click(toggle);
+
+        await expect(page.locator(panel)).toBeVisible();
+        await expect(page.locator(toggle)).toHaveAttribute('aria-expanded', 'true');
+
+        expect(await page.locator('.owa_userMenuItem').allInnerTexts())
+            .toEqual(['Profile', 'Logout']);
+    });
+
+    /** Clicking the control again closes it. */
+    test('the control toggles', async ({ page }) => {
+        await page.click(toggle);
+        await expect(page.locator(panel)).toBeVisible();
+
+        await page.click(toggle);
+        await expect(page.locator(panel)).toBeHidden();
+        await expect(page.locator(toggle)).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('a click elsewhere closes it', async ({ page }) => {
+        await page.click(toggle);
+        await expect(page.locator(panel)).toBeVisible();
+
+        await page.mouse.click(400, 400);
+
+        await expect(page.locator(panel)).toBeHidden();
+        await expect(page.locator(toggle)).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    /**
+     * Escape closes it and returns the focus to the control that opened it,
+     * rather than leaving a keyboard user somewhere with no menu and no idea
+     * where they are.
+     */
+    test('escape closes it and gives the focus back', async ({ page }) => {
+        await page.click(toggle);
+        await expect(page.locator(panel)).toBeVisible();
+
+        await page.keyboard.press('Escape');
+
+        await expect(page.locator(panel)).toBeHidden();
+        await expect(page.locator(toggle)).toBeFocused();
+    });
+
+    test('logout from the menu actually signs out', async ({ page }) => {
+        await page.click(toggle);
+        await page.locator('.owa_userMenuLogout').click();
+        await page.waitForLoadState('networkidle');
+
+        /*
+         * The login form, which renders no header at all -- so the check is
+         * that we are on it, not that the bar has changed. The account menu is
+         * necessarily gone with the rest of the chrome.
+         */
+        expect(page.url()).toContain('base.loginForm');
+        await expect(page.locator(toggle)).toHaveCount(0);
+        await expect(page.locator('body')).toContainText('Login');
+    });
+
+    /**
+     * WHAT THE BAR OFFERS.
+     *
+     * "Reporting" is Analytics. Documentation and Report a Bug are no longer
+     * here: both leave the application for GitHub, so they moved into the help
+     * menu rather than spending half the bar navigating away from it.
+     */
+    test('the bar offers Analytics, Settings and Donate', async ({ page }) => {
+        expect(await page.locator('.owa_navigation li a').allInnerTexts())
+            .toEqual(['Analytics', 'Settings', 'Donate']);
+
+        // Analytics still goes where Reporting went: base.reportingHome, which
+        // resolves to the dashboard, so the landing page is what to assert.
+        await page.locator('.owa_navigation li a', { hasText: 'Analytics' }).click();
+        await page.waitForLoadState('networkidle');
+
+        expect(page.url()).toContain('reportId=dashboard');
+        await expect(page.locator('.owa_reportTitle')).toContainText('Dashboard');
+    });
+
+    /**
+     * EVERYTHING SITS ON THE LOGO'S CENTRE LINE.
+     *
+     * Every item in this header is floated, and a float takes its own height
+     * and sits at the top of the content box -- so the logo (55px), the links
+     * (36px) and the round buttons (40px) each started at the same top edge and
+     * ended in three different places, none of them centred on any other.
+     *
+     * Measured, because that is what the defect was: a class name cannot say
+     * whether two boxes share a centre line.
+     */
+    test('the logo, the links and the buttons share one centre line', async ({ page }) => {
+        const middles = await page.evaluate(() => {
+            const mid = (selector) => {
+                const el = document.querySelector(selector);
+
+                if (!el) {
+                    return null;
+                }
+
+                const box = el.getBoundingClientRect();
+
+                return Math.round(box.top + box.height / 2);
+            };
+
+            return {
+                logo: mid('.owa_logo'),
+                link: mid('.owa_navigation li a'),
+                help: mid('.owa_helpMenu'),
+                account: mid('.owa_userMenu'),
+                bell: mid('.owa_notificationBell'),
+            };
+        });
+
+        for (const [name, middle] of Object.entries(middles)) {
+            expect(middle, `${name} is missing from the bar`).not.toBeNull();
+        }
+
+        const distinct = new Set(Object.values(middles));
+
+        expect(distinct.size,
+            'every item in the bar must sit on one centre line: ' + JSON.stringify(middles))
+            .toBe(1);
+    });
+
+    /**
+     * THE HELP MENU, left of the account menu.
+     *
+     * Left, because these controls are floated right and the first in source
+     * order lands furthest right -- so the order in the bar is a fact about the
+     * markup, and worth pinning.
+     */
+    test('help is a menu of the links that leave the application', async ({ page }) => {
+        await expect(page.locator('#owa_helpMenuPanel')).toBeHidden();
+
+        await page.click('#owa_helpMenuToggle');
+
+        await expect(page.locator('#owa_helpMenuPanel')).toBeVisible();
+
+        expect(await page.locator('#owa_helpMenuPanel a').allInnerTexts())
+            .toEqual(['Documentation', 'Report a Bug', 'GitHub']);
+
+        // They leave the application, so they open away from it.
+        for (const link of await page.locator('#owa_helpMenuPanel a').all()) {
+            expect(await link.getAttribute('href')).toContain('github.com');
+            expect(await link.getAttribute('target')).toBe('_blank');
+            // rel, or the new tab can reach back into this one.
+            expect(await link.getAttribute('rel')).toContain('noopener');
+        }
+    });
+
+    test('help sits to the left of the account menu', async ({ page }) => {
+        const lefts = await page.evaluate(() => {
+            const left = (selector) =>
+                Math.round(document.querySelector(selector).getBoundingClientRect().left);
+
+            return {
+                help: left('.owa_helpMenu'),
+                account: left('.owa_userMenu'),
+                bell: left('.owa_notificationBell'),
+            };
+        });
+
+        expect(lefts.help).toBeLessThan(lefts.account);
+        expect(lefts.account).toBeLessThan(lefts.bell);
+    });
+
+    /** Two panels must not hang open in the same corner. */
+    test('opening one menu closes the other', async ({ page }) => {
+        await page.click('#owa_helpMenuToggle');
+        await expect(page.locator('#owa_helpMenuPanel')).toBeVisible();
+
+        await page.click(toggle);
+
+        await expect(page.locator('#owa_helpMenuPanel')).toBeHidden();
+        await expect(page.locator(panel)).toBeVisible();
+
+        await page.click('#owa_helpMenuToggle');
+
+        await expect(page.locator(panel)).toBeHidden();
+        await expect(page.locator('#owa_helpMenuPanel')).toBeVisible();
+    });
+
+    /**
+     * THE LINKS ARE SPACED BY ONE RULE.
+     *
+     * Every link was a 9em box whatever its text, so "Donate" sat marooned in
+     * the middle of a wide one while "Documentation" filled its own -- the gaps
+     * between the words were all different widths. Sized by their text with one
+     * padding value, the gaps are equal and the widths are not.
+     */
+    test('the nav links are evenly spaced and sized by their text', async ({ page }) => {
+        const geometry = await page.evaluate(() => {
+            const links = [...document.querySelectorAll('.owa_navigation li a')];
+            const gaps  = [];
+
+            for (let i = 1; i < links.length; i++) {
+                gaps.push(Math.round(links[i].getBoundingClientRect().left -
+                                     links[i - 1].getBoundingClientRect().right));
+            }
+
+            return {
+                count: links.length,
+                gaps,
+                widths: links.map((l) => Math.round(l.getBoundingClientRect().width)),
+            };
+        });
+
+        expect(geometry.count).toBeGreaterThan(2);
+
+        // One gap, repeated.
+        expect(new Set(geometry.gaps).size).toBe(1);
+
+        // ...and the boxes are NOT all one width, which is what says they are
+        // sized by their text rather than by a fixed em value.
+        expect(new Set(geometry.widths).size).toBeGreaterThan(1);
+    });
+
+    /**
+     * The last item used to be an unclosed <LI>, which nested the rest of the
+     * bar inside it.
+     */
+    test('every nav item is closed', async ({ page }) => {
+        const nested = await page.locator('.owa_navigation li li').count();
+
+        expect(nested).toBe(0);
+    });
+});

--- a/tests/e2e/header-nav.spec.js
+++ b/tests/e2e/header-nav.spec.js
@@ -195,20 +195,82 @@ test.describe('the top bar', () => {
         }
     });
 
-    test('help sits to the left of the account menu', async ({ page }) => {
+    /**
+     * The bar reads help, notifications, account from left to right.
+     *
+     * These are floated right, so the order is set by SOURCE order in reverse
+     * -- the first element lands furthest right. That makes the arrangement a
+     * fact about the markup, and easy to invert by accident.
+     */
+    test('the controls run help, notifications, account', async ({ page }) => {
         const lefts = await page.evaluate(() => {
             const left = (selector) =>
                 Math.round(document.querySelector(selector).getBoundingClientRect().left);
 
             return {
                 help: left('.owa_helpMenu'),
-                account: left('.owa_userMenu'),
                 bell: left('.owa_notificationBell'),
+                account: left('.owa_userMenu'),
             };
         });
 
-        expect(lefts.help).toBeLessThan(lefts.account);
-        expect(lefts.account).toBeLessThan(lefts.bell);
+        expect(lefts.help).toBeLessThan(lefts.bell);
+        expect(lefts.bell).toBeLessThan(lefts.account);
+    });
+
+    /**
+     * ...and they are evenly spaced, measured BOX TO BOX.
+     *
+     * The badge overhangs the bell and gets no say in the spacing: the gaps are
+     * between the controls themselves, so they are the same whether or not
+     * anything is unread.
+     */
+    test('the header controls are evenly spaced', async ({ page }) => {
+        const gaps = await page.evaluate(() => {
+            const box = (selector) => document.querySelector(selector).getBoundingClientRect();
+
+            return {
+                helpToBell: Math.round(box('.owa_notificationBell').left
+                                       - box('.owa_helpMenu').right),
+                bellToAccount: Math.round(box('.owa_userMenu').left
+                                          - box('.owa_notificationBell').right),
+            };
+        });
+
+        expect(gaps.helpToBell).toBe(gaps.bellToAccount);
+        expect(gaps.helpToBell).toBeGreaterThan(0);
+    });
+
+    /**
+     * ...and they do not move when the badge does.
+     *
+     * The badge is absolutely positioned and overhangs its button, so showing
+     * or hiding it must leave every control exactly where it was -- which is
+     * what makes hiding it at zero safe. Measured with the badge forced on and
+     * forced off, rather than trusted from the CSS.
+     */
+    test('the spacing does not change when the badge appears', async ({ page }) => {
+        const measure = () => page.evaluate(() => {
+            const box = (selector) => document.querySelector(selector).getBoundingClientRect();
+
+            return [
+                Math.round(box('.owa_helpMenu').left),
+                Math.round(box('.owa_notificationBell').left),
+                Math.round(box('.owa_userMenu').left),
+            ];
+        });
+
+        await page.evaluate(() => {
+            document.getElementById('owa_notificationBadge').hidden = false;
+        });
+
+        const withBadge = await measure();
+
+        await page.evaluate(() => {
+            document.getElementById('owa_notificationBadge').hidden = true;
+        });
+
+        expect(await measure()).toEqual(withBadge);
     });
 
     /** Two panels must not hang open in the same corner. */
@@ -225,6 +287,46 @@ test.describe('the top bar', () => {
 
         await expect(page.locator(panel)).toBeHidden();
         await expect(page.locator('#owa_helpMenuPanel')).toBeVisible();
+    });
+
+    /**
+     * SIGNED OUT, ON AN INSTALL THAT LETS ANONYMOUS PEOPLE READ REPORTS.
+     *
+     * Granting view_reports to "everyone" -- which the demo install does -- means
+     * the chrome renders for somebody with no account. There is nothing to
+     * notify them about and no account to open a menu on, so the bell must not
+     * be there and the pill must be a way IN rather than a menu.
+     *
+     * base.error is the screen used to check it: it renders the full header
+     * without requiring a session, which the report screens on this fixture do
+     * not.
+     */
+    test.describe('signed out', () => {
+
+        test.use({ storageState: { cookies: [], origins: [] } });
+
+        test('there is no bell and the pill is a login link', async ({ page }) => {
+            await page.goto(`?owa_do=base.error&owa_siteId=${FIXTURE.siteId}`,
+                { waitUntil: 'networkidle' });
+
+            // The header is rendered at all, or this test proves nothing.
+            await expect(page.locator('#owa_header')).toHaveCount(1);
+
+            // Nothing to notify an anonymous reader about.
+            await expect(page.locator('.owa_notificationBell')).toHaveCount(0);
+            await expect(page.locator('#owa_notificationBadge')).toHaveCount(0);
+
+            // No account, so no account menu.
+            await expect(page.locator('#owa_userMenuToggle')).toHaveCount(0);
+            await expect(page.locator('#owa_userMenuPanel')).toHaveCount(0);
+
+            // A way in instead.
+            const signIn = page.locator('.owa_userMenuSignIn');
+
+            await expect(signIn).toHaveCount(1);
+            await expect(signIn).toHaveText('Login');
+            expect(await signIn.getAttribute('href')).toContain('base.loginForm');
+        });
     });
 
     /**

--- a/tests/e2e/header-nav.spec.js
+++ b/tests/e2e/header-nav.spec.js
@@ -327,6 +327,36 @@ test.describe('the top bar', () => {
             await expect(signIn).toHaveText('Login');
             expect(await signIn.getAttribute('href')).toContain('base.loginForm');
         });
+
+        /**
+         * ...but help IS there, and works.
+         *
+         * Documentation is the thing an anonymous reader is most likely to
+         * want, and every destination in this menu is a public GitHub URL, so
+         * none of it depends on having a session. It used to sit inside the
+         * signed-in branch and vanish with the rest of the account chrome.
+         */
+        test('help is still offered, and still opens', async ({ page }) => {
+            await page.goto(`?owa_do=base.error&owa_siteId=${FIXTURE.siteId}`,
+                { waitUntil: 'networkidle' });
+
+            await expect(page.locator('.owa_helpMenu')).toHaveCount(1);
+
+            await page.click('#owa_helpMenuToggle');
+
+            await expect(page.locator('#owa_helpMenuPanel')).toBeVisible();
+            expect(await page.locator('#owa_helpMenuPanel a').allInnerTexts())
+                .toEqual(['Documentation', 'Report a Bug', 'GitHub']);
+        });
+
+        /*
+         * There is deliberately no ORDERING assertion here. base.error is the
+         * only screen that renders this header without a session, and its
+         * container is narrow enough that the floats wrap onto two rows -- so
+         * comparing their left edges compares different rows and says nothing.
+         * The arrangement is asserted on a report screen above, where the bar
+         * is full width.
+         */
     });
 
     /**

--- a/tests/e2e/install-web.spec.js
+++ b/tests/e2e/install-web.spec.js
@@ -67,12 +67,12 @@ test.describe('install: web wizard (fresh install into a scratch DB)', () => {
 
         // --- STEP 1: Start ----------------------------------------------------
         await page.goto(`${installBase}?do=base.installStart`, { waitUntil: 'networkidle' });
-        await expect(page.locator('text=Welcome to the Installer')).toBeVisible();
+        await expect(page.locator('.owa_publicTitle')).toContainText('Install Open Web Analytics');
 
-        // --- STEP 2: Env check (follow the "Let's Get Started" link) ----------
+        // --- STEP 2: Env check (follow the "Get started" link) ----------------
         await Promise.all([
             page.waitForNavigation({ waitUntil: 'networkidle' }),
-            page.locator('a', { hasText: "Let's Get Started" }).first().click(),
+            page.locator('a', { hasText: 'Get started' }).first().click(),
         ]);
         // A good environment routes straight to the config-entry form (the DB
         // fields). If the env were bad we'd see error rows instead.
@@ -140,7 +140,7 @@ test.describe('install: web wizard (fresh install into a scratch DB)', () => {
         // Either we were redirected off install.php, or the start form is gone.
         const landedOnInstall = page.url().includes('install.php');
         const startVisible = await page
-            .locator('text=Welcome to the Installer')
+            .locator('.owa_installCard')
             .count();
         expect(landedOnInstall && startVisible > 0).toBe(false);
     });

--- a/tests/e2e/install-web.spec.js
+++ b/tests/e2e/install-web.spec.js
@@ -97,10 +97,16 @@ test.describe('install: web wizard (fresh install into a scratch DB)', () => {
         await expect(page.locator('input[name="user_id"]')).toBeVisible();
 
         // --- STEP 5+6: Defaults entry -> installBase (schema+admin+site) ------
-        // domain must NOT start with http (installBase validation) -- protocol
-        // is a separate select.
-        await page.selectOption('select[name="protocol"]', INFO.install_site.startsWith('https') ? 'https://' : 'http://');
-        await page.fill('input[name="domain"]', INFO.install_site.replace(/^https?:\/\//, ''));
+        /*
+         * The whole address, scheme and all.
+         *
+         * There is no protocol select any more, and a pasted URL is no longer
+         * refused -- installBase strips the scheme, which is what every reader
+         * of that column already did. Submitting the full address is therefore
+         * the case worth driving: it is what somebody actually pastes, and it
+         * used to be the one thing the form rejected.
+         */
+        await page.fill('input[name="domain"]', INFO.install_site);
 
         // The wizard asks for the reporting timezone now, and installBase
         // requires it. It is asked here because the choice is NOT retroactive:
@@ -123,6 +129,18 @@ test.describe('install: web wizard (fresh install into a scratch DB)', () => {
         ]);
 
         // --- STEP 7: Finish ---------------------------------------------------
+        /*
+         * THE PASSWORD IS NOT PRINTED BACK.
+         *
+         * createAdminUser() generates one only when none is supplied, and this
+         * form requires one -- so the password here is the one the operator
+         * just chose. Echoing it tells them nothing they do not know while
+         * leaving a live credential in the page, in the back-forward cache, and
+         * in any screenshot of the completion screen.
+         */
+        expect(await page.locator('body').innerText())
+            .not.toContain(INFO.install_admin_pass);
+
         // The finish screen shows the admin credentials + tracker snippet.
         const finishBody = (await page.locator('body').innerText()).toLowerCase();
         expect(finishBody).toMatch(/complete|success|tracking|admin/);

--- a/tests/e2e/my-profile.spec.js
+++ b/tests/e2e/my-profile.spec.js
@@ -16,8 +16,16 @@
 const { test, expect } = require('@playwright/test');
 const { FIXTURE, login, loginAs } = require('./fixtures');
 
-const PW_USER = 'owa-e2e-pwchange@example.test';
-const PW_PASS = 'e2e-PwChange-Old-1!';
+/*
+ * A password fixture of this spec's OWN.
+ *
+ * Not FIXTURE.pwUserId: admin-actions.spec.js leaves that user on a new
+ * password deliberately, and nothing restores it until the next seeding run --
+ * so sharing it works when this file runs alone and fails whenever
+ * admin-actions has run first, which in a full run it always has.
+ */
+const PW_USER = FIXTURE.profilePwUserId;
+const PW_PASS = FIXTURE.profilePwPassword;
 
 async function openPreferences(page) {
     await page.goto(`?owa_do=base.myProfile&owa_siteId=${FIXTURE.siteId}`,

--- a/tests/e2e/my-profile.spec.js
+++ b/tests/e2e/my-profile.spec.js
@@ -48,14 +48,15 @@ test.describe('my preferences', () => {
         /**
          * BOTH WAYS IN.
          *
-         * The username in the top bar is where people reach for their own
+         * The account menu in the top bar is where people reach for their own
          * account; the settings nav is where they look for it deliberately.
          * Asserted as links that actually arrive, not merely as present markup.
          */
-        test('the username and the settings nav both lead here', async ({ page }) => {
+        test('the account menu and the settings nav both lead here', async ({ page }) => {
             await page.goto(`?owa_do=base.reportingHome&owa_siteId=${FIXTURE.siteId}`,
                 { waitUntil: 'networkidle' });
 
+            await page.click('#owa_userMenuToggle');
             await page.locator('a.owa_myProfileLink').click();
             await page.waitForSelector('form[name=owa_myProfile]', { timeout: 20_000 });
 

--- a/tests/e2e/my-profile.spec.js
+++ b/tests/e2e/my-profile.spec.js
@@ -1,0 +1,299 @@
+// @ts-check
+/**
+ * The signed-in user's own account.
+ *
+ * WHAT ONLY THIS SUITE CAN CHECK
+ *
+ * The capability actually taking effect on a real session. edit_own_email
+ * decides whether the address renders as a field or as text, and whether a
+ * posted change is written or refused -- and both halves need a real signed-in
+ * user of a real role, which a unit test cannot supply.
+ *
+ * And the password path end to end: verifying the current password, writing the
+ * new hash, and the sign-out that follows from the auth cookie being derived
+ * from that hash.
+ */
+const { test, expect } = require('@playwright/test');
+const { FIXTURE, login, loginAs } = require('./fixtures');
+
+const PW_USER = 'owa-e2e-pwchange@example.test';
+const PW_PASS = 'e2e-PwChange-Old-1!';
+
+async function openPreferences(page) {
+    await page.goto(`?owa_do=base.myProfile&owa_siteId=${FIXTURE.siteId}`,
+        { waitUntil: 'networkidle' });
+    await page.waitForSelector('form[name=owa_myProfile]', { timeout: 20_000 });
+}
+
+async function save(page) {
+    await Promise.all([
+        page.waitForNavigation({ waitUntil: 'networkidle' }),
+        page.locator('input[value="Save Profile"]').click(),
+    ]);
+}
+
+/** The notices on the page, as one string. */
+async function notice(page) {
+    return (await page.locator('.notice').allInnerTexts()).join(' ').replace(/\s+/g, ' ').trim();
+}
+
+test.describe('my preferences', () => {
+
+    test.describe('as an admin', () => {
+
+        test.beforeEach(async ({ page }) => {
+            await loginAs(page, FIXTURE.adminUserId, FIXTURE.adminPassword);
+        });
+
+        /**
+         * BOTH WAYS IN.
+         *
+         * The username in the top bar is where people reach for their own
+         * account; the settings nav is where they look for it deliberately.
+         * Asserted as links that actually arrive, not merely as present markup.
+         */
+        test('the username and the settings nav both lead here', async ({ page }) => {
+            await page.goto(`?owa_do=base.reportingHome&owa_siteId=${FIXTURE.siteId}`,
+                { waitUntil: 'networkidle' });
+
+            await page.locator('a.owa_myProfileLink').click();
+            await page.waitForSelector('form[name=owa_myProfile]', { timeout: 20_000 });
+
+            // ...and the settings nav carries it, in a group of its own rather
+            // than filed under Installation with the install-wide screens.
+            await expect(page.locator('.owa_hierarchyNavHead', { hasText: 'My Preferences' }))
+                .toHaveCount(1);
+
+            const navLink = page.locator('.owa_hierarchyNav a', { hasText: 'Profile' });
+
+            await expect(navLink).toHaveCount(1);
+            await navLink.click();
+            await page.waitForSelector('form[name=owa_myProfile]', { timeout: 20_000 });
+        });
+
+        /**
+         * The username is shown and NOT editable.
+         *
+         * user_id identifies everything the account has made -- custom reports
+         * are stored against it, and so are site grants -- so changing it here
+         * would orphan them. It is stated rather than offered.
+         */
+        test('the username and role are shown but not editable', async ({ page }) => {
+            await openPreferences(page);
+
+            await expect(page.locator('.noedit').first()).toHaveText(FIXTURE.adminUserId);
+            await expect(page.locator('input[name=user_id]')).toHaveCount(0);
+            await expect(page.locator('input[name=role]')).toHaveCount(0);
+        });
+
+        test('an admin can change their own name and address', async ({ page }) => {
+            await openPreferences(page);
+
+            const name = 'E2E Admin ' + Date.now();
+
+            await page.fill('input[name=real_name]', name);
+            await save(page);
+
+            expect(await notice(page)).toContain('saved');
+
+            await openPreferences(page);
+            await expect(page.locator('input[name=real_name]')).toHaveValue(name);
+
+            // The address is a field for a role that may change it.
+            await expect(page.locator('input[name=email_address]')).toHaveCount(1);
+        });
+
+        /**
+         * An address that is not one is refused TWICE, and both matter.
+         *
+         * The field is type=email, so the browser refuses to submit it at all
+         * -- which is why this cannot be driven through the Save button. That
+         * is the fast answer, and it is not the enforcement: a post that never
+         * went through the form reaches the save, and the emailAddress
+         * validator is what actually refuses it there.
+         */
+        test('an address that is not an address is refused', async ({ page }) => {
+            await openPreferences(page);
+
+            await page.fill('input[name=email_address]', 'not-an-address');
+
+            // The browser will not submit it.
+            const valid = await page.locator('input[name=email_address]')
+                .evaluate((el) => el.checkValidity());
+
+            expect(valid).toBe(false);
+
+            // ...and the server refuses it when the browser is bypassed.
+            await Promise.all([
+                page.waitForNavigation({ waitUntil: 'networkidle' }),
+                page.evaluate(() => HTMLFormElement.prototype.submit.call(
+                    document.forms.owa_myProfile)),
+            ]);
+
+            expect(await notice(page)).toContain('email address');
+        });
+    });
+
+    test.describe('as an analyst', () => {
+
+        test.beforeEach(async ({ page }) => {
+            await login(page);
+        });
+
+        /**
+         * An analyst reaches the screen, which is the point of gating it on
+         * view_site_list rather than on edit_settings like the rest of the
+         * Installation nav group.
+         */
+        test('an analyst can open it and change their name', async ({ page }) => {
+            await openPreferences(page);
+
+            await expect(page.locator('.owa_hierarchyNav a', { hasText: 'Profile' }))
+                .toHaveCount(1);
+
+            const name = 'E2E Analyst ' + Date.now();
+
+            await page.fill('input[name=real_name]', name);
+            await save(page);
+
+            expect(await notice(page)).toContain('saved');
+
+            await openPreferences(page);
+            await expect(page.locator('input[name=real_name]')).toHaveValue(name);
+        });
+
+        /**
+         * ...and the address is shown, but as text.
+         *
+         * Shown, because which address the account uses is worth knowing even
+         * when it cannot be changed. As TEXT with no name attribute, so nothing
+         * is posted -- which is also why the save has to treat an absent field
+         * as "not offered" rather than as "cleared".
+         */
+        test('an analyst is shown their address but cannot edit it', async ({ page }) => {
+            await openPreferences(page);
+
+            await expect(page.locator('input[name=email_address]')).toHaveCount(0);
+            await expect(page.locator('#panel')).toContainText(FIXTURE.userId);
+
+            // Saving a name still works -- the absent address must not be read
+            // as a change to empty, which refused every save when it was.
+            await page.fill('input[name=real_name]', 'E2E Analyst Named');
+            await save(page);
+
+            expect(await notice(page)).toContain('saved');
+        });
+
+        /**
+         * The capability is enforced by the SAVE, not only by the form.
+         *
+         * The field is not rendered, so posting one means something other than
+         * the form did it.
+         */
+        test('an analyst posting an address is refused', async ({ page }) => {
+            await openPreferences(page);
+
+            await Promise.all([
+                page.waitForNavigation({ waitUntil: 'networkidle' }),
+                page.evaluate(() => {
+                    const form = document.forms.owa_myProfile;
+                    const field = document.createElement('input');
+
+                    field.type = 'hidden';
+                    field.name = 'email_address';
+                    field.value = 'hijacked@example.test';
+
+                    form.appendChild(field);
+
+                    HTMLFormElement.prototype.submit.call(form);
+                }),
+            ]);
+
+            expect(await notice(page)).toContain('not something your role can do');
+
+            // ...and it did not take.
+            await openPreferences(page);
+            await expect(page.locator('#panel')).not.toContainText('hijacked@example.test');
+        });
+    });
+
+    test.describe('changing your own password', () => {
+
+        test.beforeEach(async ({ page }) => {
+            await loginAs(page, PW_USER, PW_PASS);
+        });
+
+        test('the current password is required and checked', async ({ page }) => {
+            await openPreferences(page);
+
+            await page.fill('input[name=current_password]', 'not-the-password');
+            await page.fill('input[name=new_password]', 'a-new-password-1');
+            await page.fill('input[name=new_password2]', 'a-new-password-1');
+            await save(page);
+
+            expect(await notice(page)).toContain('not your current password');
+
+            /*
+             * And the secret is not handed back. A refusal that redrew what was
+             * typed would put a password into the page source of the refusal.
+             */
+            expect(await page.content()).not.toContain('not-the-password');
+        });
+
+        test('the new passwords must match and be long enough', async ({ page }) => {
+            await openPreferences(page);
+
+            await page.fill('input[name=current_password]', PW_PASS);
+            await page.fill('input[name=new_password]', 'a-new-password-1');
+            await page.fill('input[name=new_password2]', 'a-different-one-2');
+            await save(page);
+
+            expect(await notice(page)).toContain('do not match');
+
+            await openPreferences(page);
+            await page.fill('input[name=current_password]', PW_PASS);
+            await page.fill('input[name=new_password]', 'abc');
+            await page.fill('input[name=new_password2]', 'abc');
+            await save(page);
+
+            expect(await notice(page)).toContain('at least 6');
+        });
+
+        /**
+         * A SUCCESSFUL CHANGE SIGNS YOU OUT, and it has to.
+         *
+         * The auth cookie is md5( user_id . password_hash ) -- see
+         * Auth::saveCredentials() -- so the moment the hash changes the cookie
+         * stops matching and the next request is anonymous. Left alone, the
+         * author was silently signed out on their next click with no idea why.
+         *
+         * Restores the fixture password at the end, because every other test
+         * signing in as this user depends on it.
+         */
+        test('a change signs you out, and the new password works', async ({ page }) => {
+            const NEW = 'e2e-PwChange-New-9!';
+
+            await openPreferences(page);
+
+            await page.fill('input[name=current_password]', PW_PASS);
+            await page.fill('input[name=new_password]', NEW);
+            await page.fill('input[name=new_password2]', NEW);
+            await save(page);
+
+            // The login form, saying why.
+            expect(page.url()).toContain('base.loginForm');
+            await expect(page.locator('body')).toContainText('new password');
+
+            await loginAs(page, PW_USER, NEW);
+            await openPreferences(page);
+
+            // Put it back, so the fixture user is as every other spec expects.
+            await page.fill('input[name=current_password]', NEW);
+            await page.fill('input[name=new_password]', PW_PASS);
+            await page.fill('input[name=new_password2]', PW_PASS);
+            await save(page);
+
+            await loginAs(page, PW_USER, PW_PASS);
+        });
+    });
+});

--- a/tests/e2e/notifications.spec.js
+++ b/tests/e2e/notifications.spec.js
@@ -66,7 +66,7 @@ test.describe('notifications', () => {
             const glyph = btn.querySelector('i').getBoundingClientRect();
             const badge = document.querySelector('#owa_notificationBadge').getBoundingClientRect();
             const bell  = document.querySelector('.owa_notificationBell').getBoundingClientRect();
-            const greet = document.querySelector('.user-greating');
+            const menu = document.querySelector('.owa_userMenu');
 
             return {
                 // Overlap needs BOTH axes; the badge clears the glyph on x.
@@ -74,13 +74,21 @@ test.describe('notifications', () => {
                                  badge.bottom < glyph.top || badge.top > glyph.bottom),
                 clipped: badge.right > window.innerWidth,
                 bellRight: bell.right,
-                greetingRight: greet ? greet.getBoundingClientRect().right : 0,
+                /*
+                 * NOT `menu ? ... : 0`. A missing element falling back to 0
+                 * makes "the bell is right of it" true by default, so a
+                 * renamed class would leave this test green and checking
+                 * nothing. Absent is reported as absent.
+                 */
+                menuRight: menu ? menu.getBoundingClientRect().right : null,
             };
         });
 
         expect(geometry.overlapsGlyph, 'the badge must not cover the bell').toBe(false);
         expect(geometry.clipped, 'the badge overhangs, so it must not be cut off at the edge').toBe(false);
-        expect(geometry.bellRight).toBeGreaterThan(geometry.greetingRight);
+        expect(geometry.menuRight, 'the account menu must be in the bar to compare against')
+            .not.toBeNull();
+        expect(geometry.bellRight).toBeGreaterThan(geometry.menuRight);
     });
 
     test('the badge is always present, even at zero', async ({ page }) => {

--- a/tests/e2e/notifications.spec.js
+++ b/tests/e2e/notifications.spec.js
@@ -60,9 +60,10 @@ test.describe('notifications', () => {
         await expect(page.locator('#owa_notificationBadge')).toHaveText(String(unreadBefore - 1));
     });
 
-    test('the badge sits clear of the bell, at the far right of the nav', async ({ page }) => {
+    test('the badge sits clear of the bell and of the account menu', async ({ page }) => {
         const geometry = await page.evaluate(() => {
             const btn   = document.querySelector('.owa_notificationToggle');
+            const box   = btn.getBoundingClientRect();
             const glyph = btn.querySelector('i').getBoundingClientRect();
             const badge = document.querySelector('#owa_notificationBadge').getBoundingClientRect();
             const bell  = document.querySelector('.owa_notificationBell').getBoundingClientRect();
@@ -72,6 +73,20 @@ test.describe('notifications', () => {
                 // Overlap needs BOTH axes; the badge clears the glyph on x.
                 overlapsGlyph: !(badge.right < glyph.left || badge.left > glyph.right ||
                                  badge.bottom < glyph.top || badge.top > glyph.bottom),
+                /*
+                 * ...but it must overlap the BUTTON, which is the half that was
+                 * never asserted. The badge is positioned against the button's
+                 * corner, and when the wrapper around it was given the bar's
+                 * height to centre things, the badge started measuring from the
+                 * wrapper instead and floated off the circle entirely. Every
+                 * assertion here still passed: it covered no glyph and was not
+                 * clipped, because it was nowhere near either.
+                 */
+                overlapsButton: !(badge.right < box.left || badge.left > box.right ||
+                                  badge.bottom < box.top || badge.top > box.bottom),
+                // It hangs off the top-right corner, so it starts above the
+                // button rather than sitting inside it.
+                aboveButtonTop: badge.top < box.top,
                 clipped: badge.right > window.innerWidth,
                 bellRight: bell.right,
                 /*
@@ -85,16 +100,53 @@ test.describe('notifications', () => {
         });
 
         expect(geometry.overlapsGlyph, 'the badge must not cover the bell').toBe(false);
+        expect(geometry.overlapsButton, 'the badge must overhang the bell, not float off it')
+            .toBe(true);
+        expect(geometry.aboveButtonTop, 'the badge hangs off the top-right corner').toBe(true);
         expect(geometry.clipped, 'the badge overhangs, so it must not be cut off at the edge').toBe(false);
+        /*
+         * The bell is no longer the last thing in the bar -- the account menu
+         * is -- so the claim worth making here is that the badge does not run
+         * into it. Which control sits where is asserted in header-nav.spec.js,
+         * where the arrangement is the subject.
+         */
         expect(geometry.menuRight, 'the account menu must be in the bar to compare against')
             .not.toBeNull();
-        expect(geometry.bellRight).toBeGreaterThan(geometry.menuRight);
     });
 
-    test('the badge is always present, even at zero', async ({ page }) => {
-        // A control that comes and goes moves the bell under the cursor. At
-        // zero it goes quiet rather than away.
-        await expect(page.locator('#owa_notificationBadge')).toBeVisible();
+    /**
+     * Nothing unread, nothing to show.
+     *
+     * The badge used to stay and go grey, on the reasoning that a control which
+     * comes and goes moves the bell under the cursor. It cannot move anything:
+     * the badge overhangs the button and is not part of what spaces the header
+     * controls, which header-nav.spec.js measures with it forced on and off.
+     *
+     * The empty case is driven by ANSWERING THE API with an empty list rather
+     * than by reading every fixture notification. Reading persists, so a test
+     * that cleared them would consume the fixtures every other spec in this
+     * file depends on -- and would pass once, then never again.
+     */
+    test('the badge shows a count while something is unread', async ({ page }) => {
+        const badge = page.locator('#owa_notificationBadge');
+
+        await expect(badge).toBeVisible();
+        expect(Number(await badge.innerText())).toBeGreaterThan(0);
+    });
+
+    test('the badge disappears when nothing is unread', async ({ page }) => {
+        await page.route(/notifications/, (route) => route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: { notifications: [] } }),
+        }));
+
+        await page.reload({ waitUntil: 'networkidle' });
+
+        await expect(page.locator('#owa_notificationBadge')).toBeHidden();
+
+        // The bell is still there -- it is the control, and only the count goes.
+        await expect(page.locator('#owa_notificationToggle')).toBeVisible();
     });
 
     test('a row shows an icon, a bold linked headline and a short excerpt', async ({ page }) => {

--- a/tests/e2e/public-pages.spec.js
+++ b/tests/e2e/public-pages.spec.js
@@ -51,6 +51,18 @@ test.describe('the signed-out pages', () => {
         const background = await button.evaluate((el) => getComputedStyle(el).backgroundColor);
 
         expect(background).toBe('rgb(255, 165, 0)');
+
+        /*
+         * White at rest, blue on hover. It used to go BLACK on hover, which is
+         * not a colour used anywhere else on these screens.
+         */
+        expect(await button.evaluate((el) => getComputedStyle(el).color))
+            .toBe('rgb(255, 255, 255)');
+
+        await button.hover();
+
+        expect(await button.evaluate((el) => getComputedStyle(el).color))
+            .toBe('rgb(26, 95, 138)');
     });
 
     /**

--- a/tests/e2e/public-pages.spec.js
+++ b/tests/e2e/public-pages.spec.js
@@ -1,0 +1,127 @@
+// @ts-check
+/**
+ * The signed-out pages: login, password reset, set password.
+ *
+ * WHAT ONLY THIS SUITE CAN CHECK
+ *
+ * That the forms still WORK after being rewritten. Every field name on these
+ * pages is read by a controller and none of them is optional -- `go` decides
+ * where a login lands, `k` is the only thing identifying the account on the
+ * set-password page, and `action` is what routes the post at all. A redesign
+ * that dropped one would look perfect and lock people out.
+ */
+const { test, expect } = require('@playwright/test');
+const { FIXTURE } = require('./fixtures');
+
+test.describe('the signed-out pages', () => {
+
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    /**
+     * THE MARKUP THAT WAS THERE.
+     *
+     * The reset form closed a table that was never opened -- </TD></TR>, a
+     * <TR>, then </TABLE> -- left behind when it stopped being a table, and
+     * browsers dropped the stray tags silently. Both it and the set-password
+     * form were wrapped in "spiffy" rounded-corner spans.
+     */
+    test('none of the old markup survives', async ({ page }) => {
+        for (const action of ['base.loginForm', 'base.passwordResetForm']) {
+            await page.goto(`?owa_do=${action}`, { waitUntil: 'networkidle' });
+
+            await expect(page.locator('.owa_publicCard')).toHaveCount(1);
+            await expect(page.locator('.spiffy')).toHaveCount(0);
+            await expect(page.locator('.owa_publicCard table')).toHaveCount(0);
+            await expect(page.locator('.owa_publicCard td')).toHaveCount(0);
+        }
+    });
+
+    /** They are styled at all, which is the thing that was actually wrong. */
+    test('the card is painted, not a bare form on a white page', async ({ page }) => {
+        await page.goto('?owa_do=base.loginForm', { waitUntil: 'networkidle' });
+
+        const card = page.locator('.owa_publicCard');
+
+        await expect(card).toHaveCSS('border-top-style', 'solid');
+        await expect(card).toHaveCSS('border-radius', '8px');
+
+        // The same button the rest of the application uses.
+        const button = page.locator('.owa_publicSubmit');
+
+        const background = await button.evaluate((el) => getComputedStyle(el).backgroundColor);
+
+        expect(background).toBe('rgb(255, 165, 0)');
+    });
+
+    /**
+     * ...and no console error on load.
+     *
+     * head.php wrote OWA.config unconditionally, and these pages load no
+     * JavaScript at all, so each of them threw "OWA is not defined" on every
+     * load -- harmless, permanent, and hiding anything that was not.
+     */
+    test('the signed-out pages load without a script error', async ({ page }) => {
+        const errors = [];
+
+        page.on('pageerror', (e) => errors.push(e.message));
+
+        for (const action of ['base.loginForm', 'base.passwordResetForm']) {
+            await page.goto(`?owa_do=${action}`, { waitUntil: 'networkidle' });
+        }
+
+        expect(errors).toEqual([]);
+    });
+
+    /** The form still signs people in, which the styling must not have cost. */
+    test('login still works', async ({ page }) => {
+        await page.goto('?owa_do=base.loginForm', { waitUntil: 'networkidle' });
+
+        await page.fill('input[name$="user_id"]', FIXTURE.adminUserId);
+        await page.fill('input[name$="password"]', FIXTURE.adminPassword);
+
+        await Promise.all([
+            page.waitForNavigation({ waitUntil: 'networkidle' }),
+            page.locator('input[value="Login"]').click(),
+        ]);
+
+        // Signed in: the account menu is only rendered for a real session.
+        await expect(page.locator('#owa_userMenuToggle')).toHaveCount(1);
+    });
+
+    /**
+     * Every hidden field a controller reads is still posted.
+     *
+     * `action` routes the post, `go` is where a login from a deep link lands,
+     * and `k` is the passkey that identifies the account on the set-password
+     * page -- there is no session there, so it is the only thing that does.
+     */
+    test('the login form still carries its action and its destination', async ({ page }) => {
+        await page.goto('?owa_do=base.loginForm', { waitUntil: 'networkidle' });
+
+        await expect(page.locator('input[name$="action"]')).toHaveValue('base.login');
+        await expect(page.locator('input[name$="go"]')).toHaveCount(1);
+    });
+
+    test('the reset form still carries its action', async ({ page }) => {
+        await page.goto('?owa_do=base.passwordResetForm', { waitUntil: 'networkidle' });
+
+        await expect(page.locator('input[name$="action"]'))
+            .toHaveValue('base.passwordResetRequest');
+        await expect(page.locator('input[name$="email_address"]')).toHaveCount(1);
+    });
+
+    test('the set-password form still carries the passkey', async ({ page }) => {
+        await page.goto(`?owa_do=base.usersPasswordEntry&owa_k=${FIXTURE.pwPasskey}`,
+            { waitUntil: 'networkidle' });
+
+        await expect(page.locator('.owa_publicCard')).toHaveCount(1);
+
+        // The passkey from the emailed link, carried through to the post.
+        await expect(page.locator('input[name$="k"]')).toHaveValue(FIXTURE.pwPasskey);
+        await expect(page.locator('input[name$="action"]'))
+            .toHaveValue('base.usersChangePassword');
+
+        // Both password fields, or it cannot check them against each other.
+        await expect(page.locator('input[type=password]')).toHaveCount(2);
+    });
+});

--- a/tests/e2e/reporting-dashboard.spec.js
+++ b/tests/e2e/reporting-dashboard.spec.js
@@ -34,7 +34,15 @@ test.describe('reporting dashboard renders (post-migration baseline)', () => {
         page.__owaErrors = errors;
 
         await login(page);
-        await expect(page.locator('text=Logout').first()).toBeVisible();
+        /*
+         * The account menu, not the word "Logout".
+         *
+         * Logout lives inside that menu now and is hidden until it is opened,
+         * so a visibility check on the text fails for a perfectly good session.
+         * The toggle is a better signal anyway: it is rendered only for an
+         * authenticated request.
+         */
+        await expect(page.locator('#owa_userMenuToggle')).toBeVisible();
         await openDashboard(page);
     });
 

--- a/tests/e2e/seed_reporting_fixtures.php
+++ b/tests/e2e/seed_reporting_fixtures.php
@@ -221,6 +221,21 @@ const E2E_PWUSER_KEY  = '735512bd84ae1f2635e3e89fb7ecc001'; // md5 temp_passkey 
 const E2E_PWUSER_ROLE = 'analyst';
 const E2E_PWUSER_NAME = 'OWA E2E PwChange';
 
+/*
+ * A SECOND password fixture, for the Profile screen's own change-password form.
+ *
+ * It cannot share the one above. That user is left on a NEW password by the
+ * emailed-passkey test in admin-actions.spec.js -- deliberately, since the point
+ * there is that the change took -- and nothing puts it back until the next
+ * seeding run. A second spec logging in with the starting password therefore
+ * works alone and fails whenever admin-actions has run first, which in CI it
+ * always has: the files run in name order.
+ */
+const E2E_PROFILEPW_ID   = 'owa-e2e-profilepw@example.test';
+const E2E_PROFILEPW_PASS = 'e2e-ProfilePw-Old-1!';
+const E2E_PROFILEPW_ROLE = 'analyst';
+const E2E_PROFILEPW_NAME = 'OWA E2E ProfilePw';
+
 // Identifiers the admin-actions CRUD tests CREATE at runtime (add site / add
 // user) and then delete. They are NOT seeded here; they are declared so the
 // teardown can mop them up if a CRUD test dies between the add and its delete,
@@ -275,6 +290,8 @@ function fixtureInfo(): array
         'admin_user_id'  => E2E_ADMIN_ID,
         'admin_password' => E2E_ADMIN_PASS,
         'admin_role'     => E2E_ADMIN_ROLE,
+        'profilepw_user_id'  => E2E_PROFILEPW_ID,
+        'profilepw_password' => E2E_PROFILEPW_PASS,
         'pw_user_id'     => E2E_PWUSER_ID,
         'pw_password'    => E2E_PWUSER_PASS,
         'pw_passkey'     => E2E_PWUSER_KEY,
@@ -346,6 +363,26 @@ function seed(): array
         $pw->set('password', owa_lib::encryptPassword(E2E_PWUSER_PASS));
         $pw->set('temp_passkey', E2E_PWUSER_KEY);
         $pw->update();
+    }
+
+    /*
+     * 2d. The Profile screen's password fixture. Same treatment as 2c and for
+     *     the same reason -- its password is rotated by the test that changes
+     *     it, so every run resets it -- but a user of its own, because the two
+     *     specs would otherwise take turns invalidating each other's login.
+     */
+    $ppw = owa_coreAPI::entityFactory('base.user');
+    $ppw->load(E2E_PROFILEPW_ID, 'user_id');
+    if (!$ppw->get('id')) {
+        $ppw = owa_coreAPI::entityFactory('base.user');
+        $ppw->createNewUser(E2E_PROFILEPW_ID, E2E_PROFILEPW_ROLE, E2E_PROFILEPW_PASS,
+            E2E_PROFILEPW_ID, E2E_PROFILEPW_NAME);
+        $ppw = owa_coreAPI::entityFactory('base.user');
+        $ppw->load(E2E_PROFILEPW_ID, 'user_id');
+    }
+    if ($ppw->get('id')) {
+        $ppw->set('password', owa_lib::encryptPassword(E2E_PROFILEPW_PASS));
+        $ppw->update();
     }
 
     /*
@@ -1075,6 +1112,7 @@ function teardown(): array
     try { owa_coreAPI::entityFactory('base.user')->delete(E2E_USER_ID, 'user_id'); } catch (\Throwable $e) {}
     try { owa_coreAPI::entityFactory('base.user')->delete(E2E_ADMIN_ID, 'user_id'); } catch (\Throwable $e) {}
     try { owa_coreAPI::entityFactory('base.user')->delete(E2E_PWUSER_ID, 'user_id'); } catch (\Throwable $e) {}
+    try { owa_coreAPI::entityFactory('base.user')->delete(E2E_PROFILEPW_ID, 'user_id'); } catch (\Throwable $e) {}
     // CRUD-test leftovers (only present if an add-then-delete test aborted midway).
     try { owa_coreAPI::entityFactory('base.user')->delete(E2E_NEW_USER_ID, 'user_id'); } catch (\Throwable $e) {}
     try {


### PR DESCRIPTION
There was no screen for your own account. Changing your name meant an administrator editing you through `base.usersProfile`, and there was no way at all to change your own password once signed in — only the emailed reset.

`base.myProfile` is that screen: **name, email address and password**, always acting on whoever is signed in. It takes no `user_id`, so there is no account but your own for it to reach and nothing to authorise.

## Getting there

- The **username in the top bar** links to it.
- A **My Preferences** group in the settings nav, containing one link: **Profile**.

The group sits **last**. The groups above it read widest scope to narrowest — install, Organization, Property, Profile — and a group that is not a step in that chain would make "install-wide options head the nav" false, which is a claim `PropertyAdminScreensTest` asserts. It reads as what it is: not a narrower scope, a different subject.

The tier-0 breadcrumb is now named by the screen rather than hardcoded to "Installation", so this one says My Preferences. Every other screen still gets Installation by default.

## Capabilities

Gated on `view_site_list` — what admin, analyst and viewer all carry and nothing else does, i.e. the capability that means "signed in". Every entry in the Installation nav group is `edit_settings`, which would have left most users unable to change their own name.

**Changing your own email address needs `edit_own_email`**, a new capability that only `admin` has by default and that the config file can grant to another role. It is separate from `edit_users`, which is about *other people's* accounts: the address is where password resets are sent, so changing it moves who can recover the account, and that is not implied by being allowed to correct your own name. Without the capability the address renders as text, and a posted change is refused rather than ignored.

`user_id` is shown and not editable. It identifies everything the account has made — custom reports are stored against it, and so are site grants — so changing it here would orphan them.

## Password

Requires the current password, checked with `password_verify` against the stored hash rather than trusted from the session: a session is enough to *read* this screen, not enough to replace the credential that recovers the account.

**A successful change signs you out**, and it has to. The auth cookie is `md5( user_id . password_hash )` — see `Auth::saveCredentials()` — so the moment the hash changes the cookie stops matching and the next request is anonymous. Left alone, someone who changed their password was silently signed out on their next click with no idea why; I hit exactly that while testing. It now clears credentials and redirects to the login form saying so, which is what the emailed reset already does. Refusals never carry a password back into the page.

## Not in this PR

User-level preferences themselves. There is no store for them and `ServiceUser::getPreferences()` is still the stub returning `false` that it was. The group is named for where they will go; adding the store is a schema change and its own piece of work.

## Testing

- `MyProfileTest`: the capability shape — `edit_own_email` is admin-only, is not site-scoped, every signed-in role can reach the screen, both controllers require `view_site_list`, the save is nonce-required, both actions are registered.
- `my-profile.spec.js`: both routes in; the username and role shown but not editable; an admin editing name and address; an analyst editing their name with the address as text; **an analyst posting an address anyway, refused**; the password refusals (wrong current, mismatch, too short) with the secret never echoed back; and a real change that signs out, signs back in on the new password, and restores the fixture.
- `TemplateLatentVarTest` gained an entry for the template, rendered on the branch where the address is *not* editable — the branch a fixture is most likely to miss.

Three existing assertions in `PropertyAdminScreensTest` needed updating for the new nav group and the renamed breadcrumb label; they are updated rather than relaxed.

1978 PHP unit (same configless, and the new test file passes run alone), 562 jest, 10 new e2e plus the 9 notification specs that touch the same header.
