### PR TITLE
Activating a module installs it, and install() stops skipping updates

### DIFF
--- a/Core/Db/MysqlDialect.php
+++ b/Core/Db/MysqlDialect.php
@@ -380,6 +380,37 @@ trait MysqlDialect
      * @param string $column_name  one column, or a comma-separated list
      * @return bool
      */
+    /**
+     * Whether a table is already there.
+     *
+     * Schema introspection, so it lives in the dialect: the spelling is
+     * MySQL's, and a query written at the call site would work here and answer
+     * wrongly on any other backend.
+     *
+     * Used by Module::install() to tell a FRESH install from a re-run over
+     * tables that already exist -- CREATE TABLE IF NOT EXISTS cannot report
+     * which of the two happened, and the difference decides whether recording
+     * the current schema version is a repair or a way to skip every pending
+     * update.
+     *
+     * @param string $table_name
+     * @return bool
+     */
+    function tableExists( $table_name ) {
+
+        if ( ! preg_match( '/^[A-Za-z0-9_]+$/', (string) $table_name ) ) {
+
+            return false;
+        }
+
+        $row = $this->get_row( sprintf(
+            "SELECT COUNT(*) AS n FROM information_schema.TABLES "
+          . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s'",
+            $table_name ) );
+
+        return ( is_array( $row ) && isset( $row['n'] ) && (int) $row['n'] > 0 );
+    }
+
     function indexExists( $table_name, $column_name ) {
 
         $cols = $this->normalizeIndexColumns( $column_name );

--- a/Core/Module.php
+++ b/Core/Module.php
@@ -762,11 +762,10 @@ abstract class Module {
              * Three cases, and only the first two can be answered here:
              *
              *  - Already recorded: leave it. cmd=update migrates from there.
-             *  - Not recorded, and nothing to migrate -- either every table was
-             *    just created at the current definition, or the module has no
-             *    updates at all (required version 1). The required version is
-             *    then the truth, and recording it REPAIRS a module that was
-             *    activated without being installed.
+             *  - Not recorded, and every table was just created at the current
+             *    definition (which includes a module with no tables at all).
+             *    The required version is then the truth, and recording it
+             *    REPAIRS a module that was activated without being installed.
              *  - Not recorded, tables already existed, and updates exist between
              *    1 and required: unknowable from here. Say so and leave it
              *    absent -- getSchemaVersion() reads that as 1, so cmd=update
@@ -777,7 +776,18 @@ abstract class Module {
 
             if ( ! $recorded ) {
 
-                if ( $all_tables_are_new || $this->getRequiredSchemaVersion() <= 1 ) {
+                /*
+                 * Freshness alone decides it. A second clause for "the module
+                 * requires schema 1, so nothing could be pending" was correct
+                 * but unreachable: only base registers entities, so for every
+                 * other module the loop above never runs and this is already
+                 * true, and for base it is already false. An untestable branch
+                 * that no module can exercise is one nobody will notice going
+                 * wrong -- and omitting it fails in the safe direction, since
+                 * the cost is a version left unrecorded rather than one
+                 * wrongly claimed current.
+                 */
+                if ( $all_tables_are_new ) {
 
                     \OWA\Core\CoreAPI::persistSetting(
                         $this->name, 'schema_version', $this->getRequiredSchemaVersion() );

--- a/Core/Module.php
+++ b/Core/Module.php
@@ -695,12 +695,31 @@ abstract class Module {
 
         $errors = '';
 
+        /*
+         * Whether every table this module owns had to be created.
+         *
+         * createTable() is CREATE TABLE IF NOT EXISTS and returns true either
+         * way, so it cannot say whether it built the table or found it. That
+         * difference decides what the schema version may be set to below, so it
+         * is measured here instead.
+         */
+        $all_tables_are_new = true;
+
         // Install schema
         if (!empty($this->entities)) {
+
+            $db = \OWA\Core\CoreAPI::dbSingleton();
 
             foreach ($this->entities as $k => $v) {
 
                 $entity = \OWA\Core\CoreAPI::entityFactory($this->name.'.'.$v);
+
+                if ( is_object( $db ) && method_exists( $db, 'tableExists' )
+                     && $db->tableExists( $entity->getTableName() ) ) {
+
+                    $all_tables_are_new = false;
+                }
+
                 //owa_coreAPI::debug("about to  execute createtable");
                 $status = $entity->createTable();
 
@@ -728,8 +747,49 @@ abstract class Module {
                 \OWA\Core\CoreAPI::notice("Post install procedure failed.");
             }
 
-            // save schema version to configuration
-            \OWA\Core\CoreAPI::persistSetting( $this->name, 'schema_version', $this->getRequiredSchemaVersion() );
+            /*
+             * The schema version, written only when it is provably correct.
+             *
+             * Writing the REQUIRED version unconditionally was wrong on a re-run:
+             * CREATE TABLE IF NOT EXISTS leaves existing tables untouched, so the
+             * version jumped to the latest while the tables stayed old. update()
+             * selects work with `$seq > $current_schema_version`, so every update
+             * in between was skipped -- permanently, since nothing revisits them
+             * and isSchemaCurrent() then answers true. Reachable from the admin
+             * UI, whose "Activate" control calls install(): deactivate a module,
+             * upgrade OWA, activate it again, and its migrations were gone.
+             *
+             * Three cases, and only the first two can be answered here:
+             *
+             *  - Already recorded: leave it. cmd=update migrates from there.
+             *  - Not recorded, and nothing to migrate -- either every table was
+             *    just created at the current definition, or the module has no
+             *    updates at all (required version 1). The required version is
+             *    then the truth, and recording it REPAIRS a module that was
+             *    activated without being installed.
+             *  - Not recorded, tables already existed, and updates exist between
+             *    1 and required: unknowable from here. Say so and leave it
+             *    absent -- getSchemaVersion() reads that as 1, so cmd=update
+             *    replays the updates and records the version as it goes, which
+             *    is the safe direction.
+             */
+            $recorded = \OWA\Core\CoreAPI::getSetting( $this->name, 'schema_version' );
+
+            if ( ! $recorded ) {
+
+                if ( $all_tables_are_new || $this->getRequiredSchemaVersion() <= 1 ) {
+
+                    \OWA\Core\CoreAPI::persistSetting(
+                        $this->name, 'schema_version', $this->getRequiredSchemaVersion() );
+
+                } else {
+
+                    \OWA\Core\CoreAPI::notice( sprintf(
+                        'Module %s has tables but no recorded schema version, so its version '
+                      . 'was left unset rather than assumed current. Run "cmd=update" to apply '
+                      . 'any pending updates and record it.', $this->name ) );
+                }
+            }
             //activate the module and save the configuration
             $this->activate();
             \OWA\Core\CoreAPI::notice("Installation complete.");

--- a/modules/Base/Controller/InstanceInfoCli.php
+++ b/modules/Base/Controller/InstanceInfoCli.php
@@ -218,14 +218,45 @@ class InstanceInfoCli extends \OWA\Core\Controller\Cli {
 
             $current = ! in_array( $name, $behind, true );
 
+            /*
+             * The STORED version, which is not the same question as the one the
+             * verdict beside it answers. Module::getSchemaVersion() defaults an
+             * absent value to 1, so a module that was never installed reads as
+             * current; printing the raw setting instead rendered "(schema )".
+             * Both are reported, because the gap between them IS the finding.
+             */
+            $stored = \OWA\Core\CoreAPI::getSetting( $name, 'schema_version' );
+
             $rows[] = $this->row(
                 $current ? self::OK : self::FAIL,
                 $name,
                 sprintf( '%s (schema %s)',
                     $current ? 'up to date' : 'UPDATE REQUIRED',
-                    (string) \OWA\Core\CoreAPI::getSetting( $name, 'schema_version' ) ),
+                    $stored ? (string) $stored : 'not recorded' ),
                 "Run 'php cli.php cmd=update'. Until you do, the job scheduler "
               . 'refuses every job.' );
+
+            /*
+             * Active, but never installed.
+             *
+             * install() is what creates a module's tables and records its
+             * version; activate() only sets is_active. A module enabled by the
+             * older cmd=activate therefore runs with no tables and no version,
+             * and nothing says so -- the default of 1 makes it read as current.
+             * Harmless while a module has no updates and no entities, which is
+             * why it has gone unnoticed; the first update such a module ships
+             * will run against tables that were never created.
+             */
+            if ( ! $stored ) {
+
+                $rows[] = $this->row( self::WARN, '  ' . $name,
+                    'active, but never installed',
+                    sprintf( 'No schema version was recorded, so this module was activated '
+                           . 'without being installed and its tables may never have been '
+                           . "created. Run 'php cli.php cmd=activate module=%s' to install "
+                           . 'it properly; that is safe to run on an installed module.',
+                             $name ) );
+            }
         }
 
         if ( ! $rows ) {

--- a/modules/Base/Controller/ModuleActivateCli.php
+++ b/modules/Base/Controller/ModuleActivateCli.php
@@ -45,7 +45,22 @@ class ModuleActivateCli extends \OWA\Core\Controller\Cli {
         
         if ( $module ) {
     
-            $ret = \OWA\Core\CoreAPI::activateModule($module);
+            /*
+             * INSTALL, not activate.
+             *
+             * The admin UI's "Activate" control has always called
+             * installModule() -- it creates the module's tables, records its
+             * schema version and then activates it. This command called
+             * activateModule(), which sets is_active and nothing else, so the
+             * same word did two different things depending on where it was
+             * typed, and the CLI one left a module switched on with no tables
+             * and no schema version. Nothing reported that: getSchemaVersion()
+             * defaults an absent version to 1, so the module read as current.
+             *
+             * install() is idempotent (see Module::install), so this is safe to
+             * run against a module that is already installed.
+             */
+            $ret = \OWA\Core\CoreAPI::installModule($module);
             
         } else {
             \OWA\Core\CoreAPI::notice('No module argument was specified. Use module=xxx');

--- a/modules/Base/Controller/ModuleInstallCli.php
+++ b/modules/Base/Controller/ModuleInstallCli.php
@@ -43,13 +43,27 @@ class ModuleInstallCli extends \OWA\Core\Controller\Cli {
 
         $module = $this->getParam('module');
 
-        if ( $module ) {
+        if ( ! $module ) {
 
-            $ret = \OWA\Core\CoreAPI::installModule($module);
-
-        } else {
-            \OWA\Core\CoreAPI::notice('No module argument was specified. Use module=xxx');
+            return $this->refuse( 'No module argument was specified. Use module=xxx' );
         }
+
+        /*
+         * DEPRECATED. Two commands did the same job under different names while
+         * a third name, cmd=activate, did only half of it -- so which of the
+         * three to type depended on knowing that history. cmd=activate now
+         * installs, matching what the admin UI's "Activate" control has always
+         * done, which leaves this one redundant.
+         *
+         * Still does exactly what it did, because scripts call it. It goes away
+         * at v2.0, alongside the other deprecations.
+         */
+        \OWA\Core\CoreAPI::notice(
+            'cmd=install-module is deprecated and will be removed in 2.0. '
+          . 'Use "cmd=activate module=' . $module . '" instead -- it installs '
+          . 'and activates, which is what this command does.' );
+
+        return \OWA\Core\CoreAPI::installModule($module);
     }
 
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -253,6 +253,12 @@ parameters:
 			path: Core/Module.php
 
 		-
+			message: '#^Call to method getTableName\(\) on an unknown class OWA\\Core\\unknown\.$#'
+			identifier: class.notFound
+			count: 1
+			path: Core/Module.php
+
+		-
 			message: '#^Method OWA\\Core\\Module\:\:registerEventHandler\(\) should return bool but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1

--- a/tests/ModuleActivateInstallTest.php
+++ b/tests/ModuleActivateInstallTest.php
@@ -142,6 +142,55 @@ final class ModuleActivateInstallTest extends TestCase
     }
 
     /**
+     * The decision itself: when a missing version must NOT be repaired.
+     *
+     * This is the case the repair test cannot reach. maxmind_geoip has no
+     * entities and requires schema 1, so BOTH halves of the condition
+     * ($all_tables_are_new, and required <= 1) are true there -- that test would
+     * pass against a condition hardcoded to true. It shows a repair happens, not
+     * that the decision is right.
+     *
+     * base is the only module with entities AND a required version above 1, so
+     * it is the only place the operands differ: its tables already exist, so a
+     * missing version might mean 27 updates are pending rather than none.
+     * Guessing "current" there is precisely the migration-skip this change
+     * exists to stop, so install() must refuse and leave the version unset --
+     * getSchemaVersion() then reads 1 and cmd=update replays properly.
+     */
+    public function testAMissingVersionIsNotRepairedWhenUpdatesCouldBePending(): void
+    {
+        $real = \OWA\Core\CoreAPI::getSetting('base', 'schema_version');
+
+        $this->assertGreaterThan(1, (int) $real,
+            'base must require more than schema 1 for this case to exist');
+
+        try {
+            // A module whose tables are already there, with no recorded version.
+            \OWA\Core\CoreAPI::persistSetting('base', 'schema_version', false);
+            \OWA\Core\CoreAPI::configSingleton()->save();
+
+            $this->assertEmpty(\OWA\Core\CoreAPI::getSetting('base', 'schema_version'),
+                'precondition: no version recorded');
+
+            \OWA\Core\CoreAPI::installModule('base');
+
+            $this->assertEmpty(
+                \OWA\Core\CoreAPI::getSetting('base', 'schema_version'),
+                'install() must NOT assume a module with existing tables is current: '
+                . 'recording the required version here would skip every pending update'
+            );
+
+        } finally {
+            \OWA\Core\CoreAPI::persistSetting('base', 'schema_version', $real);
+            \OWA\Core\CoreAPI::configSingleton()->save();
+
+            $this->assertSame((int) $real,
+                (int) \OWA\Core\CoreAPI::getSetting('base', 'schema_version'),
+                'the installation must be left exactly as it was found');
+        }
+    }
+
+    /**
      * install() must be able to tell a fresh table from one that was already
      * there. Without this the decision above cannot be made at all.
      */

--- a/tests/ModuleActivateInstallTest.php
+++ b/tests/ModuleActivateInstallTest.php
@@ -1,0 +1,199 @@
+<?php
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Turning a module on must leave it INSTALLED, and doing it twice must be safe.
+ *
+ * THE STATE THIS EXISTS TO PREVENT. A module has two things: its tables, and a
+ * recorded schema_version. install() creates both; activate() sets is_active and
+ * nothing else. The admin UI's "Activate" control has always called install(),
+ * but `cmd=activate` called activate() -- so the same word did different things
+ * depending on where it was typed, and the CLI one left a module switched on
+ * with no tables and no version. Nothing reported it, because
+ * Module::getSchemaVersion() defaults an absent version to 1 and every module
+ * currently requires 1, so the module read as current. demo's maxmind_geoip has
+ * been in exactly that state.
+ *
+ * WHY RE-RUNNING install() USED TO BE DESTRUCTIVE. createTable() is
+ * CREATE TABLE IF NOT EXISTS, so a re-run leaves existing tables untouched --
+ * but install() then wrote the REQUIRED schema version anyway. update() selects
+ * work with `$seq > $current_schema_version`, so every update between the real
+ * version and the required one was skipped, permanently, and isSchemaCurrent()
+ * answered true afterwards. Reachable from the UI: deactivate a module, upgrade
+ * OWA, activate it again.
+ *
+ * So install() now records the version only when that is provably right, and
+ * these tests pin each branch of that decision.
+ */
+final class ModuleActivateInstallTest extends TestCase
+{
+    /** @var mixed */
+    private $saved;
+    private bool $had = false;
+
+    protected function setUp(): void
+    {
+        if (!owa_test_db_available()) {
+            $this->markTestSkipped('needs a database');
+        }
+
+        $this->saved = \OWA\Core\CoreAPI::getSetting('maxmind_geoip', 'schema_version');
+        $this->had = (bool) $this->saved;
+    }
+
+    protected function tearDown(): void
+    {
+        if (!owa_test_db_available()) {
+            return;
+        }
+
+        // Put the installation back exactly as it was found.
+        if ($this->had) {
+            \OWA\Core\CoreAPI::persistSetting('maxmind_geoip', 'schema_version', $this->saved);
+            \OWA\Core\CoreAPI::configSingleton()->save();
+        }
+    }
+
+    /**
+     * The repair. A module carrying no recorded version, whose required version
+     * is 1, has nothing that could be pending -- so recording it is safe, and
+     * turning the module on should do it.
+     */
+    public function testActivatingRepairsAMissingSchemaVersion(): void
+    {
+        // Reproduce demo: activated but never installed -- is_active present,
+        // schema_version absent. Writing false is how a key is removed from the
+        // settings blob, so this produces a genuinely absent key rather than a
+        // zero, which is the state the repair has to recognise.
+        \OWA\Core\CoreAPI::persistSetting('maxmind_geoip', 'schema_version', false);
+        \OWA\Core\CoreAPI::configSingleton()->save();
+
+        $this->assertEmpty(
+            \OWA\Core\CoreAPI::getSetting('maxmind_geoip', 'schema_version'),
+            'the precondition must hold: no schema version recorded'
+        );
+
+        \OWA\Core\CoreAPI::installModule('maxmind_geoip');
+
+        $this->assertSame(
+            1,
+            (int) \OWA\Core\CoreAPI::getSetting('maxmind_geoip', 'schema_version'),
+            'installing a module with no recorded version must record it'
+        );
+    }
+
+    /**
+     * The destructive case. A module that already has a version keeps it, so
+     * its pending updates survive a re-install.
+     */
+    public function testReinstallingDoesNotOverwriteAnExistingSchemaVersion(): void
+    {
+        \OWA\Core\CoreAPI::persistSetting('maxmind_geoip', 'schema_version', 1);
+        \OWA\Core\CoreAPI::configSingleton()->save();
+
+        \OWA\Core\CoreAPI::installModule('maxmind_geoip');
+
+        $this->assertSame(
+            1,
+            (int) \OWA\Core\CoreAPI::getSetting('maxmind_geoip', 'schema_version'),
+            'a recorded version must survive a re-install, or pending updates are skipped'
+        );
+    }
+
+    /**
+     * The destructive case, pinned where it can actually fail.
+     *
+     * maxmind_geoip requires schema 1, so "do not overwrite" cannot be wrong
+     * there -- the value written would be the value already present. base is the
+     * only module that has ever shipped updates, so it is the only place the
+     * difference between "keep 20" and "jump to 27" is observable.
+     */
+    public function testReinstallingAnOutOfDateModuleLeavesItsUpdatesPending(): void
+    {
+        $real = \OWA\Core\CoreAPI::getSetting('base', 'schema_version');
+
+        $this->assertGreaterThan(1, (int) $real, 'base must have a real schema version');
+
+        try {
+            // Pretend this install is several updates behind.
+            \OWA\Core\CoreAPI::persistSetting('base', 'schema_version', 20);
+            \OWA\Core\CoreAPI::configSingleton()->save();
+
+            \OWA\Core\CoreAPI::installModule('base');
+
+            $this->assertSame(
+                20,
+                (int) \OWA\Core\CoreAPI::getSetting('base', 'schema_version'),
+                'install() must not advance the schema version of a module whose tables '
+                . 'it did not create -- doing so skips every update in between, permanently'
+            );
+
+        } finally {
+            \OWA\Core\CoreAPI::persistSetting('base', 'schema_version', $real);
+            \OWA\Core\CoreAPI::configSingleton()->save();
+
+            $this->assertSame((int) $real,
+                (int) \OWA\Core\CoreAPI::getSetting('base', 'schema_version'),
+                'the installation must be left exactly as it was found');
+        }
+    }
+
+    /**
+     * install() must be able to tell a fresh table from one that was already
+     * there. Without this the decision above cannot be made at all.
+     */
+    public function testTheDialectCanTellWhetherATableExists(): void
+    {
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+
+        $this->assertTrue(method_exists($db, 'tableExists'),
+            'schema introspection belongs in the dialect');
+
+        $e = \OWA\Core\CoreAPI::entityFactory('base.site');
+
+        $this->assertTrue($db->tableExists($e->getTableName()),
+            'an installed table must be reported as present');
+
+        $this->assertFalse($db->tableExists('owa_no_such_table_here'),
+            'a table that does not exist must not be reported as present');
+
+        $this->assertFalse($db->tableExists("owa_site'; DROP TABLE owa_site; --"),
+            'the name is validated before it reaches the query');
+    }
+
+    /**
+     * The two CLI commands must agree with the admin UI, which has always
+     * installed. Asserted against the source: the difference between
+     * installModule() and activateModule() is one identifier, and it is the
+     * whole defect.
+     */
+    public function testTheActivateCommandInstalls(): void
+    {
+        $src = (string) file_get_contents(
+            OWA_DIR . 'modules/Base/Controller/ModuleActivateCli.php');
+
+        $this->assertStringContainsString('CoreAPI::installModule(', $src,
+            'cmd=activate must install, matching the admin UI');
+
+        $this->assertStringNotContainsString('CoreAPI::activateModule(', $src,
+            'cmd=activate must not set is_active alone -- that leaves a module with no tables');
+    }
+
+    public function testTheInstallModuleCommandIsDeprecatedButStillWorks(): void
+    {
+        $src = (string) file_get_contents(
+            OWA_DIR . 'modules/Base/Controller/ModuleInstallCli.php');
+
+        $this->assertMatchesRegularExpression('/deprecated/i', $src,
+            'cmd=install-module must announce its deprecation');
+
+        $this->assertStringContainsString('cmd=activate', $src,
+            'the deprecation notice must name the command that replaces it');
+
+        $this->assertStringContainsString('CoreAPI::installModule(', $src,
+            'it must keep working for the scripts that call it');
+    }
+}


### PR DESCRIPTION
## Two commands, one word, different meanings

A module has two things: its **tables**, and a recorded **schema_version**. `install()` creates both; `activate()` sets `is_active` and nothing else.

| entry point | calls | result |
|---|---|---|
| Admin UI "Activate" control | `installModule()` | tables + version + active |
| `cli.php cmd=activate` | `activateModule()` | **active only** |
| `cli.php cmd=install-module` | `installModule()` | tables + version + active |

So a module turned on from the CLI was left switched on with **no tables and no schema version** — and nothing said so, because `getSchemaVersion()` defaults an absent version to `1` and every module currently requires `1`, so it reads as current.

demo's `maxmind_geoip` is in exactly that state: `is_active` and `db_license_key` stored, `schema_version` absent. It surfaced only because `instance-info` printed `up to date (schema )`.

This is harmless *only* while a module has no updates and no entities. Today **only `base` has ever shipped an update** — every other module has no `Update/` directory at all — which is why nothing has broken. The first non-base module to ship one would run it against tables that were never created.

## Why `install()` couldn't just be called more often

`createTable()` is `CREATE TABLE IF NOT EXISTS`, so a re-run leaves existing tables untouched — but `install()` then wrote the **required** version anyway. `update()` selects work with `$seq > $current_schema_version`, so every update in between was skipped **permanently**: nothing revisits them, and `isSchemaCurrent()` answers true afterwards.

Reachable from the UI: deactivate a module, upgrade OWA, click Activate — migrations gone.

## What changed

`install()` now records the version only where that is provably right:

- **already recorded** → leave it; `cmd=update` migrates from there
- **not recorded, nothing to migrate** (every table just created, or the module has no updates at all) → record it. This is the **repair**: a module activated without being installed heals itself
- **not recorded, tables already existed, updates exist in between** → unknowable here. Say so and leave it absent; `getSchemaVersion()` reads that as `1`, so `cmd=update` replays and records as it goes

Telling those apart needs to know whether a table was *created* or *found*, which `CREATE TABLE IF NOT EXISTS` cannot report — so `Db` gains **`tableExists()`**, in the dialect, because schema introspection is backend-specific (the portability lint's own reasoning).

With `install()` idempotent, **`cmd=activate` now calls it**, so CLI and UI agree. **`cmd=install-module` is deprecated** — still works, names its replacement, goes at v2.0.

`cmd=instance-info` now reports the condition instead of hiding it:

```
SCHEMA
  +  maxmind_geoip                   up to date (schema not recorded)
  !    maxmind_geoip                 active, but never installed
        No schema version was recorded, so this module was activated without
        being installed and its tables may never have been created. Run
        'php cli.php cmd=activate module=maxmind_geoip' to install it properly;
        that is safe to run on an installed module.
```

It was also printing the raw setting beside a verdict computed from the *defaulting* accessor — two different reads of one fact, which is how `(schema )` happened.

## Testing

One note worth stating plainly: the "do not overwrite" case is pinned against **`base`, not `maxmind_geoip`**. Maxmind requires schema 1, so the value written would equal the value already present and the assertion could not fail there. `base` is the only module that has ever shipped updates and therefore the only place the difference between "keep 20" and "jump to 27" is observable. The test sets base to 20, re-installs, asserts it stays 20, and restores the real value in a `finally`.

- Full suite: 1995 tests, 48541 assertions, 2 skipped — green
- Configless (CI-shaped): green
- `composer phpstan`: no errors
- Mutation-checked: restoring the unconditional `persistSetting` fails the base test

The one baseline addition mirrors an entry already present for the same root cause in the same file — `entityFactory()` is declared `@return unknown`, which is a separate cleanup.