### PR TITLE
Make the Hello module an example worth copying

### DIFF
--- a/modules/Hello/Controller/ExampleSettingsController.php
+++ b/modules/Hello/Controller/ExampleSettingsController.php
@@ -1,5 +1,5 @@
 <?php
-namespace OWA\Module\Hello;
+namespace OWA\Module\Hello\Controller;
 
 
 //
@@ -54,7 +54,7 @@ class ExampleSettingsController extends \OWA\Core\AdminController {
         $this->set( 'hierarchy_nav', $this->getHierarchyNav( $owa_site_id ) );
         $this->set( 'hierarchy_tier', 0 );
         $this->setView('base.optionsHierarchy');
-        $this->setSubview('base.exampleSettings');
+        $this->setSubview('hello.exampleSettings');
     }
 
 }

--- a/modules/Hello/Module.php
+++ b/modules/Hello/Module.php
@@ -45,7 +45,7 @@ class Module extends \OWA\Core\Module {
         $this->config_required = false;
         $this->required_schema_version = 1;
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     /**

--- a/modules/Hello/Module.php
+++ b/modules/Hello/Module.php
@@ -49,6 +49,27 @@ class Module extends \OWA\Core\Module {
     }
 
     /**
+     * Map this module's actions to their classes.
+     *
+     * Without this an action resolves through the legacy path, which rebuilds a
+     * class name and a file path out of the request's own `do` parameter. Naming
+     * the class here keeps CoreAPI::performAction() on the registered branch,
+     * and is what a module should do.
+     *
+     * The path argument is empty on purpose: registerAction() prefixes it with
+     * OWA_BASE_MODULE_DIR, which is hardcoded to modules/Base/, so a non-Base
+     * module cannot express a correct path through it. The class name is the
+     * PSR-4 name, so Composer autoloads it and the path is never consulted.
+     */
+    function registerActions() {
+
+        $this->registerAction(
+            'hello.exampleSettings',
+            'OWA\\Module\\Hello\\Controller\\ExampleSettingsController',
+            '' );
+    }
+
+    /**
      * Registers Admin panels with the core API
      *
      */

--- a/modules/Hello/View/ExampleSettings.php
+++ b/modules/Hello/View/ExampleSettings.php
@@ -1,5 +1,5 @@
 <?php
-namespace OWA\Module\Hello;
+namespace OWA\Module\Hello\View;
 
 
 //
@@ -31,7 +31,7 @@ namespace OWA\Module\Hello;
  * @since        owa 1.0.0
  */
 
-class ExampleSettingsView extends \OWA\Core\View {
+class ExampleSettings extends \OWA\Core\View {
 
     function __construct($params) {
         //set page type

--- a/modules/Hello/View/ExampleSettings.php
+++ b/modules/Hello/View/ExampleSettings.php
@@ -33,10 +33,11 @@ namespace OWA\Module\Hello\View;
 
 class ExampleSettings extends \OWA\Core\View {
 
-    function __construct($params) {
-        //set page type
-        $this->_setPageType('Administration Page');
-        return parent::__construct($params);
+    function __construct( $params ) {
+
+        parent::__construct( $params );
+
+        $this->_setPageType( 'Administration Page' );
     }
 
     function render($data) {

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -304,8 +304,8 @@ function owa_compat_class_map(): array
         'owa_domstreamsRestView' => 'OWA\\Module\\Domstream\\View\\DomstreamsRest',
         'owa_domstreamHandlers' => 'OWA\\Module\\Domstream\\Handler\\DomstreamHandlers',
         'owa_fileCache' => 'OWA\\Module\\FileCache\\Classes\\FileCache',
-        'owa_exampleSettingsController' => 'OWA\\Module\\Hello\\ExampleSettingsController',
-        'owa_exampleSettingsView' => 'OWA\\Module\\Hello\\ExampleSettingsView',
+        'owa_exampleSettingsController' => 'OWA\\Module\\Hello\\Controller\\ExampleSettingsController',
+        'owa_exampleSettingsView' => 'OWA\\Module\\Hello\\View\\ExampleSettings',
         'owa_maxmind' => 'OWA\\Module\\MaxmindGeoip\\Classes\\Maxmind',
         'owa_memcachedCache' => 'OWA\\Module\\MemcachedCache\\Classes\\MemcachedCache',
 

--- a/phpstan-migration-baseline.neon
+++ b/phpstan-migration-baseline.neon
@@ -625,18 +625,6 @@ parameters:
 			path: modules/FileCache/Module.php
 
 		-
-			message: '#^Result of method OWA\\Core\\View\:\:__construct\(\) \(void\) is used\.$#'
-			identifier: staticMethod.void
-			count: 1
-			path: modules/Hello/ExampleSettingsView.php
-
-		-
-			message: '#^Result of method OWA\\Core\\Module\:\:__construct\(\) \(void\) is used\.$#'
-			identifier: staticMethod.void
-			count: 1
-			path: modules/Hello/Module.php
-
-		-
 			message: '#^Instantiated class Client not found\.$#'
 			identifier: class.notFound
 			count: 1

--- a/tests/PropertyAdminScreensTest.php
+++ b/tests/PropertyAdminScreensTest.php
@@ -1287,7 +1287,7 @@ final class PropertyAdminScreensTest extends TestCase
 
         /* Including the module screens -- they are settings like any other. */
         foreach ( array( 'modules/MaxmindGeoip/Controller/OptionsGeoip.php',
-                         'modules/Hello/ExampleSettingsController.php' ) as $module ) {
+                         'modules/Hello/Controller/ExampleSettingsController.php' ) as $module ) {
 
             $src = (string) file_get_contents( OWA_DIR . $module );
 


### PR DESCRIPTION
`modules/Hello/` is what someone opens to see the shape of an OWA module. It was showing the wrong one.

## Three problems

**The layout was pre-PSR-4.** The controller and view sat at the module root instead of `Controller/` and `View/`, so the structure it demonstrated is not the structure the autoloader expects.

**The action was not registered.** `hello.exampleSettings` resolved through the legacy path, which rebuilds a class name and file path from the request's own `do` parameter — exactly what a module should not depend on.

**Its settings screen could not render.** The controller asked for the subview `base.exampleSettings`:

```
base.exampleSettings  -> FAILS: Class File .../modules/Base/owa_exampleSettings.php
hello.exampleSettings -> OWA\Module\Hello\View\ExampleSettings
```

No such view ships in Base. Anyone copying this module inherited a screen that fails.

## Now

`Controller/ExampleSettingsController.php` and `View/ExampleSettings.php` in their own namespaces, `registerActions()` naming the controller class, and the subview pointing at this module's own view. Verified by resolving the action and subview, not by reading the code.

## Two things that moved with it

- `PropertyAdminScreensTest` read the controller by its old hardcoded path. After the move `file_get_contents` returned `''` and the assertion failed — it would otherwise have passed vacuously against an empty string.
- The compat bridge mapped `owa_exampleSettingsController` and `owa_exampleSettingsView` at the old class names, so the rename broke two legacy aliases. `LegacyClassNameContractTest` caught it; both are repointed and resolve.

Full suite 1998/48555 green, configless green, phpstan clean.