### PR TITLE
Tell people what an unbuilt download is missing, instead of a blank 500

### DIFF
--- a/Core/Db/Pdo.php
+++ b/Core/Db/Pdo.php
@@ -209,8 +209,8 @@ abstract class Pdo extends \OWA\Core\Db
                  *
                  * PDO binds what it is given; MySQL then reports a type error
                  * against whichever column happens to line up with a misplaced
-                 * value -- "Incorrect integer value: 'ludhiana' for column
-                 * 'is_browser'" is what that looks like from the log, with
+                 * value -- an "Incorrect integer value" naming a column that was
+                 * never sent a string is what that looks like from the log, with
                  * nothing to say the values were offset rather than the data
                  * bad. Worse, an offset that lands a string in another string
                  * column raises nothing at all and writes the wrong value.

--- a/Core/Template.php
+++ b/Core/Template.php
@@ -791,6 +791,69 @@ class Template extends TemplateEngine {
 
     }
 
+    /**
+     * Whether the webpack build has produced the public/ asset tree.
+     *
+     * public/ is gitignored and built by 'npm run build', so a source checkout
+     * -- or the GitHub "Source code" archive rather than the packaged release
+     * tarball -- has none of it. Every makeImageLink() target then 404s, which
+     * is how an unbuilt install shows up on screen: a broken logo on every page
+     * including the installer's own.
+     *
+     * The same directory the installer's environment check tests, deliberately:
+     * modules/Base/Controller/InstallCheckEnv.php reads this method rather than
+     * repeating the path, so "built" cannot come to mean two different things.
+     *
+     * @return bool
+     */
+    public static function assetsAreBuilt() {
+
+        static $built = null;
+
+        if ( $built === null ) {
+
+            $built = is_dir( OWA_DIR . 'public/base/dist' );
+        }
+
+        return $built;
+    }
+
+    /**
+     * makeImageLink(), but only when the file is actually there.
+     *
+     * Answers false instead of a URL so a template can fall back to text rather
+     * than emit a broken <img>. Checks the build first because that is the
+     * common cause and costs one cached stat; the per-file test then also
+     * catches a logo_image_path pointing at something that was never there.
+     *
+     * @param string $path
+     * @param bool $absolute
+     * @return string|false
+     */
+    function makeImageLinkIfPresent( $path, $absolute = false ) {
+
+        if ( ! $path || ! self::assetsAreBuilt() ) {
+
+            return false;
+        }
+
+        $public_path = \OWA\Core\CoreAPI::getSetting( 'base', 'public_path' );
+
+        if ( ! $public_path ) {
+
+            $public_path = OWA_DIR . 'public/';
+        }
+
+        $file = rtrim( $public_path, '/' ) . '/' . ltrim( $path, '/' );
+
+        if ( ! is_readable( $file ) ) {
+
+            return false;
+        }
+
+        return $this->makeImageLink( $path, $absolute );
+    }
+
     function includeTemplate($file) {
 
         $this->set_template($file);

--- a/Core/ViewScope.php
+++ b/Core/ViewScope.php
@@ -84,6 +84,7 @@ namespace OWA\Core;
  * @method mixed makeAbsoluteLink($params = [], $add_state = false, $url = '', $xml = false)
  * @method mixed makeApiLink($params = [], $add_state = false, $add_apiKey = false)
  * @method mixed makeImageLink($path, $absolute = false)
+ * @method string|false makeImageLinkIfPresent($path, $absolute = false)
  * @method mixed makeJson($array)
  * @method mixed makeLink($params = [], $add_state = false, $url = '', $xml = false, $add_nonce = false)
  * @method mixed makeNavigationMenu($links, $currentSiteId, $current = '')

--- a/log.php
+++ b/log.php
@@ -99,11 +99,10 @@ if ( $owa->isEndpointEnabled( basename( __FILE__ ) ) ) {
     /*
      * Parameters naming a property the server computes are dropped here.
      *
-     * These were copied onto the event wholesale, so any parameter whose name
-     * matched a column was written to that column -- a request carrying
-     * owa_is_browser=ludhiana put a city name into a boolean column, and
-     * owa_ip_address or owa_timestamp would have replaced the observed values
-     * that IP exclusion and event ordering depend on.
+     * A tracking request is untrusted input, and a property the server derives
+     * for itself is the server's to set: a request naming one must not be able
+     * to replace it. TrackingEventHelpers::serverOwnedProperties() is that
+     * list, assembled from what the modules register.
      *
      * Unregistered names still pass through: this refuses to let a request
      * OVERWRITE a derivation, it does not restrict what a site may send. Custom

--- a/modules/Base/Classes/Error.php
+++ b/modules/Base/Classes/Error.php
@@ -48,9 +48,19 @@ class Error {
     /**
      * logger instance
      *
-     * @var array
+     * Constructed lazily -- see logger(). Null until something is actually
+     * logged, and null forever on an installation whose vendor/ is missing.
+     *
+     * @var \Monolog\Logger|null
      */
     var $logger;
+
+    /**
+     * Whether the log handlers have been attached to the logger yet.
+     *
+     * @var bool
+     */
+    private $handlers_attached = false;
     
     /**
      * Buffered Msgs
@@ -66,8 +76,6 @@ class Error {
      *
      */
     function __construct() {
-		
-		$this->logger = new Logger('errors');
 		
 /*
 		if ( owa_lib::inDebug() ) {
@@ -91,50 +99,91 @@ class Error {
     // This is called by a client after the owas global config object has been created.
     public function setHandler($type) {
 
-        switch ($type) {
-            case "development":
-                $this->createDevelopmentHandler();
-                break;
-            case "production":
-                $this->createProductionHandler();
-                break;
-            default:
-                $this->createProductionHandler();
+        /*
+         * Do not build the log handlers here.
+         *
+         * Attaching a handler means constructing Monolog objects, and Monolog
+         * is a Composer package: on a source checkout with no vendor/ that is a
+         * fatal during boot, which is why an unbuilt download used to answer
+         * every request with a blank 500 instead of the installer's environment
+         * check saying so. Nothing here needs a logger, so nothing here builds
+         * one -- logger() does, on the first message that is actually written.
+         *
+         * The rest of what these handlers set up is not Monolog's and stays
+         * eager, because it has to be in place before the next line of code
+         * runs, not before the next message is logged.
+         */
+        if ( $type === 'development' ) {
+
+            $this->logPhpErrors();
         }
+
+        set_exception_handler( [ $this, 'handleUncaughtException' ] );
 
         $this->init = true;
         $this->logBufferedMsgs();
     }
 
-    function createDevelopmentHandler() {
-		
-		$this->logPhpErrors();
-		
-        // make file logger
-        $this->make_file_logger();
-        
-        // if the CLI is in use, also make a console logger
-        if ( defined('OWA_CLI') ) {
+    /**
+     * The logger, built on first use.
+     *
+     * Answers null when Monolog is not installed, which is the whole point:
+     * every caller below treats "no logger" as "do not log" rather than as an
+     * error. An installation in that state cannot write a log file, but it can
+     * still render the page that explains why -- see
+     * modules/Base/Controller/InstallCheckEnv.php.
+     *
+     * @return \Monolog\Logger|null
+     */
+    private function logger() {
 
-            $this->make_console_logger();
+        if ( ! class_exists( Logger::class ) ) {
+
+            return null;
         }
-        
+
+        if ( ! $this->logger ) {
+
+            $this->logger = new Logger( 'errors' );
+        }
+
+        if ( ! $this->handlers_attached ) {
+
+            // Before the handlers, so a handler that logs cannot recurse into
+            // this method and attach a second copy of everything.
+            $this->handlers_attached = true;
+
+            $this->make_file_logger();
+
+            // if the CLI is in use, also make a console logger
+            if ( defined( 'OWA_CLI' ) ) {
+
+                $this->make_console_logger();
+            }
+        }
+
+        return $this->logger;
+    }
+
+    /**
+     * Kept for callers that want the handlers attached now rather than on the
+     * first message. Both builders route through logger(), so the attachment
+     * happens exactly once however it is reached.
+     */
+    function createDevelopmentHandler() {
+
+        $this->logPhpErrors();
+
         set_exception_handler( [ $this, 'handleUncaughtException' ] );
 
+        $this->logger();
     }
 
     function createProductionHandler() {
 
-        // make file logger
-        $this->make_file_logger();
-        
-        // if the CLI is in use, also make a console logger
-        if ( defined('OWA_CLI') ) {
-
-            $this->make_console_logger();
-        }
-
         set_exception_handler( [ $this, 'handleUncaughtException' ] );
+
+        $this->logger();
     }
 
     /**
@@ -235,48 +284,61 @@ class Error {
 
             $msg = print_r( $msg, true );
         }
+
+        /*
+         * No Monolog, no log file. An installation missing vendor/ cannot write
+         * one, and saying so is the installer's job -- not this method's, which
+         * runs long before there is a page to say it on. Dropping the message is
+         * what lets the environment check render and name the real problem.
+         */
+        $logger = $this->logger();
+
+        if ( ! $logger ) {
+
+            return;
+        }
         
         switch ( $priority ) {
 	        
 	        case 'debug':
 	        	
-	        	$this->logger->debug( $msg );
+	        	$logger->debug( $msg );
 	        	
 	        	break;
 	        	
 	        case 'info':
 	        	
-	        	$this->logger->info( $msg );
+	        	$logger->info( $msg );
 	        	break;
 	        	
 	        case 'notice':
 	        
-	        	$this->logger->notice( $msg );
+	        	$logger->notice( $msg );
 	        	break;
 	        	
 	        case 'warning':
 	        	
-	        	$this->logger->warning( $msg );
+	        	$logger->warning( $msg );
 	        	break;
 	        	
 	        case 'error':
 	        	
-	        	$this->logger->error( $msg );
+	        	$logger->error( $msg );
 	        	break;
 	        	
 	        case 'critical':
 	        
-	        	$this->logger->critical( $msg );
+	        	$logger->critical( $msg );
 	        	break;
 	        	
 	        case 'alert':
 	        	
-	        	$this->logger->alert( $msg );
+	        	$logger->alert( $msg );
 	        	break;
 	        	
 	        case 'emergency':
 	        	
-	        	$this->logger->emergency( $msg );
+	        	$logger->emergency( $msg );
 	        	break;
         }
     }
@@ -328,7 +390,12 @@ class Error {
 	   $stream->setFormatter( $formatter );
 	   
 	   // add the stream hadnler to the logger
-       $this->logger->pushHandler( $stream );
+       $logger = $this->logger();
+
+       if ( $logger ) {
+
+           $logger->pushHandler( $stream );
+       }
     }
     
     function getLogLevel() {
@@ -392,7 +459,12 @@ class Error {
 		$stream->setFormatter($formatter);
 
 		// add stream handler to logger
-		$this->logger->pushHandler($stream);
+		$logger = $this->logger();
+
+		if ( $logger ) {
+
+			$logger->pushHandler( $stream );
+		}
     }
 
     /**

--- a/modules/Base/Classes/TrackingEventHelpers.php
+++ b/modules/Base/Classes/TrackingEventHelpers.php
@@ -77,11 +77,9 @@ class TrackingEventHelpers {
     /**
      * The properties a tracking request is allowed to set.
      *
-     * A request reaches log.php with arbitrary owa_* parameters and they used
-     * to be copied onto the event wholesale, so anything whose name matched a
-     * column was written to that column -- owa_is_browser=ludhiana put a city
-     * name in a boolean, and owa_ip_address would have replaced the observed
-     * one.
+     * A request reaches log.php carrying arbitrary owa_* parameters, so what a
+     * request may set has to be decided here, deliberately, rather than by
+     * whether a parameter's name happens to match a column.
      *
      * Membership is DECLARED, not inferred from which map a property lives in.
      * `regular` is client-set by definition, but the classification is not a

--- a/modules/Base/Controller/InstallCheckEnv.php
+++ b/modules/Base/Controller/InstallCheckEnv.php
@@ -156,10 +156,12 @@ class InstallCheckEnv extends \OWA\Core\Controller\Install {
          * public/base/dist, and public/ is gitignored -- so a fresh source
          * checkout has none of it until 'npm run build' runs.
          */
+        $built = \OWA\Core\Template::assetsAreBuilt();
+
         $checks[] = $this->check(
             'Built assets',
-            is_dir( OWA_DIR . 'public/base/dist' ) ? 'built' : 'missing',
-            is_dir( OWA_DIR . 'public/base/dist' ),
+            $built ? 'built' : 'missing',
+            $built,
             "Run 'npm run build' in the top level OWA directory." );
 
         /*

--- a/modules/Base/Controller/ProcessEvent.php
+++ b/modules/Base/Controller/ProcessEvent.php
@@ -99,11 +99,10 @@ class ProcessEvent extends \OWA\Core\Controller {
          * re-apply at the end of this method put it back on top of the value
          * the derivation had just computed.
          *
-         * That is how a tracking request carrying owa_is_browser=ludhiana ended
-         * up writing 'ludhiana' into a boolean column: the derivation ran
-         * correctly and was then undone. Environmental properties -- ip_address,
-         * timestamp -- were overwritable the same way, which is the more
-         * serious half.
+         * The derivation ran correctly and was then undone, so a value sent
+         * with the request reached a column only the server should decide.
+         * Environmental properties were reachable the same way, which is the
+         * more serious half.
          */
         $protected = $properties + $teh->serverOwnedProperties();
 

--- a/modules/Base/View/InstallCheckEnv.php
+++ b/modules/Base/View/InstallCheckEnv.php
@@ -35,6 +35,10 @@ class InstallCheckEnv extends \OWA\Core\View {
 
         //page title
         $this->t->set('page_title', 'Server Environment Check');
+        // Both, not just the failures: the template lists every check so that
+        // "looked at and fine" is distinguishable from "never looked at", and
+        // reading an unset view var is fatal rather than empty.
+        $this->body->set('checks', $this->get('checks'));
         $this->body->set('errors', $this->get('errors'));
         // load body template
         $this->body->set_template('install_check_env.php');

--- a/modules/Base/templates/header.php
+++ b/modules/Base/templates/header.php
@@ -1,7 +1,8 @@
 <?php /** @var \OWA\Core\ViewScope $view */ ?>
 <div id="owa_header">
 
-    <span class="owa_logo"><img src="<?php echo $view->makeImageLink( \OWA\Core\CoreAPI::getSetting( 'base', 'logo_image_path' ) ); ?>" alt="Open Web Analytics"></span>
+    <?php $owa_logo = $view->makeImageLinkIfPresent( \OWA\Core\CoreAPI::getSetting( 'base', 'logo_image_path' ) ); ?>
+    <span class="owa_logo"><?php if ( $owa_logo ): ?><img src="<?php echo $owa_logo; ?>" alt="Open Web Analytics"><?php else: ?>Open Web Analytics<?php endif; ?></span>
      &nbsp
     <span class="owa_navigation">
         <UL>

--- a/modules/Base/templates/wrapper_public.php
+++ b/modules/Base/templates/wrapper_public.php
@@ -34,9 +34,13 @@
                  * way in.
                  */
             ?>
+            <?php $owa_logo = $view->makeImageLinkIfPresent( \OWA\Core\CoreAPI::getSetting( 'base', 'logo_image_path' ) ); ?>
             <div class="owa_publicLogo">
-                <img src="<?php echo $view->makeImageLink( \OWA\Core\CoreAPI::getSetting( 'base', 'logo_image_path' ) ); ?>"
-                     alt="Open Web Analytics">
+                <?php if ( $owa_logo ): ?>
+                    <img src="<?php echo $owa_logo; ?>" alt="Open Web Analytics">
+                <?php else: ?>
+                    <span class="owa_publicLogoText">Open Web Analytics</span>
+                <?php endif; ?>
             </div>
 
             <div class="owa_publicMain">

--- a/owa_env.php
+++ b/owa_env.php
@@ -47,6 +47,50 @@ define('OWA_VENDOR_DIR', OWA_DIR.'vendor/');
 if ( file_exists( OWA_VENDOR_DIR . 'autoload.php' ) ) {
 
 	require_once ( OWA_VENDOR_DIR . 'autoload.php' );
+
+} else {
+
+	/*
+	 * No vendor/ -- a source checkout, or the GitHub "Source code" archive
+	 * rather than the packaged release tarball.
+	 *
+	 * OWA's own classes are loaded by Composer's PSR-4 map, so without an
+	 * autoloader the very next file fatals on `class owa extends
+	 * \OWA\Core\Caller` and every request answers with a blank 500. That
+	 * included install.php, whose environment check exists precisely to say
+	 * "Dependencies: missing -- run composer install": it could never run.
+	 *
+	 * This registers the same two PSR-4 prefixes composer.json declares, for
+	 * OWA's own code only. It deliberately does NOT stand in for the packages
+	 * in vendor/; it boots far enough to reach the screen that explains they
+	 * are missing. The one package on that path is Monolog, which
+	 * modules/Base/Classes/Error.php now builds lazily for this reason.
+	 */
+	spl_autoload_register( function ( $class ) {
+
+		$prefixes = array(
+			'OWA\\Core\\'   => OWA_DIR . 'Core/',
+			'OWA\\Module\\' => OWA_DIR . 'modules/',
+		);
+
+		foreach ( $prefixes as $prefix => $base_dir ) {
+
+			if ( strncmp( $class, $prefix, strlen( $prefix ) ) !== 0 ) {
+
+				continue;
+			}
+
+			$relative = substr( $class, strlen( $prefix ) );
+			$file     = $base_dir . str_replace( '\\', '/', $relative ) . '.php';
+
+			if ( is_readable( $file ) ) {
+
+				require_once $file;
+			}
+
+			return;
+		}
+	} );
 }
 
 // Backward-compat bridge for the PSR-4 namespace migration. Registers a LAZY

--- a/tests/SourceCheckoutInstallTest.php
+++ b/tests/SourceCheckoutInstallTest.php
@@ -1,0 +1,198 @@
+<?php
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An unbuilt download must SAY what is missing, not answer with a blank 500.
+ *
+ * WHY IT MATTERS
+ * A GitHub release page offers three downloads: the packaged tarball, which
+ * carries vendor/ and public/, and the two "Source code" archives, which carry
+ * neither and cannot be run as they are. People take the source archive, and
+ * what OWA did about it was nothing visible -- every entry point, install.php
+ * included, answered 500 with an empty body:
+ *
+ *   PHP Fatal error: Uncaught Error: Class "OWA\Core\Caller" not found in owa.php:19
+ *
+ * OWA's own classes load through Composer's PSR-4 map, so with no vendor/ the
+ * autoloader that would find them is the thing that is missing. The installer
+ * has had a "Dependencies: missing -- run composer install" check the whole
+ * time (modules/Base/Controller/InstallCheckEnv.php); it could never run,
+ * because reaching it needed the autoloader it was there to ask about.
+ *
+ * Three things had to be true for that screen to render, and this test pins all
+ * three, because each fails silently and none is covered by booting normally:
+ *
+ *   1. owa_env.php registers a fallback PSR-4 autoloader for OWA's own classes.
+ *   2. Nothing on the boot path REQUIRES a Composer package. Monolog was the
+ *      only one -- constructed eagerly in Error::__construct() -- and is now
+ *      built lazily. A single new `use` of a vendor class on this path puts the
+ *      blank 500 back, which is exactly what this test is here to catch.
+ *   3. The environment check screen renders at all. It reads $view->checks, and
+ *      the view forwarded only $view->errors, so ANY failing check was a fatal.
+ *
+ * HOW IT IS RUN
+ * OWA_PATH is pre-defined to a directory of symlinks holding everything the
+ * real tree has EXCEPT vendor/ and public/. owa_env.php derives every other
+ * path from OWA_PATH and only falls back to __DIR__ when it is not already
+ * defined, so the installer boots believing it lives somewhere with no
+ * dependencies and no built assets -- without copying the tree or touching it.
+ */
+final class SourceCheckoutInstallTest extends TestCase
+{
+    /**
+     * What a source checkout does NOT have, plus what this fake root supplies
+     * itself. Everything else in the repository root is linked in as-is, rather
+     * than listed here: a list of what to include goes stale silently the next
+     * time the tree gains a directory, and the failure would look like this
+     * test finding a bug.
+     */
+    private const OMITTED = [
+        '.', '..', '.git',
+        'vendor', 'public',          // the two the packaged tarball carries
+        'node_modules', 'test-results', 'playwright-report', '.phpunit.cache',
+        'owa-data',                  // created for real below
+        'owa-config.php',            // a fresh install has none
+    ];
+
+    private string $fake = '';
+
+    private function root(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    protected function setUp(): void
+    {
+        $this->fake = sys_get_temp_dir() . '/owa-src-checkout-' . getmypid() . '-' . uniqid();
+
+        if ( ! mkdir( $this->fake, 0777, true ) ) {
+            $this->fail( 'could not create the fake install root' );
+        }
+
+        $entries = scandir( $this->root() );
+
+        foreach ( $entries as $entry ) {
+
+            if ( in_array( $entry, self::OMITTED, true ) ) {
+
+                continue;
+            }
+
+            symlink( $this->root() . '/' . $entry, $this->fake . '/' . $entry );
+        }
+
+        // The pieces the installer must find, whatever else the tree holds.
+        foreach ( [ 'Core', 'modules', 'owa.php', 'owa_env.php' ] as $needed ) {
+
+            $this->assertFileExists( $this->fake . '/' . $needed,
+                $needed . ' must be present for the installer to boot' );
+        }
+
+        // Real directories: the installer checks these are writable, and the
+        // logger would write into them if it had a logger to write with.
+        mkdir( $this->fake . '/owa-data/logs', 0777, true );
+        mkdir( $this->fake . '/owa-data/caches', 0777, true );
+    }
+
+    protected function tearDown(): void
+    {
+        if ( $this->fake && is_dir( $this->fake ) ) {
+            exec( 'rm -rf ' . escapeshellarg( $this->fake ) );
+        }
+    }
+
+    /**
+     * Run install.php as the installer, from a root with no vendor/ or public/.
+     */
+    private function runInstaller( string $do ): string
+    {
+        $script = sprintf(
+            'define("OWA_PATH", %s);' .
+            '$_GET["do"] = %s;' .
+            '$_SERVER["REQUEST_METHOD"] = "GET";' .
+            '$_SERVER["SCRIPT_NAME"] = "/install.php";' .
+            '$_SERVER["HTTP_HOST"] = "localhost";' .
+            '$_SERVER["SERVER_NAME"] = "localhost";' .
+            '$_SERVER["SERVER_PORT"] = "80";' .
+            '$_SERVER["REQUEST_URI"] = "/install.php";' .
+            'include %s;',
+            var_export( $this->fake, true ),
+            var_export( $do, true ),
+            var_export( $this->root() . '/install.php', true )
+        );
+
+        return (string) shell_exec(
+            escapeshellarg( PHP_BINARY ) . ' -d error_reporting=E_ALL -r ' . escapeshellarg( $script ) . ' 2>&1'
+        );
+    }
+
+    public function testTheInstallerBootsWithoutVendorOrPublic(): void
+    {
+        $this->assertDirectoryDoesNotExist( $this->fake . '/vendor' );
+        $this->assertDirectoryDoesNotExist( $this->fake . '/public' );
+
+        $out = $this->runInstaller( 'base.installStart' );
+
+        $this->assertStringNotContainsString( 'Fatal error', $out,
+            'install.php must not fatal on a source checkout; got: ' . substr( $out, 0, 400 ) );
+
+        $this->assertStringNotContainsString( 'Class "OWA\Core\Caller" not found', $out,
+            'the fallback PSR-4 autoloader in owa_env.php is not registering' );
+
+        $this->assertStringContainsString( 'Install Open Web Analytics', $out,
+            'the installer should render its start screen' );
+    }
+
+    /**
+     * The screen must NAME both problems. This is the whole point: a person who
+     * downloaded the wrong archive has to be told which command to run.
+     */
+    public function testTheEnvironmentCheckNamesBothMissingPieces(): void
+    {
+        $out = $this->runInstaller( 'base.installCheckEnv' );
+
+        $this->assertStringNotContainsString( 'Fatal error', $out,
+            'the environment check must render, not fatal; got: ' . substr( $out, 0, 400 ) );
+
+        $this->assertStringContainsString( 'Dependencies', $out );
+        $this->assertStringContainsString( 'composer install', $out,
+            'the missing vendor/ must be reported with its remedy' );
+
+        $this->assertStringContainsString( 'Built assets', $out );
+        $this->assertStringContainsString( 'npm run build', $out,
+            'the missing public/ must be reported with its remedy' );
+    }
+
+    /**
+     * Every check is listed, not just the failures -- which is what $view->checks
+     * carries. If the view stops forwarding it the screen fatals, so assert on a
+     * check that PASSES: its presence proves the full list rendered.
+     */
+    public function testTheScreenListsPassingChecksToo(): void
+    {
+        $out = $this->runInstaller( 'base.installCheckEnv' );
+
+        $this->assertStringContainsString( 'PHP version', $out,
+            '$view->checks is not reaching the template' );
+
+        $this->assertStringContainsString( 'Database driver', $out );
+    }
+
+    /**
+     * With no public/ there is no logo file, and an <img> pointing at one is a
+     * broken image on every install screen. It must degrade to text instead.
+     */
+    public function testTheLogoDegradesToTextWhenAssetsAreNotBuilt(): void
+    {
+        $out = $this->runInstaller( 'base.installCheckEnv' );
+
+        $this->assertStringNotContainsString( 'owa-logo-100w.png', $out,
+            'the logo <img> must not be emitted when public/ was never built' );
+
+        $this->assertStringContainsString( 'Open Web Analytics', $out,
+            'the name should still appear, as text' );
+    }
+}


### PR DESCRIPTION
## The problem

A GitHub release page offers three downloads. `owa_<version>_packaged.tar` carries `vendor/` and `public/`; the two GitHub-generated "Source code" archives carry neither. People take the source archive, and OWA said nothing about it — `install.php`, `index.php` and `log.php` all answered **500 with an empty body**:

```
PHP Fatal error: Uncaught Error: Class "OWA\Core\Caller" not found in owa.php:19
```

`owa_env.php` already guards its `require` of `vendor/autoload.php` with `file_exists()`, so that is not where it dies. It dies one file later, because OWA's own classes load through Composer's PSR-4 map — the autoloader that would find them is the thing that is missing.

The installer has had the right check the whole time. `InstallCheckEnv` tests `is_dir( OWA_VENDOR_DIR )` and answers *"Dependencies: missing — run `composer install`"*, and tests `public/base/dist` and answers *"run `npm run build`"*. Neither could ever be seen: reaching that screen needed the autoloader it was there to ask about.

## What it does now

<img> — a bare source checkout, both directories absent:

```
2 things need fixing before OWA can be installed.
  ✓ PHP version 8.2.33      ✓ Database driver   ✓ json / mbstring / pcre
  ✓ Log directory           ✓ Cache directory   ✓ Configuration file
  ✗ Dependencies   missing  Run 'composer install' in the top level OWA directory.
  ✗ Built assets   missing  Run 'npm run build' in the top level OWA directory.
```

## Three separate things were false

**1. No autoloader.** `owa_env.php` now registers a fallback PSR-4 loader for the two prefixes `composer.json` declares, for OWA's own code only. It does not stand in for anything in `vendor/`; it boots far enough to reach the screen that explains `vendor/` is missing.

**2. Something on the boot path required a Composer package.** Measured, not assumed — an instrumented install request touches five `vendor/` entries, three of them Composer's own autoloader and one a dev-only phpstan phar. The only runtime library is **Monolog**, constructed eagerly in `Error::__construct()` and then handed `StreamHandler` and `LineFormatter` by `setHandler()`. It is now built on first use, and `logger()` answers `null` when Monolog is absent, which every caller treats as "do not log". Such an installation cannot write a log file; it can render the page that says why. Guzzle, PHPMailer, `symfony/*` and ua-parser are declared by the module `composer.json` files and are never loaded during install.

**3. The environment check screen never rendered.** The controller sets both `checks` and `errors`; `View/InstallCheckEnv` forwarded only `errors`, and `install_check_env.php` reads `$view->checks`. Reading an unset view var throws — so **any** failing check was a blank 500, not just this one. A non-writable log directory or a missing `mbstring` produced the same white page. The controller grew `checks` when the screen changed to list every check rather than only the failures; the view was not updated with it.

## Also

With no `public/` there is no logo file either, so every install screen — and the whole signed-in UI — carried a broken `<img>`. Both call sites go through `makeImageLinkIfPresent()` and fall back to text. Its first test is `Template::assetsAreBuilt()`, which `InstallCheckEnv` now reads too, so "built" is defined in one place instead of a path literal repeated in two.

The second commit removes a worked reproduction of the parameter-overwrite bug (a named parameter, its triggering value, the column it landed in) from four comments in shipped code. The comments still say what the code does and why; the tests keep the concrete case, where it belongs.

## Testing

`tests/SourceCheckoutInstallTest.php` builds a root of symlinks holding everything except `vendor/` and `public/` and runs `install.php` against it, asserting the screen names both problems with both remedies.

Point 2 above is the fragile one — a single new `use` of a vendor class on the boot path puts the blank 500 straight back, silently — and this test is what catches it.

- Full suite: 1981 tests, 48444 assertions, 2 skipped, green
- Configless (CI-shaped, no database): green, and the new test executes rather than skipping
- `composer phpstan` and `composer phpstan:templates`: no errors
- Mutation-checked: removing the fallback autoloader (4 failures), restoring eager Monolog (4), dropping the `checks` forward (3), and un-guarding the logo (1) each fail the suite