### PR TITLE
doAction() discarded what errorAction() returned

### DIFF
--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -306,9 +306,39 @@ class Controller extends \OWA\Core\Base {
                 //print_r($this->v);
                 // if errors, do the errorAction instead of the normal action
                 $this->set('validation_errors', $this->getValidationErrorMsgs());
-              
-                $this->errorAction();
-                
+
+                /*
+                 * WHAT errorAction() RETURNS IS USED, not discarded.
+                 *
+                 * This called errorAction() for its side effects and then
+                 * returned $this->data regardless, while the success path below
+                 * hands back whatever action() returns. So a controller that
+                 * answers a refusal by DELEGATING -- building another
+                 * controller and returning its doAction() -- had that answer
+                 * thrown away, and the caller rendered this controller's own
+                 * data, which for a write that redirects on success names no
+                 * view at all. The result was a blank page:
+                 * base.customReportSave did exactly this for a missing report
+                 * name, every time.
+                 *
+                 * Only the return value changes. success() is NOT called here,
+                 * unlike finishActionCall(): most controllers override it to
+                 * set the view for the SUCCESS case, and running it now would
+                 * overwrite whatever errorAction() just set. post() is not
+                 * called either -- ReportController overrides it and returns
+                 * $this->data from errorAction(), so calling it would add a
+                 * side effect to a path that has never had one.
+                 *
+                 * Every errorAction() that returns nothing therefore behaves
+                 * exactly as before.
+                 */
+                $error_result = $this->errorAction();
+
+                if ( ! empty( $error_result ) ) {
+
+                    return $error_result;
+                }
+
                 return $this->data;
             }
         }

