### PR TITLE
A goal event could be given a slot number nothing supports

### DIFF
--- a/modules/Base/Controller/GoalEventSave.php
+++ b/modules/Base/Controller/GoalEventSave.php
@@ -231,6 +231,25 @@ class GoalEventSave extends \OWA\Core\AdminController {
             $condition->create();
         }
     }
+    /**
+     * The lowest numbered slot not already taken on this site, or null.
+     *
+     * The ceiling is numGoals, and has to be: that one setting is what sizes
+     * every other half of a numbered slot. owa_session carries physical
+     * goal_<N>, goal_<N>_start and goal_<N>_value columns for 1..numGoals
+     * (Entity\Session), the goal<N>Completions metric family is registered
+     * over the same range (Base\Module), and GoalManager::saveGoal() refuses a
+     * number above it.
+     *
+     * This loop used to run to a hardcoded 20 while numGoals was 15, so slots
+     * 16-20 were handed out with none of that behind them: ConversionHandlers
+     * builds 'goal_' . <number> and sets it on the session, which for 16 names
+     * a column that does not exist, so the completion was dropped in silence
+     * and no metric could have reported it anyway. That is strictly worse than
+     * returning null, which is the deliberate, handled "no numbered slot"
+     * state -- the goal event is still created and still works, it just has no
+     * numbered metric.
+     */
     public static function nextFreeSlot( $siteId ) {
 
         $taken = array();
@@ -243,7 +262,9 @@ class GoalEventSave extends \OWA\Core\AdminController {
             }
         }
 
