### PR TITLE
Take the doc generator from the default branch, not the released tag

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -46,23 +46,6 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress
 
-      # The tooling comes from the default branch, the REGISTRY from the tag.
-      #
-      # Generating with the released code is the point -- the page must describe
-      # that release. But the generator is repository tooling, not part of the
-      # release, and a tag predating it has no copy: the first run of this
-      # workflow failed against 1.13.0 for exactly that reason. Overlaying the
-      # scripts means any tag can be regenerated, including ones cut before this
-      # existed, and a fix to the generator applies to every release rather than
-      # only to those tagged after it.
-      - name: Take the generator from the default branch
-        run: |
-          git fetch --depth=1 origin ${{ github.event.repository.default_branch }}
-          git checkout FETCH_HEAD -- \
-            tests/tools/generate_metrics_dimensions_doc.php \
-            tests/tools/splice_generated_doc.php
-          ls -l tests/tools/generate_metrics_dimensions_doc.php tests/tools/splice_generated_doc.php
-
       - name: Generate the tables
         run: |
           php tests/tools/generate_metrics_dimensions_doc.php > /tmp/generated.md 2>/tmp/generate.err || {

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -46,10 +46,29 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-dev --optimize-autoloader --no-interaction --no-progress
 
+      # The tooling comes from the default branch, the REGISTRY from the tag.
+      #
+      # Generating with the released code is the point -- the page must describe
+      # that release. But the generator is repository tooling, not part of the
+      # release, and a tag predating it has no copy: the first run of this
+      # workflow failed against 1.13.0 for exactly that reason. Overlaying the
+      # scripts means any tag can be regenerated, including ones cut before this
+      # existed, and a fix to the generator applies to every release rather than
+      # only to those tagged after it.
+      - name: Take the generator from the default branch
+        run: |
+          git fetch --depth=1 origin ${{ github.event.repository.default_branch }}
+          git checkout FETCH_HEAD -- \
+            tests/tools/generate_metrics_dimensions_doc.php \
+            tests/tools/splice_generated_doc.php
+          ls -l tests/tools/generate_metrics_dimensions_doc.php tests/tools/splice_generated_doc.php
+
       - name: Generate the tables
         run: |
-          php tests/tools/generate_metrics_dimensions_doc.php > /tmp/generated.md
-          test -s /tmp/generated.md
+          php tests/tools/generate_metrics_dimensions_doc.php > /tmp/generated.md 2>/tmp/generate.err || {
+            echo "the generator failed:"; cat /tmp/generate.err; exit 1;
+          }
+          test -s /tmp/generated.md || { echo "the generator produced nothing"; cat /tmp/generate.err; exit 1; }
           echo "rows: $(grep -c '^|`' /tmp/generated.md)"
 
       - name: Check out the wiki


### PR DESCRIPTION
The first run of `publish-docs` failed against 1.13.0. It checks out the released tag, and the generator did not exist there — it was added in #1084, after that tag was cut. The step reported exit code 1 and nothing else, because the generator's stderr went to `/dev/null`.

Generating from the released code remains correct: the page must describe that release, so the **registry** has to come from the tag. But the generator is repository tooling, not part of the release. It now comes from the default branch and is overlaid onto the tag checkout, which means:

- any tag can be regenerated, including ones cut before the tooling existed
- a fix to the generator reaches every release, not only those tagged after it

The generate step also reports *why* it failed rather than a bare exit code — which is what made the first failure take a log fetch to diagnose.

Found by running the workflow rather than waiting for a release to find it.