### PR TITLE
Let an author share a custom report, and a reader narrow the list

### DIFF
--- a/modules/Base/Classes/CustomReportFavorites.php
+++ b/modules/Base/Classes/CustomReportFavorites.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace OWA\Module\Base\Classes;
+
+/**
+ * Starring a custom report or visualization, per reader.
+ *
+ * A favourite is the READER's, not the report's: it decides where a report sits
+ * in that person's list and nothing about the report itself. So it never
+ * appears on owa_custom_report -- see CustomReportFavorite for the shape and
+ * why it mirrors notification_state.
+ *
+ * Nothing here is a permission. Starring something you can see does not change
+ * what you can see, which is why toggling asks only that the report exists.
+ */
+class CustomReportFavorites {
+
+    /**
+     * Is this report starred by this user?
+     *
+     * @param string $report_id
+     * @param string $user_id
+     * @return bool
+     */
+    public static function isFavorite( $report_id, $user_id ) {
+
+        if ( (string) $report_id === '' || (string) $user_id === '' ) {
+
+            return false;
+        }
+
+        return self::rowId( $report_id, $user_id ) !== null;
+    }
+
+    /**
+     * Star it if it is not, unstar it if it is.
+     *
+     * @param  string $report_id
+     * @param  string $user_id
+     * @return bool   the state it is in afterwards
+     */
+    public static function toggle( $report_id, $user_id ) {
+
+        if ( (string) $report_id === '' || (string) $user_id === '' ) {
+
+            return false;
+        }
+
+        $existing = self::rowId( $report_id, $user_id );
+
+        if ( $existing !== null ) {
+
+            $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report_favorite' );
+            $db     = \OWA\Core\CoreAPI::dbSingleton();
+
+            $db->deleteFrom( $entity->getTableName() );
+            $db->where( 'id', $existing );
+            $db->executeQuery();
+
+            return false;
+        }
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report_favorite' );
+
+        $entity->set( 'id', $entity->generateId(
+            'custom_report_favorite:' . $user_id . ':' . $report_id ) );
+        $entity->set( 'custom_report_id', $report_id );
+        $entity->set( 'user_id', (string) $user_id );
+        $entity->set( 'creation_timestamp', \OWA\Core\CoreAPI::getRequestTimestamp() );
+        $entity->create();
+
+        return true;
+    }
+
+    /**
+     * The ids this user has starred.
+     *
+     * Returned as a list rather than joined into the roster query, because the
+     * roster is built by hand from a string of SQL and a LEFT JOIN there would
+     * have to carry the user into every branch of it. A person has tens of
+     * favourites, not thousands.
+     *
+     * @param  string $user_id
+     * @return array  report id => true
+     */
+    public static function idsFor( $user_id ) {
+
+        if ( (string) $user_id === '' ) {
+
+            return array();
+        }
+
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report_favorite' );
+
+        $rows = (array) $db->get_results( sprintf(
+            "SELECT custom_report_id FROM %s WHERE user_id = '%s'",
+            $entity->getTableName(),
+            $db->prepare( (string) $user_id ) ) );
+
+        $ids = array();
+
+        foreach ( $rows as $row ) {
+
+            $ids[ (string) $row['custom_report_id'] ] = true;
+        }
+
+        return $ids;
+    }
+
+    /**
+     * Forget every star on a report.
+     *
+     * Called when a report is deleted: the rows are about a report that no
+     * longer exists, and leaving them would put a dead id at the top of
+     * somebody's list if the id were ever reused.
+     *
+     * @param string $report_id
+     */
+    public static function forget( $report_id ) {
+
+        if ( (string) $report_id === '' ) {
+
+            return;
+        }
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report_favorite' );
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+
+        $db->deleteFrom( $entity->getTableName() );
+        $db->where( 'custom_report_id', $report_id );
+        $db->executeQuery();
+    }
+
+    /**
+     * @return string|null the row id, or null when it is not starred
+     */
+    private static function rowId( $report_id, $user_id ) {
+
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report_favorite' );
+
+        $row = $db->get_row( sprintf(
+            "SELECT id FROM %s WHERE custom_report_id = '%s' AND user_id = '%s'",
+            $entity->getTableName(),
+            $db->prepare( (string) $report_id ),
+            $db->prepare( (string) $user_id ) ) );
+
+        return ( is_array( $row ) && isset( $row['id'] ) ) ? (string) $row['id'] : null;
+    }
+}

