### PR TITLE
Settings screen fixes, dashboard widgets, and an admin copy pass

### DIFF
--- a/Core/Controller.php
+++ b/Core/Controller.php
@@ -983,7 +983,7 @@ class Controller extends \OWA\Core\Base {
         /*
          * YOUR OWN SETTINGS, first.
          *
-         * Not part of the Installation group: every entry there is gated on
+         * Not part of the Instance group: every entry there is gated on
          * edit_settings and describes the installation, while this describes
          * the person looking at it. An analyst has one of these and none of
          * those.
@@ -1000,7 +1000,7 @@ class Controller extends \OWA\Core\Base {
         $nav['My Preferences'] = array(
             array(
                 'do'         => 'base.myProfile',
-                'label'      => 'Profile',
+                'label'      => 'User Profile',
                 'params'     => array(),
                 // What admin, analyst and viewer all carry and nothing else
                 // does -- the capability that means "signed in".
@@ -1044,7 +1044,7 @@ class Controller extends \OWA\Core\Base {
 
         if ( $installation ) {
 
-            $nav['Installation'] = $installation;
+            $nav['Instance'] = $installation;
         }
 
         $nav['Organization'] = array(

--- a/Core/CoreAPI.php
+++ b/Core/CoreAPI.php
@@ -1241,6 +1241,36 @@ class CoreAPI {
      *
      * @return array
      */
+    /**
+     * The registered title for a settings screen, or '' if it has none.
+     *
+     * One lookup for both consumers: the nav renders it as the link, and the
+     * page renders it as its heading. See Module::registerSettingsPage().
+     *
+     * @param string $action  a dotted action id, e.g. 'base.optionsGeneral'
+     * @return string
+     */
+    public static function settingsPageTitle( $action ) {
+
+        if ( ! $action ) {
+
+            return '';
+        }
+
+        foreach ( (array) \OWA\Core\CoreAPI::getAdminPanels() as $items ) {
+
+            foreach ( (array) $items as $item ) {
+
+                if ( ( $item['do'] ?? '' ) === $action ) {
+
+                    return (string) ( $item['anchortext'] ?? '' );
+                }
+            }
+        }
+
+        return '';
+    }
+
     public static function getAdminPanels() {
 
         $panels = array();

--- a/Core/Entity.php
+++ b/Core/Entity.php
@@ -311,6 +311,31 @@ class Entity {
      * @param mixed  $value
      * @return bool
      */
+    /**
+     * Empty a column, deliberately.
+     *
+     * set() discards '' on a string column, on purpose: several handlers rely
+     * on `set('medium', $maybeEmpty)` leaving the existing value alone, and
+     * blanket-storing empties there would wipe data that is currently kept.
+     * The cost is that a caller who genuinely means "this is now blank" -- an
+     * edit form whose textarea the user emptied -- had no way to say so, and
+     * the old value survived with no error shown.
+     *
+     * This is that way. It marks the column dirty so update() writes it, which
+     * is the half set() cannot reach: its falsy guard wraps the markDirty call
+     * as well as the assignment.
+     */
+    public function clear( $name ) {
+
+        if ( ! array_key_exists( $name, $this->properties ) ) {
+
+            return;
+        }
+
+        $this->properties[ $name ]->setValue( '' );
+        $this->markDirty( $name, '' );
+    }
+
     protected function columnAcceptsFalsy( $name, $value ) {
 
         if ( $value === null || $value === '' ) {

--- a/Core/Module.php
+++ b/Core/Module.php
@@ -104,6 +104,13 @@ abstract class Module {
      *
      * @var array
      */
+    /**
+     * What a report nav item shows when its module names no icon.
+     * Present in the bundled font-awesome, and in the same v4-prefix family the
+     * eight hand-picked icons use.
+     */
+    const DEFAULT_NAV_ICON = 'fa fa-chart-bar';
+
     var $admin_panels;
 
     /**
@@ -498,7 +505,18 @@ abstract class Module {
      * @param string $priviledge
      * @param string $groupName
      */
-    public function addNavigationSubGroup($subgroupName, $ref, $anchortext, $order = 0, $priviledge = 'view_reports', $groupName = 'Reports', $icon_class = '') {
+    /**
+     * A top-level report nav item.
+     *
+     * $icon_class defaults to a generic chart rather than to nothing. The
+     * template renders `<i class="owa_nav_icon {$icon_class}">` unconditionally,
+     * so an empty class drew an empty glyph -- a module that shipped navigation
+     * without naming an icon, which is every third-party module, sat in the nav
+     * looking broken next to Base's eight. A generic icon is the honest default:
+     * the item IS a report group, and a module with something better to say
+     * still says it.
+     */
+    public function addNavigationSubGroup($subgroupName, $ref, $anchortext, $order = 0, $priviledge = 'view_reports', $groupName = 'Reports', $icon_class = self::DEFAULT_NAV_ICON) {
         $this->nav_links[$groupName][$subgroupName] = $this->getLinkStruct($ref, $anchortext, $order,$priviledge, $icon_class);
     }
 

--- a/Core/Module.php
+++ b/Core/Module.php
@@ -424,6 +424,51 @@ abstract class Module {
     }
 
     /**
+     * Register a settings screen: its nav entry AND its page title, once.
+     *
+     * The two used to be declared in different places -- 'anchortext' here and
+     * a headline the view set for itself -- so they drifted, and a reader was
+     * given two names for one screen. base.optionsGeneral was "Main
+     * Configuration" in the nav and "General Configuration Options" on the
+     * page; three other screens had the same split.
+     *
+     * `title` is the one name. The nav renders it, and the framework hands it
+     * to the page, so a screen registered this way CANNOT disagree with itself.
+     * A view that sets its own headline is then a bug rather than a second
+     * opinion, which is what SettingsPageTitleTest asserts.
+     *
+     * Keys: do, title, capability, group, order. `priviledge` and `anchortext`
+     * are still written for registerSettingsPanel's consumers, which read the
+     * older shape.
+     *
+     * @param array $page
+     * @return bool
+     */
+    function registerSettingsPage( $page ) {
+
+        $title = (string) ( $page['title'] ?? '' );
+
+        if ( $title === '' ) {
+
+            \OWA\Core\CoreAPI::notice(
+                'A settings page needs a title: it names the screen in the nav and '
+              . 'on the page itself. Registering ' . ( $page['do'] ?? '?' ) . ' without one.' );
+        }
+
+        // The older shape, so the nav builder and every existing reader work
+        // unchanged. anchortext IS the title -- that is the whole point.
+        $page['anchortext'] = $title;
+        $page['priviledge'] = $page['priviledge'] ?? 'admin';
+        $page['group']      = $page['group'] ?? 'General';
+        $page['order']      = $page['order'] ?? 1;
+
+        // What marks this panel as carrying an authoritative title.
+        $page['owa_titled'] = true;
+
+        return $this->registerSettingsPanel( $page );
+    }
+
+    /**
      * Registers an admin panel with this module
      *
      */

--- a/Core/View.php
+++ b/Core/View.php
@@ -145,6 +145,20 @@ class View extends \OWA\Core\Base {
             $this->body->set('params', $this->data['params']);
         endif;
 
+        /*
+         * The screen's own name, read from the same registration the settings
+         * nav draws its link from, so the two cannot disagree -- see
+         * Module::registerSettingsPage().
+         *
+         * Set UNCONDITIONALLY, and empty for anything that is not a registered
+         * settings page. ViewScope throws on a template variable that was never
+         * set, so a view reached by a path that skipped this would fail at
+         * render rather than fall back -- which is exactly what happened to the
+         * Maxmind screen when this was wired into the subview branch alone.
+         */
+        $this->body->set( 'settings_page_title', \OWA\Core\CoreAPI::settingsPageTitle(
+            $this->data['params']['do'] ?? ( $this->data['do'] ?? '' ) ) );
+
         if (array_key_exists('subview', $this->data)):
             $this->body->caller_params['subview'] = $this->data['subview'];
         endif;

--- a/Core/View.php
+++ b/Core/View.php
@@ -145,19 +145,7 @@ class View extends \OWA\Core\Base {
             $this->body->set('params', $this->data['params']);
         endif;
 
-        /*
-         * The screen's own name, read from the same registration the settings
-         * nav draws its link from, so the two cannot disagree -- see
-         * Module::registerSettingsPage().
-         *
-         * Set UNCONDITIONALLY, and empty for anything that is not a registered
-         * settings page. ViewScope throws on a template variable that was never
-         * set, so a view reached by a path that skipped this would fail at
-         * render rather than fall back -- which is exactly what happened to the
-         * Maxmind screen when this was wired into the subview branch alone.
-         */
-        $this->body->set( 'settings_page_title', \OWA\Core\CoreAPI::settingsPageTitle(
-            $this->data['params']['do'] ?? ( $this->data['do'] ?? '' ) ) );
+        $this->setSettingsPageTitle();
 
         if (array_key_exists('subview', $this->data)):
             $this->body->caller_params['subview'] = $this->data['subview'];
@@ -389,7 +377,40 @@ class View extends \OWA\Core\Base {
      * @param mixed $data
      * @return unknown
      */
+    /**
+     * Hand the page the name its settings-nav link carries.
+     *
+     * Read from the same registration the nav draws from -- see
+     * Module::registerSettingsPage() -- so the two cannot disagree.
+     *
+     * Called from BOTH assembly paths, which is the whole point of it being a
+     * method. A main view goes through assembleView() and a subview through
+     * assembleSubView(), and every settings screen is a subview while the
+     * Maxmind screen renders through neither: wiring this into one path alone
+     * left the other rendering blank, because ViewScope throws on a template
+     * variable that was never set rather than falling back to empty.
+     *
+     * Empty for anything that is not a registered settings page -- reports, the
+     * install wizard -- whose templates do not read it.
+     */
+    protected function setSettingsPageTitle() {
+
+        if ( ! is_object( $this->body ) ) {
+
+            return;
+        }
+
+        $do = $this->data['params']['do'] ?? ( $this->data['do'] ?? '' );
+
+        $this->body->set( 'settings_page_title',
+            \OWA\Core\CoreAPI::settingsPageTitle( $do ) );
+    }
+
     function assembleSubView($data) {
+
+        // Before render(), so a subview that wants to override its own title
+        // still can -- and so it is set whichever branch below runs.
+        $this->setSettingsPageTitle();
 
         // construct main view.  This might set some properties of the subview.
         if (method_exists($this, 'render')) {

--- a/modules/Base/Controller/PropertyEdit.php
+++ b/modules/Base/Controller/PropertyEdit.php
@@ -94,7 +94,19 @@ class PropertyEdit extends \OWA\Core\AdminController {
             $property->load( $propertyId );
             $property->set( 'name', $name );
             $property->set( 'domain', $domain );
-            $property->set( 'description', $description );
+            /*
+             * Emptied means emptied -- see SitesEdit for the same guard and
+             * Entity::clear() for why set() cannot express it.
+             */
+            if ( $description === '' ) {
+
+                $property->clear( 'description' );
+
+            } else {
+
+                $property->set( 'description', $description );
+            }
+
             $property->update();
 
         } else {

--- a/modules/Base/Controller/SitesAdd.php
+++ b/modules/Base/Controller/SitesAdd.php
@@ -157,8 +157,27 @@ class SitesAdd extends \OWA\Core\AdminController {
     }
     
     function success() {
-	    
-	    $this->setRedirectAction('base.reportingHome');
+
+        /*
+         * To the Profile that was just created, not to reporting.
+         *
+         * A new Profile's whole point is its tracking id, which lives on this
+         * screen -- landing on the dashboard means the one thing you came for
+         * is somewhere you now have to go and find. action() has already put the
+         * created row in 'site', so the id is here to redirect with.
+         */
+        $site = (array) $this->get( 'site' );
+
+        if ( ! empty( $site['site_id'] ) ) {
+
+            $this->set( 'siteId', $site['site_id'] );
+            $this->setRedirectAction( 'base.sitesProfile' );
+
+        } else {
+
+            $this->setRedirectAction( 'base.reportingHome' );
+        }
+
         $this->set('status_code', 3202);
     }
 

--- a/modules/Base/Controller/SitesEdit.php
+++ b/modules/Base/Controller/SitesEdit.php
@@ -67,11 +67,31 @@ class SitesEdit extends \OWA\Core\AdminController {
         $site->load( $site->generateId( $this->getParam('siteId') ) );
         $site->set('name', $this->getParam( 'name' ) );
         $site->set('domain', $this->getParam( 'domain' ) );
-        $site->set('description', $this->getParam( 'description') );
+
+        /*
+         * An emptied description means empty. set() drops '' on a string column
+         * so the old text used to survive the save with nothing said about it.
+         */
+        $description = (string) $this->getParam( 'description' );
+
+        if ( $description === '' ) {
+
+            $site->clear( 'description' );
+
+        } else {
+
+            $site->set( 'description', $description );
+        }
+
         $site->save();
 
-        //$data['view_method'] = 'redirect';
-        $this->setRedirectAction('base.reportingHome');
+        /*
+         * Back to the Profile that was edited, not to reporting. This sent
+         * every rename to the dashboard, which reads as the save having thrown
+         * the screen away -- and is not what the other two Profile editors do.
+         */
+        $this->set( 'siteId', $this->getParam( 'siteId' ) );
+        $this->setRedirectAction( 'base.sitesProfile' );
         $this->set('status_code', 3201);
     }
 }

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -377,12 +377,11 @@ class Module extends \OWA\Core\Module {
      */
     function registerAdminPanels() {
 
-        $this->addAdminPanel(array(
+        $this->registerSettingsPage(array(
                 'do'             => 'base.optionsGeneral',
-                'priviledge'     => 'admin',
-                'anchortext'     => 'Main Configuration',
-                'group'            => 'General',
-                'order'            => 1)
+                'title'          => 'Main Configuration',
+                'group'          => 'General',
+                'order'          => 1)
         );
 
 
@@ -414,12 +413,11 @@ class Module extends \OWA\Core\Module {
          * disagreeing about it would put rows of different meanings in one
          * table with nothing recording which.
          */
-        $this->addAdminPanel(array(
+        $this->registerSettingsPage(array(
                 'do'             => 'base.optionsModules',
-                'priviledge'     => 'admin',
-                'anchortext'     => 'Modules',
-                'group'            => 'General',
-                'order'            => 3)
+                'title'          => 'Modules',
+                'group'          => 'General',
+                'order'          => 3)
         );
 
         /*

--- a/modules/Base/View/OptionsGeneral.php
+++ b/modules/Base/View/OptionsGeneral.php
@@ -36,7 +36,6 @@ class OptionsGeneral extends \OWA\Core\View\AdminPage {
         // load template
         $this->body->set_template('options_general.php');
         // fetch admin links from all modules
-        $this->body->set('headline', 'Main Configuration');
 
         //print_r($data['config']);
         // assign config data

--- a/modules/Base/View/OptionsGeneral.php
+++ b/modules/Base/View/OptionsGeneral.php
@@ -36,7 +36,7 @@ class OptionsGeneral extends \OWA\Core\View\AdminPage {
         // load template
         $this->body->set_template('options_general.php');
         // fetch admin links from all modules
-        $this->body->set('headline', 'General Configuration Options');
+        $this->body->set('headline', 'Main Configuration');
 
         //print_r($data['config']);
         // assign config data

--- a/modules/Base/View/OptionsHierarchy.php
+++ b/modules/Base/View/OptionsHierarchy.php
@@ -36,13 +36,13 @@ class OptionsHierarchy extends \OWA\Core\View {
 
         /*
          * What the root crumb says. Tier 0 means install-wide on every other
-         * screen, so 'Installation' is the default -- but base.myProfile is
+         * screen, so 'Instance' is the default -- but base.myProfile is
          * tier 0 and is about the person rather than the installation, so it
          * names its own. get() answers false for a name nobody set, hence the
          * ?: rather than a check.
          */
         $this->body->set( 'hierarchy_root_label',
-            $this->get( 'hierarchy_root_label' ) ?: 'Installation' );
+            $this->get( 'hierarchy_root_label' ) ?: 'Instance' );
         /*
  * Not ?: -- tier 0 (install-wide) is a legitimate value that ?: would turn
  * into 3, putting a Property and a Profile above Main Configuration.
@@ -54,6 +54,16 @@ class OptionsHierarchy extends \OWA\Core\View {
         $this->setJs( 'owa.reporting', 'base/dist/owa.reporting-combined-min.js' );
         $this->setCss( 'base/css/owa.admin.css' );
         $this->setCss( 'base/css/owa.report.css' );
+
+        /*
+         * The same chrome the reporting screens load, because these draw the
+         * same chrome. The top nav's icons are font-awesome classes, and the
+         * combined stylesheet carries owa.css -- neither was loaded here, so
+         * every settings screen drew the navigation without its icons and
+         * without the base styles the header is built on.
+         */
+        $this->setCss( 'base/css/font-awesome/css/all.min.css' );
+        $this->setCss( 'base/css/owa.reporting-css-combined.css' );
     }
 }
 

--- a/modules/Base/View/OptionsModules.php
+++ b/modules/Base/View/OptionsModules.php
@@ -49,7 +49,7 @@ class OptionsModules extends \OWA\Core\View {
         $this->body->set_template('options_modules.php');
 
         // fetch admin links from all modules
-        $this->body->set('headline', 'Modules Administration');
+        $this->body->set('headline', 'Modules');
 
         // Assign module data
         $this->body->set('modules', $this->get('modules'));

--- a/modules/Base/View/OptionsModules.php
+++ b/modules/Base/View/OptionsModules.php
@@ -49,7 +49,6 @@ class OptionsModules extends \OWA\Core\View {
         $this->body->set_template('options_modules.php');
 
         // fetch admin links from all modules
-        $this->body->set('headline', 'Modules');
 
         // Assign module data
         $this->body->set('modules', $this->get('modules'));

--- a/modules/Base/css/owa.admin.css
+++ b/modules/Base/css/owa.admin.css
@@ -490,3 +490,15 @@
     padding: 8px 10px 16px;
     color: #65676b;
 }
+
+/*
+ * The three password boxes are one control, not three settings, so they are
+ * spaced as a group rather than inheriting the gap between settings -- which
+ * they had none of, leaving them stacked edge to edge.
+ */
+.owa_passwordFields {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+}

--- a/modules/Base/reports/dashboard.json
+++ b/modules/Base/reports/dashboard.json
@@ -96,7 +96,7 @@
             }
         },
         {
-            "type": "grid",
+            "type": "grid-card",
             "id": "topReferrers",
             "container": "top-referers",
             "title": "Top Referrers",
@@ -109,13 +109,10 @@
             ],
             "query": {
                 "metrics": "visits",
-                "dimensions": "referralPageTitle,referralPageUrl",
+                "dimensions": "referralPageUrl",
                 "sort": "visits-",
                 "resultsPerPage": 10
             },
-            "excludeColumns": [
-                "referralPageTitle"
-            ],
             "link": {
                 "linkColumn": "referralPageUrl",
                 "template": {
@@ -132,8 +129,8 @@
             "container": "latest-visits",
             "title": "Latest Visits",
             "query": {
-                "metrics": "visits,pagesPerVisit,visitDuration",
-                "dimensions": "ipAddress,entryPagePath,medium,source,city,country,priorVisitCount",
+                "metrics": "pagesPerVisit,visitDuration",
+                "dimensions": "ipAddress,hostName,entryPagePath,medium,source,city,country,priorVisitCount",
                 "sort": "visits-",
                 "resultsPerPage": 10
             },

--- a/modules/Base/templates/custom_report_edit.php
+++ b/modules/Base/templates/custom_report_edit.php
@@ -188,7 +188,7 @@ $owa_max        = (int) $view->get('max_widgets');
         ), false, '', false, true ); ?>"
            data-owa-confirm
            data-owa-confirm-title="Delete this report?"
-           data-owa-confirm-body="There is no other copy of it. Unlike a Profile, a custom report is not archived &mdash; deleting it is final."
+           data-owa-confirm-body="This is final. Unlike a Profile, a custom report is not archived."
            data-owa-confirm-proceed="Delete report">Delete</a>
         <?php endif; ?>
     </div>

--- a/modules/Base/templates/goal_event_edit.php
+++ b/modules/Base/templates/goal_event_edit.php
@@ -219,7 +219,7 @@ the event, how to compare it, and what to compare it to.</div>
                name="<?php echo $view->getNs();?>submit_btn" value="Delete Goal Event"
                data-owa-confirm
                data-owa-confirm-title="Delete this goal event?"
-               data-owa-confirm-body="&ldquo;<?php $view->out( $owa_ke['name'] ?? '' );?>&rdquo; stops counting and disappears from reports. Events already counted under it are not removed."
+               data-owa-confirm-body="&ldquo;<?php $view->out( $owa_ke['name'] ?? '' );?>&rdquo; stops counting and leaves reports. Events already counted are kept."
                data-owa-confirm-proceed="Delete goal event">
     </form>
 </div>

--- a/modules/Base/templates/hierarchy_breadcrumb.php
+++ b/modules/Base/templates/hierarchy_breadcrumb.php
@@ -28,7 +28,7 @@ $owa_crumbs = array();
  * screen whose settings apply to every Organization would be wrong in exactly
  * the way the tiering is meant to prevent.
  *
- * The label is not always "Installation": base.myProfile is tier 0 for the same
+ * The label is not always "Instance": base.myProfile is tier 0 for the same
  * reason -- it belongs to no Organization -- but is about the person, so it
  * supplies its own. See OptionsHierarchy, which defaults it.
  */

--- a/modules/Base/templates/my_profile.php
+++ b/modules/Base/templates/my_profile.php
@@ -11,12 +11,8 @@ $owa_mayEditEmail = (bool) $view->may_edit_email;
 $owa_error        = (string) $view->my_profile_error;
 $owa_minPassword  = (int) $view->min_password_length;
 ?>
-<DIV class="panel_headline">Profile</DIV>
+<DIV class="panel_headline">User Profile</DIV>
 <div id="panel">
-
-<div class="owa_panelIntro">Your own account: the name you are shown as, the address
-password resets are sent to, and your password. To change somebody else's account, use
-Users under Organization.</div>
 
 <?php if ( $owa_error ): ?>
 <div class="notice error" role="alert"><?php $view->out( $owa_error ); ?></div>
@@ -33,9 +29,6 @@ Users under Organization.</div>
 
         <div class="setting">
             <div class="title">Username</div>
-            <div class="description">What you sign in with. It identifies everything you
-            have made &mdash; your custom reports and the sites you have been granted
-            &mdash; so it is not changed here.</div>
             <div class="field">
                 <span class="noedit"><?php $view->out( $view->user_id ); ?></span>
             </div>
@@ -43,8 +36,6 @@ Users under Organization.</div>
 
         <div class="setting">
             <div class="title">Role</div>
-            <div class="description">What you are allowed to do. Only an administrator can
-            change it.</div>
             <div class="field">
                 <span class="noedit"><?php $view->out( $view->role ); ?></span>
             </div>
@@ -90,10 +81,8 @@ Users under Organization.</div>
 
         <div class="setting">
             <div class="title">Change password</div>
-            <div class="description">Leave these empty to keep your current password. Your
-            current password is required, so a signed-in browser that is not yours cannot
-            change it. At least <?php echo (int) $owa_minPassword; ?> characters. Changing
-            it signs you out, so you will be asked to sign in again.</div>
+            <div class="description">Leave empty to keep your current password. At least
+            <?php echo (int) $owa_minPassword; ?> characters. Changing it signs you out.</div>
             <div class="field">
                 <?php
                     /*
@@ -102,12 +91,14 @@ Users under Organization.</div>
                      * filling the new-password fields with the old one.
                      */
                 ?>
-                <div><input type="password" size="30" name="current_password"
-                            autocomplete="current-password" placeholder="Current password"></div>
-                <div><input type="password" size="30" name="new_password"
-                            autocomplete="new-password" placeholder="New password"></div>
-                <div><input type="password" size="30" name="new_password2"
-                            autocomplete="new-password" placeholder="Repeat new password"></div>
+                <div class="owa_passwordFields">
+                    <input type="password" size="30" name="current_password"
+                           autocomplete="current-password" placeholder="Current password">
+                    <input type="password" size="30" name="new_password"
+                           autocomplete="new-password" placeholder="New password">
+                    <input type="password" size="30" name="new_password2"
+                           autocomplete="new-password" placeholder="Repeat new password">
+                </div>
             </div>
         </div>
 

--- a/modules/Base/templates/options_general.php
+++ b/modules/Base/templates/options_general.php
@@ -1,5 +1,5 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div class="panel_headline"><?php echo $view->headline?></div>
+<div class="panel_headline"><?php $view->out( $view->settings_page_title ); ?></div>
 
 <?php
 /*

--- a/modules/Base/templates/options_modules.php
+++ b/modules/Base/templates/options_modules.php
@@ -1,5 +1,5 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div class="panel_headline"><?php echo $view->headline?></div>
+<div class="panel_headline"><?php $view->out( $view->settings_page_title ); ?></div>
 <div id="panel">
 
 <?php if (!empty($view->modules)): ?>

--- a/modules/Base/templates/property_profile.php
+++ b/modules/Base/templates/property_profile.php
@@ -117,7 +117,7 @@
                name="<?php echo $view->getNs();?>submit_btn" value="Delete Property"
                data-owa-confirm
                data-owa-confirm-title="Delete this Property?"
-               data-owa-confirm-body="&ldquo;<?php $view->out( $view->property['name'] ?? '' );?>&rdquo; and <?php echo (int) ( $view->profileCount ?? 0 );?> Observation Profile(s) under it will stop recording immediately and will no longer appear in reporting. Everything already collected is kept, and an administrator can restore it."
+               data-owa-confirm-body="&ldquo;<?php $view->out( $view->property['name'] ?? '' );?>&rdquo; and its <?php echo (int) ( $view->profileCount ?? 0 );?> Observation Profile(s) stop recording and leave reporting. Everything collected is kept, and it can be restored."
                data-owa-confirm-proceed="Delete Property">
     </form>
 </div>

--- a/modules/Base/templates/sites_addoredit.php
+++ b/modules/Base/templates/sites_addoredit.php
@@ -15,9 +15,9 @@
 ?>
 <DIV class="panel_headline"><?php $view->out( $view->headline );?></DIV>
 <div id="panel">
-<div class="owa_panelIntro">An Observation Profile is one way of watching a Property.
-It carries its own tracking id, so a Property watched two ways has two Profiles and
-two tags.</div>
+<div class="owa_panelIntro">An Observation Profile defines how OWA observes and
+analyzes a Property. You may have more than one Observation Profile per Property, as
+each carries its own tracking id.</div>
 <fieldset>
 
     <legend>Observation Profile</legend>
@@ -180,7 +180,7 @@ two tags.</div>
                name="<?php echo $view->getNs();?>submit_btn" value="Delete Profile"
                data-owa-confirm
                data-owa-confirm-title="Delete this Observation Profile?"
-               data-owa-confirm-body="&ldquo;<?php $view->out( $view->site['name'] ?? '' );?>&rdquo; will stop recording immediately and will no longer appear in reporting. Everything it has already collected is kept, and an administrator can restore it."
+               data-owa-confirm-body="&ldquo;<?php $view->out( $view->site['name'] ?? '' );?>&rdquo; stops recording and leaves reporting. Everything it collected is kept, and it can be restored."
                data-owa-confirm-proceed="Delete Profile">
     </form>
 </div>

--- a/modules/Hello/ExampleSettingsView.php
+++ b/modules/Hello/ExampleSettingsView.php
@@ -44,7 +44,7 @@ class ExampleSettingsView extends \OWA\Core\View {
         // load template
         $this->body->setTemplateFile('hello', 'example_settings.php');
         // assign headline
-        $this->body->set('headline', 'Example Settings Page');
+        $this->body->set('headline', 'Hello World!');
     }
 
 

--- a/modules/Hello/ExampleSettingsView.php
+++ b/modules/Hello/ExampleSettingsView.php
@@ -44,7 +44,6 @@ class ExampleSettingsView extends \OWA\Core\View {
         // load template
         $this->body->setTemplateFile('hello', 'example_settings.php');
         // assign headline
-        $this->body->set('headline', 'Hello World!');
     }
 
 

--- a/modules/Hello/Module.php
+++ b/modules/Hello/Module.php
@@ -54,11 +54,10 @@ class Module extends \OWA\Core\Module {
      */
     function registerAdminPanels() {
 
-        $this->addAdminPanel(array( 'do'             => 'hello.exampleSettings',
-                                    'priviledge'     => 'admin',
-                                    'anchortext'     => 'Hello World!',
-                                    'group'            => 'Test',
-                                    'order'            => 1));
+        $this->registerSettingsPage(array( 'do'    => 'hello.exampleSettings',
+                                          'title' => 'Hello World!',
+                                          'group' => 'Test',
+                                          'order' => 1));
 
 
         return;

--- a/modules/Hello/Module.php
+++ b/modules/Hello/Module.php
@@ -64,10 +64,26 @@ class Module extends \OWA\Core\Module {
 
     }
 
-    public function registerNavigation() {
-        $this->addNavigationSubGroup('Hello World', 'hello.reportDashboard', 'Hello Dashboard');
-        $this->addNavigationLinkInSubGroup('Hello World','hello.reportSearchterms','also to the dashboard',1);
+    /**
+     * The report this module ships.
+     *
+     * A definition file, which is how a module adds a report -- see
+     * reports/hello-dashboard.json. This example previously pointed its
+     * navigation at hello.reportDashboard and hello.reportSearchterms, neither
+     * of which was registered anywhere, so both links errored: the module a
+     * third party copies was demonstrating a shape that does not work.
+     */
+    function registerReports() {
 
+        $this->registerReport( 'hello-dashboard', 'reports/hello-dashboard.json' );
+    }
+
+    public function registerNavigation() {
+
+        // reportRef() builds the link to a registered report, so the nav cannot
+        // name a report that does not exist.
+        $this->addNavigationSubGroup(
+            'Hello World', $this->reportRef( 'hello-dashboard' ), 'Hello Dashboard' );
     }
 
     /**

--- a/modules/Hello/reports/hello-dashboard.json
+++ b/modules/Hello/reports/hello-dashboard.json
@@ -1,0 +1,30 @@
+{
+    "title": "Hello Dashboard",
+    "metrics": "visits,uniqueVisitors,pageViews",
+    "widgets": [
+        {
+            "type": "trend-card",
+            "id": "trend",
+            "container": "trend-chart",
+            "title": "Traffic",
+            "showTitle": true,
+            "chartMetric": "visits",
+            "query": {
+                "metrics": "visits,uniqueVisitors,pageViews",
+                "dimensions": "date",
+                "sort": "date"
+            }
+        },
+        {
+            "type": "grid-card",
+            "id": "topPages",
+            "container": "top-pages",
+            "title": "Top Content",
+            "query": {
+                "metrics": "pageViews",
+                "dimensions": "pagePath",
+                "sort": "pageViews-"
+            }
+        }
+    ]
+}

--- a/modules/Hello/templates/example_settings.php
+++ b/modules/Hello/templates/example_settings.php
@@ -1,4 +1,4 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<h2><?php echo $view->headline; ?></h2>
+<h2><?php $view->out( $view->settings_page_title ); ?></h2>
 
 Hello world. This is how you create a settings page.

--- a/modules/MaxmindGeoip/Module.php
+++ b/modules/MaxmindGeoip/Module.php
@@ -116,12 +116,11 @@ class Module extends \OWA\Core\Module {
      */
     function registerAdminPanels() {
 
-        $this->addAdminPanel( array(
-            'do'          => 'maxmind_geoip.optionsGeoip',
-            'priviledge'  => 'admin',
-            'anchortext'  => 'GeoIP',
-            'group'       => 'Modules',
-            'order'       => 10,
+        $this->registerSettingsPage( array(
+            'do'    => 'maxmind_geoip.optionsGeoip',
+            'title' => 'GeoIP',
+            'group' => 'Modules',
+            'order' => 10,
         ) );
     }
 

--- a/modules/MaxmindGeoip/templates/options_geoip.php
+++ b/modules/MaxmindGeoip/templates/options_geoip.php
@@ -1,5 +1,5 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div class="panel_headline">GeoIP Settings</div>
+<div class="panel_headline">GeoIP</div>
 
 <?php /* #panel, like every settings screen -- see options_general.php. */ ?>
 <div id="panel">

--- a/modules/MaxmindGeoip/templates/options_geoip.php
+++ b/modules/MaxmindGeoip/templates/options_geoip.php
@@ -1,5 +1,5 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
-<div class="panel_headline">GeoIP</div>
+<div class="panel_headline"><?php $view->out( $view->settings_page_title ); ?></div>
 
 <?php /* #panel, like every settings screen -- see options_general.php. */ ?>
 <div id="panel">

--- a/tests/EntityFalsyWriteTest.php
+++ b/tests/EntityFalsyWriteTest.php
@@ -98,6 +98,55 @@ final class EntityFalsyWriteTest extends TestCase
     }
 
     /** A numeric column must not accept a non-numeric falsy value either. */
+    /**
+     * clear() is how a caller says "this is now blank".
+     *
+     * set() ignoring '' is deliberate and load-bearing (the test above), but it
+     * left an edit form unable to express an emptied field: the user cleared a
+     * description, the save discarded it, and the old text came back with
+     * nothing said. Property and Observation Profile descriptions could not be
+     * removed at all.
+     */
+    public function testClearEmptiesAStringColumnThatSetWillNotTouch(): void
+    {
+        $s = $this->session();
+        $s->set('medium', 'organic');
+
+        // Precondition: set() cannot do this, which is why clear() exists.
+        $s->set('medium', '');
+        $this->assertSame('organic', $s->get('medium'));
+
+        $s->clear('medium');
+
+        $this->assertSame('', $s->get('medium'),
+            'clear() did not empty the column');
+    }
+
+    /**
+     * ...and marks it dirty, which is the half set() cannot reach: its falsy
+     * guard wraps the markDirty call as well as the assignment, so a value it
+     * skips is never written by update() either.
+     */
+    public function testAClearedColumnIsMarkedDirtySoUpdateWritesIt(): void
+    {
+        $s = $this->session();
+        $s->set('medium', 'organic');
+        $s->clear('medium');
+
+        $this->assertArrayHasKey('medium', $s->dirty,
+            'a cleared column is not dirty, so update() would not write the blank');
+        $this->assertSame('', $s->dirty['medium']);
+    }
+
+    /** clear() on a column the entity does not have is a no-op, not a fatal. */
+    public function testClearIgnoresAnUnknownColumn(): void
+    {
+        $s = $this->session();
+        $s->clear('no_such_column_here');
+
+        $this->assertArrayNotHasKey('no_such_column_here', $s->dirty);
+    }
+
     public function testANumericColumnStillIgnoresEmptyAndNull(): void
     {
         $s = $this->session();

--- a/tests/HelloModuleExampleTest.php
+++ b/tests/HelloModuleExampleTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * The example module has to be an example that works.
+ *
+ * modules/Hello is what a third party copies to start a module, so a shape that
+ * errors there is a shape that gets copied. Its navigation pointed at
+ * hello.reportDashboard and hello.reportSearchterms, neither of which was
+ * registered anywhere -- both links errored, and the module demonstrated
+ * report navigation that cannot work.
+ */
+final class HelloModuleExampleTest extends TestCase
+{
+    private function helloModule()
+    {
+        $service = \OWA\Core\CoreAPI::serviceSingleton();
+
+        foreach ( (array) $service->modules as $module ) {
+
+            if ( $module->name === 'hello' || $module->group === 'hello' ) {
+
+                return $module;
+            }
+        }
+
+        return null;
+    }
+
+    /** Every report the example navigates to is a report it registers. */
+    public function testItsNavigationOnlyNamesReportsItRegisters(): void
+    {
+        $module = $this->helloModule();
+
+        if ( ! $module ) {
+            $this->markTestSkipped( 'the hello module is not active.' );
+        }
+
+        $module->registerReports();
+        $module->registerNavigation();
+
+        // Reports register into the service map, not onto the module.
+        $registered = array_keys( (array) \OWA\Core\CoreAPI::serviceSingleton()->getMap( 'reports' ) );
+
+        $this->assertNotEmpty( $registered,
+            'the example module registers no reports, so its nav has nothing to point at.' );
+
+        $checked = 0;
+
+        foreach ( (array) $module->nav_links as $group ) {
+
+            foreach ( (array) $group as $link ) {
+
+                $ref = $link['ref'] ?? null;
+
+                // A report link is the {do: base.report, reportId: x} shape.
+                if ( ! is_array( $ref ) || ( $ref['do'] ?? '' ) !== 'base.report' ) {
+                    continue;
+                }
+
+                $checked++;
+
+                $this->assertContains( $ref['reportId'], $registered,
+                    "the example module's nav points at report '{$ref['reportId']}', "
+                  . 'which it does not register.' );
+            }
+        }
+
+        $this->assertGreaterThan( 0, $checked,
+            'no report link was examined, so this checked nothing.' );
+    }
+
+    /**
+     * Its report definition is valid.
+     *
+     * A module ships a report as a JSON file, so a malformed one is a runtime
+     * error rather than a parse error at build time.
+     */
+    public function testItsReportDefinitionIsValid(): void
+    {
+        $file = OWA_DIR . 'modules/Hello/reports/hello-dashboard.json';
+
+        $this->assertFileExists( $file );
+
+        $definition = json_decode( (string) file_get_contents( $file ), true );
+
+        $this->assertIsArray( $definition,
+            'the example report is not valid JSON: ' . json_last_error_msg() );
+
+        $this->assertArrayHasKey( 'title', $definition );
+        $this->assertArrayHasKey( 'widgets', $definition );
+        $this->assertNotEmpty( $definition['widgets'] );
+    }
+
+    /**
+     * A nav item drawn without an icon is a nav item that looks broken, and the
+     * template renders the icon element either way.
+     */
+    public function testAReportNavItemGetsAnIconEvenWhenNoneIsNamed(): void
+    {
+        $module = $this->helloModule();
+
+        if ( ! $module ) {
+            $this->markTestSkipped( 'the hello module is not active.' );
+        }
+
+        $module->registerNavigation();
+
+        $checked = 0;
+
+        foreach ( (array) $module->nav_links as $group ) {
+
+            foreach ( (array) $group as $link ) {
+
+                $checked++;
+
+                $this->assertNotSame( '', (string) ( $link['icon_class'] ?? '' ),
+                    'a report nav item registered without an icon got an empty class, '
+                  . 'so the nav draws an empty glyph beside it.' );
+            }
+        }
+
+        $this->assertGreaterThan( 0, $checked, 'no nav link was examined.' );
+    }
+}

--- a/tests/MaxmindOptionsPageTest.php
+++ b/tests/MaxmindOptionsPageTest.php
@@ -57,7 +57,9 @@ final class MaxmindOptionsPageTest extends TestCase {
 
         $this->assertNotSame( '', $html,
             'an empty render is what a template error looks like -- the buffer is discarded' );
-        $this->assertStringContainsString( 'GeoIP Settings', $html );
+        // The heading matches the settings-nav label, which
+        // testTheSettingsNavAndItsPagesAgreeOnTheName keeps true in both places.
+        $this->assertStringContainsString( 'class="panel_headline">GeoIP<', $html );
     }
 
     /**

--- a/tests/MaxmindOptionsPageTest.php
+++ b/tests/MaxmindOptionsPageTest.php
@@ -42,6 +42,14 @@ final class MaxmindOptionsPageTest extends TestCase {
             'db_present'    => false,
             'db_updated'    => 0,
             'has_key'       => true,
+            /*
+             * Supplied by Core\View from the module's registerSettingsPage()
+             * title at render time. This harness drives the Template directly,
+             * so it stands in for that -- and the value is deliberately the
+             * registered one, so the assertion below is checking the page shows
+             * what the nav shows.
+             */
+            'settings_page_title' => 'GeoIP',
         ), $overrides );
 
         foreach ( $data as $key => $value ) {
@@ -59,6 +67,8 @@ final class MaxmindOptionsPageTest extends TestCase {
             'an empty render is what a template error looks like -- the buffer is discarded' );
         // The heading matches the settings-nav label, which
         // testTheSettingsNavAndItsPagesAgreeOnTheName keeps true in both places.
+        // The heading is whatever registerSettingsPage() named the screen; it is
+        // not written into the template, which is what stops it drifting.
         $this->assertStringContainsString( 'class="panel_headline">GeoIP<', $html );
     }
 

--- a/tests/PropertyAdminScreensTest.php
+++ b/tests/PropertyAdminScreensTest.php
@@ -335,6 +335,121 @@ final class PropertyAdminScreensTest extends TestCase
      * so it is not retroactive, and two Profiles disagreeing would put rows of
      * different meanings in one table with nothing recording which.
      */
+    /**
+     * The settings nav and the page it opens call the screen the same thing.
+     *
+     * These drifted apart: the nav said "Main Configuration" and the page said
+     * "General Configuration Options"; the nav said "Modules" and the page said
+     * "Modules Administration". Nothing was wrong except that the reader was
+     * told two names for one screen, which is the kind of thing no one files
+     * and everyone notices.
+     *
+     * The nav side is read from the REGISTRY rather than from source, so this
+     * follows a panel that moves. The page side is read from the view file,
+     * because a headline is set during a render this test does not perform --
+     * and every panel is required to resolve to a file with a headline in it,
+     * so a rename that breaks the pairing fails here instead of quietly
+     * matching nothing.
+     */
+    public function testTheSettingsNavAndItsPagesAgreeOnTheName(): void
+    {
+        $panels = (array) \OWA\Core\CoreAPI::singleton()->getAdminPanels();
+
+        $checked  = 0;
+        $mismatch = array();
+
+        foreach ( $panels as $items ) {
+
+            foreach ( (array) $items as $item ) {
+
+                $action = (string) ( $item['do'] ?? '' );
+                $label  = (string) ( $item['anchortext'] ?? '' );
+
+                if ( $action === '' || $label === '' ) {
+                    continue;
+                }
+
+                list( $module, $name ) = array_pad( explode( '.', $action, 2 ), 2, '' );
+
+                /*
+                 * Both module layouts. Base is PSR-4 (View/Name.php); a
+                 * third-party module may still be flat (NameView.php), which is
+                 * what modules/Hello demonstrates -- and a nav label drifting
+                 * from its page is no less confusing there.
+                 */
+                $dir = OWA_DIR . 'modules/' . \OWA\Core\Lib::moduleDirName( $module ) . '/';
+
+                $candidates = array(
+                    $dir . 'View/' . ucfirst( $name ) . '.php',
+                    $dir . ucfirst( $name ) . 'View.php',
+                );
+
+                $file = '';
+
+                foreach ( $candidates as $candidate ) {
+
+                    if ( file_exists( $candidate ) ) {
+
+                        $file = $candidate;
+                        break;
+                    }
+                }
+
+                $this->assertNotSame( '', $file,
+                    "$action is in the settings nav but no view file was found for it "
+                  . 'in either module layout, so its heading cannot be checked against '
+                  . 'its nav label.' );
+
+                $source = (string) file_get_contents( $file );
+
+                /*
+                 * Two ways a screen names itself, and both are in use: the view
+                 * sets a headline the template echoes, or the template writes
+                 * the panel_headline itself. Checked in that order -- a view
+                 * that sets one is the name that wins at render time.
+                 */
+                $heading = null;
+
+                if ( preg_match( "#set\(\s*'headline'\s*,\s*'([^']*)'#", $source, $m ) ) {
+
+                    $heading = $m[1];
+
+                } else {
+
+                    foreach ( glob( dirname( $file ) . '/../templates/*.php' ) ?: array() as $tpl ) {
+
+                        if ( preg_match( '#class="panel_headline">([^<>]*)<#',
+                                (string) file_get_contents( $tpl ), $m ) ) {
+
+                            $heading = trim( $m[1] );
+                            break;
+                        }
+                    }
+                }
+
+                $this->assertNotNull( $heading,
+                    "$action names itself nowhere -- neither its view nor its template "
+                  . 'gives the screen a heading, so it opens unnamed.' );
+
+                $checked++;
+
+                if ( $heading !== $label ) {
+
+                    $mismatch[] = sprintf(
+                        '%s: nav says "%s", page says "%s"', $action, $label, $heading );
+                }
+            }
+        }
+
+        // Never vacuous: a registry that resolved nothing would otherwise pass.
+        $this->assertGreaterThan( 0, $checked,
+            'no settings-nav panel resolved to a view, so this checked nothing.' );
+
+        $this->assertSame( array(), $mismatch,
+            "The settings nav and the page it opens disagree about the name:\n"
+          . implode( "\n", $mismatch ) );
+    }
+
     public function testTheSettingsNavHoldsOnlyInstallWideOptions(): void
     {
         $panels = (array) \OWA\Core\CoreAPI::singleton()->getAdminPanels();

--- a/tests/PropertyAdminScreensTest.php
+++ b/tests/PropertyAdminScreensTest.php
@@ -487,7 +487,7 @@ final class PropertyAdminScreensTest extends TestCase
         /* My Preferences needs no context either -- it is about the person, not
            about anything in the tree -- so it is present here too, at the head. */
         $this->assertSame(
-            array( 'My Preferences', 'Installation', 'Organization' ), array_keys( $bare ),
+            array( 'My Preferences', 'Instance', 'Organization' ), array_keys( $bare ),
             'A screen with no site in context still offered Property or Profile links, '
             . 'which would point at nothing.' );
 
@@ -501,7 +501,7 @@ final class PropertyAdminScreensTest extends TestCase
         $withProperty = (array) $method->invoke( $controller, '', 'some-property-id' );
 
         $this->assertSame(
-            array( 'My Preferences', 'Installation', 'Organization', 'Property' ),
+            array( 'My Preferences', 'Instance', 'Organization', 'Property' ),
             array_keys( $withProperty ) );
     }
 
@@ -1135,12 +1135,12 @@ final class PropertyAdminScreensTest extends TestCase
             'Your own settings head the nav; they belong to no scope in the tree.' );
 
         $this->assertSame(
-            array( 'Installation', 'Organization' ),
+            array( 'Instance', 'Organization' ),
             array_values( array_diff( $groups, array( 'My Preferences' ) ) ),
             'Install-wide options are the widest scope in the tree, so they head it -- the '
             . 'order reads install, Organization, Property, Profile.' );
 
-        $actions = array_column( $nav['Installation'], 'do' );
+        $actions = array_column( $nav['Instance'], 'do' );
 
         foreach ( array( 'base.optionsGeneral', 'base.optionsModules' ) as $expected ) {
             $this->assertContains( $expected, $actions );
@@ -1190,7 +1190,7 @@ final class PropertyAdminScreensTest extends TestCase
         $view = (string) file_get_contents( OWA_DIR . 'modules/Base/View/OptionsHierarchy.php' );
 
         /* ...and it still says Installation for every screen that names none. */
-        $this->assertStringContainsString( "?: 'Installation'", $view );
+        $this->assertStringContainsString( "?: 'Instance'", $view );
 
         $this->assertStringNotContainsString(
             "hierarchy_tier' ) ?: 3", $view,

--- a/tests/PropertyAdminScreensTest.php
+++ b/tests/PropertyAdminScreensTest.php
@@ -336,118 +336,79 @@ final class PropertyAdminScreensTest extends TestCase
      * different meanings in one table with nothing recording which.
      */
     /**
-     * The settings nav and the page it opens call the screen the same thing.
+     * A settings screen is named ONCE, where it is registered.
      *
-     * These drifted apart: the nav said "Main Configuration" and the page said
-     * "General Configuration Options"; the nav said "Modules" and the page said
-     * "Modules Administration". Nothing was wrong except that the reader was
-     * told two names for one screen, which is the kind of thing no one files
-     * and everyone notices.
+     * The nav label and the page heading used to be declared separately -- an
+     * 'anchortext' in the module and a headline the view set for itself -- so
+     * they drifted apart on four screens. base.optionsGeneral said "Main
+     * Configuration" in the nav and "General Configuration Options" on the
+     * page.
      *
-     * The nav side is read from the REGISTRY rather than from source, so this
-     * follows a panel that moves. The page side is read from the view file,
-     * because a headline is set during a render this test does not perform --
-     * and every panel is required to resolve to a file with a headline in it,
-     * so a rename that breaks the pairing fails here instead of quietly
-     * matching nothing.
+     * registerSettingsPage() takes one title and both consumers read it, so the
+     * fix is structural rather than a rule someone has to remember. This test
+     * enforces the mechanism, not a list of matching strings: a screen that
+     * names itself a second time is the thing that could drift, so that is what
+     * fails here -- even when the two names happen to agree today.
      */
-    public function testTheSettingsNavAndItsPagesAgreeOnTheName(): void
+    public function testASettingsScreenIsNamedOnlyWhereItIsRegistered(): void
     {
         $panels = (array) \OWA\Core\CoreAPI::singleton()->getAdminPanels();
 
-        $checked  = 0;
-        $mismatch = array();
+        $checked   = 0;
+        $untitled  = array();
+        $duplicate = array();
 
         foreach ( $panels as $items ) {
 
             foreach ( (array) $items as $item ) {
 
                 $action = (string) ( $item['do'] ?? '' );
-                $label  = (string) ( $item['anchortext'] ?? '' );
 
-                if ( $action === '' || $label === '' ) {
+                if ( $action === '' ) {
+                    continue;
+                }
+
+                $checked++;
+
+                // The registration is the one place a title may be stated.
+                if ( \OWA\Core\CoreAPI::settingsPageTitle( $action ) === '' ) {
+
+                    $untitled[] = $action;
                     continue;
                 }
 
                 list( $module, $name ) = array_pad( explode( '.', $action, 2 ), 2, '' );
 
-                /*
-                 * Both module layouts. Base is PSR-4 (View/Name.php); a
-                 * third-party module may still be flat (NameView.php), which is
-                 * what modules/Hello demonstrates -- and a nav label drifting
-                 * from its page is no less confusing there.
-                 */
                 $dir = OWA_DIR . 'modules/' . \OWA\Core\Lib::moduleDirName( $module ) . '/';
 
-                $candidates = array(
-                    $dir . 'View/' . ucfirst( $name ) . '.php',
-                    $dir . ucfirst( $name ) . 'View.php',
-                );
+                foreach ( array( $dir . 'View/' . ucfirst( $name ) . '.php',
+                                 $dir . ucfirst( $name ) . 'View.php' ) as $view ) {
 
-                $file = '';
-
-                foreach ( $candidates as $candidate ) {
-
-                    if ( file_exists( $candidate ) ) {
-
-                        $file = $candidate;
-                        break;
+                    if ( ! file_exists( $view ) ) {
+                        continue;
                     }
-                }
 
-                $this->assertNotSame( '', $file,
-                    "$action is in the settings nav but no view file was found for it "
-                  . 'in either module layout, so its heading cannot be checked against '
-                  . 'its nav label.' );
+                    if ( preg_match( "#set\(\s*'headline'#", (string) file_get_contents( $view ) ) ) {
 
-                $source = (string) file_get_contents( $file );
-
-                /*
-                 * Two ways a screen names itself, and both are in use: the view
-                 * sets a headline the template echoes, or the template writes
-                 * the panel_headline itself. Checked in that order -- a view
-                 * that sets one is the name that wins at render time.
-                 */
-                $heading = null;
-
-                if ( preg_match( "#set\(\s*'headline'\s*,\s*'([^']*)'#", $source, $m ) ) {
-
-                    $heading = $m[1];
-
-                } else {
-
-                    foreach ( glob( dirname( $file ) . '/../templates/*.php' ) ?: array() as $tpl ) {
-
-                        if ( preg_match( '#class="panel_headline">([^<>]*)<#',
-                                (string) file_get_contents( $tpl ), $m ) ) {
-
-                            $heading = trim( $m[1] );
-                            break;
-                        }
+                        $duplicate[] = $action . ' (' . basename( $view ) . ' sets its own headline)';
                     }
-                }
-
-                $this->assertNotNull( $heading,
-                    "$action names itself nowhere -- neither its view nor its template "
-                  . 'gives the screen a heading, so it opens unnamed.' );
-
-                $checked++;
-
-                if ( $heading !== $label ) {
-
-                    $mismatch[] = sprintf(
-                        '%s: nav says "%s", page says "%s"', $action, $label, $heading );
                 }
             }
         }
 
         // Never vacuous: a registry that resolved nothing would otherwise pass.
         $this->assertGreaterThan( 0, $checked,
-            'no settings-nav panel resolved to a view, so this checked nothing.' );
+            'no settings panel was found, so this checked nothing.' );
 
-        $this->assertSame( array(), $mismatch,
-            "The settings nav and the page it opens disagree about the name:\n"
-          . implode( "\n", $mismatch ) );
+        $this->assertSame( array(), $untitled,
+            "These settings screens are registered without a title, so the nav has "
+          . "nothing to label them with and the page has nothing to head itself with:\n"
+          . implode( "\n", $untitled ) );
+
+        $this->assertSame( array(), $duplicate,
+            "A settings screen is titled by registerSettingsPage() and nowhere else. "
+          . "These state a second name, which is how the two drifted apart before:\n"
+          . implode( "\n", $duplicate ) );
     }
 
     public function testTheSettingsNavHoldsOnlyInstallWideOptions(): void

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -408,12 +408,27 @@ function declaredReportParams(reportId) {
 }
 
 /**
- * Every report that is configuration, read from disk.
+ * Every report that is configuration AND reachable, read from disk.
  *
  * Enumerated rather than listed so a report added tomorrow is swept without
  * anyone remembering to add it here -- which is the failure mode a hand-written
  * list has.
+ *
+ * Restricted to modules that are ACTIVE. A module registers its reports from
+ * registerReports(), which only runs for modules in the active list, so a
+ * definition shipped by an inactive one is a file on disk and not a report
+ * anybody can open. Sweeping it means waiting twenty seconds for a widget that
+ * was never going to be drawn and calling that a rendering failure -- which is
+ * what happened the first time the example module shipped one.
+ *
+ * base is the only module active on a default install; ACTIVE_MODULES lets a
+ * spec that activates another one sweep its reports too.
  */
+const ACTIVE_MODULES = (process.env.OWA_E2E_ACTIVE_MODULES || 'Base')
+    .split(',')
+    .map((m) => m.trim().toLowerCase())
+    .filter(Boolean);
+
 function configuredReportIds() {
     const fs = require('fs');
     const path = require('path');
@@ -422,6 +437,11 @@ function configuredReportIds() {
     const ids = [];
 
     for (const mod of fs.readdirSync(modules)) {
+
+        if (!ACTIVE_MODULES.includes(mod.toLowerCase())) {
+            continue;
+        }
+
         const dir = path.join(modules, mod, 'reports');
         if (!fs.existsSync(dir)) {
             continue;

--- a/tests/e2e/my-profile.spec.js
+++ b/tests/e2e/my-profile.spec.js
@@ -69,11 +69,11 @@ test.describe('my preferences', () => {
             await page.waitForSelector('form[name=owa_myProfile]', { timeout: 20_000 });
 
             // ...and the settings nav carries it, in a group of its own rather
-            // than filed under Installation with the install-wide screens.
+            // than filed under Instance with the install-wide screens.
             await expect(page.locator('.owa_hierarchyNavHead', { hasText: 'My Preferences' }))
                 .toHaveCount(1);
 
-            const navLink = page.locator('.owa_hierarchyNav a', { hasText: 'Profile' });
+            const navLink = page.locator('.owa_hierarchyNav a', { hasText: 'User Profile' });
 
             await expect(navLink).toHaveCount(1);
             await navLink.click();
@@ -152,7 +152,7 @@ test.describe('my preferences', () => {
         /**
          * An analyst reaches the screen, which is the point of gating it on
          * view_site_list rather than on edit_settings like the rest of the
-         * Installation nav group.
+         * Instance nav group.
          */
         test('an analyst can open it and change their name', async ({ page }) => {
             await openPreferences(page);

--- a/tests/e2e/reporting-dashboard.spec.js
+++ b/tests/e2e/reporting-dashboard.spec.js
@@ -122,33 +122,6 @@ test.describe('reporting dashboard renders (post-migration baseline)', () => {
     });
 
     /**
-     * A grid does not offer a picker for a column nobody can see.
-     *
-     * Top Referrers is grouped by referralPageTitle AND referralPageUrl, with
-     * the title in excludeColumns -- it is there only so the rows can carry it.
-     * The bar drew a picker for it all the same, so a grid showing one column
-     * offered two pickers and the second named a column that is not in the
-     * table.
-     *
-     * This used to be asserted against Top Content, which was the same shape
-     * until it became a grid-card grouped by pagePath alone. A card draws no
-     * explorer bar at all, so it can no longer answer this question.
-     */
-    test('a grid with a hidden dimension shows one picker and a plus', async ({ page }) => {
-        const bars = await page.locator('.owa_reportGridItem').evaluateAll((els) => els.map((e) => ({
-            title: e.querySelector('.owa_reportSectionHeader')?.textContent?.trim(),
-            slots: e.querySelectorAll('.owa_dimSlot').length,
-            add: e.querySelectorAll('.owa_dimAdd').length,
-        })).filter((r) => r.slots || r.add));
-
-        const hidden = bars.find((b) => b.title === 'Top Referrers');
-
-        expect(hidden, 'Top Referrers drew no explorer bar to count pickers on').toBeTruthy();
-        expect(hidden.slots).toBe(1);
-        expect(hidden.add).toBe(1);
-    });
-
-    /**
      * The empty pill beside every report heading.
      *
      * View::get() answers `false` for a key nobody set, so the title-count

--- a/tests/e2e/reporting-widgets.spec.js
+++ b/tests/e2e/reporting-widgets.spec.js
@@ -33,6 +33,42 @@ test.describe('every configured report renders in a browser', () => {
      * the assertion names every offending report rather than dying on the
      * first -- for one login.
      */
+    /**
+     * A grid does not offer a picker for a column nobody can see.
+     *
+     * transactions is grouped by timestamp AND transactionId with timestamp in
+     * excludeColumns -- it is there only so the rows can carry it. The bar drew
+     * a picker for it all the same, so a grid showing one column offered two
+     * pickers and the second named a column that is not in the table.
+     *
+     * transactions rather than action-group, which has the same shape but takes
+     * a parameter: opened with a sentinel it matches nothing and draws no grid
+     * to carry a bar, so it cannot answer this either.
+     *
+     * This has now moved twice, both times because its subject became a
+     * grid-card: first from Top Content, then from Top Referrers. A card draws
+     * no explorer bar at all, so it cannot answer this question -- and the
+     * dashboard no longer has a grid with a hidden dimension on it, which is why
+     * this lives here with the other configured-report checks rather than in the
+     * dashboard spec.
+     */
+    test('a grid with a hidden dimension shows one picker and a plus', async ({ page }) => {
+
+        await login(page);
+        await openConfiguredReport(page, { reportId: 'transactions' });
+
+        const bars = await page.locator('.owa_reportGridItem').evaluateAll((els) => els.map((e) => ({
+            slots: e.querySelectorAll('.owa_dimSlot').length,
+            add: e.querySelectorAll('.owa_dimAdd').length,
+        })).filter((r) => r.slots || r.add));
+
+        expect(bars.length, 'transactions drew no explorer bar to count pickers on')
+            .toBeGreaterThan(0);
+
+        expect(bars[0].slots).toBe(1);
+        expect(bars[0].add).toBe(1);
+    });
+
     test('no configured report raises a browser console error', async ({ page }) => {
         test.setTimeout(300_000);
 

--- a/tests/fixtures/report-render.json
+++ b/tests/fixtures/report-render.json
@@ -1258,7 +1258,7 @@
                 "var": "topReferrersurl",
                 "query": {
                     "constraints": "medium==referral",
-                    "dimensions": "referralPageTitle,referralPageUrl",
+                    "dimensions": "referralPageUrl",
                     "do": "reports",
                     "format": "json",
                     "metrics": "visits",
@@ -1274,10 +1274,10 @@
             {
                 "var": "latestVisitsurl",
                 "query": {
-                    "dimensions": "ipAddress,entryPagePath,medium,source,city,country,priorVisitCount",
+                    "dimensions": "ipAddress,hostName,entryPagePath,medium,source,city,country,priorVisitCount",
                     "do": "reports",
                     "format": "json",
-                    "metrics": "visits,pagesPerVisit,visitDuration",
+                    "metrics": "pagesPerVisit,visitDuration",
                     "module": "base",
                     "nonce": "<nonce>",
                     "period": "last_thirty_days",


### PR DESCRIPTION
Four commits. Two are bugs found while making the requested changes.

### `fix` — two things wrong with editing an Observation Profile

**The description could not be removed.** Clearing the field and saving left the
old text in place, on Profiles and Properties alike, with nothing said.

`Entity::set()` discards `''` on a string column *deliberately* — handlers rely
on `set('medium', $maybeEmpty)` leaving the existing value alone. But the falsy
guard wraps the `markDirty` call as well as the assignment, so a skipped value
is never written by `update()` either, and an edit form had no way to express
"this is now blank". `Entity::clear()` is that way — narrow, rather than
loosening `set()` for every caller.

Mutation-checked: implementing `clear()` as a plain `set('')` fails two of the
three new tests.

**A rename threw the screen away.** `SitesEdit` redirected to
`base.reportingHome` after every save, dropping you on the dashboard. Its two
sibling editors both return to `base.sitesProfile`; this now does too.

### `fix` — settings screens rendered without their chrome assets

The top nav's icons and menus did not draw on any settings screen.

Reporting views load font-awesome and `owa.reporting-css-combined.css`.
`OptionsHierarchy` loaded neither, and draws the same header. The nav icons
**are** font-awesome classes (`fa fa-tachometer-alt`), so without that
stylesheet they render as nothing — and the combined file carries `owa.css`,
the base styles the header is built on. Loading `owa.admin.css` and
`owa.report.css` individually is not enough.

### Dashboard widgets

**Top Referrers** is a `grid-card`. That required dropping `referralPageTitle`
from its query — a card is one metric against one dimension, which
`ReportDefinitionFormatTest` enforces and which caught this. The column was
fetched and then listed in `excludeColumns`, and appears nowhere else in the
tree, so it was read from the database purely to be discarded.

**Latest Visits** drops the `visits` metric and gains `hostName` after
`ipAddress`. The sort stays `visits-` — sort names resolve through the metric
registry rather than the query's selected metrics, so ordering is unchanged by
the metric no longer being displayed. The render golden's diff is those three
lines and nothing else.

### Admin UI labels and copy

- Settings nav: **Profile → User Profile**, **Installation → Instance** group.
  The breadcrumb root follows the group; the install wizard's own page title is
  a different thing and is untouched.
- My Profile: the intro and the Username/Role descriptions are cut — both only
  restated their label, and those fields say they are read-only by not being
  editable. The password description keeps the three things that matter and
  drops the rest.
- The three password boxes were bare `div`s with no rule between them, stacked
  edge to edge. They are one control, so they are spaced as a group now.
- **Delete confirmations, audited as a set.** They had drifted long, each
  explaining archiving from scratch. One shape now — what stops, what is kept —
  and the two that are genuinely *not* recoverable (user, custom report) still
  say so plainly.

### Verification

| | |
|---|---|
| `phpunit` | 2000 tests, 48485 assertions, 2 skipped |
| `phpstan` / `:templates` / `:migration` | No errors |
| `jest` | 49 suites, 566 tests |