### PR TITLE
test: run custom-reports in parallel, on two workers

### DIFF
--- a/playwright.selfhost.config.js
+++ b/playwright.selfhost.config.js
@@ -52,7 +52,7 @@ const HARNESS = path.join(__dirname, 'tests', 'e2e', 'selfhost_harness.php');
 const BASE_URL = execFileSync('php', [HARNESS, 'baseurl'], { encoding: 'utf8' }).trim();
 
 // The php -S command serves the repo root (this dir). Multiple workers would need
-// PHP_CLI_SERVER_WORKERS, but the suite runs workers:1 (fixtures share one DB), and
+// PHP_CLI_SERVER_WORKERS; the suite runs few workers (fixtures share one DB), and
 // a single-threaded server can deadlock if a request makes a same-server subrequest;
 // give it a small worker pool so a page + its assets/beacons can be served together.
 const SERVER_URL = BASE_URL.replace(/index\.php.*$/, '');
@@ -69,10 +69,30 @@ module.exports = defineConfig({
     globalSetup: require.resolve('./tests/e2e/selfhost-global-setup.js'),
     globalTeardown: require.resolve('./tests/e2e/selfhost-global-teardown.js'),
 
+    /*
+     * Files stay serial with respect to each other; only files that opt in
+     * (test.describe.configure({ mode: 'parallel' })) split across workers.
+     * Turning this on globally would let every file's tests interleave, and
+     * several of them mutate shared fixture rows -- the beacon specs write fact
+     * rows the reporting specs then assert on.
+     */
     fullyParallel: false,
     forbidOnly: !!process.env.CI,
     retries: 0,
-    workers: 1,
+    /*
+     * Two, not one -- and not more.
+     *
+     * custom-reports.spec.js is about 40% of this suite's wall clock and opts
+     * into parallel mode, so a second worker is what lets it actually split.
+     * Beyond two, files that do NOT opt in start overlapping each other more
+     * aggressively, and several of them share fixture rows: admin-actions
+     * rewrites users and sites, and the beacon specs write the fact rows the
+     * reporting specs count.
+     *
+     * The live-server config stays at one worker. It runs on a 1.9GB box that
+     * hard-freezes rather than OOM-killing, and browsers are what fill it.
+     */
+    workers: 2,
     // In CI keep the streaming 'line' output AND write an HTML report so a
     // failing run has something to upload as an artifact for diagnosis.
     reporter: process.env.CI ? [['line'], ['html', { open: 'never' }]] : 'list',

--- a/tests/e2e/custom-reports.spec.js
+++ b/tests/e2e/custom-reports.spec.js
@@ -18,8 +18,18 @@
 const { test, expect } = require('@playwright/test');
 const { FIXTURE, login, loginAs } = require('./fixtures');
 
-/** A name unique to this run, so reruns do not collide on the roster. */
-const reportName = (label) => `E2E ${label} ${Date.now()}`;
+/**
+ * A name unique to this run AND to the test using it.
+ *
+ * Date.now() alone has millisecond resolution, which was unique enough while
+ * this file ran one test at a time. It no longer does: the describes below run
+ * in parallel, so two tests can name a report in the same millisecond. The
+ * random suffix is what keeps them apart.
+ *
+ * The 'E2E ' prefix stays -- the fixture teardown finds these by it.
+ */
+const reportName = (label) =>
+    `E2E ${label} ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 /**
  * The builder, opened ON THE FIXTURE SITE.
@@ -214,6 +224,31 @@ async function fillWidget(page, opts) {
 }
 
 test.describe('custom reports', () => {
+
+    /*
+     * THIS FILE RUNS IN PARALLEL.
+     *
+     * It is 66 tests and about 40% of the self-hosted suite's wall clock -- and
+     * because a file is the unit Playwright keeps serial by default, it was the
+     * floor under every other attempt to speed the suite up.
+     *
+     * Its tests are independent, which is what makes this safe rather than
+     * merely faster:
+     *
+     *   - every report is created under a name unique to the test that makes
+     *     it, so no two tests address the same row;
+     *   - nothing here deletes a report, so no test can pull a row out from
+     *     under another;
+     *   - the one roster COUNT assertion checks the shape of the number
+     *     (/^[0-9]+$/), not its value, so a sibling creating a report
+     *     concurrently cannot break it;
+     *   - each test signs in for itself, and parallel workers get their own
+     *     browser contexts, so no session is shared.
+     *
+     * A test added here that deletes a report, or asserts an exact roster
+     * count, breaks those assumptions and has to be marked serial.
+     */
+    test.describe.configure({ mode: 'parallel' });
 
     test.describe('as an author', () => {
 


### PR DESCRIPTION
## What

`tests/e2e/custom-reports.spec.js` is 66 tests and roughly 40% of the self-hosted E2E suite's wall clock. A **file** is the unit Playwright keeps serial by default, so that one file was the floor under the suite's runtime regardless of workers, and it is why `--shard` does not help — sharding is file-granularity, so all 66 land in one shard.

This opts that file into parallel mode and gives `playwright.selfhost.config.js` a second worker to spend on it.

## Why it is safe to parallelize this file

Not just "it seemed to pass":

- every report is created under a name unique to the test that makes it, so no two tests address the same row;
- nothing in the file deletes a report, so no test can pull a row out from under a sibling;
- the one roster **count** assertion checks the shape of the number (`/^[0-9]+$/`), not its value, so a concurrent create cannot break it;
- each test signs in for itself, and parallel workers get their own browser contexts.

Those four assumptions are written into a comment above the `configure` call, along with what would break them (a test that deletes a report, or asserts an exact roster count).

`reportName()` gained a random suffix. `Date.now()` was unique enough while the file ran one test at a time; under concurrency two tests can name a report in the same millisecond.

## What is deliberately not changed

- **`fullyParallel` stays `false`.** The other spec files share fixture rows — `admin-actions` rewrites users and sites, and the beacon specs write the fact rows the reporting specs then count. Turning it on globally would let those interleave.
- **`workers: 2`, not more.** Above two, files that have *not* opted in start overlapping each other more aggressively, which runs into exactly those shared rows.
- **`playwright.config.js` (live server) stays at `workers: 1`.** It runs on a 1.9GB / 2-vCPU box that hard-freezes rather than OOM-killing.

## Measured

Locally, `custom-reports.spec.js` alone: **7.4min → 6.0min (66 passed)**, about 19%. Not the ~50% a second worker suggests — the box has 2 vCPUs and is CPU-bound, not parallelism-bound. GitHub's standard runners are also 2-core, so **expect a modest gain in CI, not a halving**. The baseline to compare against is the 19m7s self-hosted job on the most recent master-based run.