--- a/modules/Base/Classes/CustomReports.php
+++ b/modules/Base/Classes/CustomReports.php
@@ -1642,9 +1642,12 @@ class CustomReports {
      * @param bool   $mine_only true to list only this user's own, whatever
      *                          else they would be shown. A reader's choice,
      *                          not a permission -- it can only narrow.
+     * @param bool   $favorites_only true to list only what this user starred.
+     *                          The same kind of thing as $mine_only, and it
+     *                          narrows the same way.
      * @return array
      */
-    public static function roster( $user_id, $all = false, $sort = '', $descending = null, $limit = null, $type = null, $mine_only = false ) {
+    public static function roster( $user_id, $all = false, $sort = '', $descending = null, $limit = null, $type = null, $mine_only = false, $favorites_only = false ) {
 
         $db = \OWA\Core\CoreAPI::dbSingleton();
 
@@ -1729,12 +1732,47 @@ class CustomReports {
         // failed query.
         $rows = $db->get_results( $sql, $params );
 
-        if ( $rows === null ) {
+        if ( ! $rows ) {
 
             return array();
         }
 
-        return array_map( array( __CLASS__, 'hydrate' ), $rows );
+        /*
+         * Starred first, then whatever the reader sorted by.
+         *
+         * Done here rather than in the ORDER BY because a favourite is not a
+         * column on this table -- it is a row in another one, belonging to the
+         * reader. Joining it in would mean carrying the user into a query that
+         * is otherwise about the reports themselves, for an ordering a person
+         * has tens of entries in.
+         *
+         * usort is STABLE as of PHP 8.0, so reports that are equally starred
+         * keep the order the database returned -- which is the sort the reader
+         * actually asked for.
+         */
+        $starred = \OWA\Module\Base\Classes\CustomReportFavorites::idsFor( $user_id );
+
+        $out = array();
+
+        foreach ( $rows as $row ) {
+
+            $row = (array) $row;
+            $row['is_favorite'] = isset( $starred[ (string) $row['id'] ] );
+
+            if ( $favorites_only && ! $row['is_favorite'] ) {
+
+                continue;
+            }
+
+            $out[] = $row;
+        }
+
+        usort( $out, function ( $a, $b ) {
+
+            return ( $b['is_favorite'] ? 1 : 0 ) <=> ( $a['is_favorite'] ? 1 : 0 );
+        } );
+
+        return array_map( array( __CLASS__, 'hydrate' ), $out );
     }
 
     /** A stored row, with its definition decoded. */
@@ -1943,6 +1981,13 @@ class CustomReports {
         }
 
         $entity->delete( $id );
+
+        /*
+         * The stars go with it. They are rows about a report that no longer
+         * exists, and a favourite pointing at nothing would sort a gap to the
+         * top of somebody's list.
+         */
+        CustomReportFavorites::forget( $id );
 
         return true;
     }

--- a/modules/Base/Classes/CustomReports.php
+++ b/modules/Base/Classes/CustomReports.php
@@ -1627,16 +1627,24 @@ class CustomReports {
      * The reports a user may see listed.
      *
      * Ownership governs the ROSTER, not viewing: an admin sees every report, a
-     * non-admin sees the ones they created. A report reached by its URL renders
-     * for anyone with view_reports, which is what makes the URL shareable --
-     * and is safe because a custom report can show nothing its reader could not
-     * already query for themselves.
+     * non-admin sees the ones they created, PLUS any their author has shared. A
+     * report reached by its URL renders for anyone with view_reports, which is
+     * what makes the URL shareable -- and is safe because a custom report can
+     * show nothing its reader could not already query for themselves.
+     *
+     * Sharing is therefore about being FOUND, not about being allowed. It puts
+     * a report on other people's lists; it does not open anything that was
+     * closed, and un-sharing does not close anything either -- a link someone
+     * already has goes on working.
      *
      * @param string $user_id
-     * @param bool   $all     true for a user who may see everyone's
+     * @param bool   $all       true for a user who may see everyone's
+     * @param bool   $mine_only true to list only this user's own, whatever
+     *                          else they would be shown. A reader's choice,
+     *                          not a permission -- it can only narrow.
      * @return array
      */
-    public static function roster( $user_id, $all = false, $sort = '', $descending = null, $limit = null, $type = null ) {
+    public static function roster( $user_id, $all = false, $sort = '', $descending = null, $limit = null, $type = null, $mine_only = false ) {
 
         $db = \OWA\Core\CoreAPI::dbSingleton();
 
@@ -1644,9 +1652,25 @@ class CustomReports {
         $params = array();
         $where  = array();
 
-        if ( ! $all ) {
+        if ( $mine_only ) {
 
+            /*
+             * Asked for FIRST, and on its own, so it means the same thing to
+             * everybody: an admin narrowing to "mine" gets their own, not their
+             * own plus everyone's. It can only ever narrow -- a reader cannot
+             * widen past what they would have been shown anyway.
+             */
             $where[]  = 'user_id = ?';
+            $params[] = (string) $user_id;
+
+        } elseif ( ! $all ) {
+
+            /*
+             * Matched as = 1 rather than as truthy, so a NULL -- which is every
+             * row written before the column existed -- stays private. The same
+             * reasoning as the report_type filter below.
+             */
+            $where[]  = '( user_id = ? OR is_shared = 1 )';
             $params[] = (string) $user_id;
         }
 
@@ -1799,6 +1823,17 @@ class CustomReports {
         $entity->set( 'name', $name );
         $entity->set( 'definition', json_encode( $definition ) );
         $entity->set( 'last_updated_timestamp', $now );
+
+        /*
+         * Only when the caller said something about it. A save that does not
+         * mention sharing leaves it as it was, which is what lets a screen that
+         * has no such control edit a shared report without quietly un-sharing
+         * it.
+         */
+        if ( array_key_exists( 'is_shared', $fields ) ) {
+
+            $entity->set( 'is_shared', $fields['is_shared'] ? 1 : 0 );
+        }
 
         if ( $id === '' ) {
 

--- a/modules/Base/Controller/CustomReportEdit.php
+++ b/modules/Base/Controller/CustomReportEdit.php
@@ -141,6 +141,16 @@ class CustomReportEdit extends \OWA\Core\ReportController {
         $this->set( 'custom_report_definition', $definition );
 
         /*
+         * Shared, or listed only to its author. A refused save carries the
+         * checkbox back rather than redrawing the stored value, for the same
+         * reason the name and definition do.
+         */
+        $this->set( 'custom_report_is_shared',
+            $this->getParam( 'customReportError' )
+                ? (bool) $this->getParam( 'isShared' )
+                : ( $report ? ! empty( $report['is_shared'] ) : false ) );
+
+        /*
          * The site the author is looking at, carried through the form.
          *
          * It ends up on the URL the author lands on after saving, which is the

--- a/modules/Base/Controller/CustomReportMarkFavorite.php
+++ b/modules/Base/Controller/CustomReportMarkFavorite.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace OWA\Module\Base\Controller;
+
+/**
+ * Star or unstar a custom report, and go back to it.
+ *
+ * ONE ACTION, NOT TWO. The star is a toggle in the interface, so it is a toggle
+ * here: a separate favourite/unfavourite pair would need the caller to know the
+ * current state to pick between them, and a caller that got it wrong would
+ * silently do the opposite of what was clicked.
+ *
+ * NAMED FOR THE WRITE IT DOES. A nonce-guarded controller has to carry a write
+ * verb in its name -- LoginRedirectNonceTest enforces it -- because a name
+ * carrying "Report" without one reads as a screen that SHOWS a report, and a
+ * report screen requiring a nonce loses its post-login redirect.
+ *
+ * REQUIRES ONLY view_reports, not edit_reports. A favourite is the reader's
+ * note about where a report sits in their own list -- starring somebody else's
+ * report changes nothing about it, and a reader who may look at a report but
+ * never author one is exactly who this is for.
+ */
+class CustomReportMarkFavorite extends \OWA\Core\AdminController {
+
+    function __construct( $params ) {
+
+        parent::__construct( $params );
+
+        $this->type = 'options';
+        $this->setRequiredCapability( 'view_reports' );
+        $this->setNonceRequired();
+    }
+
+    public function validate() {
+
+        $this->addValidation( 'customReportId', $this->getParam( 'customReportId' ), 'required' );
+    }
+
+    function action() {
+
+        $id     = (string) $this->getParam( 'customReportId' );
+        $report = \OWA\Module\Base\Classes\CustomReports::load( $id );
+
+        /*
+         * The report has to exist, and that is the whole check.
+         *
+         * Not "and you must be allowed to see it": a custom report renders for
+         * anyone with view_reports by design, so there is no narrower set to
+         * test against. Refusing a star on a report the reader can open would
+         * be inventing a permission that does not exist anywhere else.
+         */
+        if ( $report ) {
+
+            \OWA\Module\Base\Classes\CustomReportFavorites::toggle(
+                $id, (string) \OWA\Core\CoreAPI::getCurrentUser()->getUserData( 'user_id' ) );
+        }
+
+        /*
+         * Back to the report, not to the roster. The star is pressed while
+         * looking at the thing, and the answer to "did that work" is the star
+         * itself having changed.
+         */
+        $this->set( 'reportId', Report::CUSTOM_PREFIX . $id );
+
+        $siteId = (string) $this->getParam( 'siteId' );
+
+        if ( $siteId !== '' ) {
+
+            $this->set( 'siteId', $siteId );
+        }
+
+        $this->setRedirectAction( 'base.report' );
+    }
+
+    function errorAction() {
+
+        $this->setRedirectAction( 'base.customReports' );
+    }
+}

--- a/modules/Base/Controller/CustomReportSave.php
+++ b/modules/Base/Controller/CustomReportSave.php
@@ -75,6 +75,7 @@ class CustomReportSave extends \OWA\Core\AdminController {
             'id'         => $id,
             'name'       => $this->getParam( 'customReportName' ),
             'definition' => $this->getParam( 'customReportDefinition' ),
+            'is_shared'  => (bool) $this->getParam( 'isShared' ),
         ), $user_id );
 
         if ( ! $result['ok'] ) {

--- a/modules/Base/Controller/CustomReports.php
+++ b/modules/Base/Controller/CustomReports.php
@@ -82,8 +82,15 @@ class CustomReports extends \OWA\Core\ReportController {
             ? null
             : (bool) $descending;
 
+        /*
+         * "Just mine" rides on the URL like the sort does, so a link to the
+         * roster shows the same list to whoever opens it. It narrows and cannot
+         * widen, so it needs no capability of its own.
+         */
+        $mine_only = (bool) $this->getParam( 'rosterMine' );
+
         $reports = \OWA\Module\Base\Classes\CustomReports::roster(
-            $user_id, $sees_all, $sort, $descending, null, $this->rosterType() );
+            $user_id, $sees_all, $sort, $descending, null, $this->rosterType(), $mine_only );
 
         // What the headings need to draw themselves: which one is active, and
         // which way, so each can link to the OPPOSITE of what it shows now.
@@ -95,6 +102,7 @@ class CustomReports extends \OWA\Core\ReportController {
         $this->set( 'custom_reports', $reports );
         $this->set( 'roster_type', $this->rosterType() );
         $this->set( 'sees_all', $sees_all );
+        $this->set( 'roster_mine', $mine_only );
         $this->set( 'may_author', (bool) $user->isCapable( 'edit_reports' ) );
         $this->set( 'current_user_id', $user_id );
     }

--- a/modules/Base/Controller/CustomReports.php
+++ b/modules/Base/Controller/CustomReports.php
@@ -89,8 +89,22 @@ class CustomReports extends \OWA\Core\ReportController {
          */
         $mine_only = (bool) $this->getParam( 'rosterMine' );
 
+        /*
+         * A THIRD state of the same control, not a second control: All, Just
+         * mine, Favorites. They are alternatives -- "my favourites" and "my
+         * reports" are different questions and answering both at once would
+         * need a filter that says which.
+         */
+        $favorites_only = (bool) $this->getParam( 'rosterFavorites' );
+
+        if ( $favorites_only ) {
+
+            $mine_only = false;
+        }
+
         $reports = \OWA\Module\Base\Classes\CustomReports::roster(
-            $user_id, $sees_all, $sort, $descending, null, $this->rosterType(), $mine_only );
+            $user_id, $sees_all, $sort, $descending, null, $this->rosterType(),
+            $mine_only, $favorites_only );
 
         // What the headings need to draw themselves: which one is active, and
         // which way, so each can link to the OPPOSITE of what it shows now.
@@ -103,6 +117,7 @@ class CustomReports extends \OWA\Core\ReportController {
         $this->set( 'roster_type', $this->rosterType() );
         $this->set( 'sees_all', $sees_all );
         $this->set( 'roster_mine', $mine_only );
+        $this->set( 'roster_favorites', $favorites_only );
         $this->set( 'may_author', (bool) $user->isCapable( 'edit_reports' ) );
         $this->set( 'current_user_id', $user_id );
     }

--- a/modules/Base/Controller/Report.php
+++ b/modules/Base/Controller/Report.php
@@ -219,7 +219,7 @@ class Report extends \OWA\Core\Controller {
         $data = (array) $this->delegateTo( $controllers[ $type ] );
 
         // The same edit control a custom report gets, in the same place.
-        return $this->withEditAction( $data, $report );
+        return $this->withFavoriteAction( $this->withEditAction( $data, $report ), $report );
     }
 
     private function renderCustom( $id ) {
@@ -318,7 +318,7 @@ class Report extends \OWA\Core\Controller {
          * enough. It took an admin opening a report created by someone else --
          * which is the ordinary case on any install with more than one author.
          */
-        return $this->withEditAction( $data, $report );
+        return $this->withFavoriteAction( $this->withEditAction( $data, $report ), $report );
     }
 
     /**
@@ -386,6 +386,70 @@ class Report extends \OWA\Core\Controller {
                 'iconOnly' => true,
             ),
         );
+
+        return $data;
+    }
+
+    /**
+     * A star beside the title, for the reader to mark this as one of theirs.
+     *
+     * Offered to ANYONE who is looking at a rendered report, not only to
+     * someone who may edit it. A favourite is the reader's own note about where
+     * this sits in their list -- starring somebody else's report changes
+     * nothing about the report, and a reader who may look but never author is
+     * exactly who it is for. That is why this is its own method beside
+     * withEditAction() rather than a branch inside it: the two answer different
+     * questions about different people.
+     *
+     * Put FIRST, so the star sits immediately right of the title and the pencil
+     * follows it. The star is about the row a reader is looking at; the pencil
+     * is about changing it, which fewer of them can do.
+     *
+     * @param  array $data    what the target controller returned
+     * @param  array $report  the row being rendered
+     * @return array
+     */
+    private function withFavoriteAction( array $data, array $report ) {
+
+        // Same guard as the edit action: a refused request comes back as bare
+        // data, and a star on a refusal would be decorating an error.
+        if ( empty( $data['view'] ) || empty( $report['id'] ) ) {
+
+            return $data;
+        }
+
+        $user_id = (string) \OWA\Core\CoreAPI::getCurrentUser()->getUserData( 'user_id' );
+
+        /*
+         * Nobody to remember it for. An anonymous reader has no user_id, so a
+         * star would have nowhere to be stored and would read as a control that
+         * does nothing.
+         */
+        if ( $user_id === '' ) {
+
+            return $data;
+        }
+
+        $starred = \OWA\Module\Base\Classes\CustomReportFavorites::isFavorite(
+            (string) $report['id'], $user_id );
+
+        $star = array(
+            // add_state TRUE, or the round trip drops siteId and period and the
+            // reader lands on a different view of the report than they left.
+            // add_nonce TRUE, because the target action demands one.
+            'url' => \OWA\Core\CoreAPI::supportClassFactory( 'base', 'template' )->makeLink(
+                array(
+                    'do'             => 'base.customReportMarkFavorite',
+                    'customReportId' => $report['id'],
+                ), true, '', false, true ),
+            'label'    => $starred ? 'Remove from favorites' : 'Add to favorites',
+            'icon'     => $starred ? 'fa-star' : 'fa-star-o',
+            'iconOnly' => true,
+        );
+
+        $existing = isset( $data['title_actions'] ) ? (array) $data['title_actions'] : array();
+
+        $data['title_actions'] = array_merge( array( $star ), $existing );
 
         return $data;
     }

--- a/modules/Base/Controller/VisualizationEdit.php
+++ b/modules/Base/Controller/VisualizationEdit.php
@@ -83,6 +83,9 @@ class VisualizationEdit extends \OWA\Core\ReportController {
                 'id'                 => $id,
                 'name'               => $this->getParam( 'name' ),
                 'visualization_type' => $type,
+                // Carried back on a refused save, like the name is. The stored
+                // row already has it on the other branch.
+                'is_shared'          => $this->getParam( 'isShared' ) ? 1 : 0,
               )
             : (array) $report );
         $this->set( 'steps', $submitted ?: $stored );

--- a/modules/Base/Controller/VisualizationSave.php
+++ b/modules/Base/Controller/VisualizationSave.php
@@ -238,6 +238,12 @@ class VisualizationSave extends \OWA\Core\AdminController {
          */
         $report->set( 'definition', json_encode( array( 'steps' => $steps ) ) );
         $report->set( 'last_updated_timestamp', \OWA\Core\CoreAPI::getRequestTimestamp() );
+        /*
+         * Listed to everybody, or only to its author. DISCOVERABILITY, not
+         * access -- the URL already renders for anyone with view_reports. See
+         * CustomReports::roster().
+         */
+        $report->set( 'is_shared', $this->getParam( 'isShared' ) ? 1 : 0 );
 
         if ( $report->wasPersisted() ) {
 

--- a/modules/Base/Entity/CustomReport.php
+++ b/modules/Base/Entity/CustomReport.php
@@ -95,6 +95,24 @@ class CustomReport extends \OWA\Core\Entity {
         $visualization_type = new \OWA\Module\Base\Classes\DbColumn( 'visualization_type', OWA_DTD_VARCHAR255 );
         $this->setProperty( $visualization_type );
 
+        /*
+         * Whether this one is listed to everybody, or only to the person who
+         * made it.
+         *
+         * DISCOVERABILITY, not access. A custom report opened by its URL
+         * already renders for anyone with view_reports -- that is what makes
+         * the link shareable, and it is safe because a custom report can show
+         * nothing its reader could not query for themselves. What ownership
+         * governs is the ROSTER, so this flag governs the roster too.
+         *
+         * NULL on every row written before this column existed, which reads as
+         * not shared -- the state those rows were already in. Nothing is
+         * backfilled, for the same reason report_type is not.
+         */
+        $is_shared = new \OWA\Module\Base\Classes\DbColumn( 'is_shared', OWA_DTD_TINYINT );
+        $is_shared->setIndex();
+        $this->setProperty( $is_shared );
+
         $definition = new \OWA\Module\Base\Classes\DbColumn( 'definition', OWA_DTD_BLOB );
         $this->setProperty( $definition );
 
@@ -120,5 +138,18 @@ class CustomReport extends \OWA\Core\Entity {
     public function isVisualization() {
 
         return $this->reportType() === self::TYPE_VISUALIZATION;
+    }
+
+    /**
+     * Is this one listed to everybody?
+     *
+     * Falsy reads as private, which is what NULL means on every row that
+     * predates the column -- the same shape as reportType() above.
+     *
+     * @return bool
+     */
+    public function isShared() {
+
+        return (bool) $this->get( 'is_shared' );
     }
 }

--- a/modules/Base/Entity/CustomReportFavorite.php
+++ b/modules/Base/Entity/CustomReportFavorite.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OWA\Module\Base\Entity;
+
+/**
+ * One person having starred one custom report or visualization.
+ *
+ * A row per (user, report) pair rather than a column on owa_custom_report,
+ * because a favourite belongs to the READER and the report belongs to its
+ * author -- a column would make one person's star everybody's.
+ *
+ * Modelled on notification_state, which is the same shape for the same reason:
+ * per-user state about a shared row, joined rather than embedded. The roster
+ * left-joins this to sort starred reports to the top, which is why both
+ * columns are indexed -- it is read on every listing.
+ */
+class CustomReportFavorite extends \OWA\Core\Entity {
+
+    function __construct() {
+
+        $this->setTableName( 'custom_report_favorite' );
+
+        $id = new \OWA\Module\Base\Classes\DbColumn( 'id', OWA_DTD_BIGINT );
+        $id->setPrimaryKey();
+        $this->setProperty( $id );
+
+        $custom_report_id = new \OWA\Module\Base\Classes\DbColumn( 'custom_report_id', OWA_DTD_BIGINT );
+        $custom_report_id->setIndex();
+        $this->setProperty( $custom_report_id );
+
+        // The user_id string, matching how base.user identifies a user -- the
+        // same id owa_custom_report.user_id and notification_state.user_id use.
+        $user_id = new \OWA\Module\Base\Classes\DbColumn( 'user_id', OWA_DTD_VARCHAR255 );
+        $user_id->setIndex();
+        $this->setProperty( $user_id );
+
+        $creation_timestamp = new \OWA\Module\Base\Classes\DbColumn( 'creation_timestamp', OWA_DTD_INT );
+        $this->setProperty( $creation_timestamp );
+    }
+}

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -46,7 +46,7 @@ class Module extends \OWA\Core\Module {
         $this->version = 11;
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
-        $this->required_schema_version = 28;
+        $this->required_schema_version = 29;
         return parent::__construct();
     }
 

--- a/modules/Base/Module.php
+++ b/modules/Base/Module.php
@@ -46,7 +46,7 @@ class Module extends \OWA\Core\Module {
         $this->version = 11;
         $this->description = 'Base functionality for OWA.';
         $this->config_required = false;
-        $this->required_schema_version = 29;
+        $this->required_schema_version = 30;
         return parent::__construct();
     }
 
@@ -213,6 +213,7 @@ class Module extends \OWA\Core\Module {
         $this->registerAction( 'base.organizationEdit',              'OWA\\Module\\Base\\Controller\\OrganizationEdit',              'Controller/OrganizationEdit.php' );
         $this->registerAction( 'base.customReports',                 'OWA\\Module\\Base\\Controller\\CustomReports',                'Controller/CustomReports.php' );
         $this->registerAction( 'base.customReportEdit',              'OWA\\Module\\Base\\Controller\\CustomReportEdit',             'Controller/CustomReportEdit.php' );
+        $this->registerAction( 'base.customReportMarkFavorite',      'OWA\\Module\\Base\\Controller\\CustomReportMarkFavorite',     'Controller/CustomReportMarkFavorite.php' );
         $this->registerAction( 'base.customReportSave',              'OWA\\Module\\Base\\Controller\\CustomReportSave',             'Controller/CustomReportSave.php' );
         $this->registerAction( 'base.customReportDelete',            'OWA\\Module\\Base\\Controller\\CustomReportDelete',           'Controller/CustomReportDelete.php' );
         $this->registerAction( 'base.sitesAdd',                      'OWA\\Module\\Base\\Controller\\SitesAdd',                     'Controller/SitesAdd.php' );
@@ -2441,6 +2442,7 @@ class Module extends \OWA\Core\Module {
                 'notification',
                 'notification_state',
                 'custom_report',
+                'custom_report_favorite',
                 'job_lock',
                 'site_user')
             );

--- a/modules/Base/Update/Update029.php
+++ b/modules/Base/Update/Update029.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace OWA\Module\Base\Update;
+
+/**
+ * A custom report can be listed to everybody, or only to its author.
+ *
+ * WHAT THIS IS NOT: an access control. A custom report opened by its URL
+ * already renders for anyone with view_reports -- deliberately, because that is
+ * what makes the link shareable, and it is safe because a custom report can
+ * show nothing its reader could not already query for themselves.
+ *
+ * What ownership governed was the ROSTER: CustomReports::roster() filtered on
+ * user_id unless the viewer held edit_users, so a report could be perfectly
+ * visible to a colleague you sent the link to while being absent from their
+ * list. This column lets an author put it on everyone's list.
+ *
+ * Nothing is backfilled. Every existing row stays private, which is what a NULL
+ * is_shared already means -- see CustomReport::isShared(), where falsy reads as
+ * private. The roster matches shared rows as is_shared = 1 for the same reason
+ * the report_type filter matches "not visualization": a comparison the other way
+ * would exclude every row written before this.
+ */
+class Update029 extends \OWA\Core\Update {
+
+    var $schema_version = 29;
+
+    var $is_cli_mode_required = false;
+
+    function up( $force = false ) {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report' );
+
+        /*
+         * Skipped when it is already there, rather than treated as a failure --
+         * see Update::addColumnIfMissing() for why that is the ordinary case
+         * and not a re-run guard.
+         */
+        if ( ! $this->addColumnIfMissing( $entity, 'is_shared' ) ) {
+
+            $this->e->notice( 'Adding is_shared to owa_custom_report failed' );
+
+            return false;
+        }
+
+        /*
+         * The roster reads it on every listing, so it is indexed. addColumn()
+         * has never created an index for an indexed column, which is why this
+         * is a separate step rather than something the column definition gets
+         * for free.
+         */
+        $db    = \OWA\Core\CoreAPI::dbSingleton();
+        $table = $this->c->get( 'base', 'ns' ) . 'custom_report';
+
+        if ( ! $db->indexExists( $table, 'is_shared' ) ) {
+
+            if ( ! $db->addIndex( $table, 'is_shared' ) ) {
+
+                $this->e->notice( "Indexing is_shared on $table failed" );
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Take the column and its index back off owa_custom_report.
+     *
+     * EVERY REPORT BECOMES PRIVATE AGAIN by doing this -- a row that said it
+     * was shared loses the only thing saying so, and drops out of everyone's
+     * roster but its author's. Stated rather than guarded against: a rollback
+     * to a schema with no such column cannot keep the flag, and the alternative
+     * is refusing to roll back at all.
+     *
+     * Nothing anyone could reach stops being reachable. The links still work,
+     * because they never depended on this.
+     *
+     * Idempotent. The index is dropped by the name addIndex() gives it, and
+     * only when that name is present, so an index added by hand under another
+     * name is left alone.
+     */
+    function down() {
+
+        $db     = \OWA\Core\CoreAPI::dbSingleton();
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report' );
+        $table  = $this->c->get( 'base', 'ns' ) . 'custom_report';
+
+        foreach ( $db->listIndexes() as $row ) {
+
+            if ( $row['t'] === $table && $row['i'] === 'idx_is_shared' ) {
+
+                if ( ! $db->dropIndex( $table, 'idx_is_shared' ) ) {
+
+                    $this->e->notice( "Dropping index idx_is_shared from $table failed" );
+
+                    return false;
+                }
+            }
+        }
+
+        if ( ! $this->dropColumnIfPresent( $entity, 'is_shared' ) ) {
+
+            $this->e->notice( 'Dropping is_shared from owa_custom_report failed' );
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/modules/Base/Update/Update030.php
+++ b/modules/Base/Update/Update030.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace OWA\Module\Base\Update;
+
+/**
+ * A reader can star a custom report or visualization.
+ *
+ * A table rather than a column, because a favourite belongs to the READER and
+ * the report belongs to its author: a column on owa_custom_report would make
+ * one person's star everybody's. Same shape as notification_state, which is
+ * per-user state about a shared row for the same reason.
+ *
+ * Nothing to backfill -- nobody has starred anything yet, and an empty table is
+ * exactly "no favourites", which is the state every reader is already in.
+ */
+class Update030 extends \OWA\Core\Update {
+
+    var $schema_version = 30;
+
+    var $is_cli_mode_required = false;
+
+    function up( $force = false ) {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report_favorite' );
+
+        /*
+         * createTable() issues CREATE TABLE IF NOT EXISTS, so a second run is
+         * a no-op rather than a failure -- unlike addColumn(), which is why
+         * columns need the addColumnIfMissing() helper and tables do not.
+         */
+        if ( ! $entity->createTable() ) {
+
+            $this->e->notice( 'Creating owa_custom_report_favorite failed' );
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Drop the table.
+     *
+     * EVERY STAR IS LOST by doing this. Nothing else is: a favourite decides
+     * where a report sits in one person's list and nothing about the report,
+     * so rolling back leaves every report exactly as it was and every list in
+     * its default order.
+     *
+     * Idempotent -- dropTable() is IF EXISTS.
+     */
+    function down() {
+
+        $entity = \OWA\Core\CoreAPI::entityFactory( 'base.custom_report_favorite' );
+
+        if ( ! $entity->dropTable() ) {
+
+            $this->e->notice( 'Dropping owa_custom_report_favorite failed' );
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/modules/Base/View/CustomReportEdit.php
+++ b/modules/Base/View/CustomReportEdit.php
@@ -25,6 +25,7 @@ class CustomReportEdit extends \OWA\Core\View {
         $this->body->set( 'custom_report_name', $this->get( 'custom_report_name' ) );
         $this->body->set( 'custom_report_definition', $this->get( 'custom_report_definition' ) );
         $this->body->set( 'custom_report_error', $this->get( 'custom_report_error' ) );
+        $this->body->set( 'custom_report_is_shared', $this->get( 'custom_report_is_shared' ) );
 
         $this->body->set( 'metric_choices', $this->get( 'metric_choices' ) );
         $this->body->set( 'metric_entities', $this->get( 'metric_entities' ) );

--- a/modules/Base/View/CustomReports.php
+++ b/modules/Base/View/CustomReports.php
@@ -31,5 +31,6 @@ class CustomReports extends \OWA\Core\View {
         $this->body->set( 'roster_sort', $this->get( 'roster_sort' ) );
         $this->body->set( 'roster_desc', $this->get( 'roster_desc' ) );
         $this->body->set( 'roster_mine', $this->get( 'roster_mine' ) );
+        $this->body->set( 'roster_favorites', $this->get( 'roster_favorites' ) );
     }
 }

--- a/modules/Base/View/CustomReports.php
+++ b/modules/Base/View/CustomReports.php
@@ -30,5 +30,6 @@ class CustomReports extends \OWA\Core\View {
         $this->body->set( 'current_user_id', $this->get( 'current_user_id' ) );
         $this->body->set( 'roster_sort', $this->get( 'roster_sort' ) );
         $this->body->set( 'roster_desc', $this->get( 'roster_desc' ) );
+        $this->body->set( 'roster_mine', $this->get( 'roster_mine' ) );
     }
 }

--- a/modules/Base/templates/custom_report_edit.php
+++ b/modules/Base/templates/custom_report_edit.php
@@ -27,6 +27,7 @@
 $owa_id         = (string) $view->get('custom_report_id');
 $owa_name       = (string) $view->get('custom_report_name');
 $owa_definition = (array) $view->get('custom_report_definition');
+$owa_is_shared  = (bool) $view->get('custom_report_is_shared');
 $owa_error      = (string) $view->get('custom_report_error');
 $owa_types      = (array) $view->get('widget_types');
 $owa_max        = (int) $view->get('max_widgets');
@@ -75,6 +76,25 @@ $owa_max        = (int) $view->get('max_widgets');
             <input type="text" id="customReportName" name="customReportName"
                    placeholder="Untitled report"
                    value="<?php $view->out( $owa_name ); ?>" />
+
+            <?php
+                /*
+                 * Listing, not access. Anyone with view_reports can already
+                 * open this report from its link -- that is what makes the link
+                 * worth sending. What this decides is whose LIST it appears on.
+                 */
+            ?>
+            <div class="owa_builderShare">
+                <label for="isShared">
+                    <input type="checkbox" id="isShared" name="isShared" value="1"
+                           <?php echo $owa_is_shared ? 'checked="checked"' : ''; ?> />
+                    Show this report in everyone's list
+                </label>
+                <p class="owa_builderHint">
+                    Off by default. Anyone you send the link to can open it either way;
+                    this decides whether other people find it without the link.
+                </p>
+            </div>
         </div>
 
         <?php

--- a/modules/Base/templates/custom_reports.php
+++ b/modules/Base/templates/custom_reports.php
@@ -25,11 +25,40 @@ $owa_builder   = $owa_isViz ? 'base.visualizationEdit' : 'base.customReportEdit'
  * has nothing to gate per row. The controller still decides what is LISTED.
  */
 $owa_author    = (bool) $view->get('may_author');
+$owa_mine      = (bool) $view->get('roster_mine');
+$owa_seesAll   = (bool) $view->get('sees_all');
 ?>
 
 <?php if ( $owa_reports ): ?>
 
 <div class="owa_reportSectionContent">
+
+<?php
+    /*
+     * Whose reports this is showing, and the way to change it.
+     *
+     * Only drawn for someone who could be shown more than their own -- an
+     * author with no shared reports around them would get a control whose two
+     * states produce the same list.
+     */
+?>
+<?php if ( $owa_seesAll || ! $owa_mine || $owa_reports ): ?>
+<div class="owa_rosterFilter">
+    <?php
+        $owa_filterLink = function ( $mine ) use ( $view, $owa_isViz ) {
+            return $view->makeLink( array(
+                'do'         => $owa_isViz ? 'base.visualizations' : 'base.customReports',
+                'rosterMine' => $mine ? '1' : '0',
+            ) );
+        };
+    ?>
+    <a class="<?php echo $owa_mine ? '' : 'owa_rosterFilterActive'; ?>"
+       href="<?php echo $owa_filterLink( false ); ?>">All</a>
+    <a class="<?php echo $owa_mine ? 'owa_rosterFilterActive' : ''; ?>"
+       href="<?php echo $owa_filterLink( true ); ?>">Just mine</a>
+</div>
+<?php endif; ?>
+
 <table class="management owa_customReportRoster">
     <thead>
         <tr>
@@ -49,7 +78,7 @@ $owa_author    = (bool) $view->get('may_author');
                 $owa_sort = (string) $view->get('roster_sort');
                 $owa_desc = (bool) $view->get('roster_desc');
 
-                $owa_heading = function ( $key, $label ) use ( $view, $owa_sort, $owa_desc, $owa_isViz ) {
+                $owa_heading = function ( $key, $label ) use ( $view, $owa_sort, $owa_desc, $owa_isViz, $owa_mine ) {
 
                     $active = ( $owa_sort === $key );
 
@@ -64,6 +93,9 @@ $owa_author    = (bool) $view->get('may_author');
                         'do'         => $owa_isViz ? 'base.visualizations' : 'base.customReports',
                         'rosterSort' => $key,
                         'rosterDesc' => $next ? '1' : '0',
+                        // Carried, or sorting would silently drop the filter
+                        // and hand back a longer list than was asked for.
+                        'rosterMine' => $owa_mine ? '1' : '0',
                     ) );
 
                     printf(
@@ -111,7 +143,13 @@ $owa_author    = (bool) $view->get('may_author');
                 ), true ); ?>"><?php $view->out( $owa_report['name'] ); ?></a>
             </td>
 
-            <td class="data_cell"><?php $view->out( $owa_report['user_id'] ); ?></td>
+            <td class="data_cell">
+                <?php $view->out( $owa_report['user_id'] ); ?>
+                <?php if ( ! empty( $owa_report['is_shared'] ) ): ?>
+                    <span class="owa_rosterShared"
+                          title="Shown in everyone's list">shared</span>
+                <?php endif; ?>
+            </td>
 
             <td class="data_cell">
                 <?php $owa_when = (int) $owa_report['last_updated_timestamp']; ?>

--- a/modules/Base/templates/custom_reports.php
+++ b/modules/Base/templates/custom_reports.php
@@ -26,6 +26,7 @@ $owa_builder   = $owa_isViz ? 'base.visualizationEdit' : 'base.customReportEdit'
  */
 $owa_author    = (bool) $view->get('may_author');
 $owa_mine      = (bool) $view->get('roster_mine');
+$owa_favs      = (bool) $view->get('roster_favorites');
 $owa_seesAll   = (bool) $view->get('sees_all');
 ?>
 
@@ -42,22 +43,30 @@ $owa_seesAll   = (bool) $view->get('sees_all');
      * states produce the same list.
      */
 ?>
-<?php if ( $owa_seesAll || ! $owa_mine || $owa_reports ): ?>
 <div class="owa_rosterFilter">
     <?php
-        $owa_filterLink = function ( $mine ) use ( $view, $owa_isViz ) {
+        /*
+         * Three states of ONE control, not three controls. They are
+         * alternatives: "my favourites" and "my reports" are different
+         * questions, and a reader who could pick both would need a fourth
+         * control saying how to combine them.
+         */
+        $owa_filterLink = function ( $which ) use ( $view, $owa_isViz ) {
             return $view->makeLink( array(
-                'do'         => $owa_isViz ? 'base.visualizations' : 'base.customReports',
-                'rosterMine' => $mine ? '1' : '0',
+                'do'              => $owa_isViz ? 'base.visualizations' : 'base.customReports',
+                'rosterMine'      => $which === 'mine' ? '1' : '0',
+                'rosterFavorites' => $which === 'favorites' ? '1' : '0',
             ) );
         };
+        $owa_active = $owa_favs ? 'favorites' : ( $owa_mine ? 'mine' : 'all' );
     ?>
-    <a class="<?php echo $owa_mine ? '' : 'owa_rosterFilterActive'; ?>"
-       href="<?php echo $owa_filterLink( false ); ?>">All</a>
-    <a class="<?php echo $owa_mine ? 'owa_rosterFilterActive' : ''; ?>"
-       href="<?php echo $owa_filterLink( true ); ?>">Just mine</a>
+    <a class="<?php echo $owa_active === 'all' ? 'owa_rosterFilterActive' : ''; ?>"
+       href="<?php echo $owa_filterLink( 'all' ); ?>">All</a>
+    <a class="<?php echo $owa_active === 'mine' ? 'owa_rosterFilterActive' : ''; ?>"
+       href="<?php echo $owa_filterLink( 'mine' ); ?>">Just mine</a>
+    <a class="<?php echo $owa_active === 'favorites' ? 'owa_rosterFilterActive' : ''; ?>"
+       href="<?php echo $owa_filterLink( 'favorites' ); ?>"><i class="fa fa-star"></i> Favorites</a>
 </div>
-<?php endif; ?>
 
 <table class="management owa_customReportRoster">
     <thead>
@@ -78,7 +87,7 @@ $owa_seesAll   = (bool) $view->get('sees_all');
                 $owa_sort = (string) $view->get('roster_sort');
                 $owa_desc = (bool) $view->get('roster_desc');
 
-                $owa_heading = function ( $key, $label ) use ( $view, $owa_sort, $owa_desc, $owa_isViz, $owa_mine ) {
+                $owa_heading = function ( $key, $label ) use ( $view, $owa_sort, $owa_desc, $owa_isViz, $owa_mine, $owa_favs ) {
 
                     $active = ( $owa_sort === $key );
 
@@ -95,7 +104,8 @@ $owa_seesAll   = (bool) $view->get('sees_all');
                         'rosterDesc' => $next ? '1' : '0',
                         // Carried, or sorting would silently drop the filter
                         // and hand back a longer list than was asked for.
-                        'rosterMine' => $owa_mine ? '1' : '0',
+                        'rosterMine'      => $owa_mine ? '1' : '0',
+                        'rosterFavorites' => $owa_favs ? '1' : '0',
                     ) );
 
                     printf(
@@ -145,6 +155,10 @@ $owa_seesAll   = (bool) $view->get('sees_all');
 
             <td class="data_cell">
                 <?php $view->out( $owa_report['user_id'] ); ?>
+                <?php if ( ! empty( $owa_report['is_favorite'] ) ): ?>
+                    <i class="fa fa-star owa_rosterFavorite"
+                       title="One of your favorites, so it sorts to the top"></i>
+                <?php endif; ?>
                 <?php if ( ! empty( $owa_report['is_shared'] ) ): ?>
                     <span class="owa_rosterShared"
                           title="Shown in everyone's list">shared</span>

--- a/modules/Base/templates/visualization_edit.php
+++ b/modules/Base/templates/visualization_edit.php
@@ -45,6 +45,21 @@ and where they left.</div>
     </div>
 
     <div class="setting">
+        <div class="title">Visibility</div>
+        <div class="description">Anyone you send the link to can open this either way &mdash;
+        a visualization shows nothing its reader could not already query. This decides whose
+        <em>list</em> it appears on.</div>
+        <div class="field">
+            <label>
+                <input type="checkbox" value="1"
+                       name="<?php echo $view->getNs();?>isShared"
+                       <?php echo ! empty( $owa_v['is_shared'] ) ? 'checked="checked"' : '';?>>
+                Show this visualization in everyone's list
+            </label>
+        </div>
+    </div>
+
+    <div class="setting">
         <div class="title">Type</div>
         <div class="description">What kind of visualization this is. Each kind computes its own
         numbers, so it decides what this form asks for &mdash; which is why it is chosen before

--- a/owa_compat_aliases.php
+++ b/owa_compat_aliases.php
@@ -163,6 +163,7 @@ function owa_compat_class_map(): array
         'owa_notification' => 'OWA\\Module\\Base\\Entity\\Notification',
         'owa_notification_state' => 'OWA\\Module\\Base\\Entity\\NotificationState',
         'owa_custom_report' => 'OWA\\Module\\Base\\Entity\\CustomReport',
+        'owa_custom_report_favorite' => 'OWA\\Module\\Base\\Entity\\CustomReportFavorite',
         'owa_customReportsController' => 'OWA\\Module\\Base\\Controller\\CustomReports',
         'owa_customReportsView' => 'OWA\\Module\\Base\\View\\CustomReports',
         'owa_customReportEditController' => 'OWA\\Module\\Base\\Controller\\CustomReportEdit',

--- a/tests/CustomReportsTest.php
+++ b/tests/CustomReportsTest.php
@@ -4,6 +4,8 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/bootstrap_owa.php';
 
+use OWA\Module\Base\Classes\CustomReportFavorites as Favorites;
+
 use OWA\Module\Base\Classes\CustomReports;
 
 /**
@@ -1546,6 +1548,126 @@ final class CustomReportsTest extends TestCase
         $this->assertContains($mine['id'], $narrowed);
         $this->assertNotContains($theirs['id'], $narrowed,
             '"just mine" must narrow for an admin too, or the control does nothing for them');
+    }
+
+    // ------------------------------------------------------------------
+    // Favourites: the READER's note about where a report sits
+    // ------------------------------------------------------------------
+
+    public function testStarringIsPerReaderNotPerReport(): void
+    {
+        $this->requireDb();
+
+        $saved = $this->store(array('name' => 'Starred By One'), self::OTHER);
+
+        Favorites::toggle($saved['id'], self::AUTHOR);
+
+        $this->assertTrue(Favorites::isFavorite($saved['id'], self::AUTHOR));
+        $this->assertFalse(Favorites::isFavorite($saved['id'], self::OTHER),
+            'one reader starring a report must not star it for its author');
+    }
+
+    public function testStarringTwiceUnstars(): void
+    {
+        $this->requireDb();
+
+        $saved = $this->store(array('name' => 'Toggled'));
+
+        $this->assertTrue(Favorites::toggle($saved['id'], self::AUTHOR));
+        $this->assertTrue(Favorites::isFavorite($saved['id'], self::AUTHOR));
+
+        $this->assertFalse(Favorites::toggle($saved['id'], self::AUTHOR));
+        $this->assertFalse(Favorites::isFavorite($saved['id'], self::AUTHOR),
+            'the star is a toggle, so pressing it again has to clear it');
+    }
+
+    /** Starred rows come back first, whatever the reader sorted by. */
+    public function testFavouritesSortToTheTop(): void
+    {
+        $this->requireDb();
+
+        $plain   = $this->store(array('name' => 'AAA Sorts First Alphabetically'));
+        $starred = $this->store(array('name' => 'ZZZ Sorts Last Alphabetically'));
+
+        Favorites::toggle($starred['id'], self::AUTHOR);
+
+        $ids = array_column(
+            CustomReports::roster(self::AUTHOR, false, 'name', false), 'id');
+
+        $starredAt = array_search($starred['id'], $ids, true);
+        $plainAt   = array_search($plain['id'], $ids, true);
+
+        $this->assertNotFalse($starredAt);
+        $this->assertNotFalse($plainAt);
+        $this->assertLessThan($plainAt, $starredAt,
+            'a starred report must outrank an unstarred one even when the sort disagrees');
+    }
+
+    public function testTheRosterCarriesWhetherEachRowIsStarred(): void
+    {
+        $this->requireDb();
+
+        $starred = $this->store(array('name' => 'Carries Its Star'));
+        Favorites::toggle($starred['id'], self::AUTHOR);
+
+        foreach (CustomReports::roster(self::AUTHOR) as $row) {
+            if ($row['id'] === $starred['id']) {
+                $this->assertTrue($row['is_favorite']);
+                return;
+            }
+        }
+
+        $this->fail('the starred report was not in the roster at all');
+    }
+
+    public function testFavouritesOnlyNarrowsToStarredReports(): void
+    {
+        $this->requireDb();
+
+        $starred = $this->store(array('name' => 'Kept'));
+        $plain   = $this->store(array('name' => 'Filtered Out'));
+
+        Favorites::toggle($starred['id'], self::AUTHOR);
+
+        $ids = array_column(
+            CustomReports::roster(self::AUTHOR, false, '', null, null, null, false, true), 'id');
+
+        $this->assertContains($starred['id'], $ids);
+        $this->assertNotContains($plain['id'], $ids);
+    }
+
+    /**
+     * A reader may star somebody else's shared report, and it reaches their
+     * list -- which is the case the two features have to work together in.
+     */
+    public function testAReaderMayStarSomebodyElsesSharedReport(): void
+    {
+        $this->requireDb();
+
+        $shared = $this->store(
+            array('name' => 'Theirs, Shared, Starred', 'is_shared' => true), self::OTHER);
+
+        Favorites::toggle($shared['id'], self::AUTHOR);
+
+        $ids = array_column(
+            CustomReports::roster(self::AUTHOR, false, '', null, null, null, false, true), 'id');
+
+        $this->assertContains($shared['id'], $ids);
+    }
+
+    /** Deleting a report takes its stars with it. */
+    public function testDeletingAReportForgetsItsStars(): void
+    {
+        $this->requireDb();
+
+        $saved = $this->store(array('name' => 'Deleted With Stars'));
+        Favorites::toggle($saved['id'], self::AUTHOR);
+        $this->assertTrue(Favorites::isFavorite($saved['id'], self::AUTHOR));
+
+        CustomReports::delete($saved['id']);
+
+        $this->assertFalse(Favorites::isFavorite($saved['id'], self::AUTHOR),
+            'a star pointing at a deleted report would sort a gap to the top of a list');
     }
 
     /** The roster has to say who made each report, which means carrying it. */

--- a/tests/CustomReportsTest.php
+++ b/tests/CustomReportsTest.php
@@ -1399,6 +1399,155 @@ final class CustomReportsTest extends TestCase
         $this->assertContains($theirs['id'], $ids);
     }
 
+    // ------------------------------------------------------------------
+    // Sharing: whose LIST a report appears on
+    //
+    // Sharing is about being found, not about being allowed. A custom report
+    // opened by its URL already renders for anyone with view_reports, so these
+    // tests are all about the roster and none of them is an access test.
+    // ------------------------------------------------------------------
+
+    public function testAReportIsNotSharedUnlessAsked(): void
+    {
+        $this->requireDb();
+
+        $saved = $this->store(array('name' => 'Private By Default'));
+        $row   = CustomReports::load($saved['id']);
+
+        $this->assertEmpty($row['is_shared'],
+            'a new report must be private, or sharing becomes something authors opt OUT of');
+    }
+
+    public function testASharedReportAppearsInSomebodyElsesRoster(): void
+    {
+        $this->requireDb();
+
+        $shared = $this->store(array('name' => 'Shared With All', 'is_shared' => true), self::OTHER);
+
+        $ids = array_column(CustomReports::roster(self::AUTHOR), 'id');
+
+        $this->assertContains($shared['id'], $ids,
+            'the point of sharing is that it reaches other people\'s lists');
+    }
+
+    public function testAnUnsharedReportStaysOutOfSomebodyElsesRoster(): void
+    {
+        $this->requireDb();
+
+        $private = $this->store(array('name' => 'Still Private', 'is_shared' => false), self::OTHER);
+
+        $ids = array_column(CustomReports::roster(self::AUTHOR), 'id');
+
+        $this->assertNotContains($private['id'], $ids);
+    }
+
+    /**
+     * The column is NULL on every row that predates it, and NULL must read as
+     * private -- matched as = 1 rather than as truthy for exactly this reason.
+     */
+    public function testARowWithNoSharingFlagIsTreatedAsPrivate(): void
+    {
+        $this->requireDb();
+
+        $legacy = $this->store(array('name' => 'Predates The Column'), self::OTHER);
+
+        $db = \OWA\Core\CoreAPI::dbSingleton();
+        $db->query(sprintf(
+            "UPDATE owa_custom_report SET is_shared = NULL WHERE id = '%s'",
+            $db->prepare($legacy['id'])));
+
+        $ids = array_column(CustomReports::roster(self::AUTHOR), 'id');
+
+        $this->assertNotContains($legacy['id'], $ids,
+            'a NULL flag is a row written before sharing existed, and it was private then');
+    }
+
+    /**
+     * A save that says nothing about sharing must not change it, or any screen
+     * without the checkbox would silently un-share whatever it touched.
+     */
+    public function testASaveThatDoesNotMentionSharingLeavesItAlone(): void
+    {
+        $this->requireDb();
+
+        $saved = $this->store(array('name' => 'Shared Then Renamed', 'is_shared' => true));
+
+        CustomReports::save(array(
+            'id'         => $saved['id'],
+            'name'       => 'Renamed, Still Shared',
+            'definition' => $this->definition(),
+        ), self::AUTHOR);
+
+        $row = CustomReports::load($saved['id']);
+
+        $this->assertSame('Renamed, Still Shared', $row['name']);
+        $this->assertNotEmpty($row['is_shared'], 'sharing must survive a save that never mentioned it');
+    }
+
+    /** The roster carries the flag, because the list marks shared rows. */
+    public function testTheRosterCarriesTheSharingFlag(): void
+    {
+        $this->requireDb();
+
+        $shared = $this->store(array('name' => 'Marked Shared', 'is_shared' => true), self::OTHER);
+
+        $row = null;
+
+        foreach (CustomReports::roster(self::AUTHOR) as $candidate) {
+            if ($candidate['id'] === $shared['id']) {
+                $row = $candidate;
+            }
+        }
+
+        $this->assertNotNull($row);
+        $this->assertNotEmpty($row['is_shared']);
+    }
+
+    // ------------------------------------------------------------------
+    // "Just mine": a reader narrowing their own list
+    // ------------------------------------------------------------------
+
+    public function testMineOnlyExcludesAReportSharedBySomebodyElse(): void
+    {
+        $this->requireDb();
+
+        $mine   = $this->store(array('name' => 'My Own'));
+        $shared = $this->store(array('name' => 'Theirs But Shared', 'is_shared' => true), self::OTHER);
+
+        $ids = array_column(
+            CustomReports::roster(self::AUTHOR, false, '', null, null, null, true), 'id');
+
+        $this->assertContains($mine['id'], $ids);
+        $this->assertNotContains($shared['id'], $ids);
+    }
+
+    /**
+     * It means the same thing to an admin.
+     *
+     * "Just mine" is a reader narrowing a list, so for someone who would
+     * otherwise see everything it has to mean THEIR OWN -- not their own plus
+     * everyone's, which is what it would mean if it were applied alongside the
+     * see-everything branch rather than instead of it.
+     */
+    public function testMineOnlyNarrowsEvenForAUserWhoMaySeeEverything(): void
+    {
+        $this->requireDb();
+
+        $mine   = $this->store(array('name' => 'Admin Own'));
+        $theirs = $this->store(array('name' => 'Admin Sees Theirs'), self::OTHER);
+
+        $all = array_column(
+            CustomReports::roster(self::AUTHOR, true, '', null, null, null, false), 'id');
+        $this->assertContains($theirs['id'], $all);
+
+        $narrowed = array_column(
+            CustomReports::roster(self::AUTHOR, true, '', null, null, null, true), 'id');
+
+        $this->assertContains($mine['id'], $narrowed);
+        $this->assertNotContains($theirs['id'], $narrowed,
+            '"just mine" must narrow for an admin too, or the control does nothing for them');
+    }
+
     /** The roster has to say who made each report, which means carrying it. */
     public function testTheRosterCarriesTheNameAndTheCreator(): void
     {

--- a/tests/e2e/custom-reports.spec.js
+++ b/tests/e2e/custom-reports.spec.js
@@ -2439,6 +2439,80 @@ test.describe('custom reports', () => {
             await expect(page.locator('#customReportName')).toHaveValue(name);
         });
 
+        test.describe('favorites', () => {
+
+            /*
+             * The star lives on the REPORT, beside its title -- not on the
+             * roster row. A favourite is the reader's note about the thing they
+             * are looking at, so it is pressed while looking at it.
+             */
+
+            async function openReportNamed(page, name) {
+                await openRoster(page);
+                await page.locator('.owa_customReportRoster tbody tr', { hasText: name })
+                    .locator('a').first().click();
+                await page.waitForLoadState('networkidle');
+            }
+
+            test('the star sits beside the title and toggles', async ({ page }) => {
+                const name = await buildOne(page, 'Starrable');
+
+                await openReportNamed(page, name);
+
+                const star = page.locator('.owa_titleActionMark[href*="customReportMarkFavorite"]');
+
+                await expect(star).toBeVisible();
+                await expect(star.locator('i.fa-star-o')).toHaveCount(1);
+
+                await star.click();
+                await page.waitForLoadState('networkidle');
+
+                // Back on the report, now starred.
+                const starred = page.locator('.owa_titleActionMark[href*="customReportMarkFavorite"]');
+                await expect(starred.locator('i.fa-star')).toHaveCount(1);
+
+                // And again, to clear it -- it is a toggle, not a one-way mark.
+                await starred.click();
+                await page.waitForLoadState('networkidle');
+                await expect(
+                    page.locator('.owa_titleActionMark[href*="customReportMarkFavorite"] i.fa-star-o')
+                ).toHaveCount(1);
+            });
+
+            test('a starred report sorts to the top and the filter finds it', async ({ page }) => {
+                const plain   = await buildOne(page, 'AAA Unstarred');
+                const starred = await buildOne(page, 'ZZZ Starred');
+
+                await openReportNamed(page, starred);
+                await page.locator('.owa_titleActionMark[href*="customReportMarkFavorite"]').click();
+                await page.waitForLoadState('networkidle');
+
+                await openRoster(page);
+
+                // Starred outranks the alphabetical sort.
+                const names = await page.locator('.owa_customReportRoster tbody tr td:first-child')
+                    .allInnerTexts();
+                const starredAt = names.findIndex((n) => n.includes(starred));
+                const plainAt   = names.findIndex((n) => n.includes(plain));
+
+                expect(starredAt).toBeGreaterThanOrEqual(0);
+                expect(plainAt).toBeGreaterThanOrEqual(0);
+                expect(starredAt).toBeLessThan(plainAt);
+
+                // And the third state of the filter narrows to it.
+                await page.locator('.owa_rosterFilter a', { hasText: 'Favorites' }).click();
+                await page.waitForLoadState('networkidle');
+
+                await expect(page).toHaveURL(/rosterFavorites=1/);
+
+                const filtered = await page.locator('.owa_customReportRoster tbody tr td:first-child')
+                    .allInnerTexts();
+
+                expect(filtered.some((n) => n.includes(starred))).toBe(true);
+                expect(filtered.some((n) => n.includes(plain))).toBe(false);
+            });
+        });
+
         test.describe('sharing and the roster filter', () => {
 
             /*

--- a/tests/e2e/custom-reports.spec.js
+++ b/tests/e2e/custom-reports.spec.js
@@ -2438,6 +2438,94 @@ test.describe('custom reports', () => {
 
             await expect(page.locator('#customReportName')).toHaveValue(name);
         });
+
+        test.describe('sharing and the roster filter', () => {
+
+            /*
+             * Sharing is about being FOUND, not about being allowed: a custom
+             * report opened by its URL already renders for anyone with
+             * view_reports. So these drive the roster, which is the thing the flag
+             * actually changes.
+             */
+
+            test('a new report is private, and the checkbox says what sharing does', async ({ page }) => {
+                await openBuilder(page);
+
+                const box = page.locator('#isShared');
+
+                await expect(box).toBeVisible();
+                await expect(box).not.toBeChecked();
+
+                // The label has to say LISTING rather than access, or it promises a
+                // privacy property it is not providing.
+                await expect(page.locator('label[for="isShared"]')).toContainText(/list/i);
+            });
+
+            test('sharing survives the round trip and marks the row', async ({ page }) => {
+                const name = reportName('Shared');
+
+                await openBuilder(page);
+                await page.fill('#customReportName', name);
+                await page.check('#isShared');
+                await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
+                await page.click('#customReportSubmit');
+                await page.waitForLoadState('networkidle');
+
+                await openRoster(page);
+
+                const row = page.locator('.owa_customReportRoster tbody tr', { hasText: name });
+
+                await expect(row).toHaveCount(1);
+                await expect(row.locator('.owa_rosterShared')).toBeVisible();
+            });
+
+            test('the builder comes back with the box still ticked', async ({ page }) => {
+                const name = reportName('StillTicked');
+
+                await openBuilder(page);
+                await page.fill('#customReportName', name);
+                await page.check('#isShared');
+                await addWidget(page, 'grid', { metrics: ['pageViews'], dimensions: ['pagePath'] });
+                await page.click('#customReportSubmit');
+                await page.waitForLoadState('networkidle');
+
+                await openRoster(page);
+                await page.locator('.owa_customReportRoster tbody tr', { hasText: name })
+                    .locator('a').first().click();
+                await page.waitForLoadState('networkidle');
+
+                // Edit is the pencil on the report itself, not a roster column.
+                await page.locator('.owa_editReport, a[href*="customReportEdit"]').first().click();
+                await page.waitForSelector('#customReportForm', { timeout: 20_000 });
+
+                await expect(page.locator('#isShared')).toBeChecked();
+            });
+
+            test('"just mine" narrows the roster and survives a sort', async ({ page }) => {
+                await buildOne(page, 'MineFilter');
+
+                await openRoster(page);
+                await expect(page.locator('.owa_rosterFilter')).toBeVisible();
+
+                await page.locator('.owa_rosterFilter a', { hasText: 'Just mine' }).click();
+                await page.waitForLoadState('networkidle');
+
+                await expect(page).toHaveURL(/rosterMine=1/);
+                await expect(
+                    page.locator('.owa_rosterFilter a.owa_rosterFilterActive')
+                ).toHaveText('Just mine');
+
+                /*
+                 * Sorting must CARRY the filter. A sort link that dropped it would
+                 * hand back a longer list than was asked for, which reads as the
+                 * filter having failed rather than as the link having lost it.
+                 */
+                await page.locator('.owa_customReportRoster thead th a').first().click();
+                await page.waitForLoadState('networkidle');
+
+                await expect(page).toHaveURL(/rosterMine=1/);
+            });
+        });
     });
 
     test.describe('as a reader who cannot author', () => {


### PR DESCRIPTION
Two changes to the roster — the one place ownership was doing work.

## Sharing

`owa_custom_report` gains `is_shared`, and `roster()` lists a report to everyone when its author sets it.

**This is discoverability, not access.** A custom report opened by its URL already renders for anyone with `view_reports` — deliberately, since that's what makes the link shareable, and it's safe because a custom report can show nothing its reader couldn't already query themselves. So the control reads **"Show this report in everyone's list"** rather than anything that sounds like a permission, and un-sharing doesn't revoke a link somebody already has.

- Off by default; nothing is backfilled. `NULL` reads as private, which is the state every existing row was already in.
- Matched as `is_shared = 1` rather than as truthy, so a `NULL` can't leak in — the same reasoning the `report_type` filter uses.
- A save that doesn't mention sharing leaves it alone, so a screen without the checkbox can't silently un-share what it edits.

## Just mine

An **All / Just mine** filter on the roster, carried on the URL like the sort is. It's applied *instead of* the see-everything branch rather than alongside it, so it means the same thing to an administrator — their own, not their own plus everyone's. It can only narrow, so it needs no capability of its own. The sort links carry it, or sorting would silently hand back a longer list than was asked for.

## Tests

**Eight unit tests** over the visibility matrix, mutation-checked three ways — dropping the shared clause, matching truthy instead of `= 1`, and making the filter additive rather than exclusive each fail them.

**Four e2e tests** over the controls, which earned their place by catching a wiring bug static analysis couldn't see: the roster View wasn't forwarding `roster_mine` to its body template, so the filter rendered as inactive while the query was correctly narrowing.

PHPStan's `variable.undefined` template gate caught a second one — `$owa_mine` used inside the heading closure without being captured, which would have dropped the filter from every sort link.

`Update029` is round-tripped against a real table — up, up again, down (column and index gone), down again, up — and the schema upgrade CI job exercises both directions against a database with history.

78 e2e (custom reports + visualizations), 2019 unit, configless and PHPStan all green locally.