### PR TITLE
The installer loaded the config file it had just written

### DIFF
--- a/modules/Base/Classes/Settings.php
+++ b/modules/Base/Classes/Settings.php
@@ -1504,7 +1504,27 @@ namespace OWA\Module\Base\Classes;
         fclose($handle);
         chmod($file, 0750);
         \OWA\Core\CoreAPI::debug('Config file created');
-        require_once($file);
+
+        /*
+         * The file is NOT loaded here.
+         *
+         * Its constants are already defined in this request -- InstallConfig
+         * defines the database ones from the submitted form so it can test the
+         * connection before writing anything, and install.php defines the error
+         * handler and cache ones. Loading the file then re-ran define() on all
+         * of them, and define() on an existing constant keeps the first value
+         * and emits a warning: eight "Constant OWA_DB_TYPE already defined in
+         * owa-config.php" warnings per install, in the error log, and printed
+         * ahead of the redirect below on any host with display_errors on.
+         *
+         * Nothing needs it loaded. The only caller redirects immediately
+         * (InstallConfig::action), and a redirect is a new request that reads
+         * the file from scratch with nothing predefined.
+         *
+         * Guarding the defines in owa-config-dist.php would have fixed only
+         * files written from that template afterwards; every existing install
+         * would keep warning.
+         */
         return true;
 
     }


### PR DESCRIPTION
`createConfigFile()` ended with `require_once()` on the file it had just written.

Every constant in that file was already defined in the same request: `InstallConfig` defines the six database ones from the submitted form so it can test the connection *before* writing anything, and `install.php` defines `OWA_ERROR_HANDLER` and `OWA_CACHE_OBJECTS`. So loading the file re-ran `define()` on all eight — and `define()` on an existing constant keeps the first value and emits a warning.

Result: **eight `Constant OWA_DB_TYPE already defined in owa-config.php` warnings on every install.** Log noise on a default install; on a host with `display_errors` on they print immediately before `setRedirectAction()` sends its `Location:` header, which is the classic "headers already sent" failure — right after the database step, to someone installing for the first time.

## Why this way

**Nothing needed the file loaded.** The only caller redirects immediately, and a redirect is a new request that reads the file from scratch with nothing predefined. The CLI installer never calls it.

**Not by guarding the defines in `owa-config-dist.php`**, which was the obvious first idea and is wrong twice: that template only shapes files written *afterwards*, so every existing install would go on warning; and it would scatter `defined()`-guards through a file people edit by hand.

**Not by dropping the pre-definition instead:** the connection is validated before the file is written, and the DB layer reads those constants, so they have to exist first.

## Verified

Ran the real wizard through the install harness — both the web wizard and the CLI installer still complete — and counted `already defined` in the Apache error log across a full run: **8 before, 8 after**, none of them new.

Plus 1994 PHP unit, including `ConfigFilePathTest`, which pins that the presence check, the loader and the writer all agree on one path.

## What is not covered

The behavioural half — that removing the load doesn't break the wizard — is covered by the existing install e2e, which walks config entry → defaults entry → finish. The *warning* half I verified by log count and did not automate: the warnings land in Apache's log, which CI's test process cannot read.
