### PR TITLE
Generate the metric and dimension documentation from the registry

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,76 @@
+name: Publish reference documentation
+
+# On the release being PUBLISHED, not on it being packaged.
+#
+# The Release Packager opens a DRAFT, which a person publishes by hand and may
+# decide not to publish at all. Generating the wiki from the packager would
+# therefore document a release that does not exist yet, and sometimes one that
+# never will. `published` fires at the moment the release becomes public, which
+# is exactly when the wiki should start describing it.
+#
+# Deliberately not on push to master either: the wiki documents the released
+# version, so it must not move every time a metric is registered.
+on:
+  release:
+    types: [published]
+  # Re-run against an existing tag if a publish failed or the page was edited by
+  # hand. Generates from the tag given, so it cannot quietly document master.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The release tag to generate from (e.g. 1.13.0)
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Regenerate the metrics and dimensions page
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the released code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      # Production dependencies only. The generator reads the registry, which
+      # needs the autoloader but no database -- it pre-defines OWA_DB_TYPE so it
+      # boots without a config file.
+      - name: Install Composer dependencies
+        run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress
+
+      - name: Generate the tables
+        run: |
+          php tests/tools/generate_metrics_dimensions_doc.php > /tmp/generated.md
+          test -s /tmp/generated.md
+          echo "rows: $(grep -c '^|`' /tmp/generated.md)"
+
+      - name: Check out the wiki
+        run: |
+          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" /tmp/wiki
+
+      # Only the delimited section is replaced; the notes below it are written by
+      # hand and are not ours to overwrite. The splice refuses if the markers are
+      # missing rather than guessing at what may be replaced.
+      - name: Splice the generated tables into the page
+        run: php tests/tools/splice_generated_doc.php "/tmp/wiki/Metrics-&-Dimensions.md" /tmp/generated.md
+
+      - name: Commit, if anything changed
+        working-directory: /tmp/wiki
+        run: |
+          if git diff --quiet; then
+            echo "The page already matches this release. Nothing to do."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "Metrics-&-Dimensions.md"
+          git commit -m "Regenerate metrics and dimensions for ${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          git push

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -505,7 +505,7 @@ class Module extends \OWA\Core\Module {
         $this->registerMetricDefinition(array(
             'name'            => 'visits',
             'label'            => 'Visits',
-            'description'    => 'The total number of visits/sessions.',
+            'description'    => 'The total number of visits, also called sessions.',
             'group'            => 'Site Usage',
             'entity'        => 'base.session',
             'metric_type'    => 'distinct_count', // 'count', 'distinct_count', 'sum', or 'calculated'
@@ -517,7 +517,7 @@ class Module extends \OWA\Core\Module {
         $this->registerMetricDefinition(array(
             'name'            => 'visits',
             'label'            => 'Visits',
-            'description'    => 'The total number of visits/sessions.',
+            'description'    => 'The total number of visits, also called sessions.',
             'group'            => 'Site Usage',
             'entity'        => 'base.request',
             'metric_type'    => 'distinct_count', // 'count', 'distinct_count', 'sum', or 'calculated'
@@ -542,7 +542,7 @@ class Module extends \OWA\Core\Module {
             'base.repeatVisitors',
             '',
             'Repeat Visitors',
-            'The total number of repeat visitors',
+            'The total number of repeat visitors: unique visitors with two or more visits.',
             'Site Usage'
         );
 
@@ -560,7 +560,7 @@ class Module extends \OWA\Core\Module {
         $this->registerMetricDefinition( array(
             'name'              => 'visitDuration',
             'label'             => 'Visit Duration',
-            'description'       => 'The average duration of visits.',
+            'description'       => 'The average duration of visits, measured between the first and last page view of each visit.',
             'group'             => 'Site Usage',
             'metric_type'       => 'avg_difference',
             'data_type'         => 'timestamp',
@@ -583,7 +583,7 @@ class Module extends \OWA\Core\Module {
         $this->registerMetricDefinition( array(
             'name'          => 'bounceRate',
             'label'         => 'Bounce Rate',
-            'description'   => 'The percentage of visits that were bounces.',
+            'description'   => 'The percentage of visits that were bounces: single page view visits divided by entry pages.',
             'group'         => 'Site Usage',
             'metric_type'   => 'calculated',
             'data_type'     => 'percentage',
@@ -594,7 +594,7 @@ class Module extends \OWA\Core\Module {
         $this->registerMetricDefinition( array(
             'name'          => 'pagesPerVisit',
             'label'         => 'Pages Per Visit',
-            'description'   => 'The average pages viewed per visit.',
+            'description'   => 'The average pages viewed per visit: page views divided by visits.',
             'group'         => 'Site Usage',
             'metric_type'   => 'calculated',
             'data_type'     => 'decimal',
@@ -605,7 +605,7 @@ class Module extends \OWA\Core\Module {
         $this->registerMetricDefinition( array(
             'name'        => 'actions',
             'label'       => 'Actions',
-            'description' => 'The total number of action events.',
+            'description' => 'The total number of action events, an action being an analyst-defined event performed by a user.',
             'group'       => 'Actions',
             'metric_type' => 'distinct_count',
             'data_type'   => 'integer',
@@ -740,7 +740,7 @@ class Module extends \OWA\Core\Module {
         $this->registerMetricDefinition( array(
             'name'          => 'goalConversionRateAll',
             'label'         => 'Goal Conversion Rate',
-            'description'   => 'The rate of goals achieved in all visits.',
+            'description'   => 'The rate of goals achieved in all visits: goal completions divided by goal starts.',
             'group'         => 'Goals',
             'metric_type'   => 'calculated',
             'data_type'     => 'percentage',
@@ -1062,7 +1062,7 @@ class Module extends \OWA\Core\Module {
             'yyyymmdd',
             'Date',
             'time',
-            'The date.',
+            'A date string in YYYYMMDD format (e.g. 20200415).',
             '',
             true,
             'yyyymmdd'
@@ -1208,7 +1208,7 @@ class Module extends \OWA\Core\Module {
             'user_name',
             'User Name',
             'visitor',
-            'The name or ID of the user.',
+            'A generic string used to store the user name of the visitor.',
             '',
             true
         );
@@ -1219,7 +1219,7 @@ class Module extends \OWA\Core\Module {
             'user_email',
             'Email Address',
             'visitor',
-            'The email address of the user.'
+            'A generic string used to store the email address of the visitor.'
         );
 
         $this->registerDimension(
@@ -1228,7 +1228,7 @@ class Module extends \OWA\Core\Module {
             'is_repeat_visitor',
             'Repeat Visitor',
             'visitor',
-            'Repeat Site Visitor.',
+            'A boolean indicating whether the visitor has had two or more visits.',
             '',
             true,
             // Declared boolean so it FORMATS as Yes/No wherever it is shown.
@@ -1243,7 +1243,7 @@ class Module extends \OWA\Core\Module {
             'is_new_visitor',
             'New Visitor',
             'visitor',
-            'New Site Visitor.',
+            'A boolean indicating whether the visitor has had only one visit.',
             '',
             true
         );
@@ -1264,7 +1264,7 @@ class Module extends \OWA\Core\Module {
             'url',
             'Entry Page URL',
             'visit',
-            'The URL of the entry page.',
+            'The url of the page first viewed during a visit.',
             'first_page_id'
         );
 
@@ -1274,7 +1274,7 @@ class Module extends \OWA\Core\Module {
             'uri',
             'Entry Page Path',
             'visit',
-            'The URI of the entry page.',
+            'The path portion of the URL of the page first viewed during a visit.',
             'first_page_id'
         );
 
@@ -1284,7 +1284,7 @@ class Module extends \OWA\Core\Module {
             'page_title',
             'Entry Page Title',
             'visit',
-            'The title of the entry page.',
+            'The title of the page first viewed during a visit.',
             'first_page_id'
         );
 
@@ -1294,7 +1294,7 @@ class Module extends \OWA\Core\Module {
             'page_type',
             'Entry Page Type',
             'visit',
-            'The page type of the entry page.',
+            'The page type of the page first viewed during a visit.',
             'first_page_id'
         );
 
@@ -1304,7 +1304,7 @@ class Module extends \OWA\Core\Module {
             'url',
             'Exit Page URL',
             'visit',
-            'The URL of the exit page.',
+            'The url of the page last viewed during a visit.',
             'last_page_id'
         );
 
@@ -1314,7 +1314,7 @@ class Module extends \OWA\Core\Module {
             'uri',
             'Exit Page Path',
             'visit',
-            'The URI of the exit page.',
+            'The path of the page last viewed during a visit.',
             'last_page_id'
         );
 
@@ -1324,7 +1324,7 @@ class Module extends \OWA\Core\Module {
             'page_title',
             'Exit Page Title',
             'visit',
-            'The title of the exit page.',
+            'The title of the page last viewed during a visit.',
             'last_page_id'
         );
 
@@ -1334,7 +1334,7 @@ class Module extends \OWA\Core\Module {
             'page_type',
             'Exit Page Type',
             'visit',
-            'The page type of the exit page.',
+            'The page type of the page last viewed during a visit.',
             'last_page_id'
         );
 
@@ -1576,7 +1576,7 @@ class Module extends \OWA\Core\Module {
             'country_code',
             'Country Code',
             'geo',
-            'The ISO country code of the visitor.'
+            'The country code for the inferred country location of visitors.'
         );
 
         $this->registerDimension(
@@ -1616,7 +1616,7 @@ class Module extends \OWA\Core\Module {
             'medium',
             'Medium',
             'campaign',
-            'The medium where visit originated from.',
+            'A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.',
             '',
             true
         );
@@ -1627,7 +1627,7 @@ class Module extends \OWA\Core\Module {
             'source_domain',
             'Source',
             'campaign',
-            'The traffic source of the visit.'
+            'The origin of traffic. Possible values are the domain of referring websites (foo.com) or app search engines (Google), etc.'
         );
 
         $this->registerDimension(
@@ -1672,7 +1672,7 @@ class Module extends \OWA\Core\Module {
             'page_title',
             'Referral Page Title',
             'campaign',
-            'The title of the referring web page.'
+            'The page title of the url that referred visitors to the tracked website.'
         );
 
         $this->registerDimension(
@@ -1681,7 +1681,7 @@ class Module extends \OWA\Core\Module {
             'terms',
             'Search Terms',
             'campaign',
-            'The referring search terms.',
+            'The search term that led visitors to the tracked website.',
             'referring_search_term_id'
         );
 
@@ -1691,7 +1691,7 @@ class Module extends \OWA\Core\Module {
             'refering_anchortext',
             'Referral Link Text',
             'campaign',
-            'The text of the referring link.'
+            'The anchor text of the link that referred visitors to the tracked website.'
         );
 
         $this->registerDimension(
@@ -1700,7 +1700,7 @@ class Module extends \OWA\Core\Module {
             'is_searchengine',
             'Search Engine',
             'campaign',
-            'Is traffic source a search engine.'
+            'A boolean indicating if the referring url is a search engine.'
         );
 
         $this->registerDimension(
@@ -1730,7 +1730,7 @@ class Module extends \OWA\Core\Module {
             'url',
             'Prior Page URL',
             'content',
-            'The URL of the prior page.',
+            'The url of the page viewed before the current page view.',
             'prior_document_id'
         );
 
@@ -1760,7 +1760,7 @@ class Module extends \OWA\Core\Module {
             'page_type',
             'Prior Page Type',
             'content',
-            'The page type of the prior page.',
+            'The type of page viewed before the current page view.',
             'prior_document_id'
         );
 

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -1019,7 +1019,7 @@ class Module extends \OWA\Core\Module {
             'year',
             'Year',
             'time',
-            'The year.',
+            'The four digit year.',
             '',
             true
         );
@@ -1074,7 +1074,7 @@ class Module extends \OWA\Core\Module {
             'day',
             'Day',
             'time',
-            'The day.',
+            'The day of the month (1-31).',
             '',
             true
         );
@@ -1085,7 +1085,7 @@ class Module extends \OWA\Core\Module {
             'month',
             'Month',
             'time',
-            'The month.',
+            'The month, as yyyymm.',
             '',
             true
         );
@@ -1096,7 +1096,7 @@ class Module extends \OWA\Core\Module {
             'year',
             'Year',
             'time',
-            'The year.',
+            'The four digit year.',
             '',
             true
         );

--- a/tests/CatalogDescriptionsTest.php
+++ b/tests/CatalogDescriptionsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every metric and dimension must describe itself.
+ *
+ * The documentation is generated from the registry at release time, so whatever
+ * the registry says is what users read. That makes an absent or placeholder
+ * description a documentation defect committed months before anyone sees it, and
+ * the person who could fix it in seconds is the one registering it.
+ *
+ * This is deliberately NOT a check that the generated page is up to date. Nothing
+ * reads that page between releases, so requiring it to be regenerated on every
+ * change would add a step to ordinary work and fail a build over something that
+ * is not broken. Generation belongs to the release; this belongs here.
+ */
+final class CatalogDescriptionsTest extends TestCase
+{
+    /** Descriptions that say nothing, however long they are. */
+    private const PLACEHOLDERS = ['', 'n/a', 'na', 'tbd', 'todo', 'description', '-', '—'];
+
+    private function isUseful(string $desc, string $label): ?string
+    {
+        $d = trim($desc);
+
+        if (in_array(strtolower(rtrim($d, '.')), self::PLACEHOLDERS, true)) {
+            return 'has no description';
+        }
+
+        if (strlen($d) < 10) {
+            return 'description is too short to say anything: ' . var_export($d, true);
+        }
+
+        // A description that only restates the label tells a reader nothing they
+        // did not already have from the name next to it.
+        if (strcasecmp(rtrim($d, '.'), rtrim(trim($label), '.')) === 0) {
+            return 'description only repeats the label: ' . var_export($d, true);
+        }
+
+        return null;
+    }
+
+    public function testEveryMetricHasAUsefulDescription(): void
+    {
+        $bad = [];
+
+        foreach ((array) \OWA\Core\CoreAPI::getAllMetrics() as $name => $declarations) {
+
+            $first = is_array($declarations) ? reset($declarations) : [];
+
+            $problem = $this->isUseful(
+                (string) ($first['description'] ?? ''),
+                (string) ($first['label'] ?? '')
+            );
+
+            if ($problem !== null) {
+                $bad[] = $name . ': ' . $problem;
+            }
+        }
+
+        $this->assertSame([], $bad,
+            "These metrics are registered without a usable description. They are what a\n"
+            . "reader sees in the report builder and in the generated documentation:\n  "
+            . implode("\n  ", $bad));
+    }
+
+    public function testEveryDimensionHasAUsefulDescription(): void
+    {
+        $bad = [];
+
+        foreach ((array) \OWA\Core\CoreAPI::getAllDimensions() as $name => $d) {
+
+            $problem = $this->isUseful(
+                (string) ($d['description'] ?? ''),
+                (string) ($d['label'] ?? '')
+            );
+
+            if ($problem !== null) {
+                $bad[] = $name . ': ' . $problem;
+            }
+        }
+
+        $this->assertSame([], $bad,
+            "These dimensions are registered without a usable description:\n  "
+            . implode("\n  ", $bad));
+    }
+}

--- a/tests/fixtures/catalog.json
+++ b/tests/fixtures/catalog.json
@@ -19,7 +19,7 @@
                     "child_metrics": [],
                     "column": "id",
                     "data_type": "integer",
-                    "description": "The total number of action events.",
+                    "description": "The total number of action events, an action being an analyst-defined event performed by a user.",
                     "entity": "base.action_fact",
                     "formula": "",
                     "group": "Actions",
@@ -64,7 +64,7 @@
                     ],
                     "column": "",
                     "data_type": "percentage",
-                    "description": "The percentage of visits that were bounces.",
+                    "description": "The percentage of visits that were bounces: single page view visits divided by entry pages.",
                     "entity": "",
                     "formula": "bounces / visits",
                     "group": "Site Usage",
@@ -757,7 +757,7 @@
                     ],
                     "column": "",
                     "data_type": "percentage",
-                    "description": "The rate of goals achieved in all visits.",
+                    "description": "The rate of goals achieved in all visits: goal completions divided by goal starts.",
                     "entity": "",
                     "formula": "goalCompletionsAll / visits",
                     "group": "Goals",
@@ -964,7 +964,7 @@
                     ],
                     "column": "",
                     "data_type": "decimal",
-                    "description": "The average pages viewed per visit.",
+                    "description": "The average pages viewed per visit: page views divided by visits.",
                     "entity": "",
                     "formula": "round(pageViews / visits, 2)",
                     "group": "Site Usage",
@@ -1421,7 +1421,7 @@
                     "child_metrics": [],
                     "column": "last_req",
                     "data_type": "timestamp",
-                    "description": "The average duration of visits.",
+                    "description": "The average duration of visits, measured between the first and last page view of each visit.",
                     "entity": "base.session",
                     "formula": "",
                     "group": "Site Usage",
@@ -1577,7 +1577,7 @@
                     "child_metrics": [],
                     "column": "id",
                     "data_type": "integer",
-                    "description": "The total number of visits/sessions.",
+                    "description": "The total number of visits, also called sessions.",
                     "entity": "base.session",
                     "formula": "",
                     "group": "Site Usage",
@@ -1596,7 +1596,7 @@
                     "child_metrics": [],
                     "column": "session_id",
                     "data_type": "integer",
-                    "description": "The total number of visits/sessions.",
+                    "description": "The total number of visits, also called sessions.",
                     "entity": "base.request",
                     "formula": "",
                     "group": "Site Usage",
@@ -1707,7 +1707,7 @@
                 "column": "country_code",
                 "family": "geo",
                 "label": "Country Code",
-                "description": "The ISO country code of the visitor.",
+                "description": "The country code for the inferred country location of visitors.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": false
@@ -1720,7 +1720,7 @@
                 "column": "uri",
                 "family": "visit",
                 "label": "Entry Page Path",
-                "description": "The URI of the entry page.",
+                "description": "The path portion of the URL of the page first viewed during a visit.",
                 "foreign_key_name": "first_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1733,7 +1733,7 @@
                 "column": "page_title",
                 "family": "visit",
                 "label": "Entry Page Title",
-                "description": "The title of the entry page.",
+                "description": "The title of the page first viewed during a visit.",
                 "foreign_key_name": "first_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1746,7 +1746,7 @@
                 "column": "page_type",
                 "family": "visit",
                 "label": "Entry Page Type",
-                "description": "The page type of the entry page.",
+                "description": "The page type of the page first viewed during a visit.",
                 "foreign_key_name": "first_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1759,7 +1759,7 @@
                 "column": "url",
                 "family": "visit",
                 "label": "Entry Page URL",
-                "description": "The URL of the entry page.",
+                "description": "The url of the page first viewed during a visit.",
                 "foreign_key_name": "first_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1772,7 +1772,7 @@
                 "column": "uri",
                 "family": "visit",
                 "label": "Exit Page Path",
-                "description": "The URI of the exit page.",
+                "description": "The path of the page last viewed during a visit.",
                 "foreign_key_name": "last_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1785,7 +1785,7 @@
                 "column": "page_title",
                 "family": "visit",
                 "label": "Exit Page Title",
-                "description": "The title of the exit page.",
+                "description": "The title of the page last viewed during a visit.",
                 "foreign_key_name": "last_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1798,7 +1798,7 @@
                 "column": "page_type",
                 "family": "visit",
                 "label": "Exit Page Type",
-                "description": "The page type of the exit page.",
+                "description": "The page type of the page last viewed during a visit.",
                 "foreign_key_name": "last_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1811,7 +1811,7 @@
                 "column": "url",
                 "family": "visit",
                 "label": "Exit Page URL",
-                "description": "The URL of the exit page.",
+                "description": "The url of the page last viewed during a visit.",
                 "foreign_key_name": "last_page_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1837,7 +1837,7 @@
                 "column": "is_searchengine",
                 "family": "campaign",
                 "label": "Search Engine",
-                "description": "Is traffic source a search engine.",
+                "description": "A boolean indicating if the referring url is a search engine.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": false
@@ -1967,7 +1967,7 @@
                 "column": "page_type",
                 "family": "content",
                 "label": "Prior Page Type",
-                "description": "The page type of the prior page.",
+                "description": "The type of page viewed before the current page view.",
                 "foreign_key_name": "prior_document_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1980,7 +1980,7 @@
                 "column": "url",
                 "family": "content",
                 "label": "Prior Page URL",
-                "description": "The URL of the prior page.",
+                "description": "The url of the page viewed before the current page view.",
                 "foreign_key_name": "prior_document_id",
                 "data_type": "string",
                 "denormalized": false
@@ -1993,7 +1993,7 @@
                 "column": "refering_anchortext",
                 "family": "campaign",
                 "label": "Referral Link Text",
-                "description": "The text of the referring link.",
+                "description": "The anchor text of the link that referred visitors to the tracked website.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": false
@@ -2006,7 +2006,7 @@
                 "column": "page_title",
                 "family": "campaign",
                 "label": "Referral Page Title",
-                "description": "The title of the referring web page.",
+                "description": "The page title of the url that referred visitors to the tracked website.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": false
@@ -2032,7 +2032,7 @@
                 "column": "terms",
                 "family": "campaign",
                 "label": "Search Terms",
-                "description": "The referring search terms.",
+                "description": "The search term that led visitors to the tracked website.",
                 "foreign_key_name": "referring_search_term_id",
                 "data_type": "string",
                 "denormalized": false
@@ -2097,7 +2097,7 @@
                 "column": "source_domain",
                 "family": "campaign",
                 "label": "Source",
-                "description": "The traffic source of the visit.",
+                "description": "The origin of traffic. Possible values are the domain of referring websites (foo.com) or app search engines (Google), etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": false
@@ -2123,7 +2123,7 @@
                 "column": "user_email",
                 "family": "visitor",
                 "label": "Email Address",
-                "description": "The email address of the user.",
+                "description": "A generic string used to store the email address of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": false
@@ -3061,7 +3061,7 @@
                 "column": "yyyymmdd",
                 "family": "time",
                 "label": "Date",
-                "description": "The date.",
+                "description": "A date string in YYYYMMDD format (e.g. 20200415).",
                 "foreign_key_name": "",
                 "data_type": "yyyymmdd",
                 "denormalized": true
@@ -3759,7 +3759,7 @@
                 "column": "is_new_visitor",
                 "family": "visitor",
                 "label": "New Visitor",
-                "description": "New Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had only one visit.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -3770,7 +3770,7 @@
                 "column": "is_new_visitor",
                 "family": "visitor",
                 "label": "New Visitor",
-                "description": "New Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had only one visit.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -3781,7 +3781,7 @@
                 "column": "is_new_visitor",
                 "family": "visitor",
                 "label": "New Visitor",
-                "description": "New Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had only one visit.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -3792,7 +3792,7 @@
                 "column": "is_new_visitor",
                 "family": "visitor",
                 "label": "New Visitor",
-                "description": "New Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had only one visit.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -3803,7 +3803,7 @@
                 "column": "is_new_visitor",
                 "family": "visitor",
                 "label": "New Visitor",
-                "description": "New Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had only one visit.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -3814,7 +3814,7 @@
                 "column": "is_new_visitor",
                 "family": "visitor",
                 "label": "New Visitor",
-                "description": "New Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had only one visit.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -3825,7 +3825,7 @@
                 "column": "is_new_visitor",
                 "family": "visitor",
                 "label": "New Visitor",
-                "description": "New Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had only one visit.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -3838,7 +3838,7 @@
                 "column": "is_repeat_visitor",
                 "family": "visitor",
                 "label": "Repeat Visitor",
-                "description": "Repeat Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had two or more visits.",
                 "foreign_key_name": "",
                 "data_type": "boolean",
                 "denormalized": true
@@ -3849,7 +3849,7 @@
                 "column": "is_repeat_visitor",
                 "family": "visitor",
                 "label": "Repeat Visitor",
-                "description": "Repeat Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had two or more visits.",
                 "foreign_key_name": "",
                 "data_type": "boolean",
                 "denormalized": true
@@ -3860,7 +3860,7 @@
                 "column": "is_repeat_visitor",
                 "family": "visitor",
                 "label": "Repeat Visitor",
-                "description": "Repeat Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had two or more visits.",
                 "foreign_key_name": "",
                 "data_type": "boolean",
                 "denormalized": true
@@ -3871,7 +3871,7 @@
                 "column": "is_repeat_visitor",
                 "family": "visitor",
                 "label": "Repeat Visitor",
-                "description": "Repeat Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had two or more visits.",
                 "foreign_key_name": "",
                 "data_type": "boolean",
                 "denormalized": true
@@ -3882,7 +3882,7 @@
                 "column": "is_repeat_visitor",
                 "family": "visitor",
                 "label": "Repeat Visitor",
-                "description": "Repeat Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had two or more visits.",
                 "foreign_key_name": "",
                 "data_type": "boolean",
                 "denormalized": true
@@ -3893,7 +3893,7 @@
                 "column": "is_repeat_visitor",
                 "family": "visitor",
                 "label": "Repeat Visitor",
-                "description": "Repeat Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had two or more visits.",
                 "foreign_key_name": "",
                 "data_type": "boolean",
                 "denormalized": true
@@ -3904,7 +3904,7 @@
                 "column": "is_repeat_visitor",
                 "family": "visitor",
                 "label": "Repeat Visitor",
-                "description": "Repeat Site Visitor.",
+                "description": "A boolean indicating whether the visitor has had two or more visits.",
                 "foreign_key_name": "",
                 "data_type": "boolean",
                 "denormalized": true
@@ -4035,7 +4035,7 @@
                 "column": "medium",
                 "family": "campaign",
                 "label": "Medium",
-                "description": "The medium where visit originated from.",
+                "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4046,7 +4046,7 @@
                 "column": "medium",
                 "family": "campaign",
                 "label": "Medium",
-                "description": "The medium where visit originated from.",
+                "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4057,7 +4057,7 @@
                 "column": "medium",
                 "family": "campaign",
                 "label": "Medium",
-                "description": "The medium where visit originated from.",
+                "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4068,7 +4068,7 @@
                 "column": "medium",
                 "family": "campaign",
                 "label": "Medium",
-                "description": "The medium where visit originated from.",
+                "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4079,7 +4079,7 @@
                 "column": "medium",
                 "family": "campaign",
                 "label": "Medium",
-                "description": "The medium where visit originated from.",
+                "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4090,7 +4090,7 @@
                 "column": "medium",
                 "family": "campaign",
                 "label": "Medium",
-                "description": "The medium where visit originated from.",
+                "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4101,7 +4101,7 @@
                 "column": "medium",
                 "family": "campaign",
                 "label": "Medium",
-                "description": "The medium where visit originated from.",
+                "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4529,7 +4529,7 @@
                 "column": "user_name",
                 "family": "visitor",
                 "label": "User Name",
-                "description": "The name or ID of the user.",
+                "description": "A generic string used to store the user name of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4540,7 +4540,7 @@
                 "column": "user_name",
                 "family": "visitor",
                 "label": "User Name",
-                "description": "The name or ID of the user.",
+                "description": "A generic string used to store the user name of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4551,7 +4551,7 @@
                 "column": "user_name",
                 "family": "visitor",
                 "label": "User Name",
-                "description": "The name or ID of the user.",
+                "description": "A generic string used to store the user name of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4562,7 +4562,7 @@
                 "column": "user_name",
                 "family": "visitor",
                 "label": "User Name",
-                "description": "The name or ID of the user.",
+                "description": "A generic string used to store the user name of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4573,7 +4573,7 @@
                 "column": "user_name",
                 "family": "visitor",
                 "label": "User Name",
-                "description": "The name or ID of the user.",
+                "description": "A generic string used to store the user name of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4584,7 +4584,7 @@
                 "column": "user_name",
                 "family": "visitor",
                 "label": "User Name",
-                "description": "The name or ID of the user.",
+                "description": "A generic string used to store the user name of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4595,7 +4595,7 @@
                 "column": "user_name",
                 "family": "visitor",
                 "label": "User Name",
-                "description": "The name or ID of the user.",
+                "description": "A generic string used to store the user name of the visitor.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4934,7 +4934,7 @@
             "column": "country_code",
             "family": "geo",
             "label": "Country Code",
-            "description": "The ISO country code of the visitor.",
+            "description": "The country code for the inferred country location of visitors.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": false
@@ -5055,7 +5055,7 @@
             "column": "yyyymmdd",
             "family": "time",
             "label": "Date",
-            "description": "The date.",
+            "description": "A date string in YYYYMMDD format (e.g. 20200415).",
             "foreign_key_name": "",
             "data_type": "yyyymmdd",
             "denormalized": true
@@ -5209,7 +5209,7 @@
             "column": "uri",
             "family": "visit",
             "label": "Entry Page Path",
-            "description": "The URI of the entry page.",
+            "description": "The path portion of the URL of the page first viewed during a visit.",
             "foreign_key_name": "first_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5220,7 +5220,7 @@
             "column": "page_title",
             "family": "visit",
             "label": "Entry Page Title",
-            "description": "The title of the entry page.",
+            "description": "The title of the page first viewed during a visit.",
             "foreign_key_name": "first_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5231,7 +5231,7 @@
             "column": "page_type",
             "family": "visit",
             "label": "Entry Page Type",
-            "description": "The page type of the entry page.",
+            "description": "The page type of the page first viewed during a visit.",
             "foreign_key_name": "first_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5242,7 +5242,7 @@
             "column": "url",
             "family": "visit",
             "label": "Entry Page URL",
-            "description": "The URL of the entry page.",
+            "description": "The url of the page first viewed during a visit.",
             "foreign_key_name": "first_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5253,7 +5253,7 @@
             "column": "uri",
             "family": "visit",
             "label": "Exit Page Path",
-            "description": "The URI of the exit page.",
+            "description": "The path of the page last viewed during a visit.",
             "foreign_key_name": "last_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5264,7 +5264,7 @@
             "column": "page_title",
             "family": "visit",
             "label": "Exit Page Title",
-            "description": "The title of the exit page.",
+            "description": "The title of the page last viewed during a visit.",
             "foreign_key_name": "last_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5275,7 +5275,7 @@
             "column": "page_type",
             "family": "visit",
             "label": "Exit Page Type",
-            "description": "The page type of the exit page.",
+            "description": "The page type of the page last viewed during a visit.",
             "foreign_key_name": "last_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5286,7 +5286,7 @@
             "column": "url",
             "family": "visit",
             "label": "Exit Page URL",
-            "description": "The URL of the exit page.",
+            "description": "The url of the page last viewed during a visit.",
             "foreign_key_name": "last_page_id",
             "data_type": "string",
             "denormalized": false
@@ -5363,7 +5363,7 @@
             "column": "is_new_visitor",
             "family": "visitor",
             "label": "New Visitor",
-            "description": "New Site Visitor.",
+            "description": "A boolean indicating whether the visitor has had only one visit.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": true
@@ -5374,7 +5374,7 @@
             "column": "is_repeat_visitor",
             "family": "visitor",
             "label": "Repeat Visitor",
-            "description": "Repeat Site Visitor.",
+            "description": "A boolean indicating whether the visitor has had two or more visits.",
             "foreign_key_name": "",
             "data_type": "boolean",
             "denormalized": true
@@ -5385,7 +5385,7 @@
             "column": "is_searchengine",
             "family": "campaign",
             "label": "Search Engine",
-            "description": "Is traffic source a search engine.",
+            "description": "A boolean indicating if the referring url is a search engine.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": false
@@ -5462,7 +5462,7 @@
             "column": "medium",
             "family": "campaign",
             "label": "Medium",
-            "description": "The medium where visit originated from.",
+            "description": "A high-level classification of the traffic source through which a visitor arrives at a website. Possible values are: Direct, organic-search, etc.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": true
@@ -5572,7 +5572,7 @@
             "column": "page_type",
             "family": "content",
             "label": "Prior Page Type",
-            "description": "The page type of the prior page.",
+            "description": "The type of page viewed before the current page view.",
             "foreign_key_name": "prior_document_id",
             "data_type": "string",
             "denormalized": false
@@ -5583,7 +5583,7 @@
             "column": "url",
             "family": "content",
             "label": "Prior Page URL",
-            "description": "The URL of the prior page.",
+            "description": "The url of the page viewed before the current page view.",
             "foreign_key_name": "prior_document_id",
             "data_type": "string",
             "denormalized": false
@@ -5638,7 +5638,7 @@
             "column": "refering_anchortext",
             "family": "campaign",
             "label": "Referral Link Text",
-            "description": "The text of the referring link.",
+            "description": "The anchor text of the link that referred visitors to the tracked website.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": false
@@ -5649,7 +5649,7 @@
             "column": "page_title",
             "family": "campaign",
             "label": "Referral Page Title",
-            "description": "The title of the referring web page.",
+            "description": "The page title of the url that referred visitors to the tracked website.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": false
@@ -5671,7 +5671,7 @@
             "column": "terms",
             "family": "campaign",
             "label": "Search Terms",
-            "description": "The referring search terms.",
+            "description": "The search term that led visitors to the tracked website.",
             "foreign_key_name": "referring_search_term_id",
             "data_type": "string",
             "denormalized": false
@@ -5759,7 +5759,7 @@
             "column": "source_domain",
             "family": "campaign",
             "label": "Source",
-            "description": "The traffic source of the visit.",
+            "description": "The origin of traffic. Possible values are the domain of referring websites (foo.com) or app search engines (Google), etc.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": false
@@ -5847,7 +5847,7 @@
             "column": "user_email",
             "family": "visitor",
             "label": "Email Address",
-            "description": "The email address of the user.",
+            "description": "A generic string used to store the email address of the visitor.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": false
@@ -5858,7 +5858,7 @@
             "column": "user_name",
             "family": "visitor",
             "label": "User Name",
-            "description": "The name or ID of the user.",
+            "description": "A generic string used to store the user name of the visitor.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": true

--- a/tests/fixtures/catalog.json
+++ b/tests/fixtures/catalog.json
@@ -3151,7 +3151,7 @@
                 "column": "day",
                 "family": "time",
                 "label": "Day",
-                "description": "The day.",
+                "description": "The day of the month (1-31).",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4169,7 +4169,7 @@
                 "column": "month",
                 "family": "time",
                 "label": "Month",
-                "description": "The month.",
+                "description": "The month, as yyyymm.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4711,7 +4711,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4722,7 +4722,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4733,7 +4733,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4744,7 +4744,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4755,7 +4755,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4766,7 +4766,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4777,7 +4777,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -4788,7 +4788,7 @@
                 "column": "year",
                 "family": "time",
                 "label": "Year",
-                "description": "The year.",
+                "description": "The four digit year.",
                 "foreign_key_name": "",
                 "data_type": "string",
                 "denormalized": true
@@ -5066,7 +5066,7 @@
             "column": "day",
             "family": "time",
             "label": "Day",
-            "description": "The day.",
+            "description": "The day of the month (1-31).",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": true
@@ -5473,7 +5473,7 @@
             "column": "month",
             "family": "time",
             "label": "Month",
-            "description": "The month.",
+            "description": "The month, as yyyymm.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": true
@@ -5902,7 +5902,7 @@
             "column": "year",
             "family": "time",
             "label": "Year",
-            "description": "The year.",
+            "description": "The four digit year.",
             "foreign_key_name": "",
             "data_type": "string",
             "denormalized": true

--- a/tests/tools/generate_metrics_dimensions_doc.php
+++ b/tests/tools/generate_metrics_dimensions_doc.php
@@ -11,6 +11,24 @@
  */
 
 require __DIR__ . '/../../owa_env.php';
+
+/*
+ * The registry is all this reads, and the registry needs no database -- but
+ * booting constructs the base.configuration entity, whose column types
+ * reference OWA_DTD_* constants that only the DB driver defines, and the driver
+ * is only loaded when OWA_DB_TYPE is set. Without a config file that is an
+ * undefined-constant fatal before any module registers anything.
+ *
+ * Pre-defining the type loads the driver without connecting to anything, so
+ * this runs on a checkout with no owa-config.php -- which is what lets CI check
+ * the generated documentation is current without standing up a database. Gated
+ * on the config file being absent so a normal run is untouched; the same guard
+ * install.php and tests/bootstrap.php use.
+ */
+if ( ! defined( 'OWA_DB_TYPE' ) && ! file_exists( OWA_DIR . 'owa-config.php' ) ) {
+    define( 'OWA_DB_TYPE', 'mysql' );
+}
+
 require __DIR__ . '/../../owa.php';
 
 $owa = new owa( array( 'instance_role' => 'cli' ) );

--- a/tests/tools/generate_metrics_dimensions_doc.php
+++ b/tests/tools/generate_metrics_dimensions_doc.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Emit the Metrics & Dimensions wiki tables from the registry.
+ *
+ *   php tests/tools/generate_metrics_dimensions_doc.php
+ *
+ * The page used to be maintained by hand and drifted: it documented a dimension
+ * that did not exist, omitted eighteen that did, and named 33 of 78 metrics. The
+ * registry is the only thing that knows, so the tables are generated from it and
+ * the prose sections of the page stay hand-written.
+ */
+
+require __DIR__ . '/../../owa_env.php';
+require __DIR__ . '/../../owa.php';
+
+$owa = new owa( array( 'instance_role' => 'cli' ) );
+
+function owa_doc_row( $name, $label, $desc, $extra ) {
+
+    $desc = trim( (string) $desc );
+    $desc = $desc === '' ? '—' : $desc;
+
+    return sprintf( "|`%s` | %s | %s | %s |\n", $name, $label ?: '—', $desc, $extra ?: '—' );
+}
+
+$out = "## Metrics\n\n"
+     . "|Name | Label | Description | Measured against |\n"
+     . "|---|---|---|---|\n";
+
+$metrics = (array) \OWA\Core\CoreAPI::getAllMetrics();
+ksort( $metrics );
+
+foreach ( $metrics as $name => $declarations ) {
+
+    // A goalN metric exists once per numbered slot; listing 45 of them says
+    // nothing the family line below does not.
+    if ( preg_match( '/^goal\d+/', $name ) ) {
+
+        continue;
+    }
+
+    $first = is_array( $declarations ) ? reset( $declarations ) : array();
+
+    $entities = array();
+
+    foreach ( (array) $declarations as $d ) {
+
+        $e = $d['params']['entity'] ?? '';
+
+        if ( $e ) {
+            $entities[] = str_replace( 'base.', '', $e );
+        }
+    }
+
+    $out .= owa_doc_row( $name, $first['label'] ?? '', $first['description'] ?? '',
+        implode( ', ', array_unique( $entities ) ) );
+}
+
+$out .= "\nGoal metrics exist once per numbered goal slot — `goal1Completions`,\n"
+      . "`goal1Starts`, `goal1Value` and so on, through goal 15. See\n"
+      . "[[Conversion Tracking|Conversion-Tracking]].\n";
+
+$out .= "\n## Dimensions\n\n"
+      . "|Name | Label | Description | Family |\n"
+      . "|---|---|---|---|\n";
+
+$dims = (array) \OWA\Core\CoreAPI::getAllDimensions();
+ksort( $dims );
+
+foreach ( $dims as $name => $d ) {
+
+    $out .= owa_doc_row( $name, $d['label'] ?? '', $d['description'] ?? '', $d['family'] ?? '' );
+}
+
+/*
+ * Which dimensions can be asked for alongside which metrics.
+ *
+ * Derived the way the report builder derives it -- compatibleEntities() for a
+ * metric, isDimensionRelated() for a dimension -- so the page states what the
+ * query engine would actually accept. The previous hand-written table grouped
+ * by family names that no longer exist ('technology', 'geography', 'traffic').
+ */
+$rsm = new \OWA\Module\Base\Classes\ResultSetManager;
+
+$entities = array();
+
+foreach ( array_keys( $metrics ) as $metric ) {
+
+    foreach ( (array) $rsm->compatibleEntities( array( $metric ) ) as $e ) {
+        $entities[ $e ] = true;
+    }
+}
+
+$entities = array_keys( $entities );
+sort( $entities );
+
+$out .= "\n## Combinations\n\n"
+      . "A metric can only be broken down by a dimension that its fact table is related\n"
+      . "to. The families available against each fact table:\n\n"
+      . "|Fact table | Dimension families |\n|---|---|\n";
+
+foreach ( $entities as $entity ) {
+
+    $fams = array();
+
+    foreach ( $dims as $name => $d ) {
+
+        if ( $rsm->isDimensionRelated( $name, $entity ) ) {
+
+            $f = $d['family'] ?? '';
+
+            if ( $f ) {
+                $fams[ $f ] = true;
+            }
+        }
+    }
+
+    ksort( $fams );
+
+    $out .= sprintf( "|`%s` | %s |\n", str_replace( 'base.', '', $entity ),
+        $fams ? '`' . implode( '`, `', array_keys( $fams ) ) . '`' : '—' );
+}
+
+echo $out;

--- a/tests/tools/splice_generated_doc.php
+++ b/tests/tools/splice_generated_doc.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Replace the generated section of a wiki page, leaving the rest alone.
+ *
+ *   php tests/tools/splice_generated_doc.php <page.md> <generated.md>
+ *
+ * The page is part generated and part written by hand: the metric, dimension and
+ * combination tables come from the registry, and the notes after them do not.
+ * Overwriting the file wholesale would throw the second kind away, so the
+ * generated part is delimited and only that is replaced.
+ *
+ * Refuses rather than guesses if the markers are missing, because the failure
+ * mode of guessing is deleting prose nobody has a copy of.
+ */
+
+const BEGIN = '<!-- BEGIN GENERATED -->';
+const END   = '<!-- END GENERATED -->';
+
+$page_path = $argv[1] ?? '';
+$gen_path  = $argv[2] ?? '';
+
+if ( ! $page_path || ! $gen_path ) {
+
+    fwrite( STDERR, "usage: splice_generated_doc.php <page.md> <generated.md>\n" );
+    exit( 2 );
+}
+
+foreach ( array( $page_path, $gen_path ) as $p ) {
+
+    if ( ! is_readable( $p ) ) {
+
+        fwrite( STDERR, "cannot read $p\n" );
+        exit( 2 );
+    }
+}
+
+$page = file_get_contents( $page_path );
+$gen  = rtrim( file_get_contents( $gen_path ) );
+
+$start = strpos( $page, BEGIN );
+$end   = strpos( $page, END );
+
+if ( $start === false || $end === false || $end < $start ) {
+
+    fwrite( STDERR, sprintf(
+        "%s has no %s / %s markers, so there is no way to tell what may be replaced.\n"
+      . "Add them around the generated tables and run this again.\n",
+        $page_path, BEGIN, END ) );
+    exit( 1 );
+}
+
+$new = substr( $page, 0, $start ) . BEGIN . "\n\n" . $gen . "\n\n" . substr( $page, $end );
+
+if ( $new === $page ) {
+
+    echo "unchanged\n";
+    exit( 0 );
+}
+
+file_put_contents( $page_path, $new );
+
+echo "updated\n";


### PR DESCRIPTION
## The page had drifted, and nothing was keeping it honest

`Metrics & Dimensions` was maintained by hand. Measured against the live registry:

| | page | registry |
|---|---|---|
| Metrics | 33 | 78 |
| Dimensions | 84 | 101 |

- **`timeSinceLastVisit` does not exist.** The real dimension is `daysSinceLastVisit`. Anyone who used the documented name got nothing back.
- **Eighteen dimensions were undocumented**, including all ten custom-variable dimensions and the click/DOM ones — exactly the names you need to report on your own tracked variables.
- **The Combinations table grouped by families the code stopped using**: `technology`, `geography`, `traffic`, `e-commerce`, `action`, `domstream`, `feeds`. The registry has `system`, `geo`, `campaign`, `ecommerce`, `actions`, `dom`, `feed`.

## Each source had something the other didn't

**The wiki carried formulas and definitions the registry lacked**, and those are merged into the registry:

| metric | was | now |
|---|---|---|
| `bounceRate` | The percentage of visits that were bounces. | …: single page view visits divided by entry pages. |
| `pagesPerVisit` | The average pages viewed per visit. | …: page views divided by visits. |
| `repeatVisitors` | The total number of repeat visitors | …: unique visitors with two or more visits. |
| `visitDuration` | The average duration of visits. | …, measured between the first and last page view of each visit. |
| `goalConversionRateAll` | The rate of goals achieved in all visits. | …: goal completions divided by goal starts. |

**The registry was better where the wiki was blank, wrong, or duplicated** — the wiki gave `visitors` and `uniqueVisitors` identical text; the registry distinguishes them.

**Most dimension descriptions in code were the label restated** — `isNewVisitor` was `"New Site Visitor."` Twenty-two take the wiki's wording, which says what the dimension means and, for `date`, what format it's in (`YYYYMMDD`).

Three typos the wiki carried are fixed rather than imported (`"used ot store the the email address"`, `"has had to two or more visits"`).

## Generated from here on

`tests/tools/generate_metrics_dimensions_doc.php` emits all three tables.

**Combinations is derived the way the builder derives it** — `compatibleEntities()` for a metric, `isDimensionRelated()` for a dimension — so the page states what the query engine would actually accept:

```
|`session` | `campaign`, `campaign-special`, `custom variables`, `date`, `geo`,
            `network`, `site`, `system`, `time`, `visit`, `visitor` |
```

The 45 `goalN*` slot metrics are summarised in one line rather than 45 rows. The hand-written `Notes` section (Visit, Visit Duration, Unique Visitors, Search Term) is kept and untouched — it carries editorial value a registry can't.

## Testing

The catalog characterization fixture moves with this, which is the test doing its job. The diff is 150 lines and **every one is a description** — strip descriptions from both recordings and they are identical, so nothing registered or stopped registering.

- Full suite: 1996 tests, 48548 assertions, 2 skipped — green
- Configless: green
- `composer phpstan`: no errors