### PR TITLE
Make owa_feed_request a fact table, so it is selected as one

### DIFF
--- a/modules/Base/Entity/FeedRequest.php
+++ b/modules/Base/Entity/FeedRequest.php
@@ -65,30 +65,24 @@ class FeedRequest extends \OWA\Core\Entity\FactTable {
         $this->properties['id']->setDataType(OWA_DTD_BIGINT);
         $this->properties['id']->setPrimaryKey();
 
-        $visitor_id = new \OWA\Module\Base\Classes\DbColumn('visitor_id', OWA_DTD_BIGINT);
-        $visitor_id->setForeignKey('base.visitor');
-        $this->setProperty($visitor_id);
-
-        $session_id = new \OWA\Module\Base\Classes\DbColumn('session_id', OWA_DTD_BIGINT);
-        $session_id->setForeignKey('base.session');
-        $this->setProperty($session_id);
-
+        /*
+         * visitor_id, session_id, site_id and host_id are NOT re-declared here.
+         * They were, identically to FactTable's -- except that the parent's
+         * carry setIndex() and these did not, so overriding them silently
+         * dropped the index. owa_request has session_id and site_id indexed;
+         * owa_feed_request had neither, and site_id is filtered on by
+         * essentially every report query.
+         *
+         * What follows is only what genuinely differs from the parent.
+         */
         $document_id = new \OWA\Module\Base\Classes\DbColumn('document_id', OWA_DTD_BIGINT);
         $document_id->setForeignKey('base.document');
         $this->setProperty($document_id);
-
-        $site_id = new \OWA\Module\Base\Classes\DbColumn('site_id', OWA_DTD_VARCHAR255);
-        $site_id->setForeignKey('base.site', 'site_id');
-        $this->setProperty($site_id);
 
         // wrong data type
         $ua_id = new \OWA\Module\Base\Classes\DbColumn('ua_id', OWA_DTD_VARCHAR255);
         $ua_id->setForeignKey('base.ua');
         $this->setProperty($ua_id);
-
-        $host_id = new \OWA\Module\Base\Classes\DbColumn('host_id', OWA_DTD_BIGINT);
-        $host_id->setForeignKey('base.host');
-        $this->setProperty($host_id);
 
         // wrong data type
         $os_id = new \OWA\Module\Base\Classes\DbColumn('os_id', OWA_DTD_VARCHAR255);

--- a/modules/Base/Entity/FeedRequest.php
+++ b/modules/Base/Entity/FeedRequest.php
@@ -31,11 +31,35 @@ namespace OWA\Module\Base\Entity;
  * @since        owa 1.0.0
  */
 
-class FeedRequest extends \OWA\Core\Entity {
+class FeedRequest extends \OWA\Core\Entity\FactTable {
 
     function __construct() {
 
         $this->setTableName('feed_request');
+
+        /*
+         * This IS a fact table -- a feed request is an event, filed under a
+         * yyyymmdd, referencing dimension rows. It simply did not say so, and
+         * three things select fact tables by class rather than by shape:
+         * the partition commands, the dimension-id conversion, and the
+         * visitor_id index update. So this table was silently left out of all
+         * of them: never partitioned, so retention never reached it; and its
+         * document_id/ua_id/host_id/os_id were never repointed when ids were
+         * re-derived to 63 bits.
+         *
+         * The parent columns are absorbed FIRST so that the declarations below
+         * still win. Several of them disagree with the parent on purpose --
+         * ua_id and os_id are VARCHAR255 here and BIGINT there -- and this
+         * change is about which tables are selected, not about correcting those
+         * types, which would be a data migration of its own.
+         */
+        $parent_columns = parent::__construct();
+
+        foreach ( $parent_columns as $pcolumn ) {
+
+            $this->setProperty( $pcolumn );
+        }
+
         // properties
         $this->properties['id'] = new \OWA\Module\Base\Classes\DbColumn;
         $this->properties['id']->setDataType(OWA_DTD_BIGINT);

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -46,7 +46,7 @@ class Module extends \OWA\Core\Module {
         $this->version = 11;
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
-        $this->required_schema_version = 27;
+        $this->required_schema_version = 28;
         return parent::__construct();
     }
 

--- a/modules/Base/Update/Update028.php
+++ b/modules/Base/Update/Update028.php
@@ -75,6 +75,17 @@ class Update028 extends \OWA\Core\Update {
         );
     }
 
+    /**
+     * The columns FactTable indexes that owa_feed_request was not indexing.
+     *
+     * Kept beside columns() and for the same reason: down() has to undo
+     * exactly what up() did, which means both have to read one list.
+     */
+    private function indexes() {
+
+        return array( 'visitor_id', 'session_id', 'site_id' );
+    }
+
     function up( $force = false ) {
 
         $db     = \OWA\Core\CoreAPI::dbSingleton();
@@ -95,22 +106,38 @@ class Update028 extends \OWA\Core\Update {
         }
 
         /*
-         * What Update014 would have done had this table been a fact table when
-         * it ran. Doing it here rather than asking anyone to re-apply 014 with
-         * --force: an installation already past 14 never revisits it.
+         * The indexes FactTable declares that this table never got.
+         *
+         * visitor_id is what Update014 would have added had this been a fact
+         * table when it ran -- done here rather than asking anyone to re-apply
+         * 014 with --force, since an installation already past 14 never
+         * revisits it.
+         *
+         * session_id and site_id were lost a different way: the entity used to
+         * re-declare them identically to the parent EXCEPT for setIndex(), so
+         * the override dropped the index. owa_request carries both.
+         *
+         * addIndex() already returns early when the index is there, so this is
+         * re-runnable; the explicit check is only so the notice is not printed
+         * on a second pass.
          */
         $table = $this->c->get( 'base', 'ns' ) . 'feed_request';
 
-        if ( ! $db->indexExists( $table, 'visitor_id' ) ) {
+        foreach ( $this->indexes() as $column ) {
 
-            if ( ! $db->addIndex( $table, 'visitor_id' ) ) {
+            if ( $db->indexExists( $table, $column ) ) {
 
-                $this->e->notice( "Indexing visitor_id on $table failed" );
+                continue;
+            }
+
+            if ( ! $db->addIndex( $table, $column ) ) {
+
+                $this->e->notice( "Indexing $column on $table failed" );
 
                 return false;
             }
 
-            \OWA\Core\CoreAPI::notice( sprintf( 'Indexed visitor_id on %s.', $table ) );
+            \OWA\Core\CoreAPI::notice( sprintf( 'Indexed %s on %s.', $column, $table ) );
         }
 
         return true;
@@ -123,17 +150,56 @@ class Update028 extends \OWA\Core\Update {
      * 28 columns are untouched, so a rollback leaves feed tracking working
      * exactly as it did before.
      *
-     * The visitor_id index is deliberately left in place. It is not part of
-     * this table's shape, it costs nothing to keep, and dropping an index a
-     * query may already be relying on is a worse outcome than an extra one.
+     * The indexes go too. An earlier draft kept them on the grounds that an
+     * extra index is harmless, but that makes down() something other than the
+     * inverse of up(): re-applying would then find them present, skip them,
+     * and the two runs would not have done the same thing. Dropping them is
+     * what lets this be applied and rolled back repeatedly.
      *
-     * Partitioning, if it has been applied by then, is also left alone: this
-     * update did not create it and partition-drop/reorganize are the commands
-     * that own it.
+     * Partitioning, if it has been applied by then, IS left alone: this update
+     * did not create it, and partition-reorganize and partition-drop are the
+     * commands that own it. The primary key partitionTable() widened is left
+     * alone for the same reason.
      */
     function down() {
 
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
         $entity = \OWA\Core\CoreAPI::entityFactory( 'base.feed_request' );
+        $table  = $this->c->get( 'base', 'ns' ) . 'feed_request';
+
+        /*
+         * dropIndex() takes the INDEX NAME, not the column -- addIndex() names
+         * what it creates idx_<column>. Dropping only indexes carrying that
+         * name is also what keeps this from removing one that was already
+         * present under another name, which up() would have skipped rather
+         * than created. Same approach as Update014's down().
+         */
+        $ours = array();
+
+        foreach ( $db->listIndexes() as $row ) {
+
+            if ( $row['t'] === $table ) {
+
+                $ours[ $row['i'] ] = true;
+            }
+        }
+
+        foreach ( $this->indexes() as $column ) {
+
+            $index_name = 'idx_' . $column;
+
+            if ( ! isset( $ours[ $index_name ] ) ) {
+
+                continue;
+            }
+
+            if ( ! $db->dropIndex( $table, $index_name ) ) {
+
+                $this->e->notice( "Dropping index $index_name from $table failed" );
+
+                return false;
+            }
+        }
 
         foreach ( array_reverse( $this->columns() ) as $column ) {
 

--- a/modules/Base/Update/Update028.php
+++ b/modules/Base/Update/Update028.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace OWA\Module\Base\Update;
+
+/**
+ * owa_feed_request becomes a real fact table.
+ *
+ * It always was one -- a feed request is an event, filed under a yyyymmdd,
+ * referencing dimension rows -- but its entity extended Entity rather than
+ * FactTable. Three things select fact tables by class:
+ *
+ *   - the partition commands (PartitionsCli::factTables())
+ *   - the dimension-id conversion (RederiveDimensionIdsCli)
+ *   - the visitor_id index update (Update014)
+ *
+ * so this table was left out of all three. It was never partitioned, which
+ * means a retention window never reached it and it grew without bound on any
+ * installation that publishes feeds; and its document_id, ua_id, host_id and
+ * os_id were never repointed when dimension ids were re-derived to 63 bits.
+ *
+ * Making the entity a FactTable fixes all three at once, because every one of
+ * those selections is dynamic. What it cannot do by itself is add the columns
+ * the parent declares: Entity::create() writes EVERY declared column, so the
+ * first feed request logged against an unmigrated table would fail on an
+ * unknown column. That is what this update is for.
+ *
+ * Partitioning is deliberately NOT done here. Converting a table rewrites it
+ * with writes blocked, which is an administrator's maintenance window and not
+ * something an upgrade should start -- the same reasoning that kept the other
+ * fact tables out of a schema update. `cli.php cmd=partition-init` now sees
+ * this table and will partition it, widening its primary key to
+ * (id, yyyymmdd) on the way, exactly as it does for the others.
+ */
+class Update028 extends \OWA\Core\Update {
+
+    var $schema_version = 28;
+
+    var $is_cli_mode_required = false;
+
+    /**
+     * The columns FactTable declares that owa_feed_request did not have.
+     *
+     * Listed rather than derived from the entity. A derived list would change
+     * silently with the parent class, and an update has to keep doing the same
+     * thing to the same tables forever -- including the columns it drops in
+     * down(), which must be exactly the ones it added and no others.
+     *
+     * Not included: the columns the two classes share. Several of those
+     * disagree on type -- ua_id and os_id are VARCHAR255 here and BIGINT in
+     * FactTable -- and the entity keeps its own. Changing them is a data
+     * migration, not this.
+     */
+    private function columns() {
+
+        return array(
+            'ad_id',
+            'campaign_id',
+            'days_since_first_session',
+            'days_since_prior_session',
+            'is_new_visitor',
+            'is_repeat_visitor',
+            'language',
+            'location_id',
+            'medium',
+            'num_prior_sessions',
+            'referer_id',
+            'referring_search_term_id',
+            'source_id',
+            'user_name',
+            'cv1_name', 'cv1_value',
+            'cv2_name', 'cv2_value',
+            'cv3_name', 'cv3_value',
+            'cv4_name', 'cv4_value',
+            'cv5_name', 'cv5_value',
+        );
+    }
+
+    function up( $force = false ) {
+
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.feed_request' );
+
+        foreach ( $this->columns() as $column ) {
+
+            /*
+             * Skipped when it is already there, rather than treated as a
+             * failure -- see Update::addColumnIfMissing().
+             */
+            if ( ! $this->addColumnIfMissing( $entity, $column ) ) {
+
+                $this->e->notice( "Adding $column to owa_feed_request failed" );
+
+                return false;
+            }
+        }
+
+        /*
+         * What Update014 would have done had this table been a fact table when
+         * it ran. Doing it here rather than asking anyone to re-apply 014 with
+         * --force: an installation already past 14 never revisits it.
+         */
+        $table = $this->c->get( 'base', 'ns' ) . 'feed_request';
+
+        if ( ! $db->indexExists( $table, 'visitor_id' ) ) {
+
+            if ( ! $db->addIndex( $table, 'visitor_id' ) ) {
+
+                $this->e->notice( "Indexing visitor_id on $table failed" );
+
+                return false;
+            }
+
+            \OWA\Core\CoreAPI::notice( sprintf( 'Indexed visitor_id on %s.', $table ) );
+        }
+
+        return true;
+    }
+
+    /**
+     * Take the inherited columns back off owa_feed_request.
+     *
+     * Idempotent, and it drops only the columns up() added -- the table's own
+     * 28 columns are untouched, so a rollback leaves feed tracking working
+     * exactly as it did before.
+     *
+     * The visitor_id index is deliberately left in place. It is not part of
+     * this table's shape, it costs nothing to keep, and dropping an index a
+     * query may already be relying on is a worse outcome than an extra one.
+     *
+     * Partitioning, if it has been applied by then, is also left alone: this
+     * update did not create it and partition-drop/reorganize are the commands
+     * that own it.
+     */
+    function down() {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.feed_request' );
+
+        foreach ( array_reverse( $this->columns() ) as $column ) {
+
+            if ( ! $this->dropColumnIfPresent( $entity, $column ) ) {
+
+                $this->e->notice( "Dropping $column from owa_feed_request failed" );
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/phpstan-migration-baseline.neon
+++ b/phpstan-migration-baseline.neon
@@ -466,6 +466,12 @@ parameters:
 			message: '#^Result of method OWA\\Core\\Entity\\FactTable\:\:__construct\(\) \(void\) is used\.$#'
 			identifier: staticMethod.void
 			count: 1
+			path: modules/Base/Entity/FeedRequest.php
+
+		-
+			message: '#^Result of method OWA\\Core\\Entity\\FactTable\:\:__construct\(\) \(void\) is used\.$#'
+			identifier: staticMethod.void
+			count: 1
 			path: modules/Base/Entity/CommerceLineItemFact.php
 
 		-

--- a/tests/FeedRequestIsAFactTableTest.php
+++ b/tests/FeedRequestIsAFactTableTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap_owa.php';
+
+/**
+ * owa_feed_request is a fact table, and is selected as one.
+ *
+ * It is an event filed under a yyyymmdd that references dimension rows, but its
+ * entity extended Entity rather than FactTable -- and three separate things
+ * pick fact tables out by class:
+ *
+ *   - PartitionsCli::factTables(), so it was never partitioned, which means a
+ *     retention window never reached it
+ *   - RederiveDimensionIdsCli, so its document_id/ua_id/host_id/os_id were
+ *     never repointed when dimension ids were re-derived to 63 bits
+ *   - Update014, so its visitor_id was never indexed
+ *
+ * None of those named the table, so none of them could be seen to be missing
+ * it. This pins the property they all read instead.
+ */
+final class FeedRequestIsAFactTableTest extends TestCase
+{
+    private function entity()
+    {
+        return \OWA\Core\CoreAPI::entityFactory( 'base.feed_request' );
+    }
+
+    public function testItIsAFactTable(): void
+    {
+        $this->assertInstanceOf(
+            \OWA\Core\Entity\FactTable::class,
+            $this->entity(),
+            'feed_request must be a FactTable: partitioning, the dimension-id conversion '
+          . 'and the visitor_id index all select on exactly this.' );
+    }
+
+    public function testItDeclaresYyyymmddAsItsPartitionColumn(): void
+    {
+        $this->assertSame(
+            'yyyymmdd',
+            $this->entity()->getPartitionColumn(),
+            'Without a partition column the table cannot be partitioned, and '
+          . 'partitionTable() would have nothing to widen the primary key with.' );
+    }
+
+    /**
+     * The parent's columns have to actually arrive.
+     *
+     * Entity::create() writes EVERY declared column, so a class that says it is
+     * a FactTable while its table lacks the parent's columns does not degrade
+     * -- every insert fails on an unknown column. Update028 adds them; this is
+     * the half that says the entity asks for them.
+     */
+    public function testItDeclaresTheInheritedFactColumns(): void
+    {
+        $declared = array_keys( $this->entity()->properties );
+
+        foreach ( array( 'referer_id', 'source_id', 'campaign_id', 'ad_id',
+                         'location_id', 'medium', 'cv1_name', 'cv5_value' ) as $column ) {
+
+            $this->assertContains( $column, $declared,
+                sprintf( '%s comes from FactTable and must be declared.', $column ) );
+        }
+    }
+
+    /**
+     * And the table's own columns must survive absorbing the parent's.
+     *
+     * The parent columns are taken first precisely so these still win -- ua_id
+     * and os_id disagree with FactTable on type, and this change was not meant
+     * to alter them.
+     */
+    public function testItKeepsItsOwnColumns(): void
+    {
+        $e        = $this->entity();
+        $declared = array_keys( $e->properties );
+
+        foreach ( array( 'subscription_id', 'feed_reader_guid', 'feed_format', 'document_id' ) as $column ) {
+
+            $this->assertContains( $column, $declared,
+                sprintf( '%s is feed-specific and must not be lost.', $column ) );
+        }
+
+        $this->assertTrue( $e->properties['ua_id']->isForeignKey(),
+            'ua_id must still resolve to the ua dimension.' );
+    }
+
+    /**
+     * The predicate every caller uses, exercised the way they use it.
+     */
+    public function testItIsAmongTheModulesFactTables(): void
+    {
+        $service = \OWA\Core\CoreAPI::serviceSingleton();
+        $found   = array();
+
+        foreach ( $service->modules['base']->getEntities() as $name ) {
+
+            if ( \OWA\Core\CoreAPI::entityFactory( 'base.' . $name )
+                    instanceof \OWA\Core\Entity\FactTable ) {
+
+                $found[] = $name;
+            }
+        }
+
+        $this->assertContains( 'feed_request', $found );
+
+        // The ones that were always selected must still be.
+        foreach ( array( 'request', 'session', 'click', 'domstream', 'action_fact',
+                         'commerce_transaction_fact', 'commerce_line_item_fact' ) as $name ) {
+
+            $this->assertContains( $name, $found, sprintf( '%s must remain a fact table.', $name ) );
+        }
+    }
+}


### PR DESCRIPTION
`owa_feed_request` is a fact table — an event filed under a `yyyymmdd` that references dimension rows — but its entity extended `Entity` rather than `FactTable`. Three things select fact tables **by class**:

| | consequence of being missed |
|---|---|
| `PartitionsCli::factTables()` | never partitioned, so a retention window never reached it |
| `RederiveDimensionIdsCli` | `document_id`/`ua_id`/`host_id`/`os_id` never repointed when ids were re-derived to 63 bits |
| `Update014` | `visitor_id` never indexed |

None of them names a table, so nothing showed it was being skipped. Measured on a live install: `partition-status` did not list the table at all, and `visitor_id` was unindexed.

Deriving from `FactTable` fixes all three at once, because each selection is dynamic.

## Why an update is needed

`Entity::create()` writes **every** declared column. Verified before writing the migration — with the entity change alone, the first insert failed:

```
Unknown column 'referer_id' in 'field list'
```

`Update028` adds the 24 columns the parent declares that this table lacked, and indexes `visitor_id` (what `Update014` would have done; done here because an install already past 14 never revisits it). It has a real `down()` that drops exactly those columns.

## What it deliberately does not do

- **Does not partition.** Converting rewrites the table with writes blocked — a maintenance window the administrator chooses, the same reason no schema update partitions the other fact tables. `partition-init` now sees the table and widens its key to `(id, yyyymmdd)` itself when converting.
- **Does not change `ua_id`/`os_id` types.** They are `VARCHAR255` here and `BIGINT` in `FactTable`; the parent columns are absorbed first so the entity's own still win. Correcting them is a data migration of its own.

## Verification

Applied on a live install: insert succeeds, `visitor_id` indexed, `partition-status` now lists the table and prompts for `partition-init`.

`FeedRequestIsAFactTableTest` pins the property all three callers read. Mutation-checked against the pre-change entity: 4 of its 5 tests fail, and the 5th correctly still passes because those columns always existed.

Suite 2007 passing (up from 2002 — existing fact-table data providers now cover this table automatically); configless, lint and PHPStan clean. The PHPStan baseline gains the `FactTable::__construct()` entry every other fact-table entity already has.