-        for ( $i = 1; $i <= 20; $i++ ) {
+        $ceiling = (int) \OWA\Core\CoreAPI::getSetting( 'base', 'numGoals' );
+
+        for ( $i = 1; $i <= $ceiling; $i++ ) {
 
             if ( ! isset( $taken[ $i ] ) ) {
 

--- a/tests/GoalSlotCeilingTest.php
+++ b/tests/GoalSlotCeilingTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use OWA\Module\Base\Controller\GoalEventSave;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * A numbered goal slot only means something if every half of it exists.
+ *
+ * `numGoals` sizes four things that have to agree:
+ *
+ *   - owa_session's physical goal_<N>, goal_<N>_start and goal_<N>_value
+ *     columns (Entity\Session),
+ *   - the goal<N>Completions / Starts / Value metric families (Base\Module),
+ *   - GoalManager::saveGoal(), which refuses a number above it,
+ *   - and GoalEventSave::nextFreeSlot(), which hands the numbers out.
+ *
+ * The fourth used to run to a hardcoded 20 while the other three used numGoals
+ * (15), so slots 16-20 were issued with nothing behind them. That is not a
+ * cosmetic mismatch: ConversionHandlers builds 'goal_' . <number> and sets it
+ * on the session, so a completion on slot 16 named a column that does not
+ * exist and was dropped in silence, and no metric could have reported it.
+ *
+ * Running out of slots is a HANDLED state -- nextFreeSlot() answers null, the
+ * goal event is still created and still works, it just has no numbered metric.
+ * A number past the ceiling is strictly worse than that null, which is why
+ * these assert the ceiling rather than merely that a number came back.
+ */
+final class GoalSlotCeilingTest extends TestCase
+{
+    private array $created = [];
+
+    private string $siteId = '';
+
+    /*
+     * Goal events are stored against the PROPERTY, and GoalEvents::listFor()
+     * queries on property_id -- a fixture keyed only on site_id is invisible to
+     * the code under test, and every count silently measures an empty list.
+     */
+    private string $propertyId = '';
+
+    private int $numGoals = 0;
+
+    protected function setUp(): void
+    {
+        if ( ! owa_test_db_available() ) {
+            $this->markTestSkipped( 'OWA database not reachable.' );
+        }
+
+        $this->numGoals = (int) \OWA\Core\CoreAPI::getSetting( 'base', 'numGoals' );
+
+        if ( $this->numGoals < 1 ) {
+            $this->markTestSkipped( 'numGoals is not configured.' );
+        }
+
+        // A real Profile: goal events hang off the Property, so an invented id
+        // resolves to nothing and every count below would measure an empty list.
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->selectFrom( \OWA\Core\CoreAPI::entityFactory( 'base.site' )->getTableName() );
+        $db->selectColumn( 'site_id, property_id' );
+
+        foreach ( (array) $db->getAllRows() as $row ) {
+
+            if ( ! empty( $row['property_id'] ) ) {
+
+                $this->siteId     = $row['site_id'];
+                $this->propertyId = $row['property_id'];
+                break;
+            }
+        }
+
+        if ( ! $this->siteId ) {
+            $this->markTestSkipped( 'Needs a Profile with a Property.' );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ( $this->created as $id ) {
+
+            $e = \OWA\Core\CoreAPI::entityFactory( 'base.goal_event' );
+            $e->delete( $id );
+        }
+
+        $this->created = [];
+    }
+
+    /** Occupy $number's slot with a real row, so nextFreeSlot() has to skip it. */
+    private function occupySlot( int $number ): void
+    {
+        $e = \OWA\Core\CoreAPI::entityFactory( 'base.goal_event' );
+        $id = $e->generateId( 'goal_slot_test:' . $this->siteId . ':' . uniqid( '', true ) );
+
+        $e->set( 'id', $id );
+        $e->set( 'site_id', $this->siteId );
+        $e->set( 'property_id', $this->propertyId );
+        $e->set( 'name', 'slot ceiling fixture ' . $number );
+        $e->set( 'goal_number', $number );
+        $e->set( 'is_active', 1 );
+        $e->set( 'creation_date', \OWA\Core\CoreAPI::getRequestTimestamp() );
+        $e->create();
+
+        $this->created[] = $id;
+    }
+
+    /**
+     * The ceiling is numGoals, not a literal.
+     *
+     * Fill every slot and the answer must be null -- never numGoals + 1, which
+     * is the exact value the hardcoded 20 used to hand back on a 15-goal
+     * install.
+     */
+    public function testSlotsRunOutAtNumGoalsRatherThanAHardcodedCeiling(): void
+    {
+        for ( $i = 1; $i <= $this->numGoals; $i++ ) {
+            $this->occupySlot( $i );
+        }
+
+        $next = GoalEventSave::nextFreeSlot( $this->siteId );
+
+        $this->assertNull(
+            $next,
+            'every numbered slot is taken, so there is no slot to give out; '
+            . 'returning ' . var_export( $next, true ) . ' would name a goal_<N> '
+            . 'column and a goal<N>Completions metric that do not exist.'
+        );
+    }
+
+    /**
+     * The other half: while slots remain, the lowest free one is handed out and
+     * it is always inside the range the columns and metrics cover.
+     */
+    public function testAnIssuedSlotIsAlwaysWithinTheSupportedRange(): void
+    {
+        // Take everything except the last, so the only answer is that last one.
+        for ( $i = 1; $i < $this->numGoals; $i++ ) {
+            $this->occupySlot( $i );
+        }
+
+        $next = GoalEventSave::nextFreeSlot( $this->siteId );
+
+        $this->assertSame( $this->numGoals, $next );
+        $this->assertLessThanOrEqual( $this->numGoals, $next );
+    }
+
+    /**
+     * The invariant the fix actually restores, asserted against the schema
+     * rather than against the loop: the highest issuable slot has session
+     * columns, and one past it does not.
+     *
+     * This is what makes the two above meaningful -- without it they only pin
+     * nextFreeSlot() to a number, not to a number that works.
+     */
+    public function testTheSessionCarriesColumnsForExactlyTheIssuableSlots(): void
+    {
+        $session = \OWA\Core\CoreAPI::entityFactory( 'base.session' );
+        $columns = array_keys( (array) $session->getProperties() );
+
+        $this->assertContains(
+            'goal_' . $this->numGoals, $columns,
+            'the highest issuable slot has no column to record a completion in.'
+        );
+
+        $this->assertNotContains(
+            'goal_' . ( $this->numGoals + 1 ), $columns,
+            'a column exists past numGoals, so the ceiling and the schema '
+            . 'disagree in the other direction.'
+        );
+    }
+}


### PR DESCRIPTION
`nextFreeSlot()` handed out numbered slots **1-20** from a hardcoded literal,
while every other half of a numbered slot is sized by `numGoals` — which
defaults to 15 and is not settable from `owa-config-dist.php` or the options UI.

```php
// GoalEventSave.php:246, before
for ( $i = 1; $i <= 20; $i++ ) {
```

### What slots 16-20 were missing

| consumer | range | consequence at slot 16 |
|---|---|---|
| `Entity\Session` | `goal_<N>`, `_start`, `_value` for 1..`numGoals` | `ConversionHandlers` builds `'goal_' . 16` and sets it on the session — **names a column that does not exist, completion dropped in silence** |
| `Base\Module` | registers `goal<N>Completions` over 1..`numGoals` | nothing could report it either |
| `GoalManager::saveGoal()` | refuses `$number > $this->numGoals` | rejected outright |

The goal looked configured and recorded nothing.

### Why this is worse than running out

`nextFreeSlot()` returning `null` is a **deliberate, handled** state — the goal
event is still created and still works, it just has no numbered metric. #1064's
own comment says so: *"none at all once twenty are used… without capping goal
events at twenty the way the slots did."* Issuing a number past the ceiling
looks like success and behaves like nothing.

Only reachable on an install with 16+ goal events, which is why it hasn't bitten.

### The test pins a number that *works*

`tests/GoalSlotCeilingTest.php` covers both directions — slots run out at
`numGoals`, and an issued slot is always in range — plus the invariant
underneath them, asserted against the schema rather than the loop: the highest
issuable slot **has** session columns and one past it does **not**. Without that
third test the first two would only pin `nextFreeSlot()` to a number, not to a
number anything supports.

**Mutation-checked.** Restoring the literal fails with `Failed asserting that 16
is null` — slot 16 being the first dead-zone value, i.e. the bug exactly.

### Verification

| | |
|---|---|
| `phpunit` | 1997 tests, 48475 assertions, 2 skipped |
| `phpstan` / `:migration` | No errors |

### Found via

Reviewing the wiki against master after 1.12.0 — the question "is a user still
limited to 15 goals?" turned out to have three different answers depending on
which of the four consumers you asked.