### PR TITLE
Remove the expiration argument that state writes never used

### DIFF
--- a/modules/Base/src/common/StateManager.js
+++ b/modules/Base/src/common/StateManager.js
@@ -601,7 +601,17 @@ class StateManager {
         }
     }
     
-    set(store_name, key, value, is_perminant,format, expiration_days) {
+    /*
+     * The store's expiration is NOT a parameter here.
+     *
+     * It is declared once at registerStore(), because a store is backed by one
+     * cookie and a cookie has one lifetime: two writes asking for different
+     * expirations would quietly fight over it, last write winning. This used to
+     * take an expiration_days argument and discard it -- persist() reads
+     * getExpirationDays(store_name) -- so a caller passing one was silently
+     * ignored. The campaign store's 60 days comes from its registration.
+     */
+    set(store_name, key, value, is_perminant, format) {
         
         if ( ! this.isPresent( store_name ) && this.shouldAutoLoad( store_name ) ) {
             this.load( store_name );
@@ -714,7 +724,7 @@ class StateManager {
         Util.setCookie( OWA.getSetting('ns') + store_name, state_value, expiration_days, '/', domain );
     }
     
-    replaceStore(store_name, value, is_perminant, format, expiration_days) {
+    replaceStore(store_name, value, is_perminant, format) {
         
         OWA.debug('replace state format: %s, value: %s',format, JSON.stringify(value));
         if ( store_name ) {
@@ -876,7 +886,7 @@ class StateManager {
             
             if ( state && state.hasOwnProperty( key ) ) {
                 delete state[key];
-                this.replaceStore(store_name, state, true, this.getFormat( store_name ),  this.getExpirationDays( store_name ) );
+                this.replaceStore( store_name, state, true, this.getFormat( store_name ) );
             }
         }
     }

--- a/modules/Base/src/common/owa.js
+++ b/modules/Base/src/common/owa.js
@@ -98,16 +98,16 @@ class OWA {
         return this.state.isPresent( store_name );
     }
     
-    setState(store_name, key, value, is_perminant,format, expiration_days) {
+    setState(store_name, key, value, is_perminant, format) {
     
         this.initializeStateManager();
-        return this.state.set(store_name, key, value, is_perminant,format, expiration_days);    
+        return this.state.set(store_name, key, value, is_perminant, format);    
     }
     
-    replaceState(store_name, value, is_perminant, format, expiration_days) {
+    replaceState(store_name, value, is_perminant, format) {
     
         this.initializeStateManager();
-        return this.state.replaceStore(store_name, value, is_perminant, format, expiration_days);
+        return this.state.replaceStore(store_name, value, is_perminant, format);
     }
     
     getStateFromCookie(store_name) {

--- a/modules/Base/src/reporting/v1/owa.js
+++ b/modules/Base/src/reporting/v1/owa.js
@@ -101,16 +101,16 @@ var OWA = {
         return this.state.isPresent( store_name );
     },
     
-    setState : function(store_name, key, value, is_perminant,format, expiration_days) {
+    setState : function(store_name, key, value, is_perminant, format) {
     
         this.initializeStateManager();
-        return this.state.set(store_name, key, value, is_perminant,format, expiration_days);    
+        return this.state.set(store_name, key, value, is_perminant, format);    
     },
     
-    replaceState : function (store_name, value, is_perminant, format, expiration_days) {
+    replaceState : function (store_name, value, is_perminant, format) {
     
         this.initializeStateManager();
-        return this.state.replaceStore(store_name, value, is_perminant, format, expiration_days);
+        return this.state.replaceStore(store_name, value, is_perminant, format);
     },
     
     getStateFromCookie : function(store_name) {
@@ -366,7 +366,7 @@ OWA.stateManager.prototype = {
         }
     },
     
-    set: function(store_name, key, value, is_perminant,format, expiration_days) {
+    set: function(store_name, key, value, is_perminant, format) {
         
         if ( ! this.isPresent( store_name ) ) {
             this.load( store_name );
@@ -405,7 +405,7 @@ OWA.stateManager.prototype = {
             state_value = OWA.util.assocStringFromJson(this.stores[store_name]);
         }
         
-        expiration_days = this.getExpirationDays( store_name );
+        var expiration_days = this.getExpirationDays( store_name );
         
         if ( ! expiration_days ) {
             
@@ -423,7 +423,7 @@ OWA.stateManager.prototype = {
         OWA.util.setCookie( OWA.getSetting('ns') + store_name, state_value, expiration_days, '/', domain );
     },
     
-    replaceStore : function (store_name, value, is_perminant, format, expiration_days) {
+    replaceStore : function (store_name, value, is_perminant, format) {
         
         OWA.debug('replace state format: %s, value: %s',format, JSON.stringify(value));
         if ( store_name ) {
@@ -445,7 +445,7 @@ OWA.stateManager.prototype = {
         
             var domain = OWA.getSetting('cookie_domain') || document.domain;
             
-            expiration_days = this.getExpirationDays( store_name );
+            var expiration_days = this.getExpirationDays( store_name );
             
             OWA.debug('About to replace state store (%s) with: %s', store_name, cookie_value);
             OWA.util.setCookie( OWA.getSetting('ns') + store_name, cookie_value, expiration_days, '/', domain );
@@ -1217,14 +1217,14 @@ OWA.util =  {
         return OWA.checkForState( store_name );
     },
     
-    setState : function(store_name, key, value, is_perminant,format, expiration_days) {
+    setState : function(store_name, key, value, is_perminant, format) {
         
-        return OWA.setState(store_name, key, value, is_perminant,format, expiration_days);
+        return OWA.setState(store_name, key, value, is_perminant, format);
     },
     
-    replaceState : function (store_name, value, is_perminant, format, expiration_days) {
+    replaceState : function (store_name, value, is_perminant, format) {
 
-        return OWA.replaceState(store_name, value, is_perminant, format, expiration_days);
+        return OWA.replaceState(store_name, value, is_perminant, format);
     },
     
     getRawState : function(store_name) {

--- a/modules/Base/src/tracker/Tracker.js
+++ b/modules/Base/src/tracker/Tracker.js
@@ -294,7 +294,6 @@ class OWATracker  {
 	        domstreamLoggingInterval: 3000,
 	        domstreamEventThreshold: 10,
 	        maxPriorCampaigns: 5,
-	        campaignAttributionWindow: 60,
 	        trafficAttributionMode: 'direct',
 	        sessionLength: 1800,
 	        cookie_domain: false,
@@ -2108,7 +2107,7 @@ class OWATracker  {
 
     setCampaignCookie( values ) {
 	    
-        OWA.setState( 'c', 'attribs', values, '', 'json', this.options.campaignAttributionWindow );
+        OWA.setState( 'c', 'attribs', values, '', 'json' );
     }
     
 

--- a/tests/js/StoreExpirationFromRegistration.test.js
+++ b/tests/js/StoreExpirationFromRegistration.test.js
@@ -1,0 +1,79 @@
+jest.mock('jquery', () => {
+    const jq = jest.requireActual('jquery');
+    jq.__esModule = true;
+    return jq;
+});
+
+import { OWA_instance as OWA } from '../../modules/Base/src/common/owa.js';
+import { Util } from '../../modules/Base/src/common/Util.js';
+
+/**
+ * A store's cookie lifetime comes from its registration, and from nowhere else.
+ *
+ * WHAT THIS REPLACED. set() and replaceStore() used to accept an
+ * `expiration_days` argument and discard it: persistence reads
+ * getExpirationDays(store_name), which is the value given to registerStore().
+ * So a caller passing an expiration was silently ignored, and the tracker did
+ * exactly that -- it passed `campaignAttributionWindow` on every campaign write,
+ * and the documentation told people that setting configured the attribution
+ * window. It did not. The window worked only because the campaign store happens
+ * to be registered with the same number.
+ *
+ * The argument is gone. These tests pin the mechanism that was really doing the
+ * work, because removing a parameter nobody reads is safe only while the thing
+ * that does read something keeps working.
+ *
+ * A store is backed by one cookie and a cookie has one lifetime, which is why
+ * this belongs to the store rather than to a write: two writes asking for
+ * different expirations could only fight, last write winning.
+ */
+describe('store expiration', () => {
+
+    let cookies;
+
+    beforeEach(() => {
+        cookies = [];
+        jest.spyOn(Util, 'setCookie').mockImplementation((name, value, days) => {
+            cookies.push({ name: name, value: value, days: days });
+        });
+        OWA.setSetting('ns', 'owa_');
+        OWA.setSetting('cookie_domain', 'example.com');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('the lifetime written is the one given at registration', () => {
+
+        OWA.registerStateStore('expTest', 60, '', 'json');
+        OWA.setState('expTest', 'k', 'v');
+        OWA.state.persist('expTest', true);
+
+        const written = cookies.filter(c => c.name === 'owa_expTest');
+
+        expect(written.length).toBeGreaterThan(0);
+        expect(written[written.length - 1].days).toBe(60);
+    });
+
+    test('a different registration gives a different lifetime', () => {
+
+        OWA.registerStateStore('expTest2', 7, '', 'json');
+        OWA.setState('expTest2', 'k', 'v');
+        OWA.state.persist('expTest2', true);
+
+        const written = cookies.filter(c => c.name === 'owa_expTest2');
+
+        expect(written[written.length - 1].days).toBe(7);
+    });
+
+    /**
+     * set() takes five arguments. A sixth passed by old code must not become an
+     * expiration again by accident -- that is the bug this replaced.
+     */
+    test('set() does not take an expiration argument', () => {
+
+        expect(OWA.state.set.length).toBe(5);
+        expect(OWA.setState.length).toBe(5);
+    });
+});


### PR DESCRIPTION
`StateManager.set()` and `replaceStore()` each took an `expiration_days` argument and **discarded it**. Persistence reads `getExpirationDays(store_name)`, which returns what `registerStore()` was given.

## Why it mattered

The tracker passed `options.campaignAttributionWindow` on every campaign write, and the wiki told people that setting configured the 60-day attribution window. **It never did.** The window works only because the campaign store is registered with the same number:

```js
OWA.registerStateStore( 'c', 60, '', 'json' );
```

Two places appearing to control one value, one of them inert, is how a setting gets documented as working for years.

## Expiration belongs to the store, not to a write

A store is backed by one cookie and a cookie has one lifetime, so two writes asking for different expirations could only fight over it — last write winning. `registerStore()` is already where a store declares its behaviour; `StateManager`'s own header says as much:

> Which of those jobs a given store takes part in, and when, is **DECLARED AT REGISTRATION**.

The argument contradicted that design.

## Changed

Removed from `set()`, `replaceStore()`, `setState()`, `replaceState()`, and the one internal caller that fetched the value from `storeMeta` only to hand it straight back. Same in the reporting bundle's copy, which carried its own version of the vestige. The dead `campaignAttributionWindow` tracker option goes too; the PHP setting of that name is left alone, being annotated for the SDK.

## Testing

Nothing asserted the campaign cookie's lifetime, so removing the parameter was safe only by inspection. `StoreExpirationFromRegistration.test.js` pins the mechanism that was really doing the work — the lifetime written is the one registered, a different registration gives a different lifetime, and `set()` takes five arguments.

Mutation-checked both ways: making `persist()` ignore the registration fails it, and so does reinstating the sixth parameter.

- Jest: 569 passed
- PHP suite: 1998 tests, 48556 assertions, 2 skipped
- `npm run build` clean; the built bundle still carries `registerStateStore("c",60`