### PR TITLE
cmd=instance-info: one report describing the whole instance

### DIFF
--- a/modules/Base/Classes/EnvironmentCheck.php
+++ b/modules/Base/Classes/EnvironmentCheck.php
@@ -1,0 +1,171 @@
+<?php
+namespace OWA\Module\Base\Classes;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * What this server has to provide before OWA can run.
+ *
+ * Extracted from InstallCheckEnv so the installer and `cmd=instance-info` ask
+ * the same questions. They were the same questions in two places for about ten
+ * minutes, which is how long it takes for the two to start disagreeing about
+ * what "supported" means -- and the disagreement is invisible, because nobody
+ * runs the installer on a working instance or the diagnostic on a fresh one.
+ *
+ * Each check answers a name, what was found, whether that passes, and what to
+ * do about it. The remedy travels with the check rather than being looked up by
+ * the caller: a check that cannot say how to fix itself is a check that gets
+ * reported as "failed" and no more.
+ */
+class EnvironmentCheck {
+
+    /**
+     * The lowest PHP this release runs on. The same number composer.json requires.
+     */
+    const MIN_PHP_VERSION = '8.2';
+
+    /**
+     * Extensions OWA cannot run without, and what each is for.
+     *
+     * Checked because the alternative is finding out later and worse: with no
+     * database driver the installer takes a full page of connection details and
+     * then fails on connect, which reads as "my credentials are wrong".
+     */
+    const REQUIRED_EXTENSIONS = array(
+        'json'     => 'Encoding stored report definitions and API responses.',
+        'mbstring' => 'Handling non-ASCII page titles, URLs and search terms.',
+        'pcre'     => 'Matching URLs, goal conditions and constraint values.',
+    );
+
+    /**
+     * Every environment check, in report order.
+     *
+     * @param string $config_file  path to owa-config.php
+     * @return array[] each ['name','value','passed','msg']
+     */
+    public static function all( $config_file ) {
+
+        $checks = array();
+
+        $checks[] = self::check(
+            'PHP version',
+            phpversion(),
+            version_compare( phpversion(), self::MIN_PHP_VERSION, '>=' ),
+            sprintf( 'OWA needs PHP %s or newer. Ask your host to upgrade, or point '
+                   . 'this virtual host at a newer PHP.', self::MIN_PHP_VERSION ) );
+
+        /*
+         * A database driver: PDO with a MySQL driver, or mysqli. Either one is
+         * enough -- Db picks whichever is present -- so this is one check rather
+         * than three, and it says which ones it looked for.
+         */
+        $drivers = array();
+
+        if ( extension_loaded( 'pdo_mysql' ) ) {
+            $drivers[] = 'pdo_mysql';
+        }
+
+        if ( extension_loaded( 'mysqli' ) ) {
+            $drivers[] = 'mysqli';
+        }
+
+        $checks[] = self::check(
+            'Database driver',
+            $drivers ? implode( ', ', $drivers ) : 'none found',
+            (bool) $drivers,
+            'OWA needs the pdo_mysql or mysqli PHP extension to reach a database. '
+          . 'Install one and restart PHP.' );
+
+        foreach ( self::REQUIRED_EXTENSIONS as $extension => $what_for ) {
+
+            $checks[] = self::check(
+                sprintf( 'PHP extension: %s', $extension ),
+                extension_loaded( $extension ) ? 'loaded' : 'missing',
+                extension_loaded( $extension ),
+                $what_for . ' Install the ' . $extension . ' extension and restart PHP.' );
+        }
+
+        // Where OWA writes.
+        foreach ( array( 'logs' => 'Log directory', 'caches' => 'Cache directory' )
+                  as $dir => $label ) {
+
+            $path = OWA_DATA_DIR . $dir . '/';
+
+            $checks[] = self::check(
+                $label,
+                is_writable( $path ) ? 'writable' : 'not writable',
+                is_writable( $path ),
+                sprintf( 'Make %s writable by the user your web server runs as.', $path ) );
+        }
+
+        /*
+         * Whether the config file can be WRITTEN.
+         *
+         * On a docroot the web server cannot write to, an author used to fill in
+         * the whole database form before anything went wrong, and what went
+         * wrong was a file handle failing rather than a message. An existing
+         * file is fine: that path skips the form entirely.
+         */
+        $config_dir = dirname( $config_file );
+
+        $config_ok = file_exists( $config_file )
+            ? is_readable( $config_file )
+            : is_writable( $config_dir );
+
+        $checks[] = self::check(
+            'Configuration file',
+            file_exists( $config_file )
+                ? ( is_readable( $config_file ) ? 'present' : 'present, not readable' )
+                : ( is_writable( $config_dir ) ? 'can be created' : 'cannot be created' ),
+            $config_ok,
+            file_exists( $config_file )
+                ? sprintf( 'Make %s readable by the user your web server runs as.', $config_file )
+                : sprintf( 'Make %s writable so the installer can create owa-config.php, or '
+                         . 'copy owa-config-dist.php to owa-config.php yourself and fill it in.',
+                           $config_dir ) );
+
+        // The two directories a source checkout does not come with.
+        $checks[] = self::check(
+            'Dependencies',
+            is_dir( OWA_VENDOR_DIR ) ? 'installed' : 'missing',
+            is_dir( OWA_VENDOR_DIR ),
+            "Run 'composer install' in the top level OWA directory." );
+
+        $built = \OWA\Core\Template::assetsAreBuilt();
+
+        $checks[] = self::check(
+            'Built assets',
+            $built ? 'built' : 'missing',
+            $built,
+            "Run 'npm run build' in the top level OWA directory." );
+
+        return $checks;
+    }
+
+    /**
+     * One check, in the shape both callers render.
+     *
+     * @return array
+     */
+    public static function check( $name, $value, $passed, $msg ) {
+
+        return array(
+            'name'   => $name,
+            'value'  => $value,
+            'passed' => (bool) $passed,
+            'msg'    => $passed ? '' : $msg,
+        );
+    }
+}

--- a/modules/Base/Controller/InstallCheckEnv.php
+++ b/modules/Base/Controller/InstallCheckEnv.php
@@ -33,136 +33,18 @@ namespace OWA\Module\Base\Controller;
 
 class InstallCheckEnv extends \OWA\Core\Controller\Install {
 
-    /**
-     * The lowest PHP this release runs on.
-     *
-     * The same number composer.json requires. It was a hand-rolled comparison
-     * -- `$version[0] < 5 && $version[1] < 2` -- which cannot express a
-     * requirement at all: on PHP 8.2 the first term is false, so the whole
-     * check passed, and on PHP 5.1 it passed too because 5 is not less than 5.
-     * It has been unable to fail for every PHP anyone still runs.
-     */
-    const MIN_PHP_VERSION = '8.2';
-
-    /**
-     * Extensions OWA cannot run without, and what each is for.
-     *
-     * Checked here because the alternative is finding out later and worse: with
-     * no database driver the wizard takes a full page of connection details and
-     * then fails on connect, which reads as "my credentials are wrong".
-     */
-    const REQUIRED_EXTENSIONS = array(
-        'json'     => 'Encoding stored report definitions and API responses.',
-        'mbstring' => 'Handling non-ASCII page titles, URLs and search terms.',
-        'pcre'     => 'Matching URLs, goal conditions and constraint values.',
-    );
-
     function action() {
 
-        $checks = array();
-
-        // PHP itself.
-        $checks[] = $this->check(
-            'PHP version',
-            phpversion(),
-            version_compare( phpversion(), self::MIN_PHP_VERSION, '>=' ),
-            sprintf( 'OWA needs PHP %s or newer. Ask your host to upgrade, or point '
-                   . 'this virtual host at a newer PHP.', self::MIN_PHP_VERSION ) );
-
         /*
-         * A database driver: PDO with a MySQL driver, or mysqli. Either one is
-         * enough -- Db picks whichever is present -- so this is one check
-         * rather than three, and it says which ones it looked for.
-         */
-        $drivers = array();
-
-        if ( extension_loaded( 'pdo_mysql' ) ) {
-            $drivers[] = 'pdo_mysql';
-        }
-
-        if ( extension_loaded( 'mysqli' ) ) {
-            $drivers[] = 'mysqli';
-        }
-
-        $checks[] = $this->check(
-            'Database driver',
-            $drivers ? implode( ', ', $drivers ) : 'none found',
-            (bool) $drivers,
-            'OWA needs the pdo_mysql or mysqli PHP extension to reach a database. '
-          . 'Install one and restart PHP.' );
-
-        foreach ( self::REQUIRED_EXTENSIONS as $extension => $what_for ) {
-
-            $checks[] = $this->check(
-                sprintf( 'PHP extension: %s', $extension ),
-                extension_loaded( $extension ) ? 'loaded' : 'missing',
-                extension_loaded( $extension ),
-                $what_for . ' Install the ' . $extension . ' extension and restart PHP.' );
-        }
-
-        // Where OWA writes.
-        foreach ( array( 'logs' => 'Log directory', 'caches' => 'Cache directory' )
-                  as $dir => $label ) {
-
-            $path = OWA_DATA_DIR . $dir . '/';
-
-            $checks[] = $this->check(
-                $label,
-                is_writable( $path ) ? 'writable' : 'not writable',
-                is_writable( $path ),
-                sprintf( 'Make %s writable by the user your web server runs as.', $path ) );
-        }
-
-        /*
-         * Whether the config file can be WRITTEN, which nothing checked.
-         *
-         * The next screen collects database details and then calls
-         * createConfigFile(), which fopen()s the path for writing without
-         * asking first -- so on a docroot the web server cannot write to, an
-         * author filled in the whole form before anything went wrong, and what
-         * went wrong was a file handle failing rather than a message. Asked
-         * here, they are told before they type anything.
-         *
-         * An existing file is fine: that path skips the form entirely.
+         * The checks themselves live in EnvironmentCheck, because
+         * cmd=instance-info asks exactly the same questions of a running
+         * instance. Two copies would disagree about what "supported" means, and
+         * the disagreement would be invisible: nobody runs the installer on a
+         * working instance, or the diagnostic on a fresh one.
          */
         $config_file = $this->c->get( 'base', 'config_file' );
-        $config_dir  = dirname( $config_file );
 
-        $config_writable = file_exists( $config_file )
-            ? is_readable( $config_file )
-            : is_writable( $config_dir );
-
-        $checks[] = $this->check(
-            'Configuration file',
-            file_exists( $config_file )
-                ? ( is_readable( $config_file ) ? 'present' : 'present, not readable' )
-                : ( is_writable( $config_dir ) ? 'can be created' : 'cannot be created' ),
-            $config_writable,
-            file_exists( $config_file )
-                ? sprintf( 'Make %s readable by the user your web server runs as.', $config_file )
-                : sprintf( 'Make %s writable so the installer can create owa-config.php, or '
-                         . 'copy owa-config-dist.php to owa-config.php yourself and fill it in.',
-                           $config_dir ) );
-
-        // The two directories a source checkout does not come with.
-        $checks[] = $this->check(
-            'Dependencies',
-            is_dir( OWA_VENDOR_DIR ) ? 'installed' : 'missing',
-            is_dir( OWA_VENDOR_DIR ),
-            "Run 'composer install' in the top level OWA directory." );
-
-        /*
-         * The webpack build emits the tracker and reporting bundles under
-         * public/base/dist, and public/ is gitignored -- so a fresh source
-         * checkout has none of it until 'npm run build' runs.
-         */
-        $built = \OWA\Core\Template::assetsAreBuilt();
-
-        $checks[] = $this->check(
-            'Built assets',
-            $built ? 'built' : 'missing',
-            $built,
-            "Run 'npm run build' in the top level OWA directory." );
+        $checks = \OWA\Module\Base\Classes\EnvironmentCheck::all( $config_file );
 
         /*
          * The database connection, only when there is already a config file
@@ -175,7 +57,7 @@ class InstallCheckEnv extends \OWA\Core\Controller\Install {
 
             $connected = (bool) $this->checkDbConnection();
 
-            $checks[] = $this->check(
+            $checks[] = \OWA\Module\Base\Classes\EnvironmentCheck::check(
                 'Database connection',
                 $connected ? 'connected' : 'failed',
                 $connected,
@@ -217,24 +99,6 @@ class InstallCheckEnv extends \OWA\Core\Controller\Install {
         $this->setSubview( 'base.installCheckEnv' );
     }
 
-    /**
-     * One environment check, in the shape the template renders.
-     *
-     * @param string $name   what was looked at
-     * @param string $value  what was found
-     * @param bool   $passed
-     * @param string $msg    what to do about it, shown only when it failed
-     * @return array
-     */
-    private function check( $name, $value, $passed, $msg ) {
-
-        return array(
-            'name'   => $name,
-            'value'  => $value,
-            'passed' => (bool) $passed,
-            'msg'    => $passed ? '' : $msg,
-        );
-    }
 }
 
 ?>

--- a/modules/Base/Controller/InstanceInfoCli.php
+++ b/modules/Base/Controller/InstanceInfoCli.php
@@ -1,0 +1,765 @@
+<?php
+namespace OWA\Module\Base\Controller;
+
+//
+// Open Web Analytics - An Open Source Web Analytics Framework
+//
+// Copyright 2006 Peter Adams. All rights reserved.
+//
+// Licensed under GPL v2.0 http://www.gnu.org/copyleft/gpl.html
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * One report describing the whole instance: `php cli.php cmd=instance-info`.
+ *
+ * WHY THIS EXISTS. Everything it reports could already be found out, and that
+ * was the problem -- it took eight commands, two SQL queries and knowing which
+ * settings to read, so nobody did it, and the things that fail QUIETLY are
+ * exactly the things nobody went looking for. A stale user-agent database does
+ * not error, it misattributes. An un-run scheduler does not error, it does
+ * nothing. Retention that was never configured does not error, it accumulates.
+ *
+ * WHAT IT IS NOT. It changes nothing and it is safe to run on a live instance
+ * at any time. Every query here is a count or a metadata read.
+ *
+ * It exits 0 whether or not it finds problems, because it is an INFO command
+ * and its name says so. Pass `strict=1` to exit non-zero when anything is in a
+ * FAIL state, which is what makes it usable from monitoring.
+ */
+class InstanceInfoCli extends \OWA\Core\Controller\Cli {
+
+    /** Status ranks, worst last -- the summary reports the worst seen. */
+    const OK   = 'ok';
+    const WARN = 'warn';
+    const FAIL = 'fail';
+
+    /**
+     * Column at which values line up. Wide enough for the longest label used,
+     * which is an indented owa_commerce_transaction_fact.
+     */
+    const LABEL_WIDTH = 32;
+
+    /** @var bool */
+    private $colour = false;
+
+    /** @var array<string,int> */
+    private $tally = array( self::OK => 0, self::WARN => 0, self::FAIL => 0 );
+
+    function __construct( $params ) {
+
+        /*
+         * The same gate the other administrative CLI commands use. It reports
+         * configuration, module state and row counts, which is administrator
+         * information even though it changes nothing.
+         */
+        $this->setRequiredCapability( 'edit_modules' );
+
+        parent::__construct( $params );
+    }
+
+    function action() {
+
+        $this->colour = $this->useColour();
+
+        $lines = array();
+
+        $lines = array_merge( $lines, $this->heading() );
+        $lines = array_merge( $lines, $this->section( 'Environment',  $this->environment() ) );
+        $lines = array_merge( $lines, $this->section( 'Modules',      $this->modules() ) );
+        $lines = array_merge( $lines, $this->section( 'Schema',       $this->schema() ) );
+        $lines = array_merge( $lines, $this->section( 'Scheduler',    $this->scheduler() ) );
+        $lines = array_merge( $lines, $this->section( 'Fact tables',  $this->factTables() ) );
+        $lines = array_merge( $lines, $this->section( 'Freshness',    $this->freshness() ) );
+        $lines = array_merge( $lines, $this->section( 'Event queue',  $this->queue() ) );
+        $lines = array_merge( $lines, $this->section( 'Contents',     $this->contents() ) );
+        $lines = array_merge( $lines, $this->summary() );
+
+        $this->write( $lines );
+
+        if ( $this->getParam( 'strict' ) && $this->tally[ self::FAIL ] ) {
+
+            return $this->fail( sprintf( '%d check(s) failed.', $this->tally[ self::FAIL ] ) );
+        }
+    }
+
+    // ---------------------------------------------------------------- sections
+
+    /**
+     * Who this instance is. No status marks: these are facts, not judgements.
+     */
+    private function heading() {
+
+        $url = \OWA\Core\CoreAPI::getSetting( 'base', 'public_url' ) ?: '(no public url set)';
+
+        $rows = array(
+            $this->fact( 'Version',   OWA_VERSION ),
+            $this->fact( 'Location',  OWA_DIR ),
+            $this->fact( 'Public URL', $url ),
+            $this->fact( 'Database',  $this->databaseName() ),
+            $this->fact( 'PHP',       phpversion() . ' (' . PHP_OS . ')' ),
+            $this->fact( 'Timezone',  $this->timezone() ),
+            $this->fact( 'Reported',  date( 'Y-m-d H:i:s' ) ),
+        );
+
+        return array_merge(
+            array( '', $this->bold( 'Open Web Analytics -- instance info' ), '' ),
+            $rows );
+    }
+
+    /**
+     * The same questions the installer asks, from the same definition.
+     */
+    private function environment() {
+
+        $rows = array();
+
+        foreach ( \OWA\Module\Base\Classes\EnvironmentCheck::all(
+                      $this->c->get( 'base', 'config_file' ) ) as $check ) {
+
+            $rows[] = $this->row(
+                $check['passed'] ? self::OK : self::FAIL,
+                $check['name'], $check['value'], $check['msg'] );
+        }
+
+        // The error log has to stay writable by BOTH the web user and whoever
+        // runs the CLI. When it is not, a notice becomes a fatal, because a log
+        // write that cannot open its file raises.
+        $log = \OWA\Core\CoreAPI::getSetting( 'base', 'error_log_file' );
+
+        if ( $log ) {
+
+            $exists   = file_exists( $log );
+            $writable = $exists ? is_writable( $log ) : is_writable( dirname( $log ) );
+
+            $rows[] = $this->row(
+                $writable ? self::OK : self::FAIL,
+                'Error log',
+                $exists ? ( $writable ? 'writable' : 'NOT writable' ) : 'not created yet',
+                'Make ' . $log . ' writable by both the web server user and the CLI user '
+              . '(0664). A log write that cannot open its file turns a notice into a fatal.' );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Which modules are switched on, and which are merely present.
+     *
+     * An inactive module is the answer to "why is geolocation not working" more
+     * often than any setting is: it is on disk, it looks installed, and it is
+     * simply switched off. Being active is not a pass or a fail, so these carry
+     * no status mark -- they are inventory.
+     */
+    private function modules() {
+
+        $rows = array();
+
+        $active  = (array) \OWA\Core\CoreAPI::getActiveModules();
+        $present = (array) \OWA\Core\CoreAPI::getPresentModules();
+
+        $rows[] = $this->fact( 'Active',
+            $active ? implode( ', ', $active ) : 'none' );
+
+        $inactive = array();
+
+        foreach ( $present as $dir ) {
+
+            $is_active = false;
+
+            foreach ( $active as $name ) {
+
+                if ( \OWA\Core\Lib::moduleDirName( $name ) === $dir ) {
+
+                    $is_active = true;
+                    break;
+                }
+            }
+
+            if ( ! $is_active ) {
+
+                $inactive[] = $dir;
+            }
+        }
+
+        $rows[] = $this->fact( 'Present but inactive',
+            $inactive ? implode( ', ', $inactive ) : 'none' );
+
+        return $rows;
+    }
+
+    /**
+     * Whether each active module's schema is current.
+     *
+     * Separate from the module list because it is a different question with a
+     * different answer type: which modules exist is inventory, whether their
+     * tables match the code is a health check that stops the scheduler dead
+     * when it fails.
+     */
+    private function schema() {
+
+        $rows = array();
+
+        $pending = (bool) \OWA\Core\CoreAPI::isUpdateRequired();
+
+        /*
+         * Ask each ACTIVE module, and name the ones that are behind. A single
+         * "updates required" flag says an upgrade is needed but not by what, and
+         * on an instance with several modules that is the question.
+         */
+        $behind = (array) \OWA\Core\CoreAPI::getModulesNeedingUpdates();
+
+        foreach ( (array) \OWA\Core\CoreAPI::getActiveModules() as $name ) {
+
+            $current = ! in_array( $name, $behind, true );
+
+            $rows[] = $this->row(
+                $current ? self::OK : self::FAIL,
+                $name,
+                sprintf( '%s (schema %s)',
+                    $current ? 'up to date' : 'UPDATE REQUIRED',
+                    (string) \OWA\Core\CoreAPI::getSetting( $name, 'schema_version' ) ),
+                "Run 'php cli.php cmd=update'. Until you do, the job scheduler "
+              . 'refuses every job.' );
+        }
+
+        if ( ! $rows ) {
+
+            $rows[] = $this->row(
+                $pending ? self::FAIL : self::OK,
+                'Modules',
+                $pending ? 'UPDATE REQUIRED' : 'up to date',
+                "Run 'php cli.php cmd=update'." );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Nothing periodic happens without the cron entry, and nothing says so.
+     */
+    private function scheduler() {
+
+        $rows = array();
+
+        $enabled = (bool) \OWA\Core\CoreAPI::getSetting( 'base', 'scheduler_enabled' );
+
+        $rows[] = $this->row(
+            $enabled ? self::OK : self::WARN,
+            'Enabled', $enabled ? 'yes' : 'no (OWA_SCHEDULER_ENABLED is off)',
+            'No job will run while the scheduler is disabled.' );
+
+        $problem = \OWA\Module\Base\Classes\SchedulerHealth::problem();
+
+        $rows[] = $this->row(
+            $problem ? self::FAIL : self::OK,
+            'Cron entry',
+            $problem ? 'not running' : 'running',
+            'Add this line to the crontab of the user that owns the OWA files:  '
+          . \OWA\Module\Base\Classes\SchedulerHealth::cronLine() );
+
+        $jobs  = $this->registeredJobs();
+        $state = $this->jobState();
+
+        $rows[] = $this->fact( 'Jobs registered', (string) count( $jobs ) );
+
+        foreach ( $jobs as $name => $job ) {
+
+            $row = isset( $state[ $name ] ) ? $state[ $name ] : null;
+
+            if ( ! $row ) {
+
+                $rows[] = $this->row( self::WARN, '  ' . $name, 'never run',
+                    'The dispatcher has not reached this job yet.' );
+
+                continue;
+            }
+
+            $failures = (int) ( $row['failure_count'] ?? 0 );
+            $last     = (int) ( $row['last_run_at'] ?? 0 );
+
+            $rows[] = $this->row(
+                $failures ? self::WARN : self::OK,
+                '  ' . $name,
+                sprintf( '%s, last run %s%s',
+                    (string) ( $row['last_status'] ?? 'unknown' ),
+                    $last ? date( 'Y-m-d H:i', $last ) : 'never',
+                    $failures ? sprintf( ', %d failure(s)', $failures ) : '' ),
+                "See 'php cli.php cmd=schedule-status' for the detail." );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * Partitioning, and whether anything ever deletes.
+     */
+    private function factTables() {
+
+        $rows   = array();
+        $counts = $this->partitionCounts();
+
+        if ( $counts === null ) {
+
+            return array( $this->row( self::WARN, 'Partitioning', 'could not be read',
+                'Partition metadata was not readable. This needs MySQL 5.7 or later.' ) );
+        }
+
+        $partitioned = count( array_filter( $counts ) );
+        $total       = count( $counts );
+
+        $rows[] = $this->row(
+            $partitioned ? self::OK : self::WARN,
+            'Partitioned tables',
+            sprintf( '%d of %d', $partitioned, $total ),
+            "Not an error. Run 'php cli.php cmd=partition-init' to partition them, or "
+          . 'ignore this if the instance is small.' );
+
+        foreach ( $counts as $table => $n ) {
+
+            $rows[] = $this->fact( '  ' . $table,
+                $n ? sprintf( '%d partition(s)', $n ) : 'not partitioned' );
+        }
+
+        /*
+         * Retention is opt-in and silent. rotate-partitions EXTENDS the tables
+         * and merges old periods; it deletes nothing unless it is given a
+         * 'keep'. An instance that wanted a retention window and never set one
+         * looks identical to an instance that wanted to keep everything.
+         */
+        $jobs = $this->registeredJobs();
+        $keep = $jobs['rotate-partitions']['params']['keep'] ?? null;
+
+        $rows[] = $this->row(
+            $keep ? self::OK : self::WARN,
+            'Retention',
+            $keep ? sprintf( 'keeping %d month(s)', (int) $keep ) : 'unlimited (nothing is deleted)',
+            'Not an error, and a reasonable default -- but it is a choice. Set a '
+          . "'keep' param on the rotate-partitions job in owa-config.php to bound it." );
+
+        return $rows;
+    }
+
+    /**
+     * The two datasets that rot without erroring.
+     */
+    private function freshness() {
+
+        $rows = array();
+
+        $dir  = \OWA\Core\CoreAPI::getSetting( 'base', 'ua_regexes_dir' ) ?: OWA_DATA_DIR . 'ua-parser/';
+        $file = $dir . 'regexes.php';
+
+        if ( file_exists( $file ) ) {
+
+            $age = (int) floor( ( time() - filemtime( $file ) ) / 86400 );
+
+            $rows[] = $this->row(
+                $age > 180 ? self::WARN : self::OK,
+                'User-agent patterns',
+                sprintf( 'updated %s (%d day(s) ago)', date( 'Y-m-d', filemtime( $file ) ), $age ),
+                "Run 'php cli.php cmd=update-ua-regexes'. Stale patterns do not error -- "
+              . 'new browsers and crawlers are just counted as something else.' );
+
+        } else {
+
+            $rows[] = $this->row( self::WARN, 'User-agent patterns',
+                'never updated (using the bundled copy)',
+                "Run 'php cli.php cmd=update-ua-regexes'. The bundled patterns are as old "
+              . "as the PHP library's last release, so updating the dependency does not help." );
+        }
+
+        $geo = $this->geoipStatus();
+
+        if ( $geo ) {
+
+            $rows[] = $geo;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * A queue that stops draining accumulates in silence.
+     */
+    private function queue() {
+
+        $rows = array();
+
+        $item = \OWA\Core\CoreAPI::entityFactory( 'base.queue_item' );
+        $table = $item->getTableName();
+
+        $total = $this->countOf( sprintf( 'SELECT COUNT(*) AS n FROM %s', $table ) );
+
+        if ( $total === null ) {
+
+            return array( $this->fact( 'Queued events', 'table not present' ) );
+        }
+
+        $rows[] = $this->row(
+            $total > 10000 ? self::WARN : self::OK,
+            'Queued events', (string) $total,
+            'A queue this size usually means the drain stopped. Check '
+          . "'php cli.php cmd=processEventQueue' and the error log." );
+
+        $oldest = $this->countOf( sprintf(
+            'SELECT MIN(not_before_timestamp) AS n FROM %s', $table ) );
+
+        if ( $total && $oldest ) {
+
+            $rows[] = $this->fact( '  oldest', date( 'Y-m-d H:i', (int) $oldest ) );
+        }
+
+        return $rows;
+    }
+
+    /**
+     * What the instance actually holds.
+     */
+    private function contents() {
+
+        $rows = array();
+
+        foreach ( array(
+            'Organizations' => 'base.organization',
+            'Properties'    => 'base.property',
+            'Sites'         => 'base.site',
+            'Users'         => 'base.user',
+        ) as $label => $entity ) {
+
+            $n = null;
+
+            try {
+
+                $e = \OWA\Core\CoreAPI::entityFactory( $entity );
+                $n = $this->countOf( sprintf( 'SELECT COUNT(*) AS n FROM %s', $e->getTableName() ) );
+
+            } catch ( \Throwable $e ) {
+
+                $n = null;
+            }
+
+            $rows[] = $this->fact( $label, $n === null ? 'not available' : (string) $n );
+        }
+
+        return $rows;
+    }
+
+    // ----------------------------------------------------------------- helpers
+
+    /**
+     * Partition count per fact table, or null when the metadata is unreadable.
+     *
+     * Through the dialect's listPartitions() rather than a query written here:
+     * schema introspection is backend-specific, and a spelling that only works
+     * on MySQL would be invisible until someone ran OWA on something else.
+     *
+     * @return array<string,int>|null
+     */
+    private function partitionCounts() {
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        // A backend with no partitioning at all is a fact about the backend,
+        // not a fault in this instance -- say so rather than guessing zero.
+        if ( ! is_object( $db ) || ! method_exists( $db, 'listPartitions' ) ) {
+
+            return null;
+        }
+
+        $tables = array(
+            'request', 'session', 'click', 'domstream',
+            'action_fact', 'commerce_transaction_fact', 'commerce_line_item_fact',
+        );
+
+        $counts = array();
+
+        foreach ( $tables as $short ) {
+
+            try {
+
+                $e = \OWA\Core\CoreAPI::entityFactory( 'base.' . $short );
+
+            } catch ( \Throwable $ex ) {
+
+                continue;
+            }
+
+            $table = $e->getTableName();
+
+            try {
+
+                $parts = $db->listPartitions( $table );
+
+            } catch ( \Throwable $ex ) {
+
+                return null;
+            }
+
+            $counts[ $table ] = count( (array) $parts );
+        }
+
+        return $counts;
+    }
+
+    /**
+     * The GeoIP database, when the module that uses it is active.
+     */
+    private function geoipStatus() {
+
+        if ( ! \OWA\Core\CoreAPI::getSetting( 'maxmind_geoip', 'is_active' ) ) {
+
+            return null;
+        }
+
+        $file = OWA_DATA_DIR . 'maxmind/GeoLite2-City.mmdb';
+
+        if ( ! file_exists( $file ) ) {
+
+            return $this->row( self::WARN, 'GeoIP database', 'not downloaded',
+                "Run 'php cli.php cmd=update-geoip-db'. Needs a MaxMind licence key." );
+        }
+
+        $age = (int) floor( ( time() - filemtime( $file ) ) / 86400 );
+
+        return $this->row(
+            $age > 60 ? self::WARN : self::OK,
+            'GeoIP database',
+            sprintf( 'updated %s (%d day(s) ago)', date( 'Y-m-d', filemtime( $file ) ), $age ),
+            "Run 'php cli.php cmd=update-geoip-db'. A stale database does not fail; it "
+          . 'answers, and the reports look normal.' );
+    }
+
+    /**
+     * The jobs the scheduler knows about.
+     *
+     * Through the service rather than the raw setting: a job can be registered
+     * by a module as well as declared in owa-config.php, and reading the setting
+     * alone reports zero jobs on an instance that is running several.
+     *
+     * @return array<string,array>
+     */
+    private function registeredJobs() {
+
+        try {
+
+            $s = \OWA\Core\CoreAPI::serviceSingleton();
+            $s->loadCliCommands();
+            $s->loadJobs();
+
+            return (array) $s->getJobs();
+
+        } catch ( \Throwable $e ) {
+
+            return array();
+        }
+    }
+
+    /**
+     * Scheduler state rows, keyed by job name.
+     *
+     * @return array<string,array>
+     */
+    private function jobState() {
+
+        $out = array();
+
+        try {
+
+            $e = \OWA\Core\CoreAPI::entityFactory( 'base.scheduled_job' );
+            $db = \OWA\Core\CoreAPI::dbSingleton();
+            $rows = $db->get_results( sprintf( 'SELECT * FROM %s', $e->getTableName() ) );
+
+            foreach ( (array) $rows as $row ) {
+
+                $out[ (string) $row['job_name'] ] = $row;
+            }
+
+        } catch ( \Throwable $ex ) {
+
+            return array();
+        }
+
+        return $out;
+    }
+
+    /**
+     * A single numeric answer, or null when the query could not run.
+     *
+     * Db::query() swallows errors and returns falsy, so "0" and "the table is
+     * not there" are the same value unless they are told apart here.
+     *
+     * @return int|null
+     */
+    private function countOf( $sql ) {
+
+        try {
+
+            $db  = \OWA\Core\CoreAPI::dbSingleton();
+            $row = $db->get_row( $sql );
+
+        } catch ( \Throwable $e ) {
+
+            return null;
+        }
+
+        if ( ! is_array( $row ) || ! array_key_exists( 'n', $row ) || $row['n'] === null ) {
+
+            return null;
+        }
+
+        return (int) $row['n'];
+    }
+
+    private function databaseName() {
+
+        $name = \OWA\Core\CoreAPI::getSetting( 'base', 'db_name' );
+        $host = \OWA\Core\CoreAPI::getSetting( 'base', 'db_host' );
+
+        return $name ? $name . ( $host ? ' @ ' . $host : '' ) : '(not configured)';
+    }
+
+    private function timezone() {
+
+        return \OWA\Core\CoreAPI::getSetting( 'base', 'timezone' ) ?: date_default_timezone_get();
+    }
+
+    // ------------------------------------------------------------- formatting
+
+    /**
+     * A row with a status mark, counted towards the summary.
+     */
+    private function row( $status, $label, $value, $remedy = '' ) {
+
+        $this->tally[ $status ]++;
+
+        $line = sprintf( '  %s  %s%s',
+            $this->mark( $status ),
+            $this->pad( $label ),
+            $this->paint( $value, $status ) );
+
+        if ( $status !== self::OK && $remedy ) {
+
+            // Under the value, indented past the mark, so the eye can skip it.
+            $line .= PHP_EOL . '        ' . $this->dim( $this->wrap( $remedy, 8 ) );
+        }
+
+        return $line;
+    }
+
+    /**
+     * A row with no judgement attached -- a number or a name.
+     */
+    private function fact( $label, $value ) {
+
+        return sprintf( '     %s%s', $this->pad( $label ), $value );
+    }
+
+    private function section( $title, $rows ) {
+
+        if ( ! $rows ) {
+
+            return array();
+        }
+
+        return array_merge( array( '', $this->bold( strtoupper( $title ) ) ), $rows );
+    }
+
+    private function summary() {
+
+        $bad  = $this->tally[ self::FAIL ];
+        $warn = $this->tally[ self::WARN ];
+
+        if ( $bad ) {
+
+            $verdict = $this->paint( sprintf( '%d problem(s) need fixing', $bad ), self::FAIL );
+
+        } elseif ( $warn ) {
+
+            $verdict = $this->paint( sprintf( '%d thing(s) worth a look', $warn ), self::WARN );
+
+        } else {
+
+            $verdict = $this->paint( 'Everything checks out', self::OK );
+        }
+
+        return array(
+            '',
+            str_repeat( '-', 64 ),
+            sprintf( '  %s   (%d ok, %d warning(s), %d failure(s))',
+                $verdict, $this->tally[ self::OK ], $warn, $bad ),
+            '',
+        );
+    }
+
+    private function pad( $label ) {
+
+        $width = self::LABEL_WIDTH;
+
+        return $label . str_repeat( ' ', max( 1, $width - strlen( $label ) ) );
+    }
+
+    /**
+     * Wrap a remedy so a long one does not run off the terminal.
+     */
+    private function wrap( $text, $indent ) {
+
+        return str_replace( "\n", PHP_EOL . str_repeat( ' ', $indent ),
+            wordwrap( $text, 72 - $indent, "\n", false ) );
+    }
+
+    private function mark( $status ) {
+
+        $glyphs = array( self::OK => '+', self::WARN => '!', self::FAIL => 'x' );
+
+        return $this->paint( $glyphs[ $status ], $status );
+    }
+
+    /**
+     * Colour, but only when a person is looking at it.
+     *
+     * Piped or redirected output gets none: escape codes in a log file or a
+     * monitoring check are noise that the reader cannot turn off.
+     */
+    private function useColour() {
+
+        if ( $this->getParam( 'no-color' ) || getenv( 'NO_COLOR' ) !== false ) {
+
+            return false;
+        }
+
+        if ( ! defined( 'STDOUT' ) ) {
+
+            return false;
+        }
+
+        return function_exists( 'stream_isatty' ) ? @stream_isatty( STDOUT ) : false;
+    }
+
+    private function paint( $text, $status ) {
+
+        if ( ! $this->colour ) {
+
+            return $text;
+        }
+
+        $codes = array( self::OK => '0;32', self::WARN => '0;33', self::FAIL => '0;31' );
+
+        return "\033[" . $codes[ $status ] . 'm' . $text . "\033[0m";
+    }
+
+    private function bold( $text ) {
+
+        return $this->colour ? "\033[1m" . $text . "\033[0m" : $text;
+    }
+
+    private function dim( $text ) {
+
+        return $this->colour ? "\033[2m" . $text . "\033[0m" : $text;
+    }
+}

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -193,6 +193,7 @@ class Module extends \OWA\Core\Module {
         $this->registerAction( 'base.rederiveDimensionIdsCli',       'OWA\\Module\\Base\\Controller\\RederiveDimensionIdsCli',    'Controller/RederiveDimensionIdsCli.php' );
         $this->registerAction( 'base.scheduleRunCli',                'OWA\\Module\\Base\\Controller\\ScheduleRunCli',             'Controller/ScheduleRunCli.php' );
         $this->registerAction( 'base.scheduleStatusCli',             'OWA\\Module\\Base\\Controller\\ScheduleStatusCli',          'Controller/ScheduleStatusCli.php' );
+        $this->registerAction( 'base.instanceInfoCli',              'OWA\\Module\\Base\\Controller\\InstanceInfoCli',           'Controller/InstanceInfoCli.php' );
         $this->registerAction( 'base.partitionInitCli',              'OWA\\Module\\Base\\Controller\\PartitionInitCli',           'Controller/PartitionInitCli.php' );
         $this->registerAction( 'base.partitionDropCli',              'OWA\\Module\\Base\\Controller\\PartitionDropCli',           'Controller/PartitionDropCli.php' );
         $this->registerAction( 'base.partitionReorganizeCli',        'OWA\\Module\\Base\\Controller\\PartitionReorganizeCli',     'Controller/PartitionReorganizeCli.php' );
@@ -275,6 +276,7 @@ class Module extends \OWA\Core\Module {
         $this->registerCliCommand('reset-secrets', 'base.resetSecretsCli');
         $this->registerCliCommand('schedule-run', 'base.scheduleRunCli');
         $this->registerCliCommand('schedule-status', 'base.scheduleStatusCli');
+        $this->registerCliCommand('instance-info', 'base.instanceInfoCli');
     }
 
     /**

--- a/tests/InstanceInfoCliTest.php
+++ b/tests/InstanceInfoCliTest.php
@@ -1,0 +1,212 @@
+<?php
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `cmd=instance-info` describes the whole instance in one report.
+ *
+ * WHAT IT IS FOR. Everything it reports could already be found out -- and that
+ * was the problem. It took several commands, some SQL and knowing which
+ * settings to read, so nobody did it, and the things that fail QUIETLY are
+ * exactly the things nobody goes looking for: a stale user-agent database
+ * misattributes rather than erroring, an un-run scheduler does nothing rather
+ * than complaining, retention that was never configured accumulates forever.
+ *
+ * WHAT THESE TESTS PIN. Two things, and the second is the one that would rot:
+ *
+ *   1. The report actually reports -- every section present, the counts
+ *      answered, and no fatal on the way through.
+ *   2. It never becomes a way to BREAK an instance. It is run on installations
+ *      that are already unwell, so every reader has to tolerate the thing it
+ *      reads on being absent. A missing table, an unreadable setting or a
+ *      module that will not load must degrade to a line saying so, never to an
+ *      exception -- a diagnostic that dies on a sick instance is worse than
+ *      none, because it dies exactly when it is needed.
+ */
+final class InstanceInfoCliTest extends TestCase
+{
+    private function root(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    /**
+     * Run the command as a person would, and hand back stdout+stderr.
+     */
+    private function report(string $extra = ''): string
+    {
+        $cmd = escapeshellarg(PHP_BINARY) . ' '
+             . escapeshellarg($this->root() . '/cli.php')
+             . ' cmd=instance-info' . ($extra ? ' ' . $extra : '') . ' 2>&1';
+
+        return (string) shell_exec($cmd);
+    }
+
+    /**
+     * The environment half is shared with the installer, so it must answer
+     * without a database, a config file or anything else being present.
+     */
+    public function testEnvironmentChecksAnswerWithoutADatabase(): void
+    {
+        $checks = \OWA\Module\Base\Classes\EnvironmentCheck::all(
+            OWA_DIR . 'owa-config.php');
+
+        $this->assertNotEmpty($checks);
+
+        $names = array_column($checks, 'name');
+
+        foreach (['PHP version', 'Database driver', 'Dependencies', 'Built assets'] as $expected) {
+            $this->assertContains($expected, $names,
+                $expected . ' must be one of the environment checks');
+        }
+
+        foreach ($checks as $check) {
+            $this->assertArrayHasKey('name', $check);
+            $this->assertArrayHasKey('value', $check);
+            $this->assertArrayHasKey('passed', $check);
+            $this->assertArrayHasKey('msg', $check);
+            $this->assertIsBool($check['passed']);
+
+            // A failing check that cannot say what to do about it is a check
+            // that gets reported and ignored.
+            if (!$check['passed']) {
+                $this->assertNotSame('', $check['msg'],
+                    $check['name'] . ' fails without saying how to fix it');
+            }
+        }
+    }
+
+    /**
+     * The installer must not keep its own copy of those checks. If it grows one
+     * back, the two drift and nobody notices -- nobody runs the installer on a
+     * working instance, or the diagnostic on a fresh one.
+     */
+    public function testTheInstallerReadsTheSharedEnvironmentChecks(): void
+    {
+        $source = (string) file_get_contents(
+            OWA_DIR . 'modules/Base/Controller/InstallCheckEnv.php');
+
+        $this->assertStringContainsString('EnvironmentCheck::all(', $source,
+            'the installer must ask EnvironmentCheck rather than rebuild the list');
+
+        $this->assertStringNotContainsString('extension_loaded(', $source,
+            'the installer is testing extensions itself again');
+
+        $this->assertStringNotContainsString("is_dir( OWA_VENDOR_DIR )", $source,
+            'the installer is testing for vendor/ itself again');
+    }
+
+    public function testTheCommandIsRegistered(): void
+    {
+        $source = (string) file_get_contents(OWA_DIR . 'modules/Base/Module.php');
+
+        $this->assertStringContainsString("registerCliCommand('instance-info'", $source);
+    }
+
+    /**
+     * @group needs-db
+     */
+    public function testTheReportNamesEverySection(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('needs a database to boot the CLI');
+        }
+
+        $out = $this->report();
+
+        $this->assertStringNotContainsString('Fatal error', $out,
+            'the report must not fatal: ' . substr($out, 0, 500));
+
+        foreach (['ENVIRONMENT', 'MODULES', 'SCHEMA', 'SCHEDULER',
+                  'FACT TABLES', 'FRESHNESS', 'EVENT QUEUE', 'CONTENTS'] as $section) {
+
+            $this->assertStringContainsString($section, $out,
+                'the report is missing its ' . $section . ' section');
+        }
+    }
+
+    /**
+     * Modules and schema are two different questions. They were one section
+     * once, which sent a reader looking for "what is switched on" into a list
+     * of version numbers.
+     *
+     * @group needs-db
+     */
+    public function testModulesAndSchemaAreReportedSeparately(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('needs a database to boot the CLI');
+        }
+
+        $out = $this->report();
+
+        $this->assertStringContainsString('Active', $out,
+            'the module list must say which modules are active');
+
+        $this->assertStringContainsString('Present but inactive', $out,
+            'an inactive module explains a feature that "does not work"');
+
+        $this->assertMatchesRegularExpression('/SCHEMA.*schema \d+/s', $out,
+            'the schema section must report a version per module');
+    }
+
+    /**
+     * @group needs-db
+     */
+    public function testItCountsWhatTheInstanceHolds(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('needs a database to boot the CLI');
+        }
+
+        $out = $this->report();
+
+        foreach (['Organizations', 'Properties', 'Sites', 'Users'] as $label) {
+
+            $this->assertMatchesRegularExpression(
+                '/' . $label . '\s+\d+/', $out,
+                $label . ' must be reported with a number');
+        }
+    }
+
+    /**
+     * Colour is for a person at a terminal. Piped into a file or a monitoring
+     * check, escape codes are noise the reader cannot turn off -- and shell_exec
+     * here is exactly that case, so the report must come back clean.
+     *
+     * @group needs-db
+     */
+    public function testNoAnsiEscapesWhenOutputIsNotATerminal(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('needs a database to boot the CLI');
+        }
+
+        $this->assertStringNotContainsString("\033[", $this->report(),
+            'colour escapes must not reach a pipe');
+    }
+
+    /**
+     * It reports; it does not change anything. Asserted against the source
+     * because the destructive case cannot be exercised safely.
+     */
+    public function testItOnlyReads(): void
+    {
+        $source = (string) file_get_contents(
+            OWA_DIR . 'modules/Base/Controller/InstanceInfoCli.php');
+
+        /*
+         * Match SQL STATEMENTS, not words. A plain search for "UPDATE " fails
+         * on the string 'UPDATE REQUIRED' that the schema section prints, which
+         * would be a test that has to be weakened the first time it is right
+         * about nothing.
+         */
+        $writes = '/\b(INSERT\s+INTO|UPDATE\s+\w+\s+SET|DELETE\s+FROM'
+                . '|DROP\s+(TABLE|DATABASE)|ALTER\s+TABLE|TRUNCATE\s+(TABLE\s+)?\w)/i';
+
+        $this->assertDoesNotMatchRegularExpression($writes, $source,
+            'instance-info must only ever read');
+    }
+}


### PR DESCRIPTION
## Why

Everything this reports could already be found out, and that was the problem. It took several commands, some SQL and knowing which settings to read — so nobody did it, and **the things that fail quietly are exactly the things nobody goes looking for**:

- a stale user-agent database does not error, it misattributes
- an un-run scheduler does not error, it does nothing
- retention that was never configured does not error, it accumulates
- a module that is switched off looks identical to one that is broken

Each of those is now a line in one report.

```
  php cli.php cmd=instance-info
```

```
ENVIRONMENT
  +  PHP version                     8.2.33
  +  Dependencies                    installed
  +  Built assets                    built
  +  Error log                       writable

MODULES
     Active                          base, domstream, hello, maxmind_geoip
     Present but inactive            FileCache, MemcachedCache, RemoteQueue

SCHEMA
  +  base                            up to date (schema 27)

SCHEDULER
  +  Cron entry                      running
     Jobs registered                 2
  +    rotate-partitions             ok, last run 2026-08-18 13:41
  !    fetch-notifications           never run

FACT TABLES
  +  Partitioned tables              7 of 7
  !  Retention                       unlimited (nothing is deleted)
        Not an error, and a reasonable default -- but it is a choice.

FRESHNESS
  +  User-agent patterns             updated 2026-09-07 (0 day(s) ago)
  +  GeoIP database                  updated 2026-08-21 (16 day(s) ago)

EVENT QUEUE
  +  Queued events                   4

CONTENTS
     Organizations                   1
     Properties                      68
     Sites                           69
     Users                           2

----------------------------------------------------------------
  2 thing(s) worth a look   (22 ok, 2 warning(s), 0 failure(s))
```

`+` fine, `!` worth a look, `x` needs fixing — and anything not fine is followed by what to do about it. The `!`/`x` split matters: `!` is usually **a choice you have not made** (unlimited retention) rather than a fault. Colour only when output is a terminal.

## It only reads, and it exits 0

Every query is a count or a metadata read; a test asserts the source contains no write statement. It exits 0 whether or not it finds problems, because it is an info command and its name says so. `strict=1` makes it exit non-zero on a failure, which is what makes it usable from monitoring.

## The environment checks are now shared

They were inline in `InstallCheckEnv::action()`, interleaved with the view decision, so a second caller could not have them. They move to `Base\Classes\EnvironmentCheck`, and the installer becomes a caller.

Two copies would disagree about what "supported" means and the disagreement would be invisible — nobody runs the installer on a working instance, or the diagnostic on a fresh one. A test asserts the installer does not grow its own copy back.

## Degrading is the point

This gets run on installations that are already unwell, so every reader tolerates what it reads on being absent: a missing table, an unreadable setting, a module that will not load, a backend with no partitioning at all. Each becomes a line saying so rather than an exception. A diagnostic that dies on a sick instance is worse than none, because it dies exactly when it is wanted.

## Notes

- Partition counts go through the dialect's `listPartitions()` rather than a query written in the controller, so the MySQL-only spelling stays in the dialect layer where the portability lint expects it.
- The command declares `edit_modules`, the same gate the other administrative CLI commands use, and is registered in the action map rather than resolving through the legacy path.

## Testing

- Full suite: 1989 tests, 48522 assertions, 2 skipped — green
- Configless (CI-shaped, no database): green
- `composer phpstan`: no errors
- Mutation-checked both source-scanning tests: injecting a `DELETE FROM` into the command, and regrowing an `extension_loaded()` check in the installer, each fail

Wiki changes are written and held until this merges — the wiki documents the released version, and this command does not exist in it yet. They add a full `instance-info` entry to the CLI page, and open *Keeping an Install Healthy* by pointing at it.