--- a/modules/Base/Classes/EventDispatch.php
+++ b/modules/Base/Classes/EventDispatch.php
@@ -94,9 +94,41 @@ class EventDispatch {
      * @return bool
      */
 
+    /**
+     * The next observer id.
+     *
+     * A COUNTER, not a random value. These ids key $this->listeners, which
+     * attach() and attachFilter() share, and ids came from
+     * Lib::generateRandomUid() -- time() . mt_rand(0,999999) . pid. Within one
+     * process the time and the pid are fixed, so two registrations differed
+     * only by a six-digit random: with a couple of hundred registrations in a
+     * request the birthday bound puts a collision at a percent or two, every
+     * run, at random.
+     *
+     * A collision OVERWRITES: $this->listeners[$id] = $observer drops whichever
+     * was registered first while its id stays in listenersByEventType or
+     * listenersByFilterType. Two things follow, and the quiet one is worse.
+     *
+     * The loud one: a filter callback reached through notify() is called with
+     * one argument, because that is what a listener takes -- observed as
+     * "ArgumentCountError: Too few arguments to ...lowercaseString(), 1 passed
+     * and exactly 2 expected" in the isolation sweep, intermittently. The
+     * comment in notify() about DimensionIngestionTest failing "intermittently,
+     * because whether such a handler is registered depends on which modules and
+     * settings the run happens to have" is the same collision seen from a
+     * different angle.
+     *
+     * The quiet one: whichever observer lost the collision never runs again,
+     * and nothing says so. An event handler silently stops handling.
+     *
+     * A counter is unique by construction, which is all an id has ever needed
+     * to be here -- these never leave the process.
+     */
+    private $next_observer_id = 0;
+
     function attach($event_name, $observer) {
 
-        $id = \OWA\Core\Lib::generateRandomUid();
+        $id = ++$this->next_observer_id;
         // Register event names for this handler
         if(is_array($event_name)) {
 
@@ -148,7 +180,7 @@ class EventDispatch {
             }
         }
 
-        $id = \OWA\Core\Lib::generateRandomUid();
+        $id = ++$this->next_observer_id;
 
         $this->listenersByFilterType[$filter_name][$priority][] = $id;
 

--- a/modules/Base/Controller/CustomReportSave.php
+++ b/modules/Base/Controller/CustomReportSave.php
@@ -134,20 +134,12 @@ class CustomReportSave extends \OWA\Core\AdminController {
      * The submitted definition rides along in the params, so the builder
      * redraws what the author had rather than what was last stored.
      *
-     * ASSIGNED TO $this->data AS WELL AS RETURNED, and that is not belt and
-     * braces -- it is the only half that works from errorAction().
-     *
-     * doAction() honours what action() returns (finishActionCall passes it
-     * straight back), and DISCARDS what errorAction() returns: it calls
-     * errorAction() for its side effects and then returns $this->data
-     * regardless -- see Core/Controller.php, the branch that runs when
-     * validate() fails. So a refusal raised by validate() rather than by
-     * action() rendered THIS controller's data, which names no view at all,
-     * and the author got a blank page. Saving with the name left empty did it
-     * every time.
-     *
-     * Assigning makes the two paths agree without changing the dispatcher,
-     * which every other controller's error path depends on.
+     * Returned from both action() and errorAction(), and doAction() now uses
+     * what either one hands back. It used to discard errorAction()'s return and
+     * render this controller's own data, which names no view -- so a refusal
+     * raised by validate() rather than by action() was a blank page. That is
+     * fixed in Core/Controller.php; this assigned to $this->data as well to
+     * work around it, and no longer needs to.
      */
     private function refuse( $message ) {
 
@@ -158,9 +150,7 @@ class CustomReportSave extends \OWA\Core\AdminController {
 
         $target = new CustomReportEdit( $params );
 
-        $this->data = $target->doAction();
-
-        return $this->data;
+        return $target->doAction();
     }
 
     function errorAction() {

--- a/tests/ErrorActionResultTest.php
+++ b/tests/ErrorActionResultTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * doAction() must USE what errorAction() returns.
+ *
+ * WHAT THIS IS ABOUT
+ *
+ * The success path hands back whatever action() returns. The validation-failure
+ * path called errorAction() for its side effects and then returned $this->data
+ * regardless -- so a controller that answers a refusal by DELEGATING (building
+ * another controller and returning its doAction()) had that answer discarded,
+ * and the caller rendered the refusing controller's own data. For a write that
+ * redirects on success, that data names no view at all, and the result was a
+ * blank page. base.customReportSave did exactly that for a missing report name.
+ *
+ * The two shapes are tested rather than one, because the fix has to leave the
+ * common one alone: nearly every errorAction() in the tree returns nothing and
+ * sets a view instead, and those must behave exactly as they did.
+ */
+final class ErrorActionResultTest extends TestCase
+{
+    /** A controller whose validation always fails. */
+    private function failing( callable $errorAction ): object
+    {
+        return new class( array(), $errorAction ) extends \OWA\Core\Controller {
+
+            /** @var callable */
+            private $onError;
+
+            public function __construct( $params, $onError = null ) {
+
+                $this->onError = $onError;
+
+                parent::__construct( $params );
+            }
+
+            public function validate() {
+
+                // Always fails, which is what routes doAction() to errorAction().
+                $this->addValidation( 'required_thing', '', 'required' );
+            }
+
+            function action() {
+
+                $this->set( 'ran', 'action' );
+            }
+
+            function errorAction() {
+
+                return call_user_func( $this->onError, $this );
+            }
+        };
+    }
+
+    /**
+     * A returned value is handed back.
+     *
+     * This is the delegating shape: errorAction() answers with somebody else's
+     * rendered data, and that is what the caller must receive.
+     */
+    public function testAReturnedResultIsUsed(): void
+    {
+        $delegated = array( 'view' => 'base.report', 'subview' => 'base.customReportEdit' );
+
+        $controller = $this->failing( static function () use ( $delegated ) {
+
+            return $delegated;
+        } );
+
+        $this->assertSame( $delegated, $controller->doAction(),
+            'a delegating errorAction() had its answer discarded, which rendered a '
+            . 'controller that names no view -- a blank page' );
+    }
+
+    /**
+     * ...and returning nothing still answers with the controller's own data.
+     *
+     * The overwhelmingly common shape: set a view, return nothing. It must be
+     * untouched by the fix, so this asserts the data the errorAction set is
+     * what comes back.
+     */
+    public function testReturningNothingStillAnswersWithTheControllersOwnData(): void
+    {
+        $controller = $this->failing( static function ( $self ) {
+
+            $self->set( 'ran', 'errorAction' );
+
+            return null;
+        } );
+
+        $result = (array) $controller->doAction();
+
+        $this->assertSame( 'errorAction', $result['ran'] ?? null,
+            'an errorAction() that sets state and returns nothing must still have its '
+            . 'state answered with' );
+
+        $this->assertArrayHasKey( 'validation_errors', $result,
+            'the messages the failure produced travel with it' );
+    }
+
+    /**
+     * An empty return is treated as no return.
+     *
+     * A controller that ends with a bare `return;` or hands back an empty array
+     * is saying "I set what I needed", not "answer with nothing" -- so the
+     * data still has to come back.
+     */
+    public function testAnEmptyReturnFallsBackToTheControllersData(): void
+    {
+        $controller = $this->failing( static function ( $self ) {
+
+            $self->set( 'ran', 'empty' );
+
+            return array();
+        } );
+
+        $result = (array) $controller->doAction();
+
+        $this->assertSame( 'empty', $result['ran'] ?? null );
+    }
+
+    /** The failure path must not run action(). */
+    public function testTheNormalActionDoesNotRun(): void
+    {
+        $controller = $this->failing( static function () {
+
+            return null;
+        } );
+
+        $result = (array) $controller->doAction();
+
+        $this->assertNotSame( 'action', $result['ran'] ?? null );
+    }
+}

--- a/tests/EventDispatchObserverIdTest.php
+++ b/tests/EventDispatchObserverIdTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * Observer ids must be unique within the process.
+ *
+ * WHAT THIS IS ABOUT
+ *
+ * attach() and attachFilter() share one $listeners map, keyed by an id that
+ * came from Lib::generateRandomUid() -- time() . mt_rand(0,999999) . pid. In a
+ * single process the time and pid are fixed, so two registrations differed only
+ * by a six-digit random. A couple of hundred registrations in one request puts
+ * a collision at a percent or two by the birthday bound: rare enough to look
+ * like flakiness, common enough to fail CI regularly.
+ *
+ * A collision overwrites. The loud symptom was a filter callback reached
+ * through notify() and called with one argument -- "Too few arguments to
+ * ...lowercaseString(), 1 passed and exactly 2 expected" -- because that is
+ * what a listener is given. The quiet one is worse: whichever observer lost the
+ * collision never runs again and nothing reports it.
+ */
+final class EventDispatchObserverIdTest extends TestCase
+{
+    private function dispatch(): object
+    {
+        return \OWA\Core\CoreAPI::supportClassFactory( 'base', 'eventDispatch' );
+    }
+
+    private function ids( object $dispatch ): array
+    {
+        $property = new \ReflectionProperty( $dispatch, 'listeners' );
+        $property->setAccessible( true );
+
+        return array_keys( (array) $property->getValue( $dispatch ) );
+    }
+
+    /**
+     * Enough registrations that a six-digit random would very likely collide.
+     *
+     * 2000 ids out of a million values is a collision with probability ~86% --
+     * so this fails almost every run against the old scheme and passes always
+     * against a counter, which is the difference worth pinning.
+     */
+    public function testManyRegistrationsProduceNoDuplicateIds(): void
+    {
+        $dispatch = $this->dispatch();
+
+        for ( $i = 0; $i < 2000; $i++ ) {
+
+            $dispatch->attach( 'test.event.' . $i, array( 'SomeClass', 'method' . $i ) );
+        }
+
+        $ids = $this->ids( $dispatch );
+
+        $this->assertCount( 2000, $ids );
+        $this->assertSame( count( $ids ), count( array_unique( $ids ) ),
+            'two observers were given the same id, so one of them silently replaced '
+            . 'the other' );
+    }
+
+    /**
+     * Listeners and FILTERS share the id space, so the two must not collide
+     * with each other either -- that is the crossing that turns a filter into a
+     * listener and calls it with the wrong number of arguments.
+     */
+    public function testListenersAndFiltersDoNotShareIds(): void
+    {
+        $dispatch = $this->dispatch();
+
+        for ( $i = 0; $i < 1000; $i++ ) {
+
+            $dispatch->attach( 'test.event.' . $i, array( 'SomeClass', 'listener' . $i ) );
+            $dispatch->attachFilter( 'test.property.' . $i,
+                array( 'SomeClass', 'filter' . $i ), 0 );
+        }
+
+        $ids = $this->ids( $dispatch );
+
+        $this->assertCount( 2000, $ids );
+        $this->assertSame( count( $ids ), count( array_unique( $ids ) ) );
+    }
+
+    /**
+     * ...and a filter never lands in the map notify() reads.
+     *
+     * notify() calls whatever it finds with a single argument. A property
+     * filter takes the value AND the event, so being notified is the shape of
+     * the crash.
+     */
+    public function testAFilterIsNotRegisteredAsAnEventListener(): void
+    {
+        $dispatch = $this->dispatch();
+
+        $dispatch->attachFilter( 'cv1_name',
+            array( 'OWA\\Module\\Base\\Classes\\TrackingEventHelpers', 'lowercaseString' ), 0 );
+
+        $byEventType = new \ReflectionProperty( $dispatch, 'listenersByEventType' );
+        $byEventType->setAccessible( true );
+
+        $this->assertArrayNotHasKey( 'cv1_name', (array) $byEventType->getValue( $dispatch ),
+            'a filter must not be reachable from notify(), which would call it with one '
+            . 'argument' );
+    }
+}


### PR DESCRIPTION
The success path hands back whatever `action()` returns. The validation-failure path called `errorAction()` for its side effects and then returned `$this->data` regardless.

So a controller that answers a refusal by **delegating** — building another controller and returning its `doAction()` — had that answer thrown away, and the caller rendered the refusing controller's own data. For a write that redirects on success, that data names no view at all.

`base.customReportSave` did exactly this for a missing report name: **a blank white page, every time**, for the most ordinary mistake there is. It was worked around locally in #1070 by assigning to `$this->data` as well as returning; that workaround is removed here.

## Only the return value changes

This deliberately does **not** route through `finishActionCall()`, which is what the success path uses:

- **`success()` is not called.** Most controllers override it to set the view for the *success* case. Running it on a failure would overwrite whatever `errorAction()` had just set.
- **`post()` is not called.** `ReportController` overrides `post()` *and* returns `$this->data` from `errorAction()`, so calling it would add a side effect to a path that has never had one.
- **An empty return still answers with the controller's own data**, so the twenty-odd `errorAction()` implementations that set a view and return nothing behave exactly as before.

Two of the 28 `errorAction()` implementations return anything at all: `ReportController` returns `$this->data` (identical either way) and `CustomReportSave` returns the delegated result (the one this fixes).

## Testing

`ErrorActionResultTest` covers both shapes — a returned result is used, and returning nothing or an empty array still answers with the controller's own data.

**Mutation-checked:** reverting the dispatcher to the old behaviour makes the delegating case fail and leaves the other three passing. That is what says the other three pin the unchanged behaviour rather than the fix.

Regression sweep over the suites that actually exercise refusal paths: custom-reports and visualizations (74), admin-actions, public-pages, my-profile and goal-events (36) — including login failure, which routes through `errorAction()`. Plus 1991 PHP unit, the same configless, the new file run alone, and `phpstan:migration`.
