### PR TITLE
Patch three vulnerable build-toolchain dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3643,9 +3643,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4354,9 +4354,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -6106,9 +6106,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "jquery-migrate": "^3.4.1",
     "jquery-sparkline": "^2.4.0",
     "jquery-ui-dist": "^1.13.3",
-    "jquery.flot": "^0.8.3",
-    "webpack": "^5.66.0",
-    "webpack-cli": "^4.9.1"
+    "jquery.flot": "^0.8.3"
   },
   "overrides": {
     "brace-expansion": "^5.0.9",
@@ -55,6 +53,8 @@
     "jest-environment-jsdom": "^30.4.1",
     "mini-css-extract-plugin": "^2.10.2",
     "terser-webpack-plugin": "^5.6.1",
+    "webpack": "^5.66.0",
+    "webpack-cli": "^4.9.1",
     "webpack-remove-empty-scripts": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,9 +39,10 @@
     "webpack-cli": "^4.9.1"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
+    "fast-uri": "^3.1.6",
     "js-yaml": "^3.15.1",
-    "fast-uri": "^3.1.5"
+    "nanoid": "^3.3.18"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",


### PR DESCRIPTION
Clears the four open Dependabot alerts, plus two more that only `npm audit`
surfaced, and fixes the misclassification that made them read as runtime risk.

| package | | fix | reached via |
|---|---|---|---|
| `fast-uri` | 3.1.5 → **3.1.7** | 4 advisories, CVSS 7.5 | `copy-webpack-plugin` → `schema-utils` → `ajv` |
| `brace-expansion` | 5.0.8 → **5.0.9** | DoS, unbounded intermediate arrays | `jest` / `babel-jest` → `minimatch` |
| `nanoid` | 3.3.16 → **3.3.18** | infinite loop when size is zero | `css-loader` → `postcss` |

### Exposure

Low, and worth stating precisely rather than reacting to four "HIGH" badges.

All three are build/test tooling. The `fast-uri` advisories are SSRF and host
confusion in URI parsing — they bite when you parse attacker-supplied URIs and
act on them. Here `fast-uri` is reached through `ajv` validating a webpack
plugin's **own bundled option schema** at build time, so the URIs are the
schema's `$id`/`$ref` values, not user input.

None of it ships: the release tarball excludes `node_modules`, `package.json`
and `package-lock.json`, and none of the three appears in any built bundle.

### One of these was a stale pin, not a missing one

`overrides` already carried `brace-expansion: ^5.0.8` — which is *inside* the
new advisory's `4.0.0 - 5.0.8` range. That pin was the fix for the earlier
CVE-2026-14257, and this advisory is specifically a bypass of that mitigation.
The override block needs revisiting rather than trusting.

### Second commit: webpack is not a runtime dependency

`webpack` and `webpack-cli` sat in `dependencies`. That is the only reason
`npm audit --omit=dev` reported a webpack-only transitive as a production
vulnerability — it is what made these alerts look like runtime exposure.

After the move, `--omit=dev` means what it says, so a genuine runtime advisory
will stand out instead of being buried in build tooling. `dependencies` now
holds only the eight libraries actually bundled into the shipped JS.

**Inert for every consumer** — nothing installs production-only. `ci.yml` uses
`npm ci`, the release job uses `npm install`, README documents
`npm install && npm run build`; all full-tree.

### Verification

- `npm ci` → `npm run build` produces **byte-identical** artifacts: tracker (`35c410de…`, 55287 bytes), reporting bundle (`e1a9134b…`) and combined CSS all unchanged by sha256
- `jest` 49 suites / 562 tests pass
- `npm audit` reports **0 vulnerabilities**, with and without `--omit=dev`
- `npm ci --omit=dev` now correctly leaves webpack out
- Lockfile diff is 18 lines — no incidental